### PR TITLE
feat(daemon,chat): commands-as-messages — record host commands in transcript

### DIFF
--- a/packages/chat/inbox-component.js
+++ b/packages/chat/inbox-component.js
@@ -803,6 +803,45 @@ export const inboxComponent = async (
       $valueMsg.appendChild($actions);
 
       $body.appendChild($valueMsg);
+    } else if (message.type === 'command') {
+      // Command message — compact card showing the operation.
+      const $cmdCard = document.createElement('div');
+      $cmdCard.className = 'command-message';
+
+      const $icon = document.createElement('span');
+      $icon.className = 'command-icon';
+      $icon.textContent = '\u25D0'; // ◐ pending
+      $cmdCard.appendChild($icon);
+
+      const $cmdText = document.createElement('span');
+      $cmdText.className = 'command-text';
+      const argsStr = message.args
+        ? Object.entries(message.args)
+            .map(([k, v]) => `${v}`)
+            .join(' ')
+        : '';
+      $cmdText.textContent = `${message.commandName} ${argsStr}`.trim();
+      $cmdCard.appendChild($cmdText);
+
+      $body.appendChild($cmdCard);
+      $envelope.classList.add('command-envelope');
+    } else if (message.type === 'command-result') {
+      // Command result — compact settled card.
+      const $resultCard = document.createElement('div');
+      $resultCard.className = `command-message ${message.success ? 'success' : 'error'}`;
+
+      const $icon = document.createElement('span');
+      $icon.className = 'command-icon';
+      $icon.textContent = message.success ? '\u2713' : '\u2717'; // ✓ or ✗
+      $resultCard.appendChild($icon);
+
+      const $resultText = document.createElement('span');
+      $resultText.className = 'command-text';
+      $resultText.textContent = message.summary || '';
+      $resultCard.appendChild($resultText);
+
+      $body.appendChild($resultCard);
+      $envelope.classList.add('command-envelope');
     }
 
     $envelope.appendChild($message);

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3751,6 +3751,31 @@ button.btn-spinner::after {
   display: block;
 }
 
