### PR TITLE
feat(daemon,cli): formula-type introspection — listWithTypes, inspect, workers tenants

### DIFF
--- a/packages/cli/src/commands/inspect.js
+++ b/packages/cli/src/commands/inspect.js
@@ -1,0 +1,45 @@
+/* global process */
+import os from 'os';
+
+import { E } from '@endo/far';
+
+import { withEndoHost } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
+
+/**
+ * Inspect the formula for a pet-named value.
+ *
+ * @param {object} options
+ * @param {string} options.name - Pet name to inspect.
+ * @param {boolean} [options.json] - Output as JSON.
+ */
+export const inspect = async ({ name, json }) =>
+  withEndoHost({ os, process }, async ({ host }) => {
+    const namePath = parsePetNamePath(name);
+    const result = await E(host).inspect(namePath);
+    if (result === undefined) {
+      console.error(`No formula found for "${name}"`);
+      process.exitCode = 1;
+      return;
+    }
+    const { id, formula } = result;
+    if (json) {
+      console.log(JSON.stringify({ id, formula }, null, 2));
+    } else {
+      console.log(`ID: ${id}`);
+      console.log(`Type: ${formula.type}`);
+      const entries = Object.entries(formula).filter(
+        ([key]) => key !== 'type',
+      );
+      if (entries.length > 0) {
+        console.log('Fields:');
+        for (const [key, value] of entries) {
+          const display =
+            typeof value === 'string'
+              ? value
+              : JSON.stringify(value);
+          console.log(`  ${key}: ${display}`);
+        }
+      }
+    }
+  });

--- a/packages/cli/src/commands/inspect.js
+++ b/packages/cli/src/commands/inspect.js
@@ -28,16 +28,12 @@ export const inspect = async ({ name, json }) =>
     } else {
       console.log(`ID: ${id}`);
       console.log(`Type: ${formula.type}`);
-      const entries = Object.entries(formula).filter(
-        ([key]) => key !== 'type',
-      );
+      const entries = Object.entries(formula).filter(([key]) => key !== 'type');
       if (entries.length > 0) {
         console.log('Fields:');
         for (const [key, value] of entries) {
           const display =
-            typeof value === 'string'
-              ? value
-              : JSON.stringify(value);
+            typeof value === 'string' ? value : JSON.stringify(value);
           console.log(`  ${key}: ${display}`);
         }
       }

--- a/packages/cli/src/commands/list.js
+++ b/packages/cli/src/commands/list.js
@@ -34,7 +34,7 @@ const pad = (fieldVal, width, minPad = 2) => {
   return ' '.repeat(spaces);
 };
 
-export const list = async ({ directory, follow, json, verbose }) =>
+export const list = async ({ directory, follow, json, verbose, types }) =>
   withEndoHost({ os, process }, async ({ host: agent }) => {
     await null;
     if (directory !== undefined) {
@@ -54,6 +54,29 @@ export const list = async ({ directory, follow, json, verbose }) =>
             console.log(`+${change.add}`);
           } else if (change.remove !== undefined) {
             console.log(`-${change.remove}`);
+          }
+        }
+      }
+    } else if (types) {
+      const entries = await E(agent).listWithTypes();
+      if (json) {
+        console.log(JSON.stringify(entries));
+      } else {
+        // Group by type.
+        /** @type {Map<string, string[]>} */
+        const groups = new Map();
+        for (const { name, type } of entries) {
+          let group = groups.get(type);
+          if (!group) {
+            group = [];
+            groups.set(type, group);
+          }
+          group.push(name);
+        }
+        for (const [type, names] of [...groups.entries()].sort()) {
+          console.log(`[${type}]`);
+          for (const name of names.sort()) {
+            console.log(`  ${name}`);
           }
         }
       }

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -389,6 +389,16 @@ export const main = async rawArgs => {
     });
 
   program
