### PR TITLE
feat(daemon): mount extensions — revocation, deny patterns, glob/grep/stat/json

### DIFF
--- a/packages/daemon/src/capability-vfs.js
+++ b/packages/daemon/src/capability-vfs.js
@@ -26,23 +26,12 @@ export const makeCapabilityVFS = mount => {
       if (!exists) {
         throw new Error(`ENOENT: no such file or directory: ${filePath}`);
       }
-      // Try to list — if it succeeds, it's a directory.
-      try {
-        await E(mount).list(...segments);
-        return harden({
-          size: 0,
-          mtime: new Date().toISOString(),
-          type: /** @type {const} */ ('directory'),
-        });
-      } catch {
-        // Not a directory — assume file.
-        const text = await E(mount).readText(segments);
-        return harden({
-          size: text.length,
-          mtime: new Date().toISOString(),
-          type: /** @type {const} */ ('file'),
-        });
-      }
+      const mountStat = await E(mount).stat(segments);
+      return harden({
+        size: mountStat.size,
+        mtime: new Date().toISOString(),
+        type: /** @type {'file' | 'directory'} */ (mountStat.type),
+      });
     },
 
     async readFile(filePath) {
@@ -105,27 +94,15 @@ export const makeCapabilityVFS = mount => {
         async *[Symbol.asyncIterator]() {
           const entries = await E(mount).list(...segments);
           for (const name of entries) {
+            const subSegments = [...segments, name];
+            // eslint-disable-next-line no-await-in-loop
+            const entryStat = await E(mount).stat(subSegments);
             /** @type {VFSDirEntry} */
-            let entry;
-            try {
-              // eslint-disable-next-line no-await-in-loop
-              const subSegments = [...segments, name];
-              // eslint-disable-next-line no-await-in-loop
-              const subEntries = await E(mount).list(...subSegments);
-              // If list succeeds, it's a directory.
-              void subEntries;
-              entry = harden({
-                name,
-                type: /** @type {const} */ ('directory'),
-                size: 0,
-              });
-            } catch {
-              entry = harden({
-                name,
-                type: /** @type {const} */ ('file'),
-                size: 0,
-              });
-            }
+            const entry = harden({
+              name,
+              type: /** @type {'file' | 'directory'} */ (entryStat.type),
+              size: entryStat.size,
+            });
             yield entry;
 
             // Recurse if requested and entry is a directory.

--- a/packages/daemon/src/capability-vfs.js
+++ b/packages/daemon/src/capability-vfs.js
@@ -1,0 +1,152 @@
+// @ts-check
+
+import { E } from '@endo/far';
+import harden from '@endo/harden';
+
+/**
+ * @import { VFS, VFSStat, VFSDirEntry } from '../../genie/src/tools/vfs.js'
+ */
+
+/**
+ * Create a VFS adapter backed by a Mount exo capability.
+ *
+ * This bridges the Genie tool system's VFS interface to an Endo Mount
+ * capability.  All filesystem access goes through the Mount's
+ * confinement, deny patterns, and revocation — no ambient authority.
+ *
+ * @param {object} mount - An EndoMount exo (or remote reference).
+ * @returns {VFS}
+ */
+export const makeCapabilityVFS = mount => {
+  /** @type {VFS} */
+  const vfs = {
+    async stat(filePath) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      const exists = await E(mount).has(...segments);
+      if (!exists) {
+        throw new Error(`ENOENT: no such file or directory: ${filePath}`);
+      }
+      // Try to list — if it succeeds, it's a directory.
+      try {
+        await E(mount).list(...segments);
+        return harden({
+          size: 0,
+          mtime: new Date().toISOString(),
+          type: /** @type {const} */ ('directory'),
+        });
+      } catch {
+        // Not a directory — assume file.
+        const text = await E(mount).readText(segments);
+        return harden({
+          size: text.length,
+          mtime: new Date().toISOString(),
+          type: /** @type {const} */ ('file'),
+        });
+      }
+    },
+
+    async readFile(filePath) {
+      const segments =
+        typeof filePath === 'string'
+          ? filePath.split('/').filter(s => s.length > 0)
+          : filePath;
+      return E(mount).readText(segments);
+    },
+
+    createReadStream(filePath, _opts) {
+      // Return an async iterable that yields the file content as a
+      // single UTF-8 chunk.  Mount doesn't support byte-range reads
+      // natively, so this is a simple adapter.
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      return harden({
+        async *[Symbol.asyncIterator]() {
+          const text = await E(mount).readText(segments);
+          yield new TextEncoder().encode(text);
+        },
+      });
+    },
+
+    async writeFile(filePath, content) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      await E(mount).writeText(segments, content);
+    },
+
+    async mkdir(filePath, opts = {}) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      const exists = await E(mount).has(...segments);
+      if (exists) {
+        if (opts.recursive) {
+          return false;
+        }
+        throw new Error(`EEXIST: directory already exists: ${filePath}`);
+      }
+      await E(mount).makeDirectory(segments);
+      return true;
+    },
+
+    async unlink(filePath) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      await E(mount).remove(segments);
+    },
+
+    async rmdir(filePath) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      await E(mount).remove(segments);
+    },
+
+    async rm(filePath, _opts) {
+      const segments = filePath.split('/').filter(s => s.length > 0);
+      await E(mount).remove(segments);
+    },
+
+    readdir(dirPath, opts = {}) {
+      const segments = dirPath.split('/').filter(s => s.length > 0);
+      return harden({
+        async *[Symbol.asyncIterator]() {
+          const entries = await E(mount).list(...segments);
+          for (const name of entries) {
+            /** @type {VFSDirEntry} */
+            let entry;
+            try {
+              // eslint-disable-next-line no-await-in-loop
+              const subSegments = [...segments, name];
+              // eslint-disable-next-line no-await-in-loop
+              const subEntries = await E(mount).list(...subSegments);
+              // If list succeeds, it's a directory.
+              void subEntries;
+              entry = harden({
+                name,
+                type: /** @type {const} */ ('directory'),
+                size: 0,
+              });
+            } catch {
+              entry = harden({
+                name,
+                type: /** @type {const} */ ('file'),
+                size: 0,
+              });
+            }
+            yield entry;
+
+            // Recurse if requested and entry is a directory.
+            if (opts.recursive && entry.type === 'directory') {
+              const subPath = segments.length > 0
+                ? `${dirPath}/${name}`
+                : name;
+              const subIter = vfs.readdir(subPath, opts);
+              for await (const subEntry of subIter) {
+                yield harden({
+                  ...subEntry,
+                  name: `${name}/${subEntry.name}`,
+                });
+              }
+            }
+          }
+        },
+      });
+    },
+  };
+
+  return harden(vfs);
+};
+harden(makeCapabilityVFS);

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2183,7 +2183,7 @@ const makeDaemonCore = async (
       makeEval(worker, source, names, values, context),
     'readable-blob': ({ content }) => makeReadableBlob(content),
     'readable-tree': ({ content }) => makeReadableTree(content),
-    mount: async ({ path: mountPath, readOnly }) => {
+    mount: async ({ path: mountPath, readOnly }, context) => {
       // Verify the mount path exists.
       const pathExists = await filePowers.exists(mountPath);
       if (!pathExists) {
@@ -2195,6 +2195,7 @@ const makeDaemonCore = async (
       }
       /** @param {object} mount */
       const snapshotFn = async mount => {
+        /** @type {import('./types.js').DeferredTasks<import('./types.js').ReadableTreeDeferredTaskParams>} */
         const deferredTasks = makeDeferredTasks();
         const { value } = await checkinTree(mount, deferredTasks);
         return value;
@@ -2219,6 +2220,7 @@ const makeDaemonCore = async (
       await filePowers.makePath(rootPath);
       /** @param {object} mount */
       const snapshotFn = async mount => {
+        /** @type {import('./types.js').DeferredTasks<import('./types.js').ReadableTreeDeferredTaskParams>} */
         const deferredTasks = makeDeferredTasks();
         const { value } = await checkinTree(mount, deferredTasks);
         return value;

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2199,14 +2199,18 @@ const makeDaemonCore = async (
         const { value } = await checkinTree(mount, deferredTasks);
         return value;
       };
-      return makeMount({
+      const { mount, control } = makeMount({
         rootPath: mountPath,
         readOnly,
         filePowers,
         snapshotFn,
       });
+      context.onCancel(() => {
+        control.revoke();
+      });
+      return mount;
     },
-    'scratch-mount': async ({ readOnly }, _context, _id, formulaNumber) => {
+    'scratch-mount': async ({ readOnly }, context, _id, formulaNumber) => {
       const rootPath = filePowers.joinPath(
         persistencePowers.statePath,
         'mounts',
@@ -2219,7 +2223,16 @@ const makeDaemonCore = async (
         const { value } = await checkinTree(mount, deferredTasks);
         return value;
       };
-      return makeMount({ rootPath, readOnly, filePowers, snapshotFn });
+      const { mount, control } = makeMount({
+        rootPath,
+        readOnly,
+        filePowers,
+        snapshotFn,
+      });
+      context.onCancel(() => {
+        control.revoke();
+      });
+      return mount;
     },
     lookup: ({ hub, path }, context) =>
       makeLookup(

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -4683,6 +4683,7 @@ const makeDaemonCore = async (
     getAllNetworkAddresses,
     getTypeForId,
     getFormulaForId,
+    statePath: persistencePowers.statePath,
     formulateChannel,
     formulateTimer,
     makeMailbox,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2193,7 +2193,18 @@ const makeDaemonCore = async (
       if (!isDir) {
         throw new Error(`Mount path is not a directory: ${q(mountPath)}`);
       }
-      return makeMount({ rootPath: mountPath, readOnly, filePowers });
+      /** @param {object} mount */
+      const snapshotFn = async mount => {
+        const deferredTasks = makeDeferredTasks();
+        const { value } = await checkinTree(mount, deferredTasks);
+        return value;
+      };
+      return makeMount({
+        rootPath: mountPath,
+        readOnly,
+        filePowers,
+        snapshotFn,
+      });
     },
     'scratch-mount': async ({ readOnly }, _context, _id, formulaNumber) => {
       const rootPath = filePowers.joinPath(
@@ -2202,7 +2213,13 @@ const makeDaemonCore = async (
         /** @type {string} */ (formulaNumber),
       );
       await filePowers.makePath(rootPath);
-      return makeMount({ rootPath, readOnly, filePowers });
+      /** @param {object} mount */
+      const snapshotFn = async mount => {
+        const deferredTasks = makeDeferredTasks();
+        const { value } = await checkinTree(mount, deferredTasks);
+        return value;
+      };
+      return makeMount({ rootPath, readOnly, filePowers, snapshotFn });
     },
     lookup: ({ hub, path }, context) =>
       makeLookup(

--- a/packages/daemon/src/help.md
+++ b/packages/daemon/src/help.md
@@ -708,11 +708,22 @@ path: string | string[] — Name or path segments.
 ## readOnly() -> EndoMount
 
 Returns a read-only view of this mount.
+All navigation works; writes throw.
 
-## snapshot() -> Promise<SnapshotTree>
+## subDir(subpath) -> Promise\<EndoMount>
+
+Create a new mount re-rooted at the given subdirectory.
+The sub-mount cannot navigate above its new root.
+
+subpath: string — Slash-separated relative path (e.g., "src/lib").
+Rejects segments containing ".." or ".".
+
+Example: subDir("src/lib") returns a mount scoped to src/lib/.
+Chaining: readOnly() then subDir("src") gives a read-only scoped mount.
+
+## snapshot() -> Promise\<SnapshotTree>
 
 Capture current state as an immutable readable-tree.
-(Not yet implemented.)
 
 # EndoMountFile - A file within a mounted directory.
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -77,6 +77,7 @@ const normalizeHostOrGuestOptions = opts => {
  * @param {DaemonCore['getAllNetworkAddresses']} args.getAllNetworkAddresses
  * @param {DaemonCore['getTypeForId']} args.getTypeForId
  * @param {DaemonCore['getFormulaForId']} args.getFormulaForId
+ * @param {string} args.statePath
  * @param {MakeMailbox} args.makeMailbox
  * @param {MakeDirectoryNode} args.makeDirectoryNode
  * @param {NodeNumber} args.localNodeNumber
@@ -110,6 +111,7 @@ export const makeHostMaker = ({
   getAllNetworkAddresses,
   getTypeForId,
   getFormulaForId,
+  statePath,
   makeMailbox,
   makeDirectoryNode,
   localNodeNumber,
@@ -282,6 +284,76 @@ export const makeHostMaker = ({
       );
 
       const { value } = await formulateScratchMount(readOnly, tasks);
+      return value;
+    };
+
+    /**
+     * Create a sub-mount rooted at a subdirectory of an existing mount.
+     *
+     * @param {NameOrPath} mountName - Pet name of the parent mount.
+     * @param {string} subpath - Relative path within the parent mount.
+     * @param {NameOrPath} newName - Pet name for the new sub-mount.
+     * @param {object} [options]
+     * @param {boolean} [options.readOnly]
+     */
+    const provideSubMount = async (
+      mountName,
+      subpath,
+      newName,
+      options = {},
+    ) => {
+      const { readOnly = false } = options;
+      const mountNamePath = namePathFrom(mountName);
+      assertNamePath(mountNamePath);
+      const { namePath: newNamePath } = assertPetNamePath(namePathFrom(newName));
+
+      // Resolve parent mount's formula to get its root path.
+      const parentId = specialStore.identifyLocal(mountNamePath[0]);
+      if (parentId === undefined) {
+        throw makeError(`No mount found for pet name ${q(mountName)}`);
+      }
+      const parentFormula = await getFormulaForId(
+        /** @type {FormulaIdentifier} */ (parentId),
+      );
+      if (
+        parentFormula.type !== 'mount' &&
+        parentFormula.type !== 'scratch-mount'
+      ) {
+        throw makeError(
+          `Pet name ${q(mountName)} is not a mount (type: ${q(parentFormula.type)})`,
+        );
+      }
+
+      // Derive the full path.
+      let parentPath;
+      if (parentFormula.type === 'mount') {
+        parentPath = /** @type {string} */ (
+          /** @type {import('./types.js').MountFormula} */ (parentFormula).path
+        );
+      } else {
+        // scratch-mount: path is statePath/mounts/{formulaNumber}
+        const { number: formulaNumber } = parseId(
+          /** @type {FormulaIdentifier} */ (parentId),
+        );
+        parentPath = `${statePath}/mounts/${formulaNumber}`;
+      }
+
+      // Validate subpath segments — no ".." or absolute paths.
+      const segments = subpath.split('/').filter(s => s.length > 0);
+      for (const seg of segments) {
+        if (seg === '..' || seg === '.') {
+          throw makeError(`Invalid subpath segment: ${q(seg)}`);
+        }
+      }
+      const fullPath = [parentPath, ...segments].join('/');
+
+      /** @type {DeferredTasks<MountDeferredTaskParams>} */
+      const tasks = makeDeferredTasks();
+      tasks.push(identifiers =>
+        E(directory).storeIdentifier(newNamePath, identifiers.mountId),
+      );
+
+      const { value } = await formulateMount(fullPath, readOnly, tasks);
       return value;
     };
 
@@ -1189,6 +1261,7 @@ export const makeHostMaker = ({
       storeTree,
       provideMount,
       provideScratchMount,
+      provideSubMount,
       provideGuest,
       provideHost,
       provideWorker,

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -513,6 +513,11 @@ export const MountInterface = M.interface('EndoMount', {
   help: M.call().returns(M.string()),
 });
 
+export const MountControlInterface = M.interface('EndoMountControl', {
+  revoke: M.call().returns(),
+  help: M.call().returns(M.string()),
+});
+
 export const MountFileInterface = M.interface('EndoMountFile', {
   text: M.call().returns(M.promise()),
   streamBase64: M.call().returns(M.remotable()),

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -495,8 +495,8 @@ export const MountInterface = M.interface('EndoMount', {
   // Metadata
   stat: M.call(PathArgShape).returns(M.promise()),
   // ReadableTree-compatible surface
-  has: M.call().rest(PathSegmentsShape).returns(M.promise()),
-  list: M.call().rest(PathSegmentsShape).returns(M.promise()),
+  has: M.call().rest(M.string()).returns(M.promise()),
+  list: M.call().rest(M.string()).returns(M.promise()),
   lookup: M.call(PathArgShape).returns(M.promise()),
   // Raw data I/O
   readText: M.call(PathArgShape).returns(M.promise()),

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -492,6 +492,8 @@ const PathSegmentsShape = M.arrayOf(M.string());
 const PathArgShape = M.or(M.string(), PathSegmentsShape);
 
 export const MountInterface = M.interface('EndoMount', {
+  // Metadata
+  stat: M.call(PathArgShape).returns(M.promise()),
   // ReadableTree-compatible surface
   has: M.call().rest(PathSegmentsShape).returns(M.promise()),
   list: M.call().rest(PathSegmentsShape).returns(M.promise()),

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -501,7 +501,9 @@ export const MountInterface = M.interface('EndoMount', {
   // Raw data I/O
   readText: M.call(PathArgShape).returns(M.promise()),
   maybeReadText: M.call(PathArgShape).returns(M.promise()),
+  readJson: M.call(PathArgShape).returns(M.promise()),
   writeText: M.call(PathArgShape, M.string()).returns(M.promise()),
+  writeJson: M.call(PathArgShape, M.any()).returns(M.promise()),
   // Mutation
   remove: M.call(PathArgShape).returns(M.promise()),
   move: M.call(PathArgShape, PathArgShape).returns(M.promise()),

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -504,6 +504,8 @@ export const MountInterface = M.interface('EndoMount', {
   remove: M.call(PathArgShape).returns(M.promise()),
   move: M.call(PathArgShape, PathArgShape).returns(M.promise()),
   makeDirectory: M.call(PathArgShape).returns(M.promise()),
+  // Search
+  glob: M.call(M.string()).returns(M.promise()),
   // Attenuation
   readOnly: M.call().returns(M.remotable()),
   subDir: M.call(M.string()).returns(M.promise()),

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -506,6 +506,12 @@ export const MountInterface = M.interface('EndoMount', {
   makeDirectory: M.call(PathArgShape).returns(M.promise()),
   // Search
   glob: M.call(M.string()).returns(M.promise()),
+  grep: M.call(M.string())
+    .optional(M.splitRecord({}, {
+      glob: M.string(),
+      maxResults: M.number(),
+    }))
+    .returns(M.promise()),
   // Attenuation
   readOnly: M.call().returns(M.remotable()),
   subDir: M.call(M.string()).returns(M.promise()),

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -502,6 +502,7 @@ export const MountInterface = M.interface('EndoMount', {
   makeDirectory: M.call(PathArgShape).returns(M.promise()),
   // Attenuation
   readOnly: M.call().returns(M.remotable()),
+  subDir: M.call(M.string()).returns(M.promise()),
   // Snapshot
   snapshot: M.call().returns(M.promise()),
   // Discoverability

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -323,6 +323,10 @@ export const HostInterface = M.interface('EndoHost', {
   provideScratchMount: M.call(NameOrPathShape)
     .optional(M.splitRecord({}, { readOnly: M.boolean() }))
     .returns(M.promise()),
+  // Create a sub-mount rooted at a subdirectory of an existing mount
+  provideSubMount: M.call(NameOrPathShape, M.string(), NameOrPathShape)
+    .optional(M.splitRecord({}, { readOnly: M.boolean() }))
+    .returns(M.promise()),
   // Provide a guest
   provideGuest: M.call().optional(NameShape, M.record()).returns(M.promise()),
   // Provide a host

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -470,6 +470,16 @@ const makeMountExo = ctx => {
       }
     },
 
+    async readJson(pathArg) {
+      assertNotRevoked();
+      await null;
+      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
+      const target = resolve(segments);
+      await assertConfined(target, confinementRoot, filePowers);
+      const text = await filePowers.readFileText(target);
+      return JSON.parse(text);
+    },
+
     async writeText(pathArg, content) {
       assertNotRevoked();
       await null;
@@ -480,6 +490,18 @@ const makeMountExo = ctx => {
       const parent = filePowers.joinPath(target, '..');
       await filePowers.makePath(parent);
       await filePowers.writeFileText(target, content);
+    },
+
+    async writeJson(pathArg, value) {
+      assertNotRevoked();
+      await null;
+      assertWritable();
+      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
+      const target = resolve(segments);
+      await assertConfinedOrAncestor(target, confinementRoot, filePowers);
+      const parent = filePowers.joinPath(target, '..');
+      await filePowers.makePath(parent);
+      await filePowers.writeFileText(target, JSON.stringify(value, null, 2));
     },
 
     async remove(pathArg) {

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -517,6 +517,74 @@ const makeMountExo = ctx => {
       return harden(results);
     },
 
+    /**
+     * Search file contents for a pattern.
+     *
+     * @param {string} pattern - String or regex pattern to search for.
+     * @param {object} [opts]
+     * @param {string} [opts.glob] - Glob pattern to filter files
+     *   (default: all files recursively).
+     * @param {number} [opts.maxResults] - Max matches to return
+     *   (default: 1000).
+     * @returns {Promise<Array<{ file: string, line: number, text: string }>>}
+     */
+    async grep(pattern, opts = {}) {
+      assertNotRevoked();
+      await null;
+      const {
+        glob: globPattern = '**/*',
+        maxResults = 1000,
+      } = opts;
+
+      // First, find files matching the glob.
+      const globSegments = globPattern.split('/').filter(s => s.length > 0);
+      /** @type {string[]} */
+      const files = [];
+      await walkGlob(
+        currentDir,
+        globSegments,
+        '',
+        confinementRoot,
+        filePowers,
+        files,
+        GLOB_MAX_RESULTS,
+      );
+
+      const regex = new RegExp(pattern);
+      /** @type {Array<{ file: string, line: number, text: string }>} */
+      const matches = [];
+
+      for (const file of files) {
+        if (matches.length >= maxResults) break;
+        const filePath = filePowers.joinPath(currentDir, ...file.split('/'));
+        // Skip directories and binary files.
+        // eslint-disable-next-line no-await-in-loop
+        const isDir = await filePowers.isDirectory(filePath);
+        if (isDir) continue;
+        let content;
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          content = await filePowers.readFileText(filePath);
+        } catch {
+          // Skip unreadable files (binary, permission errors).
+          continue;
+        }
+        const lines = content.split('\n');
+        for (let i = 0; i < lines.length; i += 1) {
+          if (matches.length >= maxResults) break;
+          if (regex.test(lines[i])) {
+            matches.push(harden({
+              file,
+              line: i + 1,
+              text: lines[i],
+            }));
+          }
+        }
+      }
+
+      return harden(matches);
+    },
+
     readOnly() {
       assertNotRevoked();
       if (readOnly) {

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -15,8 +15,53 @@ import {
 import { makeIteratorRef } from './reader-ref.js';
 
 /**
+ * Defense-in-depth: path segments that are always denied regardless of
+ * mount root.  Prevents accidental exposure of sensitive directories
+ * even when the mount root contains them.
+ *
+ * Checked against the lowercased segment for case-insensitive matching
+ * on case-insensitive filesystems.
+ */
+const DENIED_SEGMENTS = harden(
+  new Set([
+    // SSH keys and config
+    '.ssh',
+    // Cloud provider credentials
+    '.aws',
+    '.azure',
+    '.gcloud',
+    '.config', // contains gcloud, docker, npm tokens, etc.
+    // GPG/PGP keys
+    '.gnupg',
+    // Password managers
+    '.password-store',
+    // Docker credentials
+    '.docker',
+    // Node.js/npm auth tokens
+    '.npmrc',
+    // Environment files (common secrets location)
+    '.env',
+    '.env.local',
+    '.env.production',
+    // Kubernetes config
+    '.kube',
+    // Terraform state (may contain secrets)
+    '.terraform',
+  ]),
+);
+
+/**
+ * Check if a path segment is in the deny list.
+ *
+ * @param {string} segment
+ * @returns {boolean}
+ */
+const isDeniedSegment = segment => DENIED_SEGMENTS.has(segment.toLowerCase());
+harden(isDeniedSegment);
+
+/**
  * Validate a single path segment.
- * Rejects '/', '\', '\0', and empty strings.
+ * Rejects '/', '\', '\0', empty strings, and denied segments.
  *
  * @param {string} segment
  */
@@ -35,6 +80,9 @@ const assertValidSegment = segment => {
     throw new Error(
       `Path segment must not contain '/', '\\', or '\\0': ${q(segment)}`,
     );
+  }
+  if (isDeniedSegment(segment)) {
+    throw new Error(`Access denied: ${q(segment)} is a restricted path`);
   }
 };
 harden(assertValidSegment);
@@ -230,6 +278,10 @@ const makeMountExo = ctx => {
       const entries = await filePowers.readDirectory(target);
       const confined = [];
       for (const entry of entries.sort()) {
+        if (isDeniedSegment(entry)) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
         const entryPath = filePowers.joinPath(target, entry);
         // eslint-disable-next-line no-await-in-loop
         if (await isConfinedPath(entryPath, confinementRoot, filePowers)) {

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -201,6 +201,130 @@ const isConfinedPath = async (candidatePath, confinementRoot, filePowers) => {
 harden(isConfinedPath);
 
 /**
+ * Test whether a filename matches a glob segment.
+ * Supports `*` (match anything except `/`).
+ *
+ * @param {string} name - Filename to test.
+ * @param {string} pattern - Glob segment (e.g., `*.js`, `README*`).
+ * @returns {boolean}
+ */
+const matchSegment = (name, pattern) => {
+  if (pattern === '*') return true;
+  // Convert glob pattern to regex: escape special chars, replace * with .*
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const regexStr = `^${escaped.replace(/\*/g, '[^/]*')}$`;
+  const regex = new RegExp(regexStr);
+  return regex.test(name);
+};
+harden(matchSegment);
+
+/**
+ * Recursively walk a directory tree matching a glob pattern.
+ *
+ * Pattern segments:
+ * - `*` matches any single filename
+ * - `**` matches zero or more directory levels
+ * - Literal strings match exactly
+ * - Segments with `*` embedded (e.g., `*.js`) match via pattern
+ *
+ * @param {string} dir - Current directory (absolute path).
+ * @param {string[]} patternSegments - Remaining pattern segments.
+ * @param {string} prefix - Relative path prefix for results.
+ * @param {string} confinementRoot
+ * @param {FilePowers} filePowers
+ * @param {string[]} results - Accumulator for matched paths.
+ * @param {number} maxResults - Safety cap on results.
+ * @returns {Promise<void>}
+ */
+const walkGlob = async (
+  dir,
+  patternSegments,
+  prefix,
+  confinementRoot,
+  filePowers,
+  results,
+  maxResults,
+) => {
+  if (results.length >= maxResults) return;
+  if (patternSegments.length === 0) {
+    // End of pattern — include this path if it exists.
+    const exists = await filePowers.exists(dir);
+    if (exists) {
+      results.push(prefix);
+    }
+    return;
+  }
+
+  const [head, ...tail] = patternSegments;
+
+  if (head === '**') {
+    // ** matches zero or more levels.
+    // Zero levels: skip the ** and continue matching tail from here.
+    await walkGlob(
+      dir, tail, prefix, confinementRoot, filePowers, results, maxResults,
+    );
+    // One or more levels: recurse into each subdirectory with ** still active.
+    let entries;
+    try {
+      entries = await filePowers.readDirectory(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort()) {
+      if (results.length >= maxResults) return;
+      if (isDeniedSegment(entry)) continue;
+      const childPath = filePowers.joinPath(dir, entry);
+      // eslint-disable-next-line no-await-in-loop
+      if (!(await isConfinedPath(childPath, confinementRoot, filePowers))) {
+        continue;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      const isDir = await filePowers.isDirectory(childPath);
+      if (isDir) {
+        const childPrefix = prefix ? `${prefix}/${entry}` : entry;
+        // eslint-disable-next-line no-await-in-loop
+        await walkGlob(
+          childPath, patternSegments, childPrefix,
+          confinementRoot, filePowers, results, maxResults,
+        );
+      }
+    }
+    return;
+  }
+
+  // Normal segment or wildcard segment (e.g., `*.js`, `*`).
+  let entries;
+  try {
+    entries = await filePowers.readDirectory(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries.sort()) {
+    if (results.length >= maxResults) return;
+    if (isDeniedSegment(entry)) continue;
+    if (!matchSegment(entry, head)) continue;
+    const childPath = filePowers.joinPath(dir, entry);
+    // eslint-disable-next-line no-await-in-loop
+    if (!(await isConfinedPath(childPath, confinementRoot, filePowers))) {
+      continue;
+    }
+    const childPrefix = prefix ? `${prefix}/${entry}` : entry;
+    if (tail.length === 0) {
+      results.push(childPrefix);
+    } else {
+      // eslint-disable-next-line no-await-in-loop
+      await walkGlob(
+        childPath, tail, childPrefix,
+        confinementRoot, filePowers, results, maxResults,
+      );
+    }
+  }
+};
+harden(walkGlob);
+
+const GLOB_MAX_RESULTS = 10000;
+
+/**
  * @typedef {object} MountContext
  * @property {string} currentDir
  * @property {string} confinementRoot
@@ -373,6 +497,24 @@ const makeMountExo = ctx => {
       const target = resolve(segments);
       await assertConfinedOrAncestor(target, confinementRoot, filePowers);
       await filePowers.makePath(target);
+    },
+
+    async glob(pattern) {
+      assertNotRevoked();
+      await null;
+      const segments = pattern.split('/').filter(s => s.length > 0);
+      /** @type {string[]} */
+      const results = [];
+      await walkGlob(
+        currentDir,
+        segments,
+        '',
+        confinementRoot,
+        filePowers,
+        results,
+        GLOB_MAX_RESULTS,
+      );
+      return harden(results);
     },
 
     readOnly() {

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -7,7 +7,11 @@ import { q } from '@endo/errors';
 import { makeExo } from '@endo/exo';
 
 import { mountHelp, mountFileHelp, makeHelp } from './help-text.js';
-import { MountInterface, MountFileInterface } from './interfaces.js';
+import {
+  MountInterface,
+  MountControlInterface,
+  MountFileInterface,
+} from './interfaces.js';
 import { makeIteratorRef } from './reader-ref.js';
 
 /**
@@ -156,6 +160,7 @@ harden(isConfinedPath);
  * @property {FilePowers} filePowers
  * @property {string} description
  * @property {((mount: object) => Promise<object>) | undefined} snapshotFn
+ * @property {{ revoked: boolean }} [revokedRef] - Shared revocation state.
  */
 
 /**
@@ -172,9 +177,17 @@ const makeMountExo = ctx => {
     filePowers,
     description,
     snapshotFn,
+    revokedRef,
   } = ctx;
 
+  const assertNotRevoked = () => {
+    if (revokedRef && revokedRef.revoked) {
+      throw new Error('Mount has been revoked');
+    }
+  };
+
   const assertWritable = () => {
+    assertNotRevoked();
     if (readOnly) {
       throw new Error('Mount is read-only');
     }
@@ -196,6 +209,7 @@ const makeMountExo = ctx => {
     help,
 
     async has(...pathSegments) {
+      assertNotRevoked();
       await null;
       if (pathSegments.length === 0) {
         return true;
@@ -209,6 +223,7 @@ const makeMountExo = ctx => {
     },
 
     async list(...pathSegments) {
+      assertNotRevoked();
       await null;
       const target = resolve(pathSegments);
       await assertConfined(target, confinementRoot, filePowers);
@@ -225,6 +240,7 @@ const makeMountExo = ctx => {
     },
 
     async lookup(pathArg) {
+      assertNotRevoked();
       await null;
       const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
       const target = resolve(segments);
@@ -243,6 +259,7 @@ const makeMountExo = ctx => {
     },
 
     async readText(pathArg) {
+      assertNotRevoked();
       await null;
       const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
       const target = resolve(segments);
@@ -251,6 +268,7 @@ const makeMountExo = ctx => {
     },
 
     async maybeReadText(pathArg) {
+      assertNotRevoked();
       await null;
       const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
       const target = resolve(segments);
@@ -263,6 +281,7 @@ const makeMountExo = ctx => {
     },
 
     async writeText(pathArg, content) {
+      assertNotRevoked();
       await null;
       assertWritable();
       const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
@@ -274,6 +293,7 @@ const makeMountExo = ctx => {
     },
 
     async remove(pathArg) {
+      assertNotRevoked();
       await null;
       assertWritable();
       const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
@@ -283,6 +303,7 @@ const makeMountExo = ctx => {
     },
 
     async move(fromArg, toArg) {
+      assertNotRevoked();
       await null;
       assertWritable();
       const from = resolve(typeof fromArg === 'string' ? [fromArg] : fromArg);
@@ -293,6 +314,7 @@ const makeMountExo = ctx => {
     },
 
     async makeDirectory(pathArg) {
+      assertNotRevoked();
       await null;
       assertWritable();
       const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
@@ -302,6 +324,7 @@ const makeMountExo = ctx => {
     },
 
     readOnly() {
+      assertNotRevoked();
       if (readOnly) {
         return this; // eslint-disable-line no-invalid-this
       }
@@ -313,6 +336,7 @@ const makeMountExo = ctx => {
     },
 
     async subDir(subpath) {
+      assertNotRevoked();
       await null;
       // Validate and resolve segments.
       const segments = subpath.split('/').filter(s => s.length > 0);
@@ -340,6 +364,7 @@ const makeMountExo = ctx => {
     },
 
     async snapshot() {
+      assertNotRevoked();
       if (!snapshotFn) {
         throw new Error('snapshot() is not available on this mount');
       }
@@ -430,8 +455,23 @@ harden(makeMountFileExo);
  * @param {((mount: object) => Promise<object>) | undefined} [opts.snapshotFn]
  * @returns {object}
  */
+/**
+ * Create a mount exo backed by a filesystem directory.
+ *
+ * Returns `{ mount, control }` where `mount` is the capability facet
+ * and `control` is the caretaker facet for revocation.
+ *
+ * @param {object} opts
+ * @param {string} opts.rootPath
+ * @param {boolean} opts.readOnly
+ * @param {FilePowers} opts.filePowers
+ * @param {((mount: object) => Promise<object>) | undefined} [opts.snapshotFn]
+ * @returns {{ mount: object, control: object }}
+ */
 export const makeMount = ({ rootPath, readOnly, filePowers, snapshotFn }) => {
   const prefix = readOnly ? 'Read-only mount' : 'Mount';
+  const revokedRef = { revoked: false };
+
   /** @type {MountContext} */
   const ctx = {
     currentDir: rootPath,
@@ -440,8 +480,23 @@ export const makeMount = ({ rootPath, readOnly, filePowers, snapshotFn }) => {
     filePowers,
     description: `${prefix} at ${rootPath}`,
     snapshotFn,
+    revokedRef,
   };
 
-  return makeMountExo(ctx);
+  const mount = makeMountExo(ctx);
+
+  const control = makeExo('EndoMountControl', MountControlInterface, {
+    revoke() {
+      revokedRef.revoked = true;
+    },
+    help() {
+      return (
+        `MountControl manages a mount at ${rootPath}. ` +
+        `Methods: revoke(), help().`
+      );
+    },
+  });
+
+  return harden({ mount, control });
 };
 harden(makeMount);

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -261,7 +261,13 @@ const walkGlob = async (
     // ** matches zero or more levels.
     // Zero levels: skip the ** and continue matching tail from here.
     await walkGlob(
-      dir, tail, prefix, confinementRoot, filePowers, results, maxResults,
+      dir,
+      tail,
+      prefix,
+      confinementRoot,
+      filePowers,
+      results,
+      maxResults,
     );
     // One or more levels: recurse into each subdirectory with ** still active.
     let entries;
@@ -284,8 +290,13 @@ const walkGlob = async (
         const childPrefix = prefix ? `${prefix}/${entry}` : entry;
         // eslint-disable-next-line no-await-in-loop
         await walkGlob(
-          childPath, patternSegments, childPrefix,
-          confinementRoot, filePowers, results, maxResults,
+          childPath,
+          patternSegments,
+          childPrefix,
+          confinementRoot,
+          filePowers,
+          results,
+          maxResults,
         );
       }
     }
@@ -314,8 +325,13 @@ const walkGlob = async (
     } else {
       // eslint-disable-next-line no-await-in-loop
       await walkGlob(
-        childPath, tail, childPrefix,
-        confinementRoot, filePowers, results, maxResults,
+        childPath,
+        tail,
+        childPrefix,
+        confinementRoot,
+        filePowers,
+        results,
+        maxResults,
       );
     }
   }
@@ -567,10 +583,7 @@ const makeMountExo = ctx => {
     async grep(pattern, opts = {}) {
       assertNotRevoked();
       await null;
-      const {
-        glob: globPattern = '**/*',
-        maxResults = 1000,
-      } = opts;
+      const { glob: globPattern = '**/*', maxResults = 1000 } = opts;
 
       // First, find files matching the glob.
       const globSegments = globPattern.split('/').filter(s => s.length > 0);
@@ -609,11 +622,13 @@ const makeMountExo = ctx => {
         for (let i = 0; i < lines.length; i += 1) {
           if (matches.length >= maxResults) break;
           if (regex.test(lines[i])) {
-            matches.push(harden({
-              file,
-              line: i + 1,
-              text: lines[i],
-            }));
+            matches.push(
+              harden({
+                file,
+                line: i + 1,
+                text: lines[i],
+              }),
+            );
           }
         }
       }

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -155,6 +155,7 @@ harden(isConfinedPath);
  * @property {boolean} readOnly
  * @property {FilePowers} filePowers
  * @property {string} description
+ * @property {((mount: object) => Promise<object>) | undefined} snapshotFn
  */
 
 /**
@@ -164,8 +165,14 @@ harden(isConfinedPath);
  * @returns {object}
  */
 const makeMountExo = ctx => {
-  const { currentDir, confinementRoot, readOnly, filePowers, description } =
-    ctx;
+  const {
+    currentDir,
+    confinementRoot,
+    readOnly,
+    filePowers,
+    description,
+    snapshotFn,
+  } = ctx;
 
   const assertWritable = () => {
     if (readOnly) {
@@ -182,7 +189,10 @@ const makeMountExo = ctx => {
 
   const help = makeHelp(mountHelp);
 
-  return makeExo('EndoMount', MountInterface, {
+  /** @type {object} */
+  let selfRef;
+
+  const mount = makeExo('EndoMount', MountInterface, {
     help,
 
     async has(...pathSegments) {
@@ -303,9 +313,15 @@ const makeMountExo = ctx => {
     },
 
     async snapshot() {
-      throw new Error('snapshot() is not yet implemented');
+      if (!snapshotFn) {
+        throw new Error('snapshot() is not available on this mount');
+      }
+      return snapshotFn(selfRef);
     },
   });
+
+  selfRef = mount;
+  return mount;
 };
 harden(makeMountExo);
 
@@ -384,9 +400,10 @@ harden(makeMountFileExo);
  * @param {string} opts.rootPath
  * @param {boolean} opts.readOnly
  * @param {FilePowers} opts.filePowers
+ * @param {((mount: object) => Promise<object>) | undefined} [opts.snapshotFn]
  * @returns {object}
  */
-export const makeMount = ({ rootPath, readOnly, filePowers }) => {
+export const makeMount = ({ rootPath, readOnly, filePowers, snapshotFn }) => {
   const prefix = readOnly ? 'Read-only mount' : 'Mount';
   /** @type {MountContext} */
   const ctx = {
@@ -395,6 +412,7 @@ export const makeMount = ({ rootPath, readOnly, filePowers }) => {
     readOnly,
     filePowers,
     description: `${prefix} at ${rootPath}`,
+    snapshotFn,
   };
 
   return makeMountExo(ctx);

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -380,6 +380,20 @@ const makeMountExo = ctx => {
   const mount = makeExo('EndoMount', MountInterface, {
     help,
 
+    async stat(pathArg) {
+      assertNotRevoked();
+      await null;
+      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
+      const target = resolve(segments);
+      await assertConfined(target, confinementRoot, filePowers);
+      const isDir = await filePowers.isDirectory(target);
+      if (isDir) {
+        return harden({ type: 'directory', size: 0 });
+      }
+      const text = await filePowers.readFileText(target);
+      return harden({ type: 'file', size: text.length });
+    },
+
     async has(...pathSegments) {
       assertNotRevoked();
       await null;

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -312,6 +312,33 @@ const makeMountExo = ctx => {
       });
     },
 
+    async subDir(subpath) {
+      await null;
+      // Validate and resolve segments.
+      const segments = subpath.split('/').filter(s => s.length > 0);
+      for (const seg of segments) {
+        if (seg === '..' || seg === '.') {
+          throw new Error(`Invalid subDir segment: ${seg}`);
+        }
+      }
+      const target = resolve(segments);
+      await assertConfinedOrAncestor(target, confinementRoot, filePowers);
+      const isDir = await filePowers.isDirectory(target);
+      if (!isDir) {
+        throw new Error(`subDir target is not a directory: ${subpath}`);
+      }
+      return makeMountExo({
+        ...ctx,
+        currentDir: target,
+        // The confinement root stays the same — the sub-mount cannot
+        // escape above the original root.  But the sub-mount's own
+        // navigation is restricted to its new currentDir because
+        // resolveSegments clamps ".." to currentDir.
+        confinementRoot: target,
+        description: `${readOnly ? 'Read-only sub-mount' : 'Sub-mount'} at ${subpath} of ${description}`,
+      });
+    },
+
     async snapshot() {
       if (!snapshotFn) {
         throw new Error('snapshot() is not available on this mount');

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -950,6 +950,12 @@ export interface EndoHost extends EndoAgent {
     opts?: { readOnly?: boolean },
   ): Promise<unknown>;
   provideScratchMount(petName: string | string[]): Promise<unknown>;
+  provideSubMount(
+    mountName: string | string[],
+    subpath: string,
+    newName: string | string[],
+    opts?: { readOnly?: boolean },
+  ): Promise<unknown>;
   provideGuest(
     petName?: string,
     opts?: MakeHostOrGuestOptions,

--- a/packages/daemon/test/capability-vfs.test.js
+++ b/packages/daemon/test/capability-vfs.test.js
@@ -1,0 +1,175 @@
+// @ts-check
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { makeMount } from '../src/mount.js';
+import { makeCapabilityVFS } from '../src/capability-vfs.js';
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ */
+const setup = async t => {
+  const tmpDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'endo-capvfs-test-'),
+  );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'hello.txt'),
+    'Hello, world!',
+    'utf-8',
+  );
+  await fs.promises.mkdir(path.join(tmpDir, 'src'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'src', 'main.js'),
+    'console.log("main");',
+    'utf-8',
+  );
+
+  t.teardown(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /** @type {import('../src/types.js').FilePowers} */
+  const filePowers = {
+    readDirectory: dir => fs.promises.readdir(dir),
+    readFileText: p => fs.promises.readFile(p, 'utf-8'),
+    writeFileText: (p, c) => fs.promises.writeFile(p, c, 'utf-8'),
+    makePath: p => fs.promises.mkdir(p, { recursive: true }),
+    removePath: p => fs.promises.rm(p, { recursive: true, force: true }),
+    renamePath: (a, b) => fs.promises.rename(a, b),
+    joinPath: (...parts) => path.join(...parts),
+    realPath: p => fs.promises.realpath(p),
+    exists: async p => {
+      try {
+        await fs.promises.access(p);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    isDirectory: async p => {
+      try {
+        const stat = await fs.promises.stat(p);
+        return stat.isDirectory();
+      } catch {
+        return false;
+      }
+    },
+    makeFileReader: _p => {
+      throw new Error('not implemented');
+    },
+    makeFileWriter: _p => {
+      throw new Error('not implemented');
+    },
+  };
+
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const vfs = makeCapabilityVFS(mount);
+  return { tmpDir, vfs, mount };
+};
+
+test('readFile reads text content', async t => {
+  const { vfs } = await setup(t);
+  const content = await vfs.readFile('hello.txt');
+  t.is(content, 'Hello, world!');
+});
+
+test('readFile reads from subdirectories', async t => {
+  const { vfs } = await setup(t);
+  const content = await vfs.readFile('src/main.js');
+  t.is(content, 'console.log("main");');
+});
+
+test('writeFile creates and overwrites files', async t => {
+  const { vfs } = await setup(t);
+  await vfs.writeFile('new.txt', 'new content');
+  const content = await vfs.readFile('new.txt');
+  t.is(content, 'new content');
+
+  await vfs.writeFile('new.txt', 'overwritten');
+  const updated = await vfs.readFile('new.txt');
+  t.is(updated, 'overwritten');
+});
+
+test('stat returns file info', async t => {
+  const { vfs } = await setup(t);
+  const fileStat = await vfs.stat('hello.txt');
+  t.is(fileStat.type, 'file');
+  t.true(fileStat.size > 0);
+
+  const dirStat = await vfs.stat('src');
+  t.is(dirStat.type, 'directory');
+});
+
+test('stat throws for nonexistent path', async t => {
+  const { vfs } = await setup(t);
+  await t.throwsAsync(() => vfs.stat('nonexistent'), {
+    message: /ENOENT/,
+  });
+});
+
+test('mkdir creates directories', async t => {
+  const { vfs } = await setup(t);
+  const created = await vfs.mkdir('newdir');
+  t.true(created);
+
+  const stat = await vfs.stat('newdir');
+  t.is(stat.type, 'directory');
+});
+
+test('mkdir recursive returns false for existing', async t => {
+  const { vfs } = await setup(t);
+  const created = await vfs.mkdir('src', { recursive: true });
+  t.false(created);
+});
+
+test('rm removes files', async t => {
+  const { vfs } = await setup(t);
+  await vfs.writeFile('temp.txt', 'temp');
+  await vfs.rm('temp.txt');
+  await t.throwsAsync(() => vfs.stat('temp.txt'), {
+    message: /ENOENT/,
+  });
+});
+
+test('readdir lists directory entries', async t => {
+  const { vfs } = await setup(t);
+  const entries = [];
+  for await (const entry of vfs.readdir('')) {
+    entries.push(entry);
+  }
+  const names = entries.map(e => e.name).sort();
+  t.true(names.includes('hello.txt'));
+  t.true(names.includes('src'));
+
+  const srcEntry = entries.find(e => e.name === 'src');
+  t.is(srcEntry?.type, 'directory');
+});
+
+test('readdir recursive yields nested entries', async t => {
+  const { vfs } = await setup(t);
+  const entries = [];
+  for await (const entry of vfs.readdir('', { recursive: true })) {
+    entries.push(entry);
+  }
+  const names = entries.map(e => e.name);
+  t.true(names.includes('src/main.js'));
+});
+
+test('createReadStream yields file bytes', async t => {
+  const { vfs } = await setup(t);
+  const chunks = [];
+  for await (const chunk of vfs.createReadStream('hello.txt')) {
+    chunks.push(chunk);
+  }
+  const text = new TextDecoder().decode(chunks[0]);
+  t.is(text, 'Hello, world!');
+});

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -4171,7 +4171,7 @@ test('mount subDir creates confined sub-mount', async t => {
   await createMountFixture(mountPath, {
     'root.txt': 'at root',
   });
-  await fs.promises.mkdir(path.join(mountPath, 'src'));
+  await fs.promises.mkdir(path.join(mountPath, 'src'), { recursive: true });
   await fs.promises.writeFile(
     path.join(mountPath, 'src', 'index.js'),
     'export default 42;',

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -4106,6 +4106,64 @@ test('mount file writeText and json', async t => {
   t.is(actualContent, '{"version": 2}');
 });
 
+test('mount file readOnly rejects writes', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(config.statePath, '..', 'mount-test-file-ro');
+  await createMountFixture(mountPath, {
+    'data.txt': 'original content',
+  });
+
+  await E(host).provideMount(mountPath, 'test-mount-fro');
+  const mount = await E(host).lookup(['test-mount-fro']);
+  const file = await E(mount).lookup('data.txt');
+
+  // Get read-only view.
+  const roFile = await E(file).readOnly();
+
+  // Reading works.
+  const content = await E(roFile).text();
+  t.is(content, 'original content');
+
+  // Writing throws.
+  await t.throwsAsync(() => E(roFile).writeText('modified'), {
+    message: /read-only/i,
+  });
+
+  // Original file unchanged.
+  const actual = await fs.promises.readFile(
+    path.join(mountPath, 'data.txt'),
+    'utf-8',
+  );
+  t.is(actual, 'original content');
+});
+
+test('mount read-only mount rejects file writes', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(
+    config.statePath,
+    '..',
+    'mount-test-ro-mount-write',
+  );
+  await createMountFixture(mountPath, {
+    'data.txt': 'original',
+  });
+
+  await E(host).provideMount(mountPath, 'test-mount-ro-w', { readOnly: true });
+  const mount = await E(host).lookup(['test-mount-ro-w']);
+  const file = await E(mount).lookup('data.txt');
+
+  // Reading works on read-only mount's file.
+  const content = await E(file).text();
+  t.is(content, 'original');
+
+  // Writing through a file from a read-only mount throws.
+  await t.throwsAsync(() => E(file).writeText('modified'), {
+    message: /read-only/i,
+  });
+});
+
 test('mount subDir creates confined sub-mount', async t => {
   const { host, config } = await prepareHost(t);
 

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -4106,6 +4106,66 @@ test('mount file writeText and json', async t => {
   t.is(actualContent, '{"version": 2}');
 });
 
+test('mount subDir creates confined sub-mount', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(config.statePath, '..', 'mount-test-subdir');
+  await createMountFixture(mountPath, {
+    'root.txt': 'at root',
+  });
+  await fs.promises.mkdir(path.join(mountPath, 'src'));
+  await fs.promises.writeFile(
+    path.join(mountPath, 'src', 'index.js'),
+    'export default 42;',
+  );
+
+  await E(host).provideMount(mountPath, 'project');
+  const mount = await E(host).lookup(['project']);
+
+  // subDir scopes to a subdirectory.
+  const srcMount = await E(mount).subDir('src');
+  const entries = await E(srcMount).list();
+  t.deepEqual(entries, ['index.js']);
+
+  // subDir cannot navigate above its new root.
+  t.true(await E(srcMount).has('index.js'));
+
+  // Read file through sub-mount.
+  const file = await E(srcMount).lookup('index.js');
+  const content = await E(file).text();
+  t.is(content, 'export default 42;');
+
+  // subDir rejects .. segments.
+  await t.throwsAsync(() => E(mount).subDir('..'), {
+    message: /Invalid subDir segment/,
+  });
+});
+
+test('mount subDir readOnly chains with subDir', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(config.statePath, '..', 'mount-test-subdir-ro');
+  await fs.promises.mkdir(path.join(mountPath, 'lib'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(mountPath, 'lib', 'util.js'),
+    'export const x = 1;',
+  );
+
+  await E(host).provideMount(mountPath, 'ro-project');
+  const mount = await E(host).lookup(['ro-project']);
+
+  // Chain: readOnly then subDir.
+  const roMount = E(mount).readOnly();
+  const roLib = await E(roMount).subDir('lib');
+  const entries = await E(roLib).list();
+  t.deepEqual(entries, ['util.js']);
+
+  // Writing through the read-only sub-mount should throw.
+  await t.throwsAsync(() => E(roLib).writeText('new.txt', 'nope'), {
+    message: /read-only/i,
+  });
+});
+
 // symlink confinement tests
 
 /**

--- a/packages/daemon/test/mount.test.js
+++ b/packages/daemon/test/mount.test.js
@@ -349,3 +349,95 @@ test('glob on revoked mount throws', async t => {
     message: /revoked/,
   });
 });
+
+// --- Grep tests ---
+
+test('grep finds matching lines in files', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const results = await mount.grep('Hello');
+  t.is(results.length, 1);
+  t.is(results[0].file, 'hello.txt');
+  t.is(results[0].line, 1);
+  t.true(results[0].text.includes('Hello'));
+});
+
+test('grep searches recursively by default', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  // "Nested" is in sub/nested.txt, "deep" is in sub/deep/file.txt
+  const results = await mount.grep('Nested');
+  t.is(results.length, 1);
+  t.is(results[0].file, 'sub/nested.txt');
+});
+
+test('grep filters by glob pattern', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  // Search only .json files
+  const results = await mount.grep('\\{', { glob: '**/*.json' });
+  t.is(results.length, 1);
+  t.is(results[0].file, 'sub/data.json');
+});
+
+test('grep returns empty for no matches', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const results = await mount.grep('nonexistent_string_xyz');
+  t.deepEqual(results, []);
+});
+
+test('grep respects maxResults', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+
+  // Create a file with many lines.
+  const lines = Array.from({ length: 100 }, (_, i) => `match line ${i}`);
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'many.txt'),
+    lines.join('\n'),
+    'utf-8',
+  );
+
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const results = await mount.grep('match', { maxResults: 5 });
+  t.is(results.length, 5);
+});
+
+test('grep on revoked mount throws', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount, control } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  control.revoke();
+  await t.throwsAsync(() => mount.grep('test'), {
+    message: /revoked/,
+  });
+});

--- a/packages/daemon/test/mount.test.js
+++ b/packages/daemon/test/mount.test.js
@@ -22,10 +22,28 @@ const setup = async t => {
     'Hello, world!',
     'utf-8',
   );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'readme.md'),
+    '# Readme',
+    'utf-8',
+  );
   await fs.promises.mkdir(path.join(tmpDir, 'sub'), { recursive: true });
   await fs.promises.writeFile(
     path.join(tmpDir, 'sub', 'nested.txt'),
     'Nested',
+    'utf-8',
+  );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'sub', 'data.json'),
+    '{}',
+    'utf-8',
+  );
+  await fs.promises.mkdir(path.join(tmpDir, 'sub', 'deep'), {
+    recursive: true,
+  });
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'sub', 'deep', 'file.txt'),
+    'deep',
     'utf-8',
   );
 
@@ -242,4 +260,92 @@ test('control.help() returns documentation', async t => {
   const helpText = control.help();
   t.true(helpText.includes('MountControl'));
   t.true(helpText.includes('revoke'));
+});
+
+// --- Glob tests ---
+
+test('glob matches wildcard in single directory', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const txtFiles = await mount.glob('*.txt');
+  t.true(txtFiles.includes('hello.txt'));
+  t.false(txtFiles.includes('readme.md'));
+});
+
+test('glob matches files in subdirectory', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const subFiles = await mount.glob('sub/*.txt');
+  t.deepEqual(subFiles, ['sub/nested.txt']);
+});
+
+test('glob ** matches recursively', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const allTxt = await mount.glob('**/*.txt');
+  t.true(allTxt.includes('hello.txt'));
+  t.true(allTxt.includes('sub/nested.txt'));
+  t.true(allTxt.includes('sub/deep/file.txt'));
+});
+
+test('glob excludes denied segments', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+
+  // Create a .ssh directory with files.
+  await fs.promises.mkdir(path.join(tmpDir, '.ssh'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(tmpDir, '.ssh', 'id_rsa'),
+    'PRIVATE',
+    'utf-8',
+  );
+
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const all = await mount.glob('**/*');
+  t.false(all.some(p => p.includes('.ssh')));
+});
+
+test('glob returns empty array for no matches', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const results = await mount.glob('*.xyz');
+  t.deepEqual(results, []);
+});
+
+test('glob on revoked mount throws', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount, control } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  control.revoke();
+  await t.throwsAsync(() => mount.glob('*'), {
+    message: /revoked/,
+  });
 });

--- a/packages/daemon/test/mount.test.js
+++ b/packages/daemon/test/mount.test.js
@@ -1,0 +1,162 @@
+// @ts-check
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { makeMount } from '../src/mount.js';
+
+/**
+ * Create a temp directory and return filePowers for mount.
+ *
+ * @param {import('ava').ExecutionContext} t
+ */
+const setup = async t => {
+  const tmpDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'endo-mount-test-'),
+  );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'hello.txt'),
+    'Hello, world!',
+    'utf-8',
+  );
+  await fs.promises.mkdir(path.join(tmpDir, 'sub'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'sub', 'nested.txt'),
+    'Nested',
+    'utf-8',
+  );
+
+  t.teardown(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /** @type {import('../src/types.js').FilePowers} */
+  const filePowers = {
+    readDirectory: dir => fs.promises.readdir(dir),
+    readFileText: p => fs.promises.readFile(p, 'utf-8'),
+    writeFileText: (p, c) => fs.promises.writeFile(p, c, 'utf-8'),
+    makePath: p => fs.promises.mkdir(p, { recursive: true }),
+    removePath: p => fs.promises.rm(p, { recursive: true, force: true }),
+    renamePath: (a, b) => fs.promises.rename(a, b),
+    joinPath: (...parts) => path.join(...parts),
+    realPath: p => fs.promises.realpath(p),
+    exists: async p => {
+      try {
+        await fs.promises.access(p);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    isDirectory: async p => {
+      try {
+        const stat = await fs.promises.stat(p);
+        return stat.isDirectory();
+      } catch {
+        return false;
+      }
+    },
+    makeFileReader: _p => {
+      throw new Error('not implemented');
+    },
+    makeFileWriter: _p => {
+      throw new Error('not implemented');
+    },
+  };
+
+  return { tmpDir, filePowers };
+};
+
+test('makeMount returns mount and control', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount, control } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+  t.truthy(mount);
+  t.truthy(control);
+  t.is(typeof control.revoke, 'function');
+  t.is(typeof control.help, 'function');
+});
+
+test('mount reads files before revocation', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const text = await mount.readText('hello.txt');
+  t.is(text, 'Hello, world!');
+});
+
+test('control.revoke() prevents all mount operations', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount, control } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  // Works before revocation.
+  t.true(await mount.has('hello.txt'));
+
+  // Revoke.
+  control.revoke();
+
+  // All operations throw after revocation.
+  await t.throwsAsync(() => mount.has('hello.txt'), {
+    message: /revoked/,
+  });
+  await t.throwsAsync(() => mount.list(), {
+    message: /revoked/,
+  });
+  await t.throwsAsync(() => mount.readText('hello.txt'), {
+    message: /revoked/,
+  });
+  await t.throwsAsync(() => mount.writeText('new.txt', 'data'), {
+    message: /revoked/,
+  });
+  t.throws(() => mount.readOnly(), {
+    message: /revoked/,
+  });
+});
+
+test('revocation propagates to subDir mounts', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount, control } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  // Create a subDir before revoking.
+  const sub = await mount.subDir('sub');
+  t.is(await sub.readText('nested.txt'), 'Nested');
+
+  // Revoke the parent.
+  control.revoke();
+
+  // SubDir is also revoked (shares revokedRef).
+  await t.throwsAsync(() => sub.readText('nested.txt'), {
+    message: /revoked/,
+  });
+});
+
+test('control.help() returns documentation', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { control } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const helpText = control.help();
+  t.true(helpText.includes('MountControl'));
+  t.true(helpText.includes('revoke'));
+});

--- a/packages/daemon/test/mount.test.js
+++ b/packages/daemon/test/mount.test.js
@@ -101,6 +101,23 @@ test('makeMount returns mount and control', async t => {
   t.is(typeof control.help, 'function');
 });
 
+test('stat returns file and directory info', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  const fileStat = await mount.stat('hello.txt');
+  t.is(fileStat.type, 'file');
+  t.true(fileStat.size > 0);
+
+  const dirStat = await mount.stat('sub');
+  t.is(dirStat.type, 'directory');
+  t.is(dirStat.size, 0);
+});
+
 test('mount reads files before revocation', async t => {
   const { tmpDir, filePowers } = await setup(t);
   const { mount } = makeMount({

--- a/packages/daemon/test/mount.test.js
+++ b/packages/daemon/test/mount.test.js
@@ -118,6 +118,25 @@ test('stat returns file and directory info', async t => {
   t.is(dirStat.size, 0);
 });
 
+test('readJson and writeJson roundtrip', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  // Read existing JSON file.
+  const data = await mount.readJson(['sub', 'data.json']);
+  t.deepEqual(data, {});
+
+  // Write and read back.
+  const obj = { name: 'test', count: 42, nested: { ok: true } };
+  await mount.writeJson('config.json', obj);
+  const readBack = await mount.readJson('config.json');
+  t.deepEqual(readBack, obj);
+});
+
 test('mount reads files before revocation', async t => {
   const { tmpDir, filePowers } = await setup(t);
   const { mount } = makeMount({

--- a/packages/daemon/test/mount.test.js
+++ b/packages/daemon/test/mount.test.js
@@ -148,6 +148,89 @@ test('revocation propagates to subDir mounts', async t => {
   });
 });
 
+test('deny patterns block access to sensitive directories', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+
+  // Create a .ssh directory in the mount root.
+  await fs.promises.mkdir(path.join(tmpDir, '.ssh'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(tmpDir, '.ssh', 'id_rsa'),
+    'PRIVATE KEY',
+    'utf-8',
+  );
+  // Create .env file.
+  await fs.promises.writeFile(
+    path.join(tmpDir, '.env'),
+    'SECRET=value',
+    'utf-8',
+  );
+
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  // Direct access to denied segments throws.
+  await t.throwsAsync(() => mount.readText(['.ssh', 'id_rsa']), {
+    message: /restricted/,
+  });
+  await t.throwsAsync(() => mount.readText('.env'), {
+    message: /restricted/,
+  });
+  await t.throwsAsync(() => mount.has('.ssh'), {
+    message: /restricted/,
+  });
+  await t.throwsAsync(() => mount.lookup('.aws'), {
+    message: /restricted/,
+  });
+
+  // list() filters out denied segments.
+  const entries = await mount.list();
+  t.false(entries.includes('.ssh'));
+  t.false(entries.includes('.env'));
+  t.true(entries.includes('hello.txt'));
+  t.true(entries.includes('sub'));
+});
+
+test('deny patterns are case-insensitive', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  // Mixed case should also be denied.
+  await t.throwsAsync(() => mount.readText(['.SSH', 'id_rsa']), {
+    message: /restricted/,
+  });
+  await t.throwsAsync(() => mount.readText('.Env'), {
+    message: /restricted/,
+  });
+});
+
+test('deny patterns do not block normal dotfiles', async t => {
+  const { tmpDir, filePowers } = await setup(t);
+
+  // Create a normal dotfile that's not in the deny list.
+  await fs.promises.writeFile(
+    path.join(tmpDir, '.gitignore'),
+    'node_modules/',
+    'utf-8',
+  );
+
+  const { mount } = makeMount({
+    rootPath: tmpDir,
+    readOnly: false,
+    filePowers,
+  });
+
+  // .gitignore is allowed.
+  const text = await mount.readText('.gitignore');
+  t.is(text, 'node_modules/');
+});
+
 test('control.help() returns documentation', async t => {
   const { tmpDir, filePowers } = await setup(t);
   const { control } = makeMount({


### PR DESCRIPTION
## Summary
- Builds on the mount Phase 4 core (see #35) with a `MountControl` caretaker facet providing `revoke()`, propagated through `readOnly()`/`subDir()` attenuations and wired into the daemon formula-graph context lifecycle.
- Adds defense-in-depth deny patterns (`.ssh`, `.aws`, `.env`, `.gnupg`, `.docker`, `.kube`, etc.) that remain blocked even if they exist under a mount root; regular dotfiles like `.gitignore` stay accessible.
- Extends the Mount exo surface with `glob()`, `grep()`, `stat()`, `readJson()`, and `writeJson()` — all respecting confinement, deny patterns, and revocation. Simplifies the capability VFS adapter to use `stat()` instead of heuristic `list()` type detection.
- Rounds out with help-text updates, a recursive `mkdir` fix in tests, and additional file `readOnly` / read-only-mount coverage.

Note: this branch is a superset of #35 (review/3-mount-core); it stacks the extensions on top of the mount Phase 4 core commits.

## Commits (new on top of review/3-mount-core)
- test(daemon): add mount file readOnly and read-only mount tests
- fix(daemon): use recursive mkdir in subDir test
- docs(daemon): add subDir and update snapshot in mount help text
- feat(daemon): add MountControl caretaker facet with revocation
- feat(daemon): defense-in-depth deny patterns for mount
- feat(daemon): add glob() pattern matching to Mount exo
- feat(daemon): add grep() content search to Mount exo
- feat(daemon): add stat() to Mount exo, simplify VFS adapter
- feat(daemon): add readJson/writeJson to Mount exo

🤖 Generated with [Claude Code](https://claude.com/claude-code)