### PR TITLE
feat(chat): inventory drag-and-drop, cancel, type badges

### DIFF
--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3751,6 +3751,19 @@ button.btn-spinner::after {
   display: block;
 }
 
+/* Type badge on inventory items */
+.pet-type-badge {
+  font-size: 0.65em;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: rgba(128, 128, 128, 0.15);
+  color: var(--text-muted, #888);
+  margin-left: 6px;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+
 /* Cancel button */
 .cancel-button {
   background: none;

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3763,7 +3763,6 @@ button.btn-spinner::after {
   white-space: nowrap;
 }
 
-
 /* Cancel button */
 .cancel-button {
   background: none;
@@ -3800,7 +3799,6 @@ button.btn-spinner::after {
   opacity: 0.2;
 }
 
-
 /* Inventory drag and drop */
 .pet-item-row.dragging {
   opacity: 0.4;
@@ -3814,7 +3812,6 @@ button.btn-spinner::after {
   outline-color: var(--warning-color, #e67e22);
   background: rgba(230, 126, 34, 0.1);
 }
-
 
 #chat-bar.has-content #chat-menu-button,
 #chat-bar.command-mode #chat-menu-button {

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3751,6 +3751,43 @@ button.btn-spinner::after {
   display: block;
 }
 
+/* Cancel button */
+.cancel-button {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  font-size: 12px;
+  line-height: 16px;
+  text-align: center;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: all 0.2s;
+  color: inherit;
+}
+.cancel-button:hover:not(:disabled) {
+  opacity: 1;
+  border-color: currentColor;
+}
+.cancel-button.confirming {
+  opacity: 1;
+  color: var(--error-color, #e74c3c);
+  border-color: var(--error-color, #e74c3c);
+  transform: scale(1.2);
+}
+.cancel-button.cancelled {
+  opacity: 0.4;
+  border-color: currentColor;
+  border-style: dashed;
+}
+.cancel-button:disabled {
+  cursor: default;
+  opacity: 0.2;
+}
+
+
 /* Inventory drag and drop */
 .pet-item-row.dragging {
   opacity: 0.4;

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3751,6 +3751,17 @@ button.btn-spinner::after {
   display: block;
 }
 
+/* Inventory drag and drop */
+.pet-item-row.dragging {
+  opacity: 0.4;
+}
+.pet-item-row.drop-target {
+  outline: 2px solid var(--accent-color, #3498db);
+  outline-offset: -2px;
+  background: rgba(52, 152, 219, 0.1);
+}
+
+
 #chat-bar.has-content #chat-menu-button,
 #chat-bar.command-mode #chat-menu-button {
   display: none;

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3797,6 +3797,10 @@ button.btn-spinner::after {
   outline-offset: -2px;
   background: rgba(52, 152, 219, 0.1);
 }
+.pet-item-row.drop-move {
+  outline-color: var(--warning-color, #e67e22);
+  background: rgba(230, 126, 34, 0.1);
+}
 
 
 #chat-bar.has-content #chat-menu-button,

--- a/packages/chat/inventory-component.js
+++ b/packages/chat/inventory-component.js
@@ -607,6 +607,15 @@ export const inventoryComponent = async (
         const url = new URL(/** @type {string} */ (locator));
         const type = url.searchParams.get('type');
 
+        // Show type badge on the item row.
+        if (type) {
+          const $typeBadge = document.createElement('span');
+          $typeBadge.className = 'pet-type-badge';
+          $typeBadge.textContent = type;
+          $typeBadge.title = `Formula type: ${type}`;
+          $name.after($typeBadge);
+        }
+
         // Hide disclosure triangle for known non-expandable types
         if (type && NON_EXPANDABLE_TYPES.includes(type)) {
           $disclosure.classList.add('hidden');

--- a/packages/chat/inventory-component.js
+++ b/packages/chat/inventory-component.js
@@ -466,9 +466,7 @@ export const inventoryComponent = async (
           $cancel.title = 'Cancelling...';
           $cancel.disabled = true;
           E(powers)
-            .cancel(
-              .../** @type {[string, ...string[]]} */ (itemPath),
-            )
+            .cancel(.../** @type {[string, ...string[]]} */ (itemPath))
             .then(() => {
               $cancel.classList.add('cancelled');
               $cancel.title = 'Cancelled';

--- a/packages/chat/inventory-component.js
+++ b/packages/chat/inventory-component.js
@@ -400,6 +400,26 @@ export const inventoryComponent = async (
     const $row = document.createElement('div');
     $row.className = 'pet-item-row';
 
+    // Make non-special items draggable.
+    if (!isSpecialName(name)) {
+      $row.draggable = true;
+      $row.addEventListener('dragstart', e => {
+        const petNamePath = itemPath.join('/');
+        if (e.dataTransfer) {
+          e.dataTransfer.setData('text/plain', petNamePath);
+          e.dataTransfer.setData(
+            'application/x-endo-petname',
+            JSON.stringify(itemPath),
+          );
+          e.dataTransfer.effectAllowed = 'copyMove';
+        }
+        $row.classList.add('dragging');
+      });
+      $row.addEventListener('dragend', () => {
+        $row.classList.remove('dragging');
+      });
+    }
+
     // Disclosure triangle
     const $disclosure = document.createElement('button');
     $disclosure.className = 'pet-disclosure';
@@ -441,6 +461,41 @@ export const inventoryComponent = async (
     const $children = document.createElement('div');
     $children.className = 'pet-children';
     $wrapper.appendChild($children);
+
+    // Drop target for directories: accept drops to copy capabilities.
+    $row.addEventListener('dragover', e => {
+      if (!e.dataTransfer) return;
+      const hasEndoPetName = e.dataTransfer.types.includes(
+        'application/x-endo-petname',
+      );
+      if (!hasEndoPetName) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      $row.classList.add('drop-target');
+    });
+    $row.addEventListener('dragleave', () => {
+      $row.classList.remove('drop-target');
+    });
+    $row.addEventListener('drop', e => {
+      $row.classList.remove('drop-target');
+      if (!e.dataTransfer) return;
+      const raw = e.dataTransfer.getData('application/x-endo-petname');
+      if (!raw) return;
+      e.preventDefault();
+      try {
+        const sourcePath = JSON.parse(raw);
+        const sourceName = sourcePath[sourcePath.length - 1];
+        const targetPath = [...itemPath, sourceName];
+        // Copy the capability into this directory.
+        E(powers)
+          .copy(sourcePath, targetPath)
+          .catch(err => {
+            console.error('[inventory] Drop copy failed:', err);
+          });
+      } catch {
+        // Ignore malformed data.
+      }
+    });
 
     if (channelMode) {
       // Newest channels at top (reordered after type detection)

--- a/packages/chat/inventory-component.js
+++ b/packages/chat/inventory-component.js
@@ -442,6 +442,56 @@ export const inventoryComponent = async (
     $info.title = 'Inspect';
     $buttons.appendChild($info);
 
+    // Cancel button (disabled for special names)
+    const $cancel = document.createElement('button');
+    $cancel.className = 'cancel-button';
+    $cancel.textContent = '⊘';
+    if (isSpecialName(name)) {
+      $cancel.disabled = true;
+      $cancel.title = 'Cannot cancel system name';
+    } else {
+      $cancel.title = 'Cancel incarnation';
+    }
+    $buttons.appendChild($cancel);
+
+    // Cancel confirmation state
+    let cancelConfirmTimer = 0;
+    if (!isSpecialName(name)) {
+      $cancel.addEventListener('click', e => {
+        e.stopPropagation();
+        if ($cancel.classList.contains('confirming')) {
+          // Second click — execute cancel.
+          clearTimeout(cancelConfirmTimer);
+          $cancel.classList.remove('confirming');
+          $cancel.title = 'Cancelling...';
+          $cancel.disabled = true;
+          E(powers)
+            .cancel(
+              .../** @type {[string, ...string[]]} */ (itemPath),
+            )
+            .then(() => {
+              $cancel.classList.add('cancelled');
+              $cancel.title = 'Cancelled';
+            })
+            .catch(err => {
+              console.error('[inventory] Cancel failed:', err);
+              $cancel.disabled = false;
+              $cancel.title = 'Cancel incarnation';
+            });
+        } else {
+          // First click — enter confirm state.
+          $cancel.classList.add('confirming');
+          $cancel.title = 'Click again to cancel';
+          cancelConfirmTimer = /** @type {any} */ (
+            setTimeout(() => {
+              $cancel.classList.remove('confirming');
+              $cancel.title = 'Cancel incarnation';
+            }, 3000)
+          );
+        }
+      });
+    }
+
     // Remove button (disabled for special names)
     const $remove = document.createElement('button');
     $remove.className = 'remove-button';

--- a/packages/chat/inventory-component.js
+++ b/packages/chat/inventory-component.js
@@ -512,7 +512,7 @@ export const inventoryComponent = async (
     $children.className = 'pet-children';
     $wrapper.appendChild($children);
 
-    // Drop target for directories: accept drops to copy capabilities.
+    // Drop target: accept drops to copy (or move with Alt) capabilities.
     $row.addEventListener('dragover', e => {
       if (!e.dataTransfer) return;
       const hasEndoPetName = e.dataTransfer.types.includes(
@@ -520,14 +520,20 @@ export const inventoryComponent = async (
       );
       if (!hasEndoPetName) return;
       e.preventDefault();
-      e.dataTransfer.dropEffect = 'copy';
+      // Alt/Option key = move, otherwise copy.
+      e.dataTransfer.dropEffect = e.altKey ? 'move' : 'copy';
       $row.classList.add('drop-target');
+      if (e.altKey) {
+        $row.classList.add('drop-move');
+      } else {
+        $row.classList.remove('drop-move');
+      }
     });
     $row.addEventListener('dragleave', () => {
-      $row.classList.remove('drop-target');
+      $row.classList.remove('drop-target', 'drop-move');
     });
     $row.addEventListener('drop', e => {
-      $row.classList.remove('drop-target');
+      $row.classList.remove('drop-target', 'drop-move');
       if (!e.dataTransfer) return;
       const raw = e.dataTransfer.getData('application/x-endo-petname');
       if (!raw) return;
@@ -536,12 +542,25 @@ export const inventoryComponent = async (
         const sourcePath = JSON.parse(raw);
         const sourceName = sourcePath[sourcePath.length - 1];
         const targetPath = [...itemPath, sourceName];
+        const isMove = e.altKey;
         // Copy the capability into this directory.
-        E(powers)
-          .copy(sourcePath, targetPath)
-          .catch(err => {
+        const copyPromise = E(powers).copy(sourcePath, targetPath);
+        if (isMove) {
+          // Move = copy then remove source.
+          copyPromise
+            .then(() =>
+              E(powers).remove(
+                .../** @type {[string, ...string[]]} */ (sourcePath),
+              ),
+            )
+            .catch(err => {
+              console.error('[inventory] Drop move failed:', err);
+            });
+        } else {
+          copyPromise.catch(err => {
             console.error('[inventory] Drop copy failed:', err);
           });
+        }
       } catch {
         // Ignore malformed data.
       }


### PR DESCRIPTION
## Summary
- Adds HTML5 drag-and-drop on pet-store inventory items — non-special items are draggable with structured `application/x-endo-petname` data; drop onto directories copies via `E(powers).copy()`.
- Alt/Option during drop switches to move mode (copy then remove source); orange outline vs. blue for copy and `dropEffect` changes accordingly.
- Adds two-click confirmation cancel on inventory items (first click: red border/scale; second within 3s: `E(powers).cancel()`; disabled for special names).
- Renders a small type badge next to each pet name, derived from the locator URL's `type` parameter.

## Commits
- feat(chat): add drag-and-drop to inventory items
- feat(chat): add cancel button to inventory items
- feat(chat): add Alt/Option move to inventory drag-and-drop
- feat(chat): add formula type badge to inventory items

🤖 Generated with [Claude Code](https://claude.com/claude-code)