+/* Command messages in transcript */
+.command-envelope {
+  opacity: 0.8;
+}
+.command-message {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: rgba(128, 128, 128, 0.1);
+  font-size: 0.85em;
+  font-family: monospace;
+}
+.command-message.success {
+  color: var(--success-color, #27ae60);
+}
+.command-message.error {
+  color: var(--error-color, #e74c3c);
+}
+.command-icon {
+  font-size: 1.1em;
+}
+
+
 #chat-bar.has-content #chat-menu-button,
 #chat-bar.command-mode #chat-menu-button {
   display: none;

--- a/packages/chat/index.css
+++ b/packages/chat/index.css
@@ -3775,7 +3775,6 @@ button.btn-spinner::after {
   font-size: 1.1em;
 }
 
-
 #chat-bar.has-content #chat-menu-button,
 #chat-bar.command-mode #chat-menu-button {
   display: none;

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -885,13 +885,18 @@ export const makeMailboxMaker = ({
         );
         await E(resolver).resolveWithId(externalizedId);
         if (cmdNumber !== undefined) {
-          await recordCommandResult(cmdNumber, true, 'resolved', `${cmdMsgId}-result`)
-            .catch(() => {});
+          await recordCommandResult(
+            cmdNumber,
+            true,
+            'resolved',
+            `${cmdMsgId}-result`,
+          ).catch(() => {});
         }
       } catch (error) {
         if (cmdNumber !== undefined) {
           await recordCommandResult(
-            cmdNumber, false,
+            cmdNumber,
+            false,
             /** @type {Error} */ (error).message,
             `${cmdMsgId}-result`,
           ).catch(() => {});
@@ -1099,8 +1104,12 @@ export const makeMailboxMaker = ({
         await E(dismisser).dismiss();
         if (cmdNumber !== undefined) {
           const resultId = `${cmdMsgId}-result`;
-          await recordCommandResult(cmdNumber, true, 'dismissed', resultId)
-            .catch(() => {});
+          await recordCommandResult(
+            cmdNumber,
+            true,
+            'dismissed',
+            resultId,
+          ).catch(() => {});
         }
       } catch (error) {
         if (cmdNumber !== undefined) {
@@ -1150,46 +1159,51 @@ export const makeMailboxMaker = ({
       ).catch(() => undefined);
 
       try {
-      if (message.type === 'value') {
-        if (edgeName !== 'value') {
+        if (message.type === 'value') {
+          if (edgeName !== 'value') {
+            throw new Error(
+              `Value messages only have a "value" edge, not ${q(edgeName)}`,
+            );
+          }
+          const id = /** @type {FormulaIdentifier} */ (message.valueId);
+          context.thisDiesIfThatDies(id);
+          await E(directory).storeIdentifier(petNamePath, id);
+          return;
+        }
+        if (message.type !== 'package') {
           throw new Error(
-            `Value messages only have a "value" edge, not ${q(edgeName)}`,
+            `Message must be a package or value ${q(messageNumber)}`,
           );
         }
-        const id = /** @type {FormulaIdentifier} */ (message.valueId);
+        const index = message.names.lastIndexOf(edgeName);
+        if (index === -1) {
+          throw new Error(
+            `No reference named ${q(edgeName)} in message ${q(messageNumber)}`,
+          );
+        }
+        const id = message.ids[index];
+        if (id === undefined) {
+          throw new Error(
+            `panic: message must contain a formula for every name, including the name ${q(
+              edgeName,
+            )} at ${q(index)}`,
+          );
+        }
         context.thisDiesIfThatDies(id);
         await E(directory).storeIdentifier(petNamePath, id);
-        return;
-      }
-      if (message.type !== 'package') {
-        throw new Error(
-          `Message must be a package or value ${q(messageNumber)}`,
-        );
-      }
-      const index = message.names.lastIndexOf(edgeName);
-      if (index === -1) {
-        throw new Error(
-          `No reference named ${q(edgeName)} in message ${q(messageNumber)}`,
-        );
-      }
-      const id = message.ids[index];
-      if (id === undefined) {
-        throw new Error(
-          `panic: message must contain a formula for every name, including the name ${q(
-            edgeName,
-          )} at ${q(index)}`,
-        );
-      }
-      context.thisDiesIfThatDies(id);
-      await E(directory).storeIdentifier(petNamePath, id);
-      if (cmdNumber !== undefined) {
-        await recordCommandResult(cmdNumber, true, `adopted as ${petNamePath.join('/')}`, `${cmdMsgId}-result`)
-          .catch(() => {});
-      }
+        if (cmdNumber !== undefined) {
+          await recordCommandResult(
+            cmdNumber,
+            true,
+            `adopted as ${petNamePath.join('/')}`,
+            `${cmdMsgId}-result`,
+          ).catch(() => {});
+        }
       } catch (error) {
         if (cmdNumber !== undefined) {
           await recordCommandResult(
-            cmdNumber, false,
+            cmdNumber,
+            false,
             /** @type {Error} */ (error).message,
             `${cmdMsgId}-result`,
           ).catch(() => {});

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -857,24 +857,47 @@ export const makeMailboxMaker = ({
       if (message === undefined) {
         throw new Error(`Invalid request, ${q(messageNumber)}`);
       }
-      const id = await E(directory).identify(...resolutionPath);
-      if (id === undefined) {
-        throw new TypeError(
-          `No formula exists for the pet name ${q(resolutionNameOrPath)}`,
+
+      const cmdMsgId = `cmd-resolve-${normalizedMessageNumber}-${Date.now()}`;
+      const cmdNumber = await recordCommand(
+        'resolve',
+        harden({
+          messageNumber: String(normalizedMessageNumber),
+          resolution: String(resolutionNameOrPath),
+        }),
+        cmdMsgId,
+      ).catch(() => undefined);
+
+      try {
+        const id = await E(directory).identify(...resolutionPath);
+        if (id === undefined) {
+          throw new TypeError(
+            `No formula exists for the pet name ${q(resolutionNameOrPath)}`,
+          );
+        }
+        // TODO validate shape of request
+        const req = /** @type {Request} */ (message);
+        const resolver = /** @type {ERef<Responder>} */ (
+          provide(req.resolverId, 'resolver')
         );
+        const externalizedId = await externalizeForMessage(
+          /** @type {FormulaIdentifier} */ (id),
+        );
+        await E(resolver).resolveWithId(externalizedId);
+        if (cmdNumber !== undefined) {
+          await recordCommandResult(cmdNumber, true, 'resolved', `${cmdMsgId}-result`)
+            .catch(() => {});
+        }
+      } catch (error) {
+        if (cmdNumber !== undefined) {
+          await recordCommandResult(
+            cmdNumber, false,
+            /** @type {Error} */ (error).message,
+            `${cmdMsgId}-result`,
+          ).catch(() => {});
+        }
+        throw error;
       }
-      // TODO validate shape of request
-      const req = /** @type {Request} */ (message);
-      const resolver = /** @type {ERef<Responder>} */ (
-        provide(req.resolverId, 'resolver')
-      );
-      // Externalize the ID so that a remote resolver (on a different
-      // daemon) can correctly internalize it.  For same-daemon
-      // resolvers the locator is internalized back to the local ID.
-      const externalizedId = await externalizeForMessage(
-        /** @type {FormulaIdentifier} */ (id),
-      );
-      await E(resolver).resolveWithId(externalizedId);
     };
 
     /** @type {Mail['reject']} */
@@ -889,6 +912,17 @@ export const makeMailboxMaker = ({
           `Cannot reject message ${q(messageNumber)} (type ${q(message.type)})`,
         );
       }
+
+      const cmdMsgId = `cmd-reject-${normalizedMessageNumber}-${Date.now()}`;
+      await recordCommand(
+        'reject',
+        harden({
+          messageNumber: String(normalizedMessageNumber),
+          reason,
+        }),
+        cmdMsgId,
+      ).catch(() => {});
+
       const rejection = harden(Promise.reject(harden(new Error(reason))));
       // request messages use a persisted resolver formula.
       const req = /** @type {Request} */ (message);
@@ -1093,6 +1127,19 @@ export const makeMailboxMaker = ({
       if (message === undefined) {
         throw new Error(`No such message with number ${q(messageNumber)}`);
       }
+
+      const cmdMsgId = `cmd-adopt-${normalizedMessageNumber}-${Date.now()}`;
+      const cmdNumber = await recordCommand(
+        'adopt',
+        harden({
+          messageNumber: String(normalizedMessageNumber),
+          edgeName,
+          petName: petNamePath.join('/'),
+        }),
+        cmdMsgId,
+      ).catch(() => undefined);
+
+      try {
       if (message.type === 'value') {
         if (edgeName !== 'value') {
           throw new Error(
@@ -1125,6 +1172,20 @@ export const makeMailboxMaker = ({
       }
       context.thisDiesIfThatDies(id);
       await E(directory).storeIdentifier(petNamePath, id);
+      if (cmdNumber !== undefined) {
+        await recordCommandResult(cmdNumber, true, `adopted as ${petNamePath.join('/')}`, `${cmdMsgId}-result`)
+          .catch(() => {});
+      }
+      } catch (error) {
+        if (cmdNumber !== undefined) {
+          await recordCommandResult(
+            cmdNumber, false,
+            /** @type {Error} */ (error).message,
+            `${cmdMsgId}-result`,
+          ).catch(() => {});
+        }
+        throw error;
+      }
     };
 
     /** @type {Mail['request']} */

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -748,6 +748,63 @@ export const makeMailboxMaker = ({
     };
 
     /**
+     * Record a command in the agent's own inbox.
+     * Returns the message number for linking the result.
+     *
+     * @param {string} commandName
+     * @param {Record<string, unknown>} args
+     * @param {string} messageId
+     * @returns {Promise<bigint>}
+     */
+    const recordCommand = async (commandName, args, messageId) => {
+      /** @type {import('./types.js').CommandMessage & { from: FormulaIdentifier, to: FormulaIdentifier }} */
+      const message = harden({
+        type: /** @type {const} */ ('command'),
+        messageId: /** @type {FormulaNumber} */ (messageId),
+        commandName,
+        args,
+        strings: [`${commandName}`],
+        names: [],
+        ids: [],
+        from: selfId,
+        to: selfId,
+      });
+      await deliver(message);
+      // Return the message number assigned by deliver (nextMessageNumber - 1).
+      return nextMessageNumber - 1n;
+    };
+
+    /**
+     * Record a command result in the agent's own inbox.
+     *
+     * @param {bigint} commandMessageNumber - The command's message number.
+     * @param {boolean} success
+     * @param {string} summary
+     * @param {string} resultMessageId
+     */
+    const recordCommandResult = async (
+      commandMessageNumber,
+      success,
+      summary,
+      resultMessageId,
+    ) => {
+      /** @type {import('./types.js').CommandResultMessage & { from: FormulaIdentifier, to: FormulaIdentifier }} */
+      const message = harden({
+        type: /** @type {const} */ ('command-result'),
+        messageId: /** @type {FormulaNumber} */ (resultMessageId),
+        replyTo: /** @type {FormulaNumber} */ (String(commandMessageNumber)),
+        success,
+        summary,
+        strings: [summary],
+        names: [],
+        ids: [],
+        from: selfId,
+        to: selfId,
+      });
+      await deliver(message);
+    };
+
+    /**
      * Resolve a formula identifier to its handle.
      * If the id points to an agent (host or guest formula), follows the
      * formula's handle field to provide the actual handle.
@@ -985,8 +1042,34 @@ export const makeMailboxMaker = ({
       if (message === undefined) {
         throw new Error(`Invalid request number ${messageNumber}`);
       }
+      // Record the command in the agent's inbox.
+      const cmdMsgId = `cmd-dismiss-${normalizedMessageNumber}-${Date.now()}`;
+      const cmdNumber = await recordCommand(
+        'dismiss',
+        harden({ messageNumber: String(normalizedMessageNumber) }),
+        cmdMsgId,
+      ).catch(() => undefined);
+
       const { dismisser } = E.get(message);
-      return E(dismisser).dismiss();
+      try {
+        await E(dismisser).dismiss();
+        if (cmdNumber !== undefined) {
+          const resultId = `${cmdMsgId}-result`;
+          await recordCommandResult(cmdNumber, true, 'dismissed', resultId)
+            .catch(() => {});
+        }
+      } catch (error) {
+        if (cmdNumber !== undefined) {
+          const resultId = `${cmdMsgId}-result`;
+          await recordCommandResult(
+            cmdNumber,
+            false,
+            /** @type {Error} */ (error).message,
+            resultId,
+          ).catch(() => {});
+        }
+        throw error;
+      }
     };
 
     /** @type {Mail['dismissAll']} */

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -757,8 +757,8 @@ export const makeMailboxMaker = ({
      * @returns {Promise<bigint>}
      */
     const recordCommand = async (commandName, args, messageId) => {
-      /** @type {import('./types.js').CommandMessage & { from: FormulaIdentifier, to: FormulaIdentifier }} */
       const typedMessageId = /** @type {FormulaNumber} */ (messageId);
+      /** @type {import('./types.js').CommandMessage & { from: FormulaIdentifier, to: FormulaIdentifier }} */
       const message = harden({
         type: /** @type {const} */ ('command'),
         messageId: typedMessageId,

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -940,6 +940,16 @@ export const makeMailboxMaker = ({
       petNamesOrPaths,
       replyToMessageNumber,
     ) => {
+      const cmdMsgId = `cmd-send-${Date.now()}`;
+      await recordCommand(
+        'send',
+        harden({
+          to: String(toNameOrPath),
+          text: strings.join(' '),
+        }),
+        cmdMsgId,
+      ).catch(() => {});
+
       const toPath = namePathFrom(toNameOrPath);
       assertNames(edgeNames);
       assertUniqueEdgeNames(edgeNames);
@@ -1190,6 +1200,16 @@ export const makeMailboxMaker = ({
 
     /** @type {Mail['request']} */
     const request = async (toNameOrPath, description, responseName) => {
+      const cmdMsgId = `cmd-request-${Date.now()}`;
+      await recordCommand(
+        'request',
+        harden({
+          to: String(toNameOrPath),
+          description,
+        }),
+        cmdMsgId,
+      ).catch(() => {});
+
       const toPath = namePathFrom(toNameOrPath);
       await null;
       if (responseName !== undefined) {

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -758,9 +758,10 @@ export const makeMailboxMaker = ({
      */
     const recordCommand = async (commandName, args, messageId) => {
       /** @type {import('./types.js').CommandMessage & { from: FormulaIdentifier, to: FormulaIdentifier }} */
+      const typedMessageId = /** @type {FormulaNumber} */ (messageId);
       const message = harden({
         type: /** @type {const} */ ('command'),
-        messageId: /** @type {FormulaNumber} */ (messageId),
+        messageId: typedMessageId,
         commandName,
         args,
         strings: [`${commandName}`],

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -413,6 +413,27 @@ export const makeMailboxMaker = ({
         }
         return;
       }
+      if (envelope.type === 'command') {
+        if (typeof envelope.commandName !== 'string') {
+          throw new Error('Invalid command commandName');
+        }
+        if (typeof envelope.args !== 'object' || envelope.args === null) {
+          throw new Error('Invalid command args');
+        }
+        return;
+      }
+      if (envelope.type === 'command-result') {
+        if (typeof envelope.replyTo !== 'string') {
+          throw new Error('Invalid command-result replyTo');
+        }
+        if (typeof envelope.success !== 'boolean') {
+          throw new Error('Invalid command-result success');
+        }
+        if (typeof envelope.summary !== 'string') {
+          throw new Error('Invalid command-result summary');
+        }
+        return;
+      }
       throw new Error('Unknown message type');
     };
 
@@ -760,7 +781,13 @@ export const makeMailboxMaker = ({
       outbox.set(envelope, message);
       await E(recipient).receive(envelope, selfId);
       // Send to own inbox.
-      if (message.from !== message.to) {
+      // Command messages are self-addressed and must be delivered
+      // to the sender's own inbox for transcript recording.
+      if (
+        message.from !== message.to ||
+        message.type === 'command' ||
+        message.type === 'command-result'
+      ) {
         await deliver(message);
       }
     };

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -486,7 +486,38 @@ export type ValueMessage = MessageBase & {
   valueId: FormulaIdentifier;
 };
 
-export type Message = Request | Package | DefineRequest | Form | ValueMessage;
+export type CommandMessage = MessageBase & {
+  type: 'command';
+  /** The operation being performed. */
+  commandName: string;
+  /** Structured arguments for the command. */
+  args: Record<string, unknown>;
+  /** Formula identifier for the result promise (if applicable). */
+  promiseId?: FormulaIdentifier;
+  /** Formula identifier for the result resolver (if applicable). */
+  resolverId?: FormulaIdentifier;
+};
+
+export type CommandResultMessage = MessageBase & {
+  type: 'command-result';
+  /** References the command message this is a result for. */
+  replyTo: FormulaNumber;
+  /** Whether the command succeeded. */
+  success: boolean;
+  /** Human-readable result summary. */
+  summary: string;
+  /** Formula identifier of the result value (if any). */
+  valueId?: FormulaIdentifier;
+};
+
+export type Message =
+  | Request
+  | Package
+  | DefineRequest
+  | Form
+  | ValueMessage
+  | CommandMessage
+  | CommandResultMessage;
 
 export type EnvelopedMessage = Message & {
   to: FormulaIdentifier;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -306,7 +306,9 @@ type MessageFormula = {
     | 'eval-request'
     | 'definition'
     | 'form'
-    | 'value';
+    | 'value'
+    | 'command'
+    | 'command-result';
   messageId: FormulaNumber;
   replyTo?: FormulaNumber;
   from: FormulaIdentifier;


### PR DESCRIPTION
## Summary
- Adds `CommandMessage` and `CommandResultMessage` envelope types to the mail system, with validation in `assertMessageEnvelope` and self-delivery bypass so command records land in the sender's own inbox for transcript recording.
- Wires `recordCommand` / `recordCommandResult` helpers and instruments six of eight host commands (`dismiss`, `resolve`, `reject`, `adopt`, `send`, `request`) to record command and (where applicable) result messages. Recording errors are fire-and-forget and never block the operation.
- Renders command/command-result messages in the chat transcript as compact monospace cards with status icons (circle for pending, check/cross for result) and reduced opacity to visually distinguish them from conversational messages.

## Commits
- feat(daemon): add command message types and mail system support
- feat(daemon): wire dismiss to record command messages
- feat(daemon): wire resolve, reject, adopt to record command messages
- feat(daemon): wire send and request to record command messages
- feat(chat): render command messages in transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)