### PR TITLE
feat(chat): voice input via Web Speech API

### DIFF
--- a/packages/chat/chat-bar-component.js
+++ b/packages/chat/chat-bar-component.js
@@ -139,11 +139,13 @@ export const chatBarComponent = (
   const $buttonWrapper = /** @type {HTMLElement} */ (
     $parent.querySelector('#chat-button-wrapper')
   );
+  // voiceInput returns null if SpeechRecognition is not supported; we
+  // attach handlers via side effect so the return value is not consumed.
+  // eslint-disable-next-line no-unused-vars
   const voiceInput = makeVoiceInput({
     $container: $buttonWrapper,
     $input,
   });
-  // voiceInput is null if SpeechRecognition is not supported.
 
   /**
    * Update the modeline content based on the current mode.

--- a/packages/chat/chat-bar-component.js
+++ b/packages/chat/chat-bar-component.js
@@ -13,6 +13,7 @@ import { createFormBuilder } from './form-builder.js';
 import { createBlobViewer } from './blob-viewer.js';
 import { createEndowModal } from './endow-modal.js';
 import { createInlineCommandForm } from './inline-command-form.js';
+import { makeVoiceInput } from './voice-input.js';
 import { createCommandExecutor } from './command-executor.js';
 import {
   getCommand,
@@ -133,6 +134,16 @@ export const chatBarComponent = (
   const $modeline = /** @type {HTMLElement} */ (
     $parent.querySelector('#chat-modeline')
   );
+
+  // Initialize voice input (Web Speech API).
+  const $buttonWrapper = /** @type {HTMLElement} */ (
+    $parent.querySelector('#chat-button-wrapper')
+  );
+  const voiceInput = makeVoiceInput({
+    $container: $buttonWrapper,
+    $input,
+  });
+  // voiceInput is null if SpeechRecognition is not supported.
 
   /**
    * Update the modeline content based on the current mode.

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3751,6 +3751,34 @@ button.btn-spinner::after {
   display: block;
 }
 
+/* Voice input button */
+#voice-input-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
+  padding: 4px 6px;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+}
+#voice-input-button:hover {
+  opacity: 1;
+}
+#voice-input-button.listening {
+  opacity: 1;
+  color: var(--accent-color, #e74c3c);
+  animation: pulse-mic 1s ease-in-out infinite;
+}
+@keyframes pulse-mic {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+/* Hide mic when typing or in command mode */
+#chat-bar.has-content #voice-input-button,
+#chat-bar.command-mode #voice-input-button {
+  display: none;
+}
+
 #chat-bar.has-content #chat-menu-button,
 #chat-bar.command-mode #chat-menu-button {
   display: none;

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3770,8 +3770,13 @@ button.btn-spinner::after {
   animation: pulse-mic 1s ease-in-out infinite;
 }
 @keyframes pulse-mic {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 /* Hide mic when typing or in command mode */
 #chat-bar.has-content #voice-input-button,

--- a/packages/chat/voice-input.js
+++ b/packages/chat/voice-input.js
@@ -1,0 +1,134 @@
+// @ts-check
+
+/**
+ * Voice Input Module
+ *
+ * Adds a microphone button to the chat bar that uses the Web Speech
+ * API (SpeechRecognition) for voice-to-text transcription.  The
+ * transcribed text is inserted into the message input field.
+ *
+ * Falls back gracefully: if SpeechRecognition is not available
+ * (Firefox, non-browser), the button is hidden.
+ *
+ * @module
+ */
+
+/**
+ * @typedef {object} VoiceInputAPI
+ * @property {() => void} destroy - Remove event listeners and DOM.
+ */
+
+/**
+ * Initialize voice input for the chat bar.
+ *
+ * @param {object} options
+ * @param {HTMLElement} options.$container - Element to append the mic button to.
+ * @param {HTMLElement} options.$input - The contenteditable message input.
+ * @param {string} [options.lang] - BCP-47 language code (default: 'en-US').
+ * @returns {VoiceInputAPI | null} API for cleanup, or null if not supported.
+ */
+export const makeVoiceInput = ({ $container, $input, lang = 'en-US' }) => {
+  // Feature detection for Web Speech API.
+  const SpeechRecognition =
+    /** @type {any} */ (globalThis).SpeechRecognition ||
+    /** @type {any} */ (globalThis).webkitSpeechRecognition;
+
+  if (!SpeechRecognition) {
+    // Browser doesn't support speech recognition.
+    return null;
+  }
+
+  const $micButton = document.createElement('button');
+  $micButton.id = 'voice-input-button';
+  $micButton.type = 'button';
+  $micButton.title = 'Voice input (click to speak)';
+  $micButton.textContent = '\u{1F399}'; // studio microphone emoji
+  $micButton.setAttribute('aria-label', 'Voice input');
+  $container.appendChild($micButton);
+
+  const recognition = new SpeechRecognition();
+  recognition.continuous = false;
+  recognition.interimResults = true;
+  recognition.lang = lang;
+
+  let isListening = false;
+
+  /** @type {string} */
+  let savedContent = '';
+
+  const startListening = () => {
+    if (isListening) return;
+    isListening = true;
+    savedContent = $input.textContent || '';
+    $micButton.classList.add('listening');
+    $micButton.title = 'Listening... (click to stop)';
+    try {
+      recognition.start();
+    } catch {
+      // Already started — ignore.
+    }
+  };
+
+  const stopListening = () => {
+    if (!isListening) return;
+    isListening = false;
+    $micButton.classList.remove('listening');
+    $micButton.title = 'Voice input (click to speak)';
+    try {
+      recognition.stop();
+    } catch {
+      // Already stopped — ignore.
+    }
+  };
+
+  const handleClick = () => {
+    if (isListening) {
+      stopListening();
+    } else {
+      startListening();
+    }
+  };
+
+  $micButton.addEventListener('click', handleClick);
+
+  recognition.addEventListener('result', (/** @type {any} */ event) => {
+    const results = event.results;
+    if (!results || results.length === 0) return;
+
+    // Collect all results into a single transcript.
+    let transcript = '';
+    for (let i = 0; i < results.length; i += 1) {
+      transcript += results[i][0].transcript;
+    }
+
+    // Show interim results in the input.
+    $input.textContent = savedContent + transcript;
+
+    // Place cursor at end.
+    const range = document.createRange();
+    const sel = /** @type {Selection} */ (window.getSelection());
+    range.selectNodeContents($input);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+
+  recognition.addEventListener('end', () => {
+    stopListening();
+    // Trigger input event so the chat bar detects content.
+    $input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+
+  recognition.addEventListener('error', (/** @type {any} */ event) => {
+    console.warn('[voice-input] Speech recognition error:', event.error);
+    stopListening();
+  });
+
+  const destroy = () => {
+    stopListening();
+    $micButton.removeEventListener('click', handleClick);
+    $micButton.remove();
+  };
+
+  return { destroy };
+};

--- a/packages/chat/voice-input.js
+++ b/packages/chat/voice-input.js
@@ -30,8 +30,10 @@
 export const makeVoiceInput = ({ $container, $input, lang = 'en-US' }) => {
   // Feature detection for Web Speech API.
   const SpeechRecognition =
-    /** @type {any} */ (globalThis).SpeechRecognition ||
-    /** @type {any} */ (globalThis).webkitSpeechRecognition;
+    // eslint-disable-next-line no-undef
+    /** @type {any} */ (window).SpeechRecognition ||
+    // eslint-disable-next-line no-undef
+    /** @type {any} */ (window).webkitSpeechRecognition;
 
   if (!SpeechRecognition) {
     // Browser doesn't support speech recognition.
@@ -92,12 +94,13 @@ export const makeVoiceInput = ({ $container, $input, lang = 'en-US' }) => {
   $micButton.addEventListener('click', handleClick);
 
   recognition.addEventListener('result', (/** @type {any} */ event) => {
+    /** @type {any} */
     const results = event.results;
     if (!results || results.length === 0) return;
 
     // Collect all results into a single transcript.
     let transcript = '';
-    for (let i = 0; i < results.length; i += 1) {
+    for (let i = 0; i < /** @type {number} */ (results.length); i += 1) {
       transcript += results[i][0].transcript;
     }
 


### PR DESCRIPTION
## Summary
- Adds a microphone button to the chat bar that transcribes speech to text using the browser's `SpeechRecognition` API.
- Feature-detected (hidden in unsupported browsers), streams interim results into the input field, pulses red while listening, auto-hides when typing or in command mode, and exposes a `destroy()` cleanup API.

## Commits
- feat(chat): add voice input via Web Speech API

🤖 Generated with [Claude Code](https://claude.com/claude-code)