+    .command('inspect <name>')
+    .description('inspect the formula for a pet-named value')
+    .option('-j,--json', 'JSON format output')
+    .action(async (name, cmd) => {
+      const { json } = cmd.opts();
+      const { inspect: inspectCmd } = await import('./commands/inspect.js');
+      return inspectCmd({ name, json });
+    });
+
+  program
     .command('remove [names...]')
     .alias('rm')
     .description('forget a named value')

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -381,10 +381,11 @@ export const main = async rawArgs => {
     .option('-f,--follow', 'Follow updates')
     .option('-j,--json', 'JSON format output')
     .option('-v,--verbose', 'Provide more detailed output')
+    .option('-t,--types', 'Show formula types for each entry')
     .action(async (directory, cmd) => {
-      const { follow, json, verbose } = cmd.opts();
+      const { follow, json, verbose, types } = cmd.opts();
       const { list } = await import('./commands/list.js');
-      return list({ directory, follow, json, verbose });
+      return list({ directory, follow, json, verbose, types });
     });
 
   program

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -1124,6 +1124,43 @@ export const makeHostMaker = ({
     };
 
     /**
+     * Return the formula type for the value stored under a pet name.
+     *
+     * @param {NameOrPath} petNameOrPath
+     * @returns {Promise<string | undefined>}
+     */
+    const identifyType = async petNameOrPath => {
+      const namePath = namePathFrom(petNameOrPath);
+      const id = await E(directory).identify(...namePath);
+      if (id === undefined) {
+        return undefined;
+      }
+      return getTypeForId(/** @type {FormulaIdentifier} */ (id));
+    };
+
+    /**
+     * Return a list of pet names with their formula types.
+     *
+     * @returns {Promise<Array<{ name: string, type: string }>>}
+     */
+    const listWithTypes = async () => {
+      const names = await list();
+      const entries = await Promise.all(
+        names.map(async name => {
+          const id = await identify(name);
+          if (id === undefined) {
+            return harden({ name, type: 'unknown' });
+          }
+          const type = await getTypeForId(
+            /** @type {FormulaIdentifier} */ (id),
+          );
+          return harden({ name, type: type || 'unknown' });
+        }),
+      );
+      return harden(entries);
+    };
+
+    /**
      * Returns a snapshot of the formula dependency graph for all formulas
      * reachable from this agent's pet store entries.
      */
@@ -1213,6 +1250,9 @@ export const makeHostMaker = ({
       endow,
       submit,
       sendValue,
+      // Type introspection
+      identifyType,
+      listWithTypes,
       // Graph
       getFormulaGraph,
     };

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -1182,11 +1182,7 @@ export const makeHostMaker = ({
           if (id === undefined) return;
           const formulaId = /** @type {FormulaIdentifier} */ (id);
           const formula = await getFormulaForId(formulaId);
-          if (
-            formula &&
-            'worker' in formula &&
-            formula.worker === workerId
-          ) {
+          if (formula && 'worker' in formula && formula.worker === workerId) {
             const type = formula.type || 'unknown';
             tenants.push(harden({ name, type }));
           }

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -1181,6 +1181,24 @@ export const makeHostMaker = ({
       return getFormulaGraphSnapshot(seedIds);
     };
 
+    /**
+     * Inspect the formula for a pet-named value.
+     * Returns the formula type and all formula fields.
+     *
+     * @param {NameOrPath} petNameOrPath
+     * @returns {Promise<{ id: string, formula: object } | undefined>}
+     */
+    const inspect = async petNameOrPath => {
+      const namePath = namePathFrom(petNameOrPath);
+      const id = await E(directory).identify(...namePath);
+      if (id === undefined) {
+        return undefined;
+      }
+      const formulaId = /** @type {FormulaIdentifier} */ (id);
+      const formula = await getFormulaForId(formulaId);
+      return harden({ id: formulaId, formula });
+    };
+
     /** @type {EndoHost} */
     const host = {
       // Directory
@@ -1253,6 +1271,7 @@ export const makeHostMaker = ({
       // Type introspection
       identifyType,
       listWithTypes,
+      inspect,
       // Graph
       getFormulaGraph,
     };

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -1161,6 +1161,41 @@ export const makeHostMaker = ({
     };
 
     /**
+     * List capabilities whose formulas reference a given worker.
+     *
+     * @param {NameOrPath} workerPetNameOrPath
+     * @returns {Promise<Array<{ name: string, type: string }>>}
+     */
+    const listWorkerTenants = async workerPetNameOrPath => {
+      const workerNamePath = namePathFrom(workerPetNameOrPath);
+      const workerId = await E(directory).identify(...workerNamePath);
+      if (workerId === undefined) {
+        return harden([]);
+      }
+
+      const names = await list();
+      /** @type {Array<{ name: string, type: string }>} */
+      const tenants = [];
+      await Promise.all(
+        names.map(async name => {
+          const id = await identify(name);
+          if (id === undefined) return;
+          const formulaId = /** @type {FormulaIdentifier} */ (id);
+          const formula = await getFormulaForId(formulaId);
+          if (
+            formula &&
+            'worker' in formula &&
+            formula.worker === workerId
+          ) {
+            const type = formula.type || 'unknown';
+            tenants.push(harden({ name, type }));
+          }
+        }),
+      );
+      return harden(tenants);
+    };
+
+    /**
      * Returns a snapshot of the formula dependency graph for all formulas
      * reachable from this agent's pet store entries.
      */
@@ -1272,6 +1307,8 @@ export const makeHostMaker = ({
       identifyType,
       listWithTypes,
       inspect,
+      // Worker observability
+      listWorkerTenants,
       // Graph
       getFormulaGraph,
     };

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -399,6 +399,8 @@ export const HostInterface = M.interface('EndoHost', {
   // Type introspection
   identifyType: M.call(NameOrPathShape).returns(M.promise()),
   listWithTypes: M.call().returns(M.promise()),
+  // Formula inspection
+  inspect: M.call(NameOrPathShape).returns(M.promise()),
   // Get formula dependency graph snapshot for this agent's pet store
   getFormulaGraph: M.call().returns(M.promise()),
 });

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -401,6 +401,8 @@ export const HostInterface = M.interface('EndoHost', {
   listWithTypes: M.call().returns(M.promise()),
   // Formula inspection
   inspect: M.call(NameOrPathShape).returns(M.promise()),
+  // Worker observability
+  listWorkerTenants: M.call(NameOrPathShape).returns(M.promise()),
   // Get formula dependency graph snapshot for this agent's pet store
   getFormulaGraph: M.call().returns(M.promise()),
 });

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -396,6 +396,9 @@ export const HostInterface = M.interface('EndoHost', {
     MessageNumberShape, // messageNumber
     NameOrPathShape, // petNameOrPath
   ).returns(M.promise()),
+  // Type introspection
+  identifyType: M.call(NameOrPathShape).returns(M.promise()),
+  listWithTypes: M.call().returns(M.promise()),
   // Get formula dependency graph snapshot for this agent's pet store
   getFormulaGraph: M.call().returns(M.promise()),
 });

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1008,6 +1008,18 @@ export interface EndoHost extends EndoAgent {
   ): Promise<void>;
   submit(messageNumber: bigint, values: Record<string, unknown>): Promise<void>;
   sendValue: Mail['sendValue'];
+  /** Resolve a pet name to a formula type string. */
+  identifyType(petNameOrPath: string | string[]): Promise<string | undefined>;
+  /** List pet names alongside their formula types. */
+  listWithTypes(): Promise<Array<{ name: string; type: string }>>;
+  /** List capabilities whose formulas reference a given worker. */
+  listWorkerTenants(
+    workerPetNameOrPath: string | string[],
+  ): Promise<Array<{ name: string; type: string }>>;
+  /** Inspect the formula for a pet-named value. */
+  inspect(
+    petNameOrPath: string | string[],
+  ): Promise<{ id: string; formula: object } | undefined>;
   /** Returns a snapshot of the formula dependency graph reachable from this agent's pet store. */
   getFormulaGraph(): Promise<{
     nodes: Array<{ id: FormulaIdentifier; type: string }>;


### PR DESCRIPTION
## Summary
- Adds `identifyType(petName)` and `listWithTypes()` host APIs so callers can see the formula type for a pet-store entry.
- Adds `endo list --types` to group pet-store inventory by formula type (plus `--json` output), enabling the grouped inventory view in Chat UI and CLI.
- Adds `host.inspect(petName)` and `endo inspect <name>` to print a formula's type and fields in human-readable form (with `--json`) for debugging.
- Adds `listWorkerTenants` host API: reverse-lookup on the formula graph returning `[{name, type}]` for all formulas referencing a given worker, so the workers panel can show which capabilities are tenanted in each worker.

## Commits
- feat(daemon): add identifyType and listWithTypes to host API
- feat(cli): add endo list --types for grouped inventory
- feat(daemon,cli): add formula inspector API and endo inspect command
- feat(daemon): add listWorkerTenants host API for worker observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)