### PR TITLE
feat(chat): pending commands region with unlocked command bar

### DIFF
--- a/packages/chat/chat-bar-component.js
+++ b/packages/chat/chat-bar-component.js
@@ -503,22 +503,10 @@ export const chatBarComponent = (
     }
   });
 
-  let commandSubmitting = false;
-
-  const setCommandSubmitting = (/** @type {boolean} */ value) => {
-    commandSubmitting = value;
-    if (value) {
-      $chatBar.classList.add('submitting');
-      $commandSubmitButton.classList.add('btn-spinner');
-      $commandSubmitButton.disabled = true;
-      inlineForm.setDisabled(true); // eslint-disable-line no-use-before-define
-    } else {
-      $chatBar.classList.remove('submitting');
-      $commandSubmitButton.classList.remove('btn-spinner');
-      inlineForm.setDisabled(false); // eslint-disable-line no-use-before-define
-      $commandSubmitButton.disabled = !inlineForm.isValid(); // eslint-disable-line no-use-before-define
-    }
-  };
+  // Pending commands no longer block the chat bar; `commandSubmitting`
+  // remains as a guard hook for any code path that might re-introduce a
+  // blocking state, but nothing flips it to true today.
+  const commandSubmitting = false;
 
   /**
    * Run a command with spinner/disabled state management.

--- a/packages/chat/chat-bar-component.js
+++ b/packages/chat/chat-bar-component.js
@@ -13,6 +13,7 @@ import { createFormBuilder } from './form-builder.js';
 import { createBlobViewer } from './blob-viewer.js';
 import { createEndowModal } from './endow-modal.js';
 import { createInlineCommandForm } from './inline-command-form.js';
+import { createPendingCommands } from './pending-commands.js';
 import { createCommandExecutor } from './command-executor.js';
 import {
   getCommand,
@@ -105,6 +106,9 @@ export const chatBarComponent = (
   );
   const $inlineFormContainer = /** @type {HTMLElement} */ (
     $parent.querySelector('#inline-form-container')
+  );
+  const $pendingRegion = /** @type {HTMLElement} */ (
+    $parent.querySelector('#pending-commands-region')
   );
   const $commandLabel = /** @type {HTMLElement} */ (
     $parent.querySelector('#command-label')
@@ -522,6 +526,8 @@ export const chatBarComponent = (
    * @param {string} commandName
    * @param {Record<string, unknown>} data
    */
+  const pendingCommands = createPendingCommands($pendingRegion);
+
   const executeWithSpinner = async (commandName, data) => {
     messagePicker.disable();
     $commandError.textContent = '';
@@ -555,18 +561,22 @@ export const chatBarComponent = (
       commandName === 'view' ||
       commandName === 'edit' ||
       commandName === 'cat';
+
+    // Unlock the command bar immediately. The pending commands region
+    // shows progress instead of blocking the input.
     if (opensModal) {
       exitCommandMode({ skipFocus: true }); // eslint-disable-line no-use-before-define
     } else {
-      setCommandSubmitting(true);
+      exitCommandMode(); // eslint-disable-line no-use-before-define
     }
 
+    // Track the execution as a pending command card.
+    const resultPromise = executor.execute(commandName, data);
+    pendingCommands.track(commandName, data, resultPromise);
+
     try {
-      const result = await executor.execute(commandName, data);
+      const result = await resultPromise;
       if (result.success) {
-        if (!opensModal) {
-          exitCommandMode(); // eslint-disable-line no-use-before-define
-        }
         const resultName =
           'resultName' in data && data.resultName
             ? String(data.resultName)
@@ -582,10 +592,8 @@ export const chatBarComponent = (
           showValue(result.value, undefined, resultPath, undefined);
         }
       }
-    } finally {
-      if (!opensModal) {
-        setCommandSubmitting(false);
-      }
+    } catch {
+      // Error is handled by the pending command card.
     }
   };
 

--- a/packages/chat/chat.js
+++ b/packages/chat/chat.js
@@ -73,6 +73,7 @@ const template = `
     </div>
   </div>
   <div id="chat-modeline"></div>
+  <div id="pending-commands-region" class="pending-commands-region"></div>
 </div>
 
 <div id="eval-form-backdrop"></div>

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -2608,7 +2608,9 @@ body.resizing * {
   padding: 4px 8px;
   border-radius: var(--radius-sm);
   font-size: 12px;
-  transition: opacity 0.3s, background 0.2s;
+  transition:
+    opacity 0.3s,
+    background 0.2s;
 }
 
 .pending-command-card.pending {
@@ -2654,7 +2656,9 @@ body.resizing * {
 }
 
 @keyframes pending-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .pending-command-status {
@@ -2664,7 +2668,6 @@ body.resizing * {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
 
 .dismiss-button {
   padding: 4px 8px;

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -2589,6 +2589,83 @@ body.resizing * {
   opacity: 1;
 }
 
+/* Pending commands region */
+.pending-commands-region {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 12px;
+}
+
+.pending-commands-region.has-pending {
+  display: flex;
+}
+
+.pending-command-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  transition: opacity 0.3s, background 0.2s;
+}
+
+.pending-command-card.pending {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-muted);
+}
+
+.pending-command-card.success {
+  background: rgba(0, 200, 100, 0.1);
+  color: var(--success, #4caf50);
+}
+
+.pending-command-card.error {
+  background: rgba(255, 60, 60, 0.1);
+  color: var(--danger);
+  cursor: pointer;
+}
+
+.pending-command-card.fade-out {
+  opacity: 0;
+}
+
+.pending-command-label {
+  font-family: var(--font-mono);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pending-command-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid transparent;
+  border-top-color: var(--text-muted);
+  border-radius: 50%;
+  animation: pending-spin 0.8s linear infinite;
+}
+
+.pending-command-card.success .pending-command-spinner,
+.pending-command-card.error .pending-command-spinner {
+  display: none;
+}
+
+@keyframes pending-spin {
+  to { transform: rotate(360deg); }
+}
+
+.pending-command-status {
+  font-size: 11px;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+
 .dismiss-button {
   padding: 4px 8px;
   font-size: 14px;

--- a/packages/chat/pending-commands.js
+++ b/packages/chat/pending-commands.js
@@ -1,0 +1,156 @@
+// @ts-check
+
+/**
+ * @typedef {object} PendingCommandEntry
+ * @property {string} id
+ * @property {string} commandName
+ * @property {Record<string, unknown>} params
+ * @property {number} startTime
+ * @property {'pending' | 'success' | 'error'} status
+ * @property {string} [errorMessage]
+ * @property {HTMLElement} $card
+ */
+
+/**
+ * @typedef {object} PendingCommandsAPI
+ * @property {(commandName: string, params: Record<string, unknown>, promise: Promise<unknown>) => void} track
+ * @property {() => number} count
+ */
+
+let nextId = 0;
+
+/**
+ * Create the pending commands region.
+ *
+ * @param {HTMLElement} $container - Element to append pending cards to.
+ * @returns {PendingCommandsAPI}
+ */
+export const createPendingCommands = $container => {
+  /** @type {Map<string, PendingCommandEntry>} */
+  const entries = new Map();
+
+  /**
+   * Format command params for display.
+   * @param {string} commandName
+   * @param {Record<string, unknown>} params
+   * @returns {string}
+   */
+  const formatCommand = (commandName, params) => {
+    const parts = [`/${commandName}`];
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '' && key !== 'messageNumber') {
+        parts.push(String(value));
+      }
+    }
+    if (params.messageNumber !== undefined) {
+      parts.unshift(`#${params.messageNumber}`);
+    }
+    return parts.join(' ');
+  };
+
+  /**
+   * Create a card element for a pending command.
+   * @param {string} id
+   * @param {string} commandName
+   * @param {Record<string, unknown>} params
+   * @returns {HTMLElement}
+   */
+  const createCard = (id, commandName, params) => {
+    const $card = document.createElement('div');
+    $card.className = 'pending-command-card pending';
+    $card.dataset.pendingId = id;
+
+    const $label = document.createElement('span');
+    $label.className = 'pending-command-label';
+    $label.textContent = formatCommand(commandName, params);
+    $card.appendChild($label);
+
+    const $spinner = document.createElement('span');
+    $spinner.className = 'pending-command-spinner';
+    $card.appendChild($spinner);
+
+    const $status = document.createElement('span');
+    $status.className = 'pending-command-status';
+    $card.appendChild($status);
+
+    return $card;
+  };
+
+  /**
+   * Track a command execution. Shows a pending card immediately and
+   * transitions it on resolution/rejection.
+   *
+   * @param {string} commandName
+   * @param {Record<string, unknown>} params
+   * @param {Promise<unknown>} promise
+   */
+  const track = (commandName, params, promise) => {
+    nextId += 1;
+    const id = `pending-${nextId}`;
+    const $card = createCard(id, commandName, params);
+
+    /** @type {PendingCommandEntry} */
+    const entry = {
+      id,
+      commandName,
+      params,
+      startTime: Date.now(),
+      status: 'pending',
+      $card,
+    };
+    entries.set(id, entry);
+    $container.appendChild($card);
+    $container.classList.add('has-pending');
+
+    promise.then(
+      () => {
+        entry.status = 'success';
+        $card.classList.remove('pending');
+        $card.classList.add('success');
+        const $status = $card.querySelector('.pending-command-status');
+        if ($status) $status.textContent = '✓';
+        // Fade out after a brief display.
+        setTimeout(() => {
+          $card.classList.add('fade-out');
+          setTimeout(() => {
+            $card.remove();
+            entries.delete(id);
+            if (entries.size === 0) {
+              $container.classList.remove('has-pending');
+            }
+          }, 300);
+        }, 1500);
+      },
+      error => {
+        entry.status = 'error';
+        entry.errorMessage = /** @type {Error} */ (error).message;
+        $card.classList.remove('pending');
+        $card.classList.add('error');
+        const $status = $card.querySelector('.pending-command-status');
+        if ($status) {
+          $status.textContent = /** @type {Error} */ (error).message;
+        }
+        // Error cards stay until clicked.
+        $card.addEventListener(
+          'click',
+          () => {
+            $card.classList.add('fade-out');
+            setTimeout(() => {
+              $card.remove();
+              entries.delete(id);
+              if (entries.size === 0) {
+                $container.classList.remove('has-pending');
+              }
+            }, 300);
+          },
+          { once: true },
+        );
+      },
+    );
+  };
+
+  return harden({
+    track,
+    count: () => entries.size,
+  });
+};


### PR DESCRIPTION
## Summary
- Adds a `createPendingCommands()` component that tracks command executions as visual cards below the modeline: spinner while pending, checkmark on success (auto-fade after 1.5s), error message on failure (click to dismiss). Includes CSS for the region and card states.
- Wires the command bar to unlock immediately after dispatching a non-modal command (instead of blocking until the promise settles) by calling `exitCommandMode` plus `pendingCommands.track`.
- Implements the chat-pending-commands design Phase 1 (pending region + unlocked command bar).

## Commits
- feat(chat): add pending commands component and CSS
- feat(chat): wire pending commands into chat bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)