### PR TITLE
feat(daemon): mount Phase 4 — sub-mounts, snapshot, and capability VFS

### DIFF
--- a/packages/daemon/src/capability-vfs.js
+++ b/packages/daemon/src/capability-vfs.js
@@ -130,9 +130,7 @@ export const makeCapabilityVFS = mount => {
 
             // Recurse if requested and entry is a directory.
             if (opts.recursive && entry.type === 'directory') {
-              const subPath = segments.length > 0
-                ? `${dirPath}/${name}`
-                : name;
+              const subPath = segments.length > 0 ? `${dirPath}/${name}` : name;
               const subIter = vfs.readdir(subPath, opts);
               for await (const subEntry of subIter) {
                 yield harden({

--- a/packages/daemon/src/capability-vfs.js
+++ b/packages/daemon/src/capability-vfs.js
@@ -132,6 +132,7 @@ export const makeCapabilityVFS = mount => {
             if (opts.recursive && entry.type === 'directory') {
               const subPath = segments.length > 0 ? `${dirPath}/${name}` : name;
               const subIter = vfs.readdir(subPath, opts);
+              // eslint-disable-next-line no-await-in-loop
               for await (const subEntry of subIter) {
                 yield harden({
                   ...subEntry,

--- a/packages/daemon/src/capability-vfs.js
+++ b/packages/daemon/src/capability-vfs.js
@@ -1,0 +1,152 @@
+// @ts-check
+
+import { E } from '@endo/far';
+import harden from '@endo/harden';
+
+/**
+ * @import { VFS, VFSStat, VFSDirEntry } from '../../genie/src/tools/vfs.js'
+ */
+
+/**
+ * Create a VFS adapter backed by a Mount exo capability.
+ *
+ * This bridges the Genie tool system's VFS interface to an Endo Mount
+ * capability.  All filesystem access goes through the Mount's
+ * confinement, deny patterns, and revocation — no ambient authority.
+ *
+ * @param {object} mount - An EndoMount exo (or remote reference).
+ * @returns {VFS}
+ */
+export const makeCapabilityVFS = mount => {
+  /** @type {VFS} */
+  const vfs = {
+    async stat(filePath) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      const exists = await E(mount).has(...segments);
+      if (!exists) {
+        throw new Error(`ENOENT: no such file or directory: ${filePath}`);
+      }
+      // Try to list — if it succeeds, it's a directory.
+      try {
+        await E(mount).list(...segments);
+        return harden({
+          size: 0,
+          mtime: new Date().toISOString(),
+          type: /** @type {const} */ ('directory'),
+        });
+      } catch {
+        // Not a directory — assume file.
+        const text = await E(mount).readText(segments);
+        return harden({
+          size: text.length,
+          mtime: new Date().toISOString(),
+          type: /** @type {const} */ ('file'),
+        });
+      }
+    },
+
+    async readFile(filePath) {
+      const segments =
+        typeof filePath === 'string'
+          ? filePath.split('/').filter(s => s.length > 0)
+          : filePath;
+      return E(mount).readText(segments);
+    },
+
+    createReadStream(filePath, _opts) {
+      // Return an async iterable that yields the file content as a
+      // single UTF-8 chunk.  Mount doesn't support byte-range reads
+      // natively, so this is a simple adapter.
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      return harden({
+        async *[Symbol.asyncIterator]() {
+          const text = await E(mount).readText(segments);
+          yield new TextEncoder().encode(text);
+        },
+      });
+    },
+
+    async writeFile(filePath, content) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      await E(mount).writeText(segments, content);
+    },
+
+    async mkdir(filePath, opts = {}) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      const exists = await E(mount).has(...segments);
+      if (exists) {
+        if (opts.recursive) {
+          return false;
+        }
+        throw new Error(`EEXIST: directory already exists: ${filePath}`);
+      }
+      await E(mount).makeDirectory(segments);
+      return true;
+    },
+
+    async unlink(filePath) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      await E(mount).remove(segments);
+    },
+
+    async rmdir(filePath) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      await E(mount).remove(segments);
+    },
+
+    async rm(filePath, _opts) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      await E(mount).remove(segments);
+    },
+
+    readdir(dirPath, opts = {}) {
+      const segments = dirPath.split('/').filter(s => s.length > 0);
+      return harden({
+        async *[Symbol.asyncIterator]() {
+          const entries = await E(mount).list(...segments);
+          for (const name of entries) {
+            /** @type {VFSDirEntry} */
+            let entry;
+            try {
+              // eslint-disable-next-line no-await-in-loop
+              const subSegments = [...segments, name];
+              // eslint-disable-next-line no-await-in-loop
+              const subEntries = await E(mount).list(...subSegments);
+              // If list succeeds, it's a directory.
+              void subEntries;
+              entry = harden({
+                name,
+                type: /** @type {const} */ ('directory'),
+                size: 0,
+              });
+            } catch {
+              entry = harden({
+                name,
+                type: /** @type {const} */ ('file'),
+                size: 0,
+              });
+            }
+            yield entry;
+
+            // Recurse if requested and entry is a directory.
+            if (opts.recursive && entry.type === 'directory') {
+              const subPath = segments.length > 0
+                ? `${dirPath}/${name}`
+                : name;
+              const subIter = vfs.readdir(subPath, opts);
+              for await (const subEntry of subIter) {
+                yield harden({
+                  ...subEntry,
+                  name: `${name}/${subEntry.name}`,
+                });
+              }
+            }
+          }
+        },
+      });
+    },
+  };
+
+  return harden(vfs);
+};
+harden(makeCapabilityVFS);

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2195,6 +2195,7 @@ const makeDaemonCore = async (
       }
       /** @param {object} mount */
       const snapshotFn = async mount => {
+        /** @type {import('./types.js').DeferredTasks<import('./types.js').ReadableTreeDeferredTaskParams>} */
         const deferredTasks = makeDeferredTasks();
         const { value } = await checkinTree(mount, deferredTasks);
         return value;
@@ -2215,6 +2216,7 @@ const makeDaemonCore = async (
       await filePowers.makePath(rootPath);
       /** @param {object} mount */
       const snapshotFn = async mount => {
+        /** @type {import('./types.js').DeferredTasks<import('./types.js').ReadableTreeDeferredTaskParams>} */
         const deferredTasks = makeDeferredTasks();
         const { value } = await checkinTree(mount, deferredTasks);
         return value;

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -4683,6 +4683,7 @@ const makeDaemonCore = async (
     getAllNetworkAddresses,
     getTypeForId,
     getFormulaForId,
+    statePath: persistencePowers.statePath,
     formulateChannel,
     formulateTimer,
     makeMailbox,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2193,7 +2193,18 @@ const makeDaemonCore = async (
       if (!isDir) {
         throw new Error(`Mount path is not a directory: ${q(mountPath)}`);
       }
-      return makeMount({ rootPath: mountPath, readOnly, filePowers });
+      /** @param {object} mount */
+      const snapshotFn = async mount => {
+        const deferredTasks = makeDeferredTasks();
+        const { value } = await checkinTree(mount, deferredTasks);
+        return value;
+      };
+      return makeMount({
+        rootPath: mountPath,
+        readOnly,
+        filePowers,
+        snapshotFn,
+      });
     },
     'scratch-mount': async ({ readOnly }, _context, _id, formulaNumber) => {
       const rootPath = filePowers.joinPath(
@@ -2202,7 +2213,13 @@ const makeDaemonCore = async (
         /** @type {string} */ (formulaNumber),
       );
       await filePowers.makePath(rootPath);
-      return makeMount({ rootPath, readOnly, filePowers });
+      /** @param {object} mount */
+      const snapshotFn = async mount => {
+        const deferredTasks = makeDeferredTasks();
+        const { value } = await checkinTree(mount, deferredTasks);
+        return value;
+      };
+      return makeMount({ rootPath, readOnly, filePowers, snapshotFn });
     },
     lookup: ({ hub, path }, context) =>
       makeLookup(

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -305,7 +305,9 @@ export const makeHostMaker = ({
       const { readOnly = false } = options;
       const mountNamePath = namePathFrom(mountName);
       assertNamePath(mountNamePath);
-      const { namePath: newNamePath } = assertPetNamePath(namePathFrom(newName));
+      const { namePath: newNamePath } = assertPetNamePath(
+        namePathFrom(newName),
+      );
 
       // Resolve parent mount's formula to get its root path.
       const parentId = specialStore.identifyLocal(mountNamePath[0]);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -77,6 +77,7 @@ const normalizeHostOrGuestOptions = opts => {
  * @param {DaemonCore['getAllNetworkAddresses']} args.getAllNetworkAddresses
  * @param {DaemonCore['getTypeForId']} args.getTypeForId
  * @param {DaemonCore['getFormulaForId']} args.getFormulaForId
+ * @param {string} args.statePath
  * @param {MakeMailbox} args.makeMailbox
  * @param {MakeDirectoryNode} args.makeDirectoryNode
  * @param {NodeNumber} args.localNodeNumber
@@ -110,6 +111,7 @@ export const makeHostMaker = ({
   getAllNetworkAddresses,
   getTypeForId,
   getFormulaForId,
+  statePath,
   makeMailbox,
   makeDirectoryNode,
   localNodeNumber,
@@ -282,6 +284,76 @@ export const makeHostMaker = ({
       );
 
       const { value } = await formulateScratchMount(readOnly, tasks);
+      return value;
+    };
+
+    /**
+     * Create a sub-mount rooted at a subdirectory of an existing mount.
+     *
+     * @param {NameOrPath} mountName - Pet name of the parent mount.
+     * @param {string} subpath - Relative path within the parent mount.
+     * @param {NameOrPath} newName - Pet name for the new sub-mount.
+     * @param {object} [options]
+     * @param {boolean} [options.readOnly]
+     */
+    const provideSubMount = async (
+      mountName,
+      subpath,
+      newName,
+      options = {},
+    ) => {
+      const { readOnly = false } = options;
+      const mountNamePath = namePathFrom(mountName);
+      assertNamePath(mountNamePath);
+      const { namePath: newNamePath } = assertPetNamePath(namePathFrom(newName));
+
+      // Resolve parent mount's formula to get its root path.
+      const parentId = specialStore.identifyLocal(mountNamePath[0]);
+      if (parentId === undefined) {
+        throw makeError(`No mount found for pet name ${q(mountName)}`);
+      }
+      const parentFormula = await getFormulaForId(
+        /** @type {FormulaIdentifier} */ (parentId),
+      );
+      if (
+        parentFormula.type !== 'mount' &&
+        parentFormula.type !== 'scratch-mount'
+      ) {
+        throw makeError(
+          `Pet name ${q(mountName)} is not a mount (type: ${q(parentFormula.type)})`,
+        );
+      }
+
+      // Derive the full path.
+      let parentPath;
+      if (parentFormula.type === 'mount') {
+        parentPath = /** @type {string} */ (
+          /** @type {import('./types.js').MountFormula} */ (parentFormula).path
+        );
+      } else {
+        // scratch-mount: path is statePath/mounts/{formulaNumber}
+        const { number: formulaNumber } = parseId(
+          /** @type {FormulaIdentifier} */ (parentId),
+        );
+        parentPath = `${statePath}/mounts/${formulaNumber}`;
+      }
+
+      // Validate subpath segments — no ".." or absolute paths.
+      const segments = subpath.split('/').filter(s => s.length > 0);
+      for (const seg of segments) {
+        if (seg === '..' || seg === '.') {
+          throw makeError(`Invalid subpath segment: ${q(seg)}`);
+        }
+      }
+      const fullPath = [parentPath, ...segments].join('/');
+
+      /** @type {DeferredTasks<MountDeferredTaskParams>} */
+      const tasks = makeDeferredTasks();
+      tasks.push(identifiers =>
+        E(directory).storeIdentifier(newNamePath, identifiers.mountId),
+      );
+
+      const { value } = await formulateMount(fullPath, readOnly, tasks);
       return value;
     };
 
@@ -1189,6 +1261,7 @@ export const makeHostMaker = ({
       storeTree,
       provideMount,
       provideScratchMount,
+      provideSubMount,
       provideGuest,
       provideHost,
       provideWorker,

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -502,6 +502,7 @@ export const MountInterface = M.interface('EndoMount', {
   makeDirectory: M.call(PathArgShape).returns(M.promise()),
   // Attenuation
   readOnly: M.call().returns(M.remotable()),
+  subDir: M.call(M.string()).returns(M.promise()),
   // Snapshot
   snapshot: M.call().returns(M.promise()),
   // Discoverability

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -492,9 +492,9 @@ const PathSegmentsShape = M.arrayOf(M.string());
 const PathArgShape = M.or(M.string(), PathSegmentsShape);
 
 export const MountInterface = M.interface('EndoMount', {
-  // ReadableTree-compatible surface
-  has: M.call().rest(PathSegmentsShape).returns(M.promise()),
-  list: M.call().rest(PathSegmentsShape).returns(M.promise()),
+  // ReadableTree-compatible surface; rest collects individual string segments
+  has: M.call().rest(M.string()).returns(M.promise()),
+  list: M.call().rest(M.string()).returns(M.promise()),
   lookup: M.call(PathArgShape).returns(M.promise()),
   // Raw data I/O
   readText: M.call(PathArgShape).returns(M.promise()),

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -323,6 +323,10 @@ export const HostInterface = M.interface('EndoHost', {
   provideScratchMount: M.call(NameOrPathShape)
     .optional(M.splitRecord({}, { readOnly: M.boolean() }))
     .returns(M.promise()),
+  // Create a sub-mount rooted at a subdirectory of an existing mount
+  provideSubMount: M.call(NameOrPathShape, M.string(), NameOrPathShape)
+    .optional(M.splitRecord({}, { readOnly: M.boolean() }))
+    .returns(M.promise()),
   // Provide a guest
   provideGuest: M.call().optional(NameShape, M.record()).returns(M.promise()),
   // Provide a host

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -155,6 +155,7 @@ harden(isConfinedPath);
  * @property {boolean} readOnly
  * @property {FilePowers} filePowers
  * @property {string} description
+ * @property {((mount: object) => Promise<object>) | undefined} snapshotFn
  */
 
 /**
@@ -164,8 +165,14 @@ harden(isConfinedPath);
  * @returns {object}
  */
 const makeMountExo = ctx => {
-  const { currentDir, confinementRoot, readOnly, filePowers, description } =
-    ctx;
+  const {
+    currentDir,
+    confinementRoot,
+    readOnly,
+    filePowers,
+    description,
+    snapshotFn,
+  } = ctx;
 
   const assertWritable = () => {
     if (readOnly) {
@@ -182,7 +189,10 @@ const makeMountExo = ctx => {
 
   const help = makeHelp(mountHelp);
 
-  return makeExo('EndoMount', MountInterface, {
+  /** @type {object} */
+  let selfRef;
+
+  const mount = makeExo('EndoMount', MountInterface, {
     help,
 
     async has(...pathSegments) {
@@ -303,9 +313,15 @@ const makeMountExo = ctx => {
     },
 
     async snapshot() {
-      throw new Error('snapshot() is not yet implemented');
+      if (!snapshotFn) {
+        throw new Error('snapshot() is not available on this mount');
+      }
+      return snapshotFn(selfRef);
     },
   });
+
+  selfRef = mount;
+  return mount;
 };
 harden(makeMountExo);
 
@@ -384,9 +400,10 @@ harden(makeMountFileExo);
  * @param {string} opts.rootPath
  * @param {boolean} opts.readOnly
  * @param {FilePowers} opts.filePowers
+ * @param {((mount: object) => Promise<object>) | undefined} [opts.snapshotFn]
  * @returns {object}
  */
-export const makeMount = ({ rootPath, readOnly, filePowers }) => {
+export const makeMount = ({ rootPath, readOnly, filePowers, snapshotFn }) => {
   const prefix = readOnly ? 'Read-only mount' : 'Mount';
   /** @type {MountContext} */
   const ctx = {
@@ -395,6 +412,7 @@ export const makeMount = ({ rootPath, readOnly, filePowers }) => {
     readOnly,
     filePowers,
     description: `${prefix} at ${rootPath}`,
+    snapshotFn,
   };
 
   return makeMountExo(ctx);

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -312,6 +312,33 @@ const makeMountExo = ctx => {
       });
     },
 
+    async subDir(subpath) {
+      await null;
+      // Validate and resolve segments.
+      const segments = subpath.split('/').filter(s => s.length > 0);
+      for (const seg of segments) {
+        if (seg === '..' || seg === '.') {
+          throw new Error(`Invalid subDir segment: ${seg}`);
+        }
+      }
+      const target = resolve(segments);
+      await assertConfinedOrAncestor(target, confinementRoot, filePowers);
+      const isDir = await filePowers.isDirectory(target);
+      if (!isDir) {
+        throw new Error(`subDir target is not a directory: ${subpath}`);
+      }
+      return makeMountExo({
+        ...ctx,
+        currentDir: target,
+        // The confinement root stays the same — the sub-mount cannot
+        // escape above the original root.  But the sub-mount's own
+        // navigation is restricted to its new currentDir because
+        // resolveSegments clamps ".." to currentDir.
+        confinementRoot: target,
+        description: `${readOnly ? 'Read-only sub-mount' : 'Sub-mount'} at ${subpath} of ${description}`,
+      });
+    },
+
     async snapshot() {
       if (!snapshotFn) {
         throw new Error('snapshot() is not available on this mount');

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -950,6 +950,12 @@ export interface EndoHost extends EndoAgent {
     opts?: { readOnly?: boolean },
   ): Promise<unknown>;
   provideScratchMount(petName: string | string[]): Promise<unknown>;
+  provideSubMount(
+    mountName: string | string[],
+    subpath: string,
+    newName: string | string[],
+    opts?: { readOnly?: boolean },
+  ): Promise<unknown>;
   provideGuest(
     petName?: string,
     opts?: MakeHostOrGuestOptions,

--- a/packages/daemon/test/capability-vfs.test.js
+++ b/packages/daemon/test/capability-vfs.test.js
@@ -1,0 +1,175 @@
+// @ts-check
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { makeMount } from '../src/mount.js';
+import { makeCapabilityVFS } from '../src/capability-vfs.js';
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ */
+const setup = async t => {
+  const tmpDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'endo-capvfs-test-'),
+  );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'hello.txt'),
+    'Hello, world!',
+    'utf-8',
+  );
+  await fs.promises.mkdir(path.join(tmpDir, 'src'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'src', 'main.js'),
+    'console.log("main");',
+    'utf-8',
+  );
+
+  t.teardown(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /** @type {import('../src/types.js').FilePowers} */
+  const filePowers = {
+    readDirectory: dir => fs.promises.readdir(dir),
+    readFileText: p => fs.promises.readFile(p, 'utf-8'),
+    writeFileText: (p, c) => fs.promises.writeFile(p, c, 'utf-8'),
+    makePath: p => fs.promises.mkdir(p, { recursive: true }),
+    removePath: p => fs.promises.rm(p, { recursive: true, force: true }),
+    renamePath: (a, b) => fs.promises.rename(a, b),
+    joinPath: (...parts) => path.join(...parts),
+    realPath: p => fs.promises.realpath(p),
+    exists: async p => {
+      try {
+        await fs.promises.access(p);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    isDirectory: async p => {
+      try {
+        const stat = await fs.promises.stat(p);
+        return stat.isDirectory();
+      } catch {
+        return false;
+      }
+    },
+    makeFileReader: _p => {
+      throw new Error('not implemented');
+    },
+    makeFileWriter: _p => {
+      throw new Error('not implemented');
+    },
+  };
+
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const vfs = makeCapabilityVFS(mount);
+  return { tmpDir, vfs, mount };
+};
+
+test('readFile reads text content', async t => {
+  const { vfs } = await setup(t);
+  const content = await vfs.readFile('hello.txt');
+  t.is(content, 'Hello, world!');
+});
+
+test('readFile reads from subdirectories', async t => {
+  const { vfs } = await setup(t);
+  const content = await vfs.readFile('src/main.js');
+  t.is(content, 'console.log("main");');
+});
+
+test('writeFile creates and overwrites files', async t => {
+  const { vfs } = await setup(t);
+  await vfs.writeFile('new.txt', 'new content');
+  const content = await vfs.readFile('new.txt');
+  t.is(content, 'new content');
+
+  await vfs.writeFile('new.txt', 'overwritten');
+  const updated = await vfs.readFile('new.txt');
+  t.is(updated, 'overwritten');
+});
+
+test('stat returns file info', async t => {
+  const { vfs } = await setup(t);
+  const fileStat = await vfs.stat('hello.txt');
+  t.is(fileStat.type, 'file');
+  t.true(fileStat.size > 0);
+
+  const dirStat = await vfs.stat('src');
+  t.is(dirStat.type, 'directory');
+});
+
+test('stat throws for nonexistent path', async t => {
+  const { vfs } = await setup(t);
+  await t.throwsAsync(() => vfs.stat('nonexistent'), {
+    message: /ENOENT/,
+  });
+});
+
+test('mkdir creates directories', async t => {
+  const { vfs } = await setup(t);
+  const created = await vfs.mkdir('newdir');
+  t.true(created);
+
+  const stat = await vfs.stat('newdir');
+  t.is(stat.type, 'directory');
+});
+
+test('mkdir recursive returns false for existing', async t => {
+  const { vfs } = await setup(t);
+  const created = await vfs.mkdir('src', { recursive: true });
+  t.false(created);
+});
+
+test('rm removes files', async t => {
+  const { vfs } = await setup(t);
+  await vfs.writeFile('temp.txt', 'temp');
+  await vfs.rm('temp.txt');
+  await t.throwsAsync(() => vfs.stat('temp.txt'), {
+    message: /ENOENT/,
+  });
+});
+
+test('readdir lists directory entries', async t => {
+  const { vfs } = await setup(t);
+  const entries = [];
+  for await (const entry of vfs.readdir('')) {
+    entries.push(entry);
+  }
+  const names = entries.map(e => e.name).sort();
+  t.true(names.includes('hello.txt'));
+  t.true(names.includes('src'));
+
+  const srcEntry = entries.find(e => e.name === 'src');
+  t.is(srcEntry?.type, 'directory');
+});
+
+test('readdir recursive yields nested entries', async t => {
+  const { vfs } = await setup(t);
+  const entries = [];
+  for await (const entry of vfs.readdir('', { recursive: true })) {
+    entries.push(entry);
+  }
+  const names = entries.map(e => e.name);
+  t.true(names.includes('src/main.js'));
+});
+
+test('createReadStream yields file bytes', async t => {
+  const { vfs } = await setup(t);
+  const chunks = [];
+  for await (const chunk of vfs.createReadStream('hello.txt')) {
+    chunks.push(chunk);
+  }
+  const text = new TextDecoder().decode(chunks[0]);
+  t.is(text, 'Hello, world!');
+});

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -4106,6 +4106,66 @@ test('mount file writeText and json', async t => {
   t.is(actualContent, '{"version": 2}');
 });
 
+test('mount subDir creates confined sub-mount', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(config.statePath, '..', 'mount-test-subdir');
+  await createMountFixture(mountPath, {
+    'root.txt': 'at root',
+  });
+  await fs.promises.mkdir(path.join(mountPath, 'src'));
+  await fs.promises.writeFile(
+    path.join(mountPath, 'src', 'index.js'),
+    'export default 42;',
+  );
+
+  await E(host).provideMount(mountPath, 'project');
+  const mount = await E(host).lookup(['project']);
+
+  // subDir scopes to a subdirectory.
+  const srcMount = await E(mount).subDir('src');
+  const entries = await E(srcMount).list();
+  t.deepEqual(entries, ['index.js']);
+
+  // subDir cannot navigate above its new root.
+  t.true(await E(srcMount).has('index.js'));
+
+  // Read file through sub-mount.
+  const file = await E(srcMount).lookup('index.js');
+  const content = await E(file).text();
+  t.is(content, 'export default 42;');
+
+  // subDir rejects .. segments.
+  await t.throwsAsync(() => E(mount).subDir('..'), {
+    message: /Invalid subDir segment/,
+  });
+});
+
+test('mount subDir readOnly chains with subDir', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(config.statePath, '..', 'mount-test-subdir-ro');
+  await fs.promises.mkdir(path.join(mountPath, 'lib'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(mountPath, 'lib', 'util.js'),
+    'export const x = 1;',
+  );
+
+  await E(host).provideMount(mountPath, 'ro-project');
+  const mount = await E(host).lookup(['ro-project']);
+
+  // Chain: readOnly then subDir.
+  const roMount = E(mount).readOnly();
+  const roLib = await E(roMount).subDir('lib');
+  const entries = await E(roLib).list();
+  t.deepEqual(entries, ['util.js']);
+
+  // Writing through the read-only sub-mount should throw.
+  await t.throwsAsync(() => E(roLib).writeText('new.txt', 'nope'), {
+    message: /read-only/i,
+  });
+});
+
 // symlink confinement tests
 
 /**


### PR DESCRIPTION
## Summary
- Implements `Mount.snapshot()` via `checkinTree`, capturing the mount's current directory tree as a readable-tree formula (both external mounts and scratch-mounts).
- Adds `Mount.subDir(path)` scope attenuation that re-roots a confined sub-mount, chaining with `readOnly` and rejecting `..`/`.` traversal.
- Adds a capability-backed VFS adapter (`makeCapabilityVFS`) that bridges the Genie VFS interface to Mount exos over eventual send, enforcing confinement/deny/revocation — no ambient authority.
- Adds `provideSubMount(mountName, subpath, newName, options)` to `EndoHost` to create a new mount formula rooted in a subpath of an existing mount (completes mount Phase 4).

## Commits
- feat(daemon): implement mount snapshot() via checkinTree
- feat(daemon): add subDir(path) scope attenuation to Mount exo
- feat(daemon): capability-backed VFS adapter for agent tools
- feat(daemon): implement provideSubMount for mount Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)