### PR TITLE
feat(daemon): add editMessage and messageHistory

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -30,7 +30,7 @@
 | [daemon-checkin-checkout](daemon-checkin-checkout.md) | 2026-03-17 | 2026-03-17 | Not Started |
 | [daemon-capability-filesystem](daemon-capability-filesystem.md) | 2026-02-15 | 2026-02-24 | Not Started |
 | [daemon-content-store-gc](daemon-content-store-gc.md) | 2026-03-20 | 2026-03-20 | Not Started |
-| [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-03-26 | Draft |
+| [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-04-23 | Not Started |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-03-20 | In Progress |
 | [platform-fs](platform-fs.md) | 2026-03-18 | 2026-03-18 | In Progress |
 | [daemon-capability-persona](daemon-capability-persona.md) | 2026-02-16 | 2026-02-24 | Not Started |

--- a/designs/daemon-message-streaming.md
+++ b/designs/daemon-message-streaming.md
@@ -1,196 +1,275 @@
 # Daemon Message Streaming
 
-|             |                          |
-|-------------|--------------------------|
-| **Created** | 2026-03-26               |
-| **Author**  | Joshua T Corbin (evoked) |
-| **Status**  | Not Started              |
+| | |
+|---|---|
+| **Created** | 2026-03-26 |
+| **Updated** | 2026-04-23 |
+| **Author** | Kris Kowal (prompted) |
+| **Status** | Not Started |
 
 ## Motivation
 
-The Genie agent (and similar AI-powered guests) produces output incrementally:
-reasoning tokens stream in as the LLM thinks, tool call notifications arrive
-mid-turn, and the final assistant response is assembled token-by-token.  Today
-the daemon's mail system only supports discrete, complete messages — there is no
-way for a guest to stream a response that the recipient can consume
-progressively.
+The Genie agent (and similar LLM-powered guests) produces output incrementally.
+Reasoning tokens stream in as the model thinks, tool-call notifications arrive
+mid-turn, and the final assistant reply is assembled token-by-token.
+Today the daemon's mail system only supports discrete, settled messages.
+A guest that wants to show progress must emit several separate messages
+("Thinking …", "Calling tool X …", then the final text), which produces a
+choppy UX rather than a single message whose content fills in over time.
 
-This forces the Genie main module to use a workaround:
+What is actually needed is narrow.
+The sender must be able to replace the interior of a message it has already
+sent, and the recipient must be able to tell whether the message has settled.
+A prior revision of this design proposed a full stream-writer/reader protocol
+with phases, chunks, back-pressure, and a dedicated stream formula type.
+That is over-engineered for the use case.
+Appending chunks, setting phase labels, and tracking partial progress are
+all already expressible as a sequence of whole-message revisions, and the
+whole-message form is a much smaller surface.
 
-1. Send a "Thinking …" status message while the LLM reasons.
-2. Send a "Calling tool X …" message on each tool invocation.
-3. Buffer all response tokens and send the full text as a single final message.
+## Design
 
-This is functional but produces a choppy UX — the recipient sees several
-separate messages rather than a single response that builds up in real time.
+One new agent method, `editMessage`, replaces the interior of a message the
+agent previously sent.
+Messages gain a boolean `done` field that tells the recipient whether the
+message has settled.
+A companion query, `messageHistory`, returns the ordered list of revisions
+with timestamps for a given message, so that the final record and the path
+the sender took to arrive at it are both inspectable.
 
-## Use-Case Requirements
-
-From the Genie integration, the streaming facility needs to support:
-
-- **Progressive text delivery**: A sender opens a streaming message, appends
-  text fragments over time, and eventually finalises the message.  The recipient
-  sees each fragment as it arrives.
-- **Status phases**: The stream should carry metadata indicating the current
-  phase (e.g. `thinking`, `tool-call`, `responding`) so the UI can render
-  appropriate indicators.
-- **Finalisation**: The stream has a defined end.  Once finalised, the message
-  becomes an ordinary immutable message in the inbox/outbox.  The recipient can
-  dismiss it like any other message.
-- **Error / abort**: The sender can abort the stream, signalling that the
-  response will not complete.  The recipient sees the partial content plus an
-  error indicator.
-- **Back-pressure (optional, future)**: If the recipient is slow to consume,
-  the sender should be able to detect this and throttle.
-
-## Proposed Interface Changes
-
-### New mail method: `streamReply`
+### `editMessage`
 
 ```js
 /**
- * Open a streaming reply to an existing message.
+ * Replace the interior of a message the caller previously sent.
  *
- * Returns a StreamWriter that the sender uses to append content and
- * finalise the stream.
+ * The recipient's view of the message is updated in place: the inbox
+ * entry keeps the same message number, the same reply-to linkage, and
+ * the same dismissal state, but its displayed content is replaced with
+ * the new payload. The prior revision is retained in the message's
+ * history (see `messageHistory`).
  *
- * @param {bigint} messageNumber - The inbox message to reply to.
+ * A message with `done: false` is a partial submission. The sender is
+ * expected to issue one or more further `editMessage` calls ending with
+ * `done: true`. Once `done: true` has been observed, the message is
+ * settled. Later edits are still accepted and recorded in history, but
+ * the recipient should treat them as revisions of a settled message
+ * rather than as progress.
+ *
+ * @param {bigint} messageNumber - Outbox message number to edit.
+ * @param {object} payload - New message interior. Shape matches the
+ *   payload originally accepted by send/reply/sendValue/etc.
  * @param {object} [options]
- * @param {string} [options.phase] - Initial phase label (e.g. "thinking").
- * @returns {Promise<StreamWriter>}
+ * @param {boolean} [options.done] - Defaults to true. Pass false to
+ *   mark the revision as a partial submission.
+ * @returns {Promise<void>}
  */
-E(powers).streamReply(messageNumber, options?)
+E(agent).editMessage(messageNumber, payload, options?)
 ```
 
-### StreamWriter interface
+A few things fall out of this shape:
+
+- **Same message, same number.**
+  `editMessage` never creates a new inbox entry.
+  Replies that point at the edited message continue to point at it.
+  Dismissal is unchanged: the recipient dismisses the message as a whole,
+  not any particular revision.
+- **Any message type can be edited.**
+  The payload argument mirrors the union already accepted by `send`,
+  `reply`, `sendValue`, `submit`, and related verbs.
+  An edit may change the payload type (e.g. a `strings` message with a
+  "Thinking..." placeholder becomes a `value` message carrying the
+  final structured result), subject to whatever type-compatibility
+  rules the mail subsystem chooses to enforce.
+- **`done` is a first-class field on the message envelope**,
+  not a stream event.
+  The initial `send` / `reply` call accepts `done` with a default of
+  `true` so that existing callers keep the settled-on-arrival semantics
+  they have today.
+  A sender that wants progressive delivery passes `done: false` on the
+  first submission and a final `editMessage(..., { done: true })`
+  when settled.
+- **Edits after `done` are allowed.**
+  If the sender needs to correct or amend a settled message, it may call
+  `editMessage` again.
+  The prior settled revision and the amendment both live in history
+  with their own timestamps.
+  This matches how humans use edits in chat clients and lets agents
+  post-correct without fabricating a reply chain.
+- **Only the original sender may edit.**
+  Authority to edit is tied to the capability that originally sent the
+  message, the same way authority to reply is tied to possession of
+  the message reference.
+
+### `done`
+
+`done` is stored on the envelope and is surfaced to the recipient alongside
+the payload.
+The recipient UI is expected to render not-done messages with an
+indeterminate progress affordance (spinner, pulsing cursor, "…" suffix,
+whatever is locally idiomatic) and to drop that affordance once `done`
+flips to true.
+Nothing about `done` constrains what the payload can contain; a
+"Thinking..." placeholder and a fully assembled answer are both legitimate
+interiors for a not-done message.
+
+### `messageHistory`
 
 ```js
 /**
- * @typedef {object} StreamWriter
- * @prop {(text: string) => Promise<void>} append
- *   Append a text fragment to the stream.
- * @prop {(phase: string) => Promise<void>} setPhase
- *   Update the current phase label (e.g. "thinking" → "responding").
- * @prop {() => Promise<void>} end
- *   Finalise the stream.  The message becomes immutable.
- * @prop {(reason: string) => Promise<void>} abort
- *   Abort the stream with an error reason.
+ * Return the ordered revision history of a message in the caller's
+ * inbox or outbox.
+ *
+ * The returned array is in submission order, oldest first. Each entry
+ * records the payload as sent, the `done` flag at the time, and the
+ * timestamp assigned by the mail subsystem when the revision was
+ * accepted.
+ *
+ * @param {bigint} messageNumber
+ * @returns {Promise<Array<MessageRevision>>}
+ *
+ * @typedef {object} MessageRevision
+ * @prop {object} payload
+ * @prop {boolean} done
+ * @prop {number} timestamp - Milliseconds since the Unix epoch.
  */
+E(agent).messageHistory(messageNumber)
 ```
 
-### Recipient-side: StreamReader
+History is retained for the lifetime of the message (i.e. until the
+recipient dismisses and it is garbage-collected).
+The current message content, as exposed through the normal inbox read
+path, is equivalent to the last entry in `messageHistory`.
 
-Messages delivered with streaming carry a `stream` property that is an async
-iterable of `StreamEvent` objects:
+### Why this is enough
 
-```js
-/**
- * @typedef {object} StreamEvent
- * @prop {'append' | 'phase' | 'end' | 'abort'} type
- * @prop {string} [text]   - For 'append' events.
- * @prop {string} [phase]  - For 'phase' events.
- * @prop {string} [reason] - For 'abort' events.
- */
+The phased use cases from the prior design collapse onto this surface:
 
-// Recipient usage:
-for await (const event of message.stream) {
-  switch (event.type) {
-    case 'append':
-      process.stdout.write(event.text);
-      break;
-    case 'phase':
-      showStatus(event.phase);
-      break;
-    case 'end':
-      break;
-    case 'abort':
-      showError(event.reason);
-      break;
-  }
-}
-```
+| Prior concept | Expressed as |
+|---|---|
+| `append(chunk)` | `editMessage(n, { strings: [soFar + chunk] }, { done: false })` |
+| `setPhase("thinking")` | An edit whose payload text is `"Thinking..."` with `done: false` |
+| `end()` | `editMessage(n, finalPayload, { done: true })` |
+| `abort(reason)` | `editMessage(n, { strings: [..., reason] }, { done: true })` — or a reply containing the error, if the partial content should be preserved verbatim |
+| Recipient live rendering | Poll-free: the existing message-follow path already notifies on envelope changes |
 
-### Alternative: `streamSend`
-
-For initiating a brand-new streaming conversation (not a reply):
-
-```js
-E(powers).streamSend(recipientName, options?)
-// Returns Promise<StreamWriter>
-```
+The sender decides chunk granularity.
+The mail subsystem does not need a debounce, buffer, or back-pressure
+story: each `editMessage` is an ordinary eventual send.
+If a sender chooses to edit every token, it will pay CapTP overhead per
+token; if it batches every 50ms, it pays less.
+That is a caller concern, not a protocol concern.
 
 ## Implementation Sketch
 
-### 1. Stream formula
+1. **Envelope.**
+   Add `done: boolean` to the message envelope.
+   Default to `true` on the existing submission paths so unchanged callers
+   see unchanged behavior.
 
-Introduce a new formula type `stream` that holds a promise-kit-backed async
-iterator.  The stream formula is created when `streamReply` is called and its
-ID is attached to the outbound message envelope.
+2. **Revision log.**
+   For each outbound message, retain an append-only log of revisions
+   alongside the current envelope.
+   The current envelope is `revisions[revisions.length - 1]`.
+   The log is persisted with the message so it survives daemon restart
+   and can be replayed into a resumed inbox.
 
-```
-stream:<id> = {
-  phase: string,
-  chunks: AsyncIterator<StreamEvent>,
-  push(event): void,   // internal — called by the sender's StreamWriter
-  close(): void,       // internal
-}
-```
+3. **`editMessage` on the mail interface.**
+   Authorized only for the sender's outbox entry for the given message
+   number.
+   Validates that the target message exists and has not been
+   reaped.
+   Appends the new revision, updates the current envelope,
+   and notifies followers via the existing message-change path.
 
-### 2. Message envelope extension
+4. **`messageHistory` on the mail interface.**
+   Reads the revision log for a message number in the caller's inbox
+   or outbox.
+   Returns a snapshot array; it does not subscribe.
 
-Add an optional `streamId` field to the message envelope.  When present the
-recipient's inbox entry includes a `stream` property that is a Far reference
-to the stream formula's async iterable.
+5. **Recipient delivery.**
+   The existing follow-messages channel already emits a change event
+   when an envelope mutates.
+   The recipient gets the new payload and `done` on the same path it
+   already uses for new messages; no new async-iterable surface is
+   introduced.
 
-### 3. Delivery path
+6. **Chat UI.**
+   Render `done: false` messages with a progress indicator.
+   On change, swap in the new payload in place.
+   Offer a "view history" affordance that calls `messageHistory` and
+   lists prior revisions with their timestamps.
 
-- Sender calls `streamReply(number)`.
-- Mail subsystem creates a stream formula and a message envelope with
-  `streamId`.
-- The envelope is delivered to the recipient immediately (the message appears
-  in their inbox with `stream` attached).
-- The sender receives a `StreamWriter` far-reference whose methods proxy to
-  the stream formula's `push` / `close`.
-- On `end()`, the stream formula resolves; the message snapshot (all appended
-  text concatenated) is persisted as the message's `strings` for offline
-  access.
+## Dependencies
 
-### 4. Persistence
+| Design | Relationship |
+|---|---|
+| [daemon-value-message](daemon-value-message.md) | `editMessage` accepts any payload type in the message union, including `value`. No structural changes expected; this design just reuses the union. |
+| [daemon-commands-as-messages](daemon-commands-as-messages.md) | Command results can use `editMessage` to fill in output as it becomes available, superseding any ad-hoc "pending result" placeholder. |
+| [lal-reply-chain-transcripts](lal-reply-chain-transcripts.md) | Reply-chain transcripts include the current envelope of each ancestor. This design does not change what a transcript records; it simply means transcripts assembled before a message settles will show the latest revision at that moment. |
 
-- While streaming, only the stream formula's in-memory buffer is authoritative.
-- On `end()`, the assembled text is written to the message's durable record so
-  it survives daemon restart.
-- On `abort()`, partial text plus the abort reason are persisted.
+## Design Decisions
 
-### 5. Cross-peer considerations
+1. **Edits replace the whole interior, not a diff.**
+   The sender has the full text it wants to show; the mail subsystem
+   does not need to understand diffs or partial token structure.
+   Whole-payload replacement is trivial to reason about and trivial to
+   persist.
 
-For messages that cross CapTP peer boundaries, the stream events travel over
-the existing CapTP channel as method calls on the stream formula's far
-reference.  No new transport primitive is needed — the existing promise
-pipelining and method dispatch handle it.
+2. **`done` is separate from the payload union.**
+   It is tempting to model "not done" as a distinct message type, but
+   partial and settled forms are the same message at different points in
+   its life.
+   Keeping `done` as an envelope field means message-type code paths are
+   not duplicated.
 
-## Migration Path
+3. **Edits after `done` are permitted.**
+   Forbidding post-settlement edits would force senders that want to
+   correct a settled message to send a new reply, which distorts the
+   reply graph and leaves the wrong content in place.
+   History plus timestamps preserves the audit trail without that cost.
 
-1. Implement `streamReply` / `streamSend` alongside the existing `reply` /
-   `send` methods — no breaking changes.
-2. Guests that want streaming opt in; guests that don't continue to use
-   discrete messages.
-3. The Familiar chat UI checks for the `stream` property on inbox messages
-   and renders a live-updating bubble when present, falling back to the
-   static `strings` content for finalised or non-streaming messages.
+4. **Only the original sender may edit.**
+   The edit capability rides on the same authority as the original
+   submission.
+   No new delegation primitive is introduced.
 
-## Open Questions
+5. **No dedicated stream formula, writer, or reader.**
+   Revisions flow through the existing envelope-change channel.
+   This was the major simplification over the prior design.
+   The use cases do not require token-granular back-pressure, and a
+   sender that wants coarser granularity just edits less often.
 
-- **Chunk granularity**: Should `append` send individual tokens or should the
-  sender batch into larger chunks?  A minimum interval (e.g. 50ms debounce)
-  could reduce CapTP overhead without noticeably hurting perceived latency.
-- **Back-pressure**: Should `append` return a promise that resolves when the
-  recipient has consumed the chunk, or should it be fire-and-forget with an
-  internal buffer?
-- **Multiple streams per message**: Is there a use case for a single message
-  carrying multiple parallel streams (e.g. stdout + stderr)?  For now a
-  single stream per message seems sufficient.
-- **Stream cancellation by recipient**: Should the recipient be able to signal
-  the sender to stop streaming (e.g. user clicks "Stop generating")?  This
-  could be modelled as a method on the StreamReader or as a separate request
-  message.
+## Known Gaps and TODOs
+
+- [ ] Decide whether `editMessage` may change the payload type (e.g.
+      `strings` → `value`) or whether the payload type is fixed at
+      first submission.
+      Leaning toward permitting the change, with the caveat that
+      recipient code that has already rendered a particular type may
+      need to re-render.
+- [ ] Define the storage representation of the revision log
+      (flat append in the existing message record vs. a sidecar).
+- [ ] Quota: cap the number of revisions per message or the total
+      retained bytes, to prevent a runaway sender from filling the
+      inbox store.
+- [ ] Consider whether `messageHistory` should be follow-able
+      (subscribe to new revisions) or remain a snapshot query.
+      Snapshot is sufficient for the history-viewer UX; live follow is
+      already covered by the normal message-follow path for the
+      current envelope.
+
+## Prompt
+
+> Let's reset to actual/llm hard and rewrite the daemon-message-streaming
+> design document from scratch. This streaming approach is overwrought and
+> we really only need a single method on agents, editMessage. The
+> editMessage verb will replace the interior of a message. The history of
+> edits will be preserved. Messages will have a "done" boolean that
+> distinguishes messages that indicate partial submissions, like
+> "Thinking..." or "Typing..." or a prefix of the ultimate message, which
+> might be accompanied by an indeterminate progress indicator. Once
+> "done", the message will be expected to have settled, and edits received
+> after that time will be preserved, such that the revisions and their
+> timestamps can be reviewed. This will require another query verb,
+> "messageHistory".

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2522,6 +2522,8 @@ const makeDaemonCore = async (
             submit: disallowedFn,
             sendValue: disallowedFn,
             deliver: disallowedSyncFn,
+            editMessage: disallowedFn,
+            messageHistory: disallowedFn,
           })
         )
       );

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -158,6 +158,8 @@ export const makeGuestMaker = ({
       request,
       send,
       deliver,
+      editMessage,
+      messageHistory,
       define: mailboxDefine,
       form: mailboxForm,
       submit: mailboxSubmit,
@@ -351,6 +353,8 @@ export const makeGuestMaker = ({
       request,
       send,
       deliver,
+      editMessage,
+      messageHistory,
       evaluate,
       // Define/Form
       define,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -1053,6 +1053,8 @@ export const makeHostMaker = ({
       submit,
       sendValue,
       deliverValueById,
+      editMessage,
+      messageHistory,
     } = mailbox;
 
     /**
@@ -1182,6 +1184,8 @@ export const makeHostMaker = ({
       reply,
       request,
       send,
+      editMessage,
+      messageHistory,
       form,
       // Host
       storeBlob,

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -216,6 +216,17 @@ export const GuestInterface = M.interface('EndoGuest', {
     EdgeNamesShape,
     NamesOrPathsShape,
   ).returns(M.promise()),
+  // Edit a message the caller previously sent
+  editMessage: M.call(
+    MessageNumberShape,
+    M.arrayOf(M.string()),
+    EdgeNamesShape,
+    NamesOrPathsShape,
+  )
+    .optional(M.splitRecord({}, { done: M.boolean() }))
+    .returns(M.promise()),
+  // Return the revision history of a message
+  messageHistory: M.call(MessageNumberShape).returns(M.promise()),
   // Define code with named slots
   define: M.call(
     M.string(), // source
@@ -376,6 +387,17 @@ export const HostInterface = M.interface('EndoHost', {
     EdgeNamesShape,
     NamesOrPathsShape,
   ).returns(M.promise()),
+  // Edit a message the caller previously sent
+  editMessage: M.call(
+    MessageNumberShape,
+    M.arrayOf(M.string()),
+    EdgeNamesShape,
+    NamesOrPathsShape,
+  )
+    .optional(M.record())
+    .returns(M.promise()),
+  // Return the revision history of a message
+  messageHistory: M.call(MessageNumberShape).returns(M.promise()),
   // Endow a definition request with bindings
   endow: M.call(
     MessageNumberShape, // messageNumber

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -728,8 +728,8 @@ export const makeMailboxMaker = ({
         const messageNumber = nextMessageNumber;
         const date = new Date().toISOString();
         const done =
-          /** @type {EnvelopedMessage & { done?: boolean }} */ (envelope).done ??
-          true;
+          /** @type {EnvelopedMessage & { done?: boolean }} */ (envelope)
+            .done ?? true;
         const formula = makeMessageFormula(envelope, date);
         await persistMessage(messageNumber, formula);
 
@@ -1498,9 +1498,7 @@ export const makeMailboxMaker = ({
         senderId,
       );
       if (messageNumber === undefined) {
-        throw new Error(
-          `No message with id ${q(edit.messageId)} from sender`,
-        );
+        throw new Error(`No message with id ${q(edit.messageId)} from sender`);
       }
       await applyEdit(messageNumber, edit);
     };
@@ -1589,10 +1587,7 @@ export const makeMailboxMaker = ({
         );
         const editParcel = makeEnvelope();
         editOutbox.set(editParcel, editEnvelope);
-        await E(/** @type {any} */ (recipient)).receiveEdit(
-          editParcel,
-          selfId,
-        );
+        await E(/** @type {any} */ (recipient)).receiveEdit(editParcel, selfId);
       }
     };
 

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -180,6 +180,22 @@ export const makeMailboxMaker = ({
     /** @type {WeakMap<{}, EnvelopedMessage>} */
     const outbox = new WeakMap();
 
+    /**
+     * Ephemeral outbox for edits in flight.  Mirrors `outbox`: the sender
+     * populates an entry keyed by a fresh envelope, the recipient calls
+     * `openEdit` on the sender's handle to retrieve the edit payload.
+     * @type {WeakMap<{}, EnvelopedMessage & { done: boolean }>}
+     */
+    const editOutbox = new WeakMap();
+
+    /**
+     * In-memory revision log per message number.  Each entry is the
+     * envelope as accepted, the `done` flag at the time of that revision,
+     * and the ISO date assigned when it was applied.
+     * @type {Map<bigint, Array<{ envelope: EnvelopedMessage, done: boolean, date: string }>>}
+     */
+    const revisionsByNumber = new Map();
+
     /** @type {Topic<StampedMessage>} */
     const messagesTopic = makeChangeTopic();
     const mailboxStoreJobs = makeSerialJobs();
@@ -451,6 +467,9 @@ export const makeMailboxMaker = ({
       /** @type {PromiseKit<void>} */
       const dismissal = makePromiseKit();
       const dismisser = makeDismisser(messageNumber, dismissal);
+      const done =
+        /** @type {MessageFormula & { done?: boolean }} */ (formula).done ??
+        true;
 
       if (formula.messageType === 'request') {
         if (
@@ -478,6 +497,7 @@ export const makeMailboxMaker = ({
           ...(formula.replyTo !== undefined && { replyTo: formula.replyTo }),
           number: messageNumber,
           date: formula.date,
+          done,
           dismissed: dismissal.promise,
           dismisser,
         });
@@ -511,6 +531,7 @@ export const makeMailboxMaker = ({
           ...(formula.replyTo !== undefined && { replyTo: formula.replyTo }),
           number: messageNumber,
           date: formula.date,
+          done,
           dismissed: dismissal.promise,
           dismisser,
         });
@@ -530,6 +551,7 @@ export const makeMailboxMaker = ({
           ...(formula.replyTo !== undefined && { replyTo: formula.replyTo }),
           number: messageNumber,
           date: formula.date,
+          done,
           dismissed: dismissal.promise,
           dismisser,
         });
@@ -549,6 +571,7 @@ export const makeMailboxMaker = ({
           ...(formula.replyTo !== undefined && { replyTo: formula.replyTo }),
           number: messageNumber,
           date: formula.date,
+          done,
           dismissed: dismissal.promise,
           dismisser,
         });
@@ -567,6 +590,7 @@ export const makeMailboxMaker = ({
           replyTo: formula.replyTo,
           number: messageNumber,
           date: formula.date,
+          done,
           dismissed: dismissal.promise,
           dismisser,
         });
@@ -703,6 +727,9 @@ export const makeMailboxMaker = ({
         assertMessageEnvelope(envelope);
         const messageNumber = nextMessageNumber;
         const date = new Date().toISOString();
+        const done =
+          /** @type {EnvelopedMessage & { done?: boolean }} */ (envelope).done ??
+          true;
         const formula = makeMessageFormula(envelope, date);
         await persistMessage(messageNumber, formula);
 
@@ -717,11 +744,16 @@ export const makeMailboxMaker = ({
           ...envelope,
           number: messageNumber,
           date,
+          done,
           dismissed: dismissal.promise,
           dismisser,
         });
 
         messages.set(messageNumber, message);
+        revisionsByNumber.set(
+          messageNumber,
+          harden([{ envelope: harden({ ...envelope, done }), done, date }]),
+        );
         messagesTopic.publisher.next(message);
       });
     };
@@ -1363,9 +1395,235 @@ export const makeMailboxMaker = ({
       await deliver(message);
     };
 
+    /**
+     * Apply an edit envelope to an existing local message record.
+     * @param {bigint} messageNumber
+     * @param {EnvelopedMessage & { done: boolean }} editEnvelope
+     * @returns {Promise<void>}
+     */
+    const applyEdit = async (messageNumber, editEnvelope) => {
+      await mailboxStoreJobs.enqueue(async () => {
+        const existing = messages.get(messageNumber);
+        if (existing === undefined) {
+          throw new Error(`No such message with number ${q(messageNumber)}`);
+        }
+        if (existing.type !== editEnvelope.type) {
+          throw new Error(
+            `Cannot change message type on edit of ${q(messageNumber)} (was ${q(existing.type)}, got ${q(editEnvelope.type)})`,
+          );
+        }
+        if (existing.from !== editEnvelope.from) {
+          throw new Error(
+            `Edit for message ${q(messageNumber)} has mismatched sender`,
+          );
+        }
+        if (existing.messageId !== editEnvelope.messageId) {
+          throw new Error(
+            `Edit for message ${q(messageNumber)} has mismatched messageId`,
+          );
+        }
+        const date = new Date().toISOString();
+        const formula = makeMessageFormula(editEnvelope, date);
+        await persistMessage(messageNumber, formula);
+
+        const revised = harden({
+          ...editEnvelope,
+          number: messageNumber,
+          date,
+          done: editEnvelope.done,
+          dismissed: existing.dismissed,
+          dismisser: existing.dismisser,
+        });
+        messages.set(messageNumber, revised);
+
+        const prior = revisionsByNumber.get(messageNumber) ?? harden([]);
+        revisionsByNumber.set(
+          messageNumber,
+          harden([
+            ...prior,
+            {
+              envelope: harden({ ...editEnvelope }),
+              done: editEnvelope.done,
+              date,
+            },
+          ]),
+        );
+
+        messagesTopic.publisher.next(revised);
+      });
+    };
+
+    /**
+     * @param {import('./types.js').FormulaNumber} messageId
+     * @param {FormulaIdentifier} fromId
+     * @returns {bigint | undefined}
+     */
+    const findMessageNumberByMessageId = (messageId, fromId) => {
+      for (const [number, message] of messages) {
+        if (message.messageId === messageId && message.from === fromId) {
+          return number;
+        }
+      }
+      return undefined;
+    };
+
+    /**
+     * @param {Envelope} envelope
+     */
+    const openEdit = envelope => {
+      const edit = editOutbox.get(envelope);
+      if (edit === undefined) {
+        throw new Error('Mail fraud: unrecognized edit parcel');
+      }
+      return edit;
+    };
+
+    /**
+     * Receive an edit from the alleged sender.
+     * @param {ERef<Envelope>} envelope
+     * @param {string} allegedFromId
+     */
+    const receiveEdit = async (envelope, allegedFromId) => {
+      assertValidId(allegedFromId);
+      const senderId = allegedFromId;
+      const sender = provide(senderId, 'handle');
+      const edit = await E(/** @type {any} */ (sender)).openEdit(envelope);
+      if (senderId !== edit.from) {
+        throw new Error(
+          'Mail fraud: alleged sender does not recognize edit parcel',
+        );
+      }
+      const messageNumber = findMessageNumberByMessageId(
+        edit.messageId,
+        senderId,
+      );
+      if (messageNumber === undefined) {
+        throw new Error(
+          `No message with id ${q(edit.messageId)} from sender`,
+        );
+      }
+      await applyEdit(messageNumber, edit);
+    };
+
+    /** @type {Mail['editMessage']} */
+    const editMessage = async (
+      messageNumber,
+      strings,
+      edgeNames,
+      petNamesOrPaths,
+      options = {},
+    ) => {
+      const normalizedMessageNumber = mustParseBigint(messageNumber, 'message');
+      const current = messages.get(normalizedMessageNumber);
+      if (current === undefined) {
+        throw new Error(`No such message with number ${q(messageNumber)}`);
+      }
+      if (current.from !== selfId) {
+        throw new Error(
+          `Only the original sender may edit message ${q(messageNumber)}`,
+        );
+      }
+      if (current.type !== 'package') {
+        throw new Error(
+          `editMessage currently supports only package messages (message ${q(messageNumber)} is ${q(current.type)})`,
+        );
+      }
+      assertNames(edgeNames);
+      assertUniqueEdgeNames(edgeNames);
+      if (!Array.isArray(strings)) {
+        throw new Error('editMessage requires an array of strings');
+      }
+      if (petNamesOrPaths.length !== edgeNames.length) {
+        throw new Error(
+          `Edit must have one edge name (${q(
+            edgeNames.length,
+          )}) for every pet name (${q(petNamesOrPaths.length)})`,
+        );
+      }
+      if (strings.length < petNamesOrPaths.length) {
+        throw new Error(
+          `Edit must have one string before every value delivered`,
+        );
+      }
+      const { done: doneOption = true } = options;
+      if (typeof doneOption !== 'boolean') {
+        throw new Error('editMessage "done" option must be a boolean');
+      }
+
+      const ids = await Promise.all(
+        petNamesOrPaths.map(async petNameOrPath => {
+          const petPath = namePathFrom(petNameOrPath);
+          const id = await E(directory).identify(...petPath);
+          if (id === undefined) {
+            throw new Error(`Unknown pet name ${q(petNameOrPath)}`);
+          }
+          assertValidId(id);
+          return /** @type {FormulaIdentifier} */ (id);
+        }),
+      );
+
+      /** @type {EnvelopedMessage & { done: boolean }} */
+      const editEnvelope = harden({
+        type: /** @type {const} */ ('package'),
+        strings,
+        names: edgeNames,
+        ids,
+        messageId: /** @type {import('./types.js').FormulaNumber} */ (
+          current.messageId
+        ),
+        ...(current.replyTo !== undefined && {
+          replyTo: /** @type {import('./types.js').FormulaNumber} */ (
+            current.replyTo
+          ),
+        }),
+        from: selfId,
+        to: /** @type {FormulaIdentifier} */ (current.to),
+        done: doneOption,
+      });
+
+      await applyEdit(normalizedMessageNumber, editEnvelope);
+
+      if (current.to !== current.from) {
+        const recipient = await provideHandle(
+          /** @type {FormulaIdentifier} */ (current.to),
+        );
+        const editParcel = makeEnvelope();
+        editOutbox.set(editParcel, editEnvelope);
+        await E(/** @type {any} */ (recipient)).receiveEdit(
+          editParcel,
+          selfId,
+        );
+      }
+    };
+
+    /** @type {Mail['messageHistory']} */
+    const messageHistory = async messageNumber => {
+      const normalizedMessageNumber = mustParseBigint(messageNumber, 'message');
+      if (!messages.has(normalizedMessageNumber)) {
+        throw new Error(`No such message with number ${q(messageNumber)}`);
+      }
+      const revisions = revisionsByNumber.get(normalizedMessageNumber) ?? [];
+      const externalized = await Promise.all(
+        revisions.map(async revision => {
+          const externalizedEnvelope = await externalizeMessage(
+            /** @type {any} */ (revision.envelope),
+          );
+          return harden({
+            envelope: externalizedEnvelope,
+            done: revision.done,
+            date: revision.date,
+            timestamp: Date.parse(revision.date),
+          });
+        }),
+      );
+      return harden(externalized);
+    };
+
     const handle = makeExo('Handle', HandleInterface, {
       receive,
       open,
+      receiveEdit,
+      openEdit,
     });
 
     await loadMailboxState();
@@ -1391,6 +1649,8 @@ export const makeMailboxMaker = ({
       submit,
       sendValue,
       deliverValueById,
+      editMessage,
+      messageHistory,
     });
   };
 

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -312,6 +312,7 @@ type MessageFormula = {
   from: FormulaIdentifier;
   to: FormulaIdentifier;
   date: string;
+  done?: boolean;
   description?: string;
   promiseId?: FormulaIdentifier;
   resolverId?: FormulaIdentifier;
@@ -500,8 +501,16 @@ export interface Dismisser {
 export type StampedMessage = EnvelopedMessage & {
   number: bigint;
   date: string;
+  done: boolean;
   dismissed: Promise<void>;
   dismisser: ERef<Dismisser>;
+};
+
+export type MessageRevision = {
+  envelope: Message & { to: FormulaIdentifier; from: FormulaIdentifier };
+  done: boolean;
+  date: string;
+  timestamp: number;
 };
 
 export interface Invitation {
@@ -797,6 +806,31 @@ export interface Mail {
     messageNumber: bigint,
     valueId: FormulaIdentifier,
   ): Promise<void>;
+  /**
+   * Replace the interior of a message the caller previously sent.
+   *
+   * Only the original sender may edit.  Edits keep the same message
+   * number, reply-to linkage, and dismissal state but replace the
+   * payload.  The prior revision is retained in history
+   * (see `messageHistory`).
+   *
+   * `options.done` (default `true`) flags whether the revision represents
+   * a partial submission (`false`) or a settled state (`true`).  Edits
+   * after a settled revision are still accepted and recorded.
+   */
+  editMessage(
+    messageNumber: bigint,
+    strings: Array<string>,
+    edgeNames: Array<string>,
+    petNamesOrPaths: Array<string | string[]>,
+    options?: { done?: boolean },
+  ): Promise<void>;
+  /**
+   * Return the ordered revision history of a message in the caller's
+   * inbox or outbox.  Oldest entry first.  The current message content is
+   * equivalent to the last entry's envelope.
+   */
+  messageHistory(messageNumber: bigint): Promise<Array<MessageRevision>>;
 }
 
 export type MakeMailbox = (args: {
@@ -885,6 +919,8 @@ export interface EndoAgent extends EndoDirectory {
   send: Mail['send'];
   sendValue: Mail['sendValue'];
   deliver: Mail['deliver'];
+  editMessage: Mail['editMessage'];
+  messageHistory: Mail['messageHistory'];
   /**
    * @param id The formula identifier to look up.
    * @returns The pet names for the given formula identifier.

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -1111,13 +1111,9 @@ test('editMessage replaces payload and preserves history', async t => {
   t.is(editHost1.number, initialHost.number);
   t.is(editHost1.messageId, initialHost.messageId);
 
-  await E(guest).editMessage(
-    initialGuest.number,
-    ['Final answer.'],
-    [],
-    [],
-    { done: true },
-  );
+  await E(guest).editMessage(initialGuest.number, ['Final answer.'], [], [], {
+    done: true,
+  });
   const [{ value: editHost2 }, { value: editGuest2 }] = await Promise.all([
     E(hostMessages).next(),
     E(guestMessages).next(),
@@ -1180,13 +1176,9 @@ test('editMessage accepts edits after done and records them', async t => {
     E(hostMessages).next(),
   ]);
 
-  await E(guest).editMessage(
-    initialGuest.number,
-    ['corrected'],
-    [],
-    [],
-    { done: true },
-  );
+  await E(guest).editMessage(initialGuest.number, ['corrected'], [], [], {
+    done: true,
+  });
   const [{ value: editGuest }, { value: editHost }] = await Promise.all([
     E(guestMessages).next(),
     E(hostMessages).next(),

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -1076,6 +1076,133 @@ test('reply links to parent message', async t => {
   t.is(replyMessage.replyTo, hostMessage.messageId);
 });
 
+test('editMessage replaces payload and preserves history', async t => {
+  const { host } = await prepareHost(t);
+
+  const guest = E(host).provideGuest('guest');
+  const hostMessages = E(host).followMessages();
+  const guestMessages = E(guest).followMessages();
+
+  await E(guest).send('@host', ['Thinking...'], [], []);
+
+  const [{ value: initialHost }, { value: initialGuest }] = await Promise.all([
+    E(hostMessages).next(),
+    E(guestMessages).next(),
+  ]);
+  t.deepEqual(initialHost.strings, ['Thinking...']);
+  t.is(initialHost.done, true);
+  t.is(initialGuest.done, true);
+
+  await E(guest).editMessage(
+    initialGuest.number,
+    ['Thinking more...'],
+    [],
+    [],
+    { done: false },
+  );
+  const [{ value: editHost1 }, { value: editGuest1 }] = await Promise.all([
+    E(hostMessages).next(),
+    E(guestMessages).next(),
+  ]);
+  t.deepEqual(editHost1.strings, ['Thinking more...']);
+  t.is(editHost1.done, false);
+  t.deepEqual(editGuest1.strings, ['Thinking more...']);
+  t.is(editGuest1.done, false);
+  t.is(editHost1.number, initialHost.number);
+  t.is(editHost1.messageId, initialHost.messageId);
+
+  await E(guest).editMessage(
+    initialGuest.number,
+    ['Final answer.'],
+    [],
+    [],
+    { done: true },
+  );
+  const [{ value: editHost2 }, { value: editGuest2 }] = await Promise.all([
+    E(hostMessages).next(),
+    E(guestMessages).next(),
+  ]);
+  t.deepEqual(editHost2.strings, ['Final answer.']);
+  t.is(editHost2.done, true);
+  t.is(editGuest2.done, true);
+
+  const guestHistory = await E(guest).messageHistory(initialGuest.number);
+  const hostHistory = await E(host).messageHistory(initialHost.number);
+  t.is(guestHistory.length, 3);
+  t.is(hostHistory.length, 3);
+  t.deepEqual(
+    guestHistory.map(r => ({ strings: r.envelope.strings, done: r.done })),
+    [
+      { strings: ['Thinking...'], done: true },
+      { strings: ['Thinking more...'], done: false },
+      { strings: ['Final answer.'], done: true },
+    ],
+  );
+  t.deepEqual(
+    hostHistory.map(r => ({ strings: r.envelope.strings, done: r.done })),
+    [
+      { strings: ['Thinking...'], done: true },
+      { strings: ['Thinking more...'], done: false },
+      { strings: ['Final answer.'], done: true },
+    ],
+  );
+  for (const revision of guestHistory) {
+    t.true(typeof revision.date === 'string');
+    t.false(Number.isNaN(revision.timestamp));
+  }
+});
+
+test('editMessage rejects edits from non-senders', async t => {
+  const { host } = await prepareHost(t);
+
+  const guest = E(host).provideGuest('guest');
+  const hostMessages = E(host).followMessages();
+
+  await E(guest).send('@host', ['hello'], [], []);
+  const { value: hostMessage } = await E(hostMessages).next();
+
+  await t.throwsAsync(
+    () => E(host).editMessage(hostMessage.number, ['tampered'], [], []),
+    { message: /Only the original sender may edit/ },
+  );
+});
+
+test('editMessage accepts edits after done and records them', async t => {
+  const { host } = await prepareHost(t);
+
+  const guest = E(host).provideGuest('guest');
+  const hostMessages = E(host).followMessages();
+  const guestMessages = E(guest).followMessages();
+
+  await E(guest).send('@host', ['original'], [], []);
+  const [{ value: initialGuest }] = await Promise.all([
+    E(guestMessages).next(),
+    E(hostMessages).next(),
+  ]);
+
+  await E(guest).editMessage(
+    initialGuest.number,
+    ['corrected'],
+    [],
+    [],
+    { done: true },
+  );
+  const [{ value: editGuest }, { value: editHost }] = await Promise.all([
+    E(guestMessages).next(),
+    E(hostMessages).next(),
+  ]);
+  t.deepEqual(editGuest.strings, ['corrected']);
+  t.is(editGuest.done, true);
+  t.deepEqual(editHost.strings, ['corrected']);
+
+  const history = await E(guest).messageHistory(initialGuest.number);
+  t.is(history.length, 2);
+  t.deepEqual(history[0].envelope.strings, ['original']);
+  t.deepEqual(history[1].envelope.strings, ['corrected']);
+  t.true(history[0].done);
+  t.true(history[1].done);
+});
+
 test('message hub avoids kebab-case reply metadata names', async t => {
   const { host } = await prepareHost(t);
 


### PR DESCRIPTION
## Summary

- Add `editMessage` on agents that replaces the interior of a previously sent message, keeping the message number, reply-to linkage, and dismissal state intact.
- Add `messageHistory` that returns the ordered revision log for a message with `envelope`, `done`, `date`, and `timestamp`.
- Add a `done` boolean to the message envelope so recipients can distinguish partial submissions (e.g. "Thinking...") from settled ones. Defaults to `true` on the existing delivery paths.
- Rewrite `designs/daemon-message-streaming.md` around this minimal surface instead of the prior stream-writer/reader/stream-formula sketch.

## Implementation notes

- Only the original sender may edit (the first check in `editMessage`). Edits after a settled (`done: true`) revision are still accepted and recorded.
- Edits propagate to the recipient through a new `receiveEdit`/`openEdit` pair on the `Handle`, mirroring the existing `receive`/`open` envelope protocol. Recipient-side dispatch looks up the local message by `messageId` + sender.
- Revisions are retained in an in-memory log (`revisionsByNumber`), keyed by message number. Persistence across daemon restart is out of scope for this PR and flagged as a TODO in the design doc.
- `editMessage` initially supports `package` messages only (the LLM streaming use case). Type-changing edits and other payload types are flagged as TODOs.
- Added `editMessage` / `messageHistory` to `HostInterface` and `GuestInterface`, and to the `least-authority` guest exo stub (which manually enumerates every guest method).

## Test plan

- [x] New ava tests in `packages/daemon/test/endo.test.js` covering: progressive edits with `done` transitions, history preservation across both sender and recipient mailboxes, non-sender edits rejected, post-settled edits still recorded.
- [x] Full `packages/daemon` ava suite runs green (486 tests).
- [ ] CI runs on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)