### PR TITLE
refactor(daemon): migrate locator format to path-based V2

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -4419,9 +4419,8 @@ const makeDaemonCore = async (
       const { number: hostHandleNumber, node: hostHandleNode } =
         parseId(hostHandleId);
       const { number } = parseId(id);
-      const url = new URL('endo://');
-      url.hostname = node;
-      url.searchParams.set('id', number);
+      // V2 path-based format: formula number in URL path.
+      const url = new URL(`endo://${node}/${number}`);
       url.searchParams.set('type', 'invitation');
       url.searchParams.set('from', hostHandleNumber);
       // Include the handle's node if it differs from the daemon node
@@ -4442,7 +4441,10 @@ const makeDaemonCore = async (
      */
     const accept = async (guestHandleLocator, _hostNameFromGuest) => {
       const url = new URL(guestHandleLocator);
-      const guestHandleNumber = url.searchParams.get('id');
+      // Support both V2 (path-based) and old (?id=) formats.
+      const pathSegment = url.pathname.replace(/^\//, '');
+      const guestHandleNumber =
+        url.searchParams.get('id') || pathSegment || null;
       const addresses = url.searchParams.getAll('at');
       const guestDaemonNode = url.hostname;
       // The handle's node may differ from the daemon node when agent keys
@@ -4451,7 +4453,7 @@ const makeDaemonCore = async (
         url.searchParams.get('handleNode') || guestDaemonNode;
 
       if (!guestHandleNumber) {
-        throw makeError('Handle locator must have an "id" parameter');
+        throw makeError('Handle locator must include a formula number');
       }
       assertNodeNumber(guestDaemonNode);
       assertFormulaNumber(guestHandleNumber);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -822,7 +822,10 @@ export const makeHostMaker = ({
       assertPetName(guestName);
       const url = new URL(invitationLocator);
       const daemonNode = url.hostname;
-      const invitationNumber = url.searchParams.get('id');
+      // Support both V2 (path-based) and old (?id=) formats.
+      const pathSegment = url.pathname.replace(/^\//, '');
+      const invitationNumber =
+        url.searchParams.get('id') || pathSegment || null;
       const remoteHandleNumber = url.searchParams.get('from');
       // The remote handle's node may differ from the daemon node when
       // agent keys are used as formula nodes.
@@ -833,8 +836,8 @@ export const makeHostMaker = ({
       if (!remoteHandleNumber) {
         throw makeError(`Invitation must have a "from" parameter`);
       }
-      if (invitationNumber === null) {
-        throw makeError(`Invitation must have an "id" parameter`);
+      if (!invitationNumber) {
+        throw makeError(`Invitation must include a formula number`);
       }
       assertNodeNumber(daemonNode);
       assertFormulaNumber(remoteHandleNumber);
@@ -861,9 +864,8 @@ export const makeHostMaker = ({
       const { number: handleNumber, node: handleNode } = parseId(handleId);
       // eslint-disable-next-line no-use-before-define
       const { addresses: hostAddresses } = await getPeerInfo();
-      const handleUrl = new URL('endo://');
-      handleUrl.hostname = localNodeNumber;
-      handleUrl.searchParams.set('id', handleNumber);
+      // V2 path-based format: formula number in URL path.
+      const handleUrl = new URL(`endo://${localNodeNumber}/${handleNumber}`);
       // Include the handle's node if it differs from the daemon node
       // (i.e. it uses an agent key).
       if (handleNode !== localNodeNumber) {

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -42,7 +42,7 @@ const assertValidLocatorType = allegedType => {
 
 /**
  * @param {string} allegedLocator
- * @returns {{ formulaType: string, node: NodeNumber, number: FormulaNumber }}
+ * @returns {{ formulaType: string, node: NodeNumber, number: FormulaNumber, hints: string[] }}
  */
 export const parseLocator = allegedLocator => {
   const errorPrefix = `Invalid locator ${q(allegedLocator)}:`;
@@ -84,7 +84,8 @@ export const parseLocator = allegedLocator => {
 
   const nodeNumber = /** @type {NodeNumber} */ (node);
   const formulaNumber = /** @type {FormulaNumber} */ (number);
-  return { formulaType, node: nodeNumber, number: formulaNumber };
+  const hints = url.searchParams.getAll('at');
+  return { formulaType, node: nodeNumber, number: formulaNumber, hints };
 };
 
 /** @param {string} allegedLocator */
@@ -184,8 +185,7 @@ export const externalizeId = (
  * @returns {{ id: FormulaIdentifier, formulaType: string, addresses: string[] }}
  */
 export const internalizeLocator = locator => {
-  const { number, node, formulaType } = parseLocator(locator);
-  const addresses = addressesFromLocator(locator);
+  const { number, node, formulaType, hints } = parseLocator(locator);
   const id = formatId({ number, node });
-  return { id, formulaType, addresses };
+  return { id, formulaType, addresses: hints };
 };

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -129,6 +129,24 @@ export const formatLocator = (id, formulaType) => {
 };
 
 /**
+ * Format a locator using the new path-based format.
+ * The formula number appears in the URL path instead of the query string.
+ *
+ * New format: endo://{node}/{number}?type={type}
+ *
+ * @param {string} id - The full formula identifier.
+ * @param {string} formulaType - The type of the formula with the given id.
+ */
+export const formatLocatorV2 = (id, formulaType) => {
+  const { number, node } = parseId(id);
+  assertValidLocatorType(formulaType);
+  const url = new URL(`endo://${node}/${number}`);
+  url.searchParams.set('type', formulaType);
+  return url.toString();
+};
+harden(formatLocatorV2);
+
+/**
  * @param {string} locator
  */
 export const idFromLocator = locator => {

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -111,40 +111,20 @@ export const assertValidLocator = allegedLocator => {
 };
 
 /**
+ * Format a locator in the path-based format.
+ *
+ * Format: `endo://{node}/{number}?type={type}`
+ *
  * @param {string} id - The full formula identifier.
  * @param {string} formulaType - The type of the formula with the given id.
  */
 export const formatLocator = (id, formulaType) => {
-  const { number, node } = parseId(id);
-  const url = new URL(`endo://${node}`);
-  url.pathname = '/';
-
-  // The id query param is just the number
-  url.searchParams.set('id', number);
-
-  assertValidLocatorType(formulaType);
-  url.searchParams.set('type', formulaType);
-
-  return url.toString();
-};
-
-/**
- * Format a locator using the new path-based format.
- * The formula number appears in the URL path instead of the query string.
- *
- * New format: endo://{node}/{number}?type={type}
- *
- * @param {string} id - The full formula identifier.
- * @param {string} formulaType - The type of the formula with the given id.
- */
-export const formatLocatorV2 = (id, formulaType) => {
   const { number, node } = parseId(id);
   assertValidLocatorType(formulaType);
   const url = new URL(`endo://${node}/${number}`);
   url.searchParams.set('type', formulaType);
   return url.toString();
 };
-harden(formatLocatorV2);
 
 /**
  * @param {string} locator
@@ -157,18 +137,16 @@ export const idFromLocator = locator => {
 /**
  * Format a locator with connection hints for sharing with remote peers.
  *
+ * Format: `endo://{node}/{number}?type={type}&at={hint1}&at={hint2}`
+ *
  * @param {string} id - The full formula identifier.
  * @param {string} formulaType - The type of the formula with the given id.
  * @param {string[]} addresses - Network addresses (connection hints).
  */
 export const formatLocatorForSharing = (id, formulaType, addresses) => {
   const { number, node } = parseId(id);
-  const url = new URL(`endo://${node}`);
-  url.pathname = '/';
-
-  url.searchParams.set('id', number);
-
   assertValidLocatorType(formulaType);
+  const url = new URL(`endo://${node}/${number}`);
   url.searchParams.set('type', formulaType);
 
   for (const address of addresses) {

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -61,18 +61,35 @@ export const parseLocator = allegedLocator => {
     throw makeError(`${errorPrefix} Invalid node identifier.`);
   }
 
-  if (!url.searchParams.has('id') || !url.searchParams.has('type')) {
-    throw makeError(`${errorPrefix} Invalid search params.`);
-  }
+  // Detect format: old format uses ?id= query param,
+  // new format puts the formula number in the URL path.
+  const hasIdParam = url.searchParams.has('id');
+  const pathSegment = url.pathname.replace(/^\//, '');
 
-  // Only 'id', 'type', and 'at' (connection hints) are allowed.
-  for (const key of url.searchParams.keys()) {
-    if (key !== 'id' && key !== 'type' && key !== 'at') {
-      throw makeError(`${errorPrefix} Invalid search params.`);
+  /** @type {string | null} */
+  let number;
+  if (hasIdParam) {
+    // Old format: endo://{node}/?id={number}&type={type}
+    number = url.searchParams.get('id');
+    // Only 'id', 'type', and 'at' (connection hints) are allowed.
+    for (const key of url.searchParams.keys()) {
+      if (key !== 'id' && key !== 'type' && key !== 'at') {
+        throw makeError(`${errorPrefix} Invalid search params.`);
+      }
     }
+  } else if (pathSegment && isValidNumber(pathSegment)) {
+    // New format: endo://{node}/{number}?type={type}
+    number = pathSegment;
+    // Only 'type' and 'at' are allowed in the new format.
+    for (const key of url.searchParams.keys()) {
+      if (key !== 'type' && key !== 'at') {
+        throw makeError(`${errorPrefix} Invalid search params.`);
+      }
+    }
+  } else {
+    throw makeError(`${errorPrefix} Missing formula number.`);
   }
 
-  const number = url.searchParams.get('id');
   if (number === null || !isValidNumber(number)) {
     throw makeError(`${errorPrefix} Invalid id.`);
   }

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -37,6 +37,19 @@ export type FormulaKey = FormulaIdentifier;
 /** A transport-prefixed address string (e.g., "ws:example.com:8920"). */
 export type ConnectionHint = string;
 
+/** Peer key plus connection hints for reaching a peer. */
+export type PeerLocator = {
+  peerKey: PeerKey;
+  hints: ConnectionHint[];
+};
+
+/** Formula key plus connection hints and type for locating a formula. */
+export type FormulaLocator = {
+  formulaKey: FormulaKey;
+  formulaType: string;
+  hints: ConnectionHint[];
+};
+
 /** Either a pet name or a special name */
 export type Name = PetName | SpecialName;
 

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -26,6 +26,17 @@ export type NodeNumber = string & { [NodeNumberBrand]: true };
 /** A full formula identifier in the format {FormulaNumber}:{NodeNumber} */
 export type FormulaIdentifier = string & { [FormulaIdentifierBrand]: true };
 
+// Semantic aliases for the new terminology from daemon-locator-terminology.
+// These are type-level aliases — no runtime change.
+/** Ed25519 public key identifying a peer (alias for NodeNumber). */
+export type PeerKey = NodeNumber;
+/** Content address (SHA-256) or capability address (random 256-bit). */
+export type FormulaAddress = FormulaNumber;
+/** Full formula key: {formulaAddress}:{peerKey} (alias for FormulaIdentifier). */
+export type FormulaKey = FormulaIdentifier;
+/** A transport-prefixed address string (e.g., "ws:example.com:8920"). */
+export type ConnectionHint = string;
+
 /** Either a pet name or a special name */
 export type Name = PetName | SpecialName;
 

--- a/packages/daemon/test/locator.test.js
+++ b/packages/daemon/test/locator.test.js
@@ -108,10 +108,7 @@ test('parseLocator - connection hints in new format', t => {
   t.is(parsed.number, validId);
   t.is(parsed.node, validNode);
   t.is(parsed.formulaType, validType);
-  t.deepEqual(parsed.hints, [
-    'libp2p+captp0://peer1',
-    'libp2p+captp0://peer2',
-  ]);
+  t.deepEqual(parsed.hints, ['libp2p+captp0://peer1', 'libp2p+captp0://peer2']);
 });
 
 test('parseLocator - connection hints in old format', t => {

--- a/packages/daemon/test/locator.test.js
+++ b/packages/daemon/test/locator.test.js
@@ -66,6 +66,7 @@ test('parseLocator', t => {
     number: validId,
     node: validNode,
     formulaType: validType,
+    hints: [],
   });
 });
 
@@ -89,6 +90,10 @@ test('parseLocator - tolerates at= connection hints', t => {
   t.is(parsed.number, validId);
   t.is(parsed.node, validNode);
   t.is(parsed.formulaType, validType);
+  t.deepEqual(parsed.hints, [
+    'libp2p+captp0://peer1',
+    'libp2p+captp0://peer2',
+  ]);
 });
 
 test('formatLocatorForSharing', t => {

--- a/packages/daemon/test/locator.test.js
+++ b/packages/daemon/test/locator.test.js
@@ -5,7 +5,6 @@ import {
   assertValidLocator,
   formatLocator,
   formatLocatorForSharing,
-  formatLocatorV2,
   idFromLocator,
   parseLocator,
   externalizeId,
@@ -19,7 +18,22 @@ const validId =
   '5cf3d8b4d6e03fb51d71fbbb6fa6982edbff673cd193707c902b70a26b7b4680';
 const validType = 'eval';
 
+/**
+ * Build a path-based locator string for testing.
+ * Also supports constructing old-format locators for backward compat tests.
+ */
 const makeLocator = (components = {}) => {
+  const {
+    protocol = 'endo://',
+    host = validNode,
+    number = validId,
+    type = validType,
+  } = components;
+  return `${protocol}${host}/${number}?type=${type}`;
+};
+
+/** Build an old-format locator with ?id= query param for compat tests. */
+const makeOldLocator = (components = {}) => {
   const {
     protocol = 'endo://',
     host = validNode,
@@ -32,10 +46,13 @@ const makeLocator = (components = {}) => {
 test('assertValidLocator - valid', t => {
   t.notThrows(() => assertValidLocator(makeLocator()));
 
-  // Reverse search param order
+  // Old format also valid (backward compat)
+  t.notThrows(() => assertValidLocator(makeOldLocator()));
+
+  // Reverse search param order in old format
   t.notThrows(() =>
     assertValidLocator(
-      makeLocator({
+      makeOldLocator({
         param1: `type=${validType}`,
         param2: `id=${validId}`,
       }),
@@ -52,11 +69,11 @@ test('assertValidLocator - invalid', t => {
     [{}, /Invalid URL.$/u],
     [makeLocator({ protocol: 'foobar://' }), /Invalid protocol.$/u],
     [makeLocator({ host: 'foobar' }), /Invalid node identifier.$/u],
-    [makeLocator({ param1: 'foo=bar' }), /Missing formula number/],
-    [makeLocator({ param2: 'foo=bar' }), /Invalid search params.$/u],
+    [makeOldLocator({ param1: 'foo=bar' }), /Missing formula number/],
+    [makeOldLocator({ param2: 'foo=bar' }), /Invalid search params.$/u],
     [`${makeLocator()}&foo=bar`, /Invalid search params.$/u],
-    [makeLocator({ param1: 'id=foobar' }), /Invalid id.$/u],
-    [makeLocator({ param2: 'type=foobar' }), /Invalid type.$/u],
+    [makeOldLocator({ param1: 'id=foobar' }), /Invalid id.$/u],
+    [makeLocator({ type: 'foobar' }), /Invalid type.$/u],
   ].forEach(([locator, reason]) => {
     t.throws(() => assertValidLocator(locator), { message: reason });
   });
@@ -85,7 +102,7 @@ test('idFromLocator', t => {
   );
 });
 
-test('parseLocator - tolerates at= connection hints', t => {
+test('parseLocator - connection hints in new format', t => {
   const locator = `${makeLocator()}&at=libp2p%2Bcaptp0%3A%2F%2Fpeer1&at=libp2p%2Bcaptp0%3A%2F%2Fpeer2`;
   const parsed = parseLocator(locator);
   t.is(parsed.number, validId);
@@ -95,6 +112,13 @@ test('parseLocator - tolerates at= connection hints', t => {
     'libp2p+captp0://peer1',
     'libp2p+captp0://peer2',
   ]);
+});
+
+test('parseLocator - connection hints in old format', t => {
+  const locator = `${makeOldLocator()}&at=libp2p%2Bcaptp0%3A%2F%2Fpeer1`;
+  const parsed = parseLocator(locator);
+  t.is(parsed.number, validId);
+  t.deepEqual(parsed.hints, ['libp2p+captp0://peer1']);
 });
 
 test('formatLocatorForSharing', t => {
@@ -119,6 +143,8 @@ test('formatLocatorForSharing - no addresses', t => {
 
 test('addressesFromLocator - plain locator returns empty', t => {
   t.deepEqual(addressesFromLocator(makeLocator()), []);
+  // Old format too
+  t.deepEqual(addressesFromLocator(makeOldLocator()), []);
 });
 
 // --- externalizeId, internalizeLocator ---
@@ -196,30 +222,25 @@ test('internalizeLocator extracts connection hints', t => {
   t.deepEqual(result.addresses, addresses);
 });
 
-// --- New-style locator format (path-based formula number) ---
+// --- Format verification ---
 
-test('parseLocator - new format with formula number in path', t => {
-  const newLocator = `endo://${validNode}/${validId}?type=${validType}`;
-  const parsed = parseLocator(newLocator);
+test('formatLocator produces path-based format', t => {
+  const fmtId = formatId({ number: validId, node: validNode });
+  const locator = formatLocator(fmtId, validType);
+  // Formula number in path, not in ?id=
+  t.true(locator.includes(`/${validId}`));
+  t.false(locator.includes('id='));
+  t.true(locator.includes(`type=${validType}`));
+});
+
+test('formatLocator round-trips through parseLocator', t => {
+  const fmtId = formatId({ number: validId, node: validNode });
+  const locator = formatLocator(fmtId, validType);
+  const parsed = parseLocator(locator);
   t.is(parsed.number, validId);
   t.is(parsed.node, validNode);
   t.is(parsed.formulaType, validType);
   t.deepEqual(parsed.hints, []);
-});
-
-test('parseLocator - new format with connection hints', t => {
-  const newLocator = `endo://${validNode}/${validId}?type=${validType}&at=ws%3A%2F%2Fexample.com`;
-  const parsed = parseLocator(newLocator);
-  t.is(parsed.number, validId);
-  t.is(parsed.formulaType, validType);
-  t.deepEqual(parsed.hints, ['ws://example.com']);
-});
-
-test('parseLocator - new format rejects invalid search params', t => {
-  const badLocator = `endo://${validNode}/${validId}?type=${validType}&bad=param`;
-  t.throws(() => parseLocator(badLocator), {
-    message: /Invalid search params/,
-  });
 });
 
 test('parseLocator - rejects locator with no formula number', t => {
@@ -229,45 +250,31 @@ test('parseLocator - rejects locator with no formula number', t => {
   });
 });
 
-test('parseLocator - old and new formats produce identical results', t => {
-  const oldLocator = `endo://${validNode}/?id=${validId}&type=${validType}`;
-  const newLocator = `endo://${validNode}/${validId}?type=${validType}`;
-  const oldResult = parseLocator(oldLocator);
-  const newResult = parseLocator(newLocator);
-  t.is(oldResult.number, newResult.number);
-  t.is(oldResult.node, newResult.node);
-  t.is(oldResult.formulaType, newResult.formulaType);
-  t.deepEqual(oldResult.hints, newResult.hints);
+test('parseLocator - rejects invalid search params in new format', t => {
+  const badLocator = `endo://${validNode}/${validId}?type=${validType}&bad=param`;
+  t.throws(() => parseLocator(badLocator), {
+    message: /Invalid search params/,
+  });
 });
 
-// --- formatLocatorV2 ---
+// --- Backward compatibility: old ?id= format ---
 
-test('formatLocatorV2 produces path-based format', t => {
-  const fmtId = formatId({ number: validId, node: validNode });
-  const locator = formatLocatorV2(fmtId, validType);
-  // Should contain the formula number in the path, not in ?id=
-  t.true(locator.includes(`/${validId}`));
-  t.false(locator.includes('id='));
-  t.true(locator.includes(`type=${validType}`));
-});
-
-test('formatLocatorV2 round-trips through parseLocator', t => {
-  const fmtId = formatId({ number: validId, node: validNode });
-  const locator = formatLocatorV2(fmtId, validType);
-  const parsed = parseLocator(locator);
+test('parseLocator - old format with ?id= query param still works', t => {
+  const oldLocator = makeOldLocator();
+  const parsed = parseLocator(oldLocator);
   t.is(parsed.number, validId);
   t.is(parsed.node, validNode);
   t.is(parsed.formulaType, validType);
   t.deepEqual(parsed.hints, []);
 });
 
-test('formatLocatorV2 and formatLocator parse equivalently', t => {
-  const fmtId = formatId({ number: validId, node: validNode });
-  const oldLocator = formatLocator(fmtId, validType);
-  const newLocator = formatLocatorV2(fmtId, validType);
-  const oldParsed = parseLocator(oldLocator);
-  const newParsed = parseLocator(newLocator);
-  t.is(oldParsed.number, newParsed.number);
-  t.is(oldParsed.node, newParsed.node);
-  t.is(oldParsed.formulaType, newParsed.formulaType);
+test('parseLocator - old and new formats produce identical results', t => {
+  const oldLocator = makeOldLocator();
+  const newLocator = makeLocator();
+  const oldResult = parseLocator(oldLocator);
+  const newResult = parseLocator(newLocator);
+  t.is(oldResult.number, newResult.number);
+  t.is(oldResult.node, newResult.node);
+  t.is(oldResult.formulaType, newResult.formulaType);
+  t.deepEqual(oldResult.hints, newResult.hints);
 });

--- a/packages/daemon/test/locator.test.js
+++ b/packages/daemon/test/locator.test.js
@@ -5,6 +5,7 @@ import {
   assertValidLocator,
   formatLocator,
   formatLocatorForSharing,
+  formatLocatorV2,
   idFromLocator,
   parseLocator,
   externalizeId,
@@ -237,4 +238,36 @@ test('parseLocator - old and new formats produce identical results', t => {
   t.is(oldResult.node, newResult.node);
   t.is(oldResult.formulaType, newResult.formulaType);
   t.deepEqual(oldResult.hints, newResult.hints);
+});
+
+// --- formatLocatorV2 ---
+
+test('formatLocatorV2 produces path-based format', t => {
+  const fmtId = formatId({ number: validId, node: validNode });
+  const locator = formatLocatorV2(fmtId, validType);
+  // Should contain the formula number in the path, not in ?id=
+  t.true(locator.includes(`/${validId}`));
+  t.false(locator.includes('id='));
+  t.true(locator.includes(`type=${validType}`));
+});
+
+test('formatLocatorV2 round-trips through parseLocator', t => {
+  const fmtId = formatId({ number: validId, node: validNode });
+  const locator = formatLocatorV2(fmtId, validType);
+  const parsed = parseLocator(locator);
+  t.is(parsed.number, validId);
+  t.is(parsed.node, validNode);
+  t.is(parsed.formulaType, validType);
+  t.deepEqual(parsed.hints, []);
+});
+
+test('formatLocatorV2 and formatLocator parse equivalently', t => {
+  const fmtId = formatId({ number: validId, node: validNode });
+  const oldLocator = formatLocator(fmtId, validType);
+  const newLocator = formatLocatorV2(fmtId, validType);
+  const oldParsed = parseLocator(oldLocator);
+  const newParsed = parseLocator(newLocator);
+  t.is(oldParsed.number, newParsed.number);
+  t.is(oldParsed.node, newParsed.node);
+  t.is(oldParsed.formulaType, newParsed.formulaType);
 });

--- a/packages/daemon/test/locator.test.js
+++ b/packages/daemon/test/locator.test.js
@@ -51,7 +51,7 @@ test('assertValidLocator - invalid', t => {
     [{}, /Invalid URL.$/u],
     [makeLocator({ protocol: 'foobar://' }), /Invalid protocol.$/u],
     [makeLocator({ host: 'foobar' }), /Invalid node identifier.$/u],
-    [makeLocator({ param1: 'foo=bar' }), /Invalid search params.$/u],
+    [makeLocator({ param1: 'foo=bar' }), /Missing formula number/],
     [makeLocator({ param2: 'foo=bar' }), /Invalid search params.$/u],
     [`${makeLocator()}&foo=bar`, /Invalid search params.$/u],
     [makeLocator({ param1: 'id=foobar' }), /Invalid id.$/u],
@@ -193,4 +193,48 @@ test('internalizeLocator extracts connection hints', t => {
   const locator = formatLocatorForSharing(id, validType, addresses);
   const result = internalizeLocator(locator);
   t.deepEqual(result.addresses, addresses);
+});
+
+// --- New-style locator format (path-based formula number) ---
+
+test('parseLocator - new format with formula number in path', t => {
+  const newLocator = `endo://${validNode}/${validId}?type=${validType}`;
+  const parsed = parseLocator(newLocator);
+  t.is(parsed.number, validId);
+  t.is(parsed.node, validNode);
+  t.is(parsed.formulaType, validType);
+  t.deepEqual(parsed.hints, []);
+});
+
+test('parseLocator - new format with connection hints', t => {
+  const newLocator = `endo://${validNode}/${validId}?type=${validType}&at=ws%3A%2F%2Fexample.com`;
+  const parsed = parseLocator(newLocator);
+  t.is(parsed.number, validId);
+  t.is(parsed.formulaType, validType);
+  t.deepEqual(parsed.hints, ['ws://example.com']);
+});
+
+test('parseLocator - new format rejects invalid search params', t => {
+  const badLocator = `endo://${validNode}/${validId}?type=${validType}&bad=param`;
+  t.throws(() => parseLocator(badLocator), {
+    message: /Invalid search params/,
+  });
+});
+
+test('parseLocator - rejects locator with no formula number', t => {
+  const badLocator = `endo://${validNode}/?type=${validType}`;
+  t.throws(() => parseLocator(badLocator), {
+    message: /Missing formula number/,
+  });
+});
+
+test('parseLocator - old and new formats produce identical results', t => {
+  const oldLocator = `endo://${validNode}/?id=${validId}&type=${validType}`;
+  const newLocator = `endo://${validNode}/${validId}?type=${validType}`;
+  const oldResult = parseLocator(oldLocator);
+  const newResult = parseLocator(newLocator);
+  t.is(oldResult.number, newResult.number);
+  t.is(oldResult.node, newResult.node);
+  t.is(oldResult.formulaType, newResult.formulaType);
+  t.deepEqual(oldResult.hints, newResult.hints);
 });


### PR DESCRIPTION
## Summary
- Migrates daemon locators from `endo://{node}/?id={number}&type={type}` to path-based `endo://{node}/{number}?type={type}`.
- `parseLocator` accepts both old and new formats for backward compatibility; `formatLocator` produces the new format.
- Adds `PeerKey`, `FormulaAddress`, `FormulaKey`, `ConnectionHint`, `PeerLocator`, and `FormulaLocator` type aliases in `types.d.ts`, and threads a `hints` field through `parseLocator`.
- Migrates invitation and handle locators in `makeInvitation().locate()` and `host.js` `accept()` to the V2 path format.

## Commits
- feat(daemon): add type aliases and parseLocator hints field
- feat(daemon): parseLocator accepts new path-based format
- feat(daemon): add formatLocatorV2 for new path-based format
- refactor(daemon): migrate locator format to path-based V2
- refactor(daemon): migrate invitation/handle locators to V2 path format

🤖 Generated with [Claude Code](https://claude.com/claude-code)