### PR TITLE
feat(docker,daemon): docker self-hosting — foreground daemon, CIDR gate, static files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,87 @@
+name: Docker
+
+# Validate the docker/ self-hosting setup.
+#
+# Triggers on PRs that touch the docker/ tree, the daemon (whose
+# foreground/CIDR/static-files behaviour the container exercises),
+# or this workflow itself; and on pushes to the long-lived branches
+# `master` and `llm` so a regression is caught at merge time.
+#
+# The job is intentionally small: build the image, validate the
+# compose manifest, and smoke-test that the container responds on
+# the gateway port. The full daemon test suite already runs in
+# `ci.yml`; this workflow's job is to prove the container assembles
+# and starts, not to re-test the daemon.
+
+on:
+  push:
+    branches: [master, llm]
+  pull_request:
+    paths:
+      - 'docker/**'
+      - 'packages/daemon/**'
+      - '.github/workflows/docker.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke:
+    name: build-and-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate docker-compose.yml
+        # `docker compose config` parses the manifest and renders
+        # the resolved configuration. A non-zero exit means the
+        # YAML is invalid or references unknown keys.
+        working-directory: docker
+        run: docker compose config
+
+      - name: Build image
+        # Build context is the repository root because the
+        # Dockerfile copies package.json, yarn.lock, .yarnrc.yml,
+        # .yarn, and packages from there.
+        run: docker build -f docker/Dockerfile -t endo-selfhost:ci .
+
+      - name: Smoke-test the container
+        # Start the container in the background, wait for the
+        # gateway to bind, then issue an HTTP request. The default
+        # gateway response (no static dir) is the literal string
+        # `Endo Gateway`; assert that the body matches.
+        #
+        # ENDO_GATEWAY_REMOTE=1 is needed because the request
+        # arrives from the Docker bridge address, not 127.0.0.1
+        # inside the container.
+        run: |
+          set -eu
+          docker run --rm -d \
+            --name endo-smoke \
+            -p 8920:8920 \
+            -e ENDO_GATEWAY_REMOTE=1 \
+            endo-selfhost:ci
+          # Always tear down, even on failure.
+          trap 'docker logs endo-smoke || true; docker rm -f endo-smoke || true' EXIT
+
+          # Wait up to 60s for the gateway to answer.
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8920/ > /tmp/body 2>/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          # Assert the body matches the default gateway response.
+          if ! grep -Fxq 'Endo Gateway' /tmp/body; then
+            echo "Unexpected gateway response:" >&2
+            cat /tmp/body >&2 || true
+            exit 1
+          fi
+          echo "Gateway responded as expected."

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,12 +18,11 @@ VOLUME /data/endo
 # Gateway port
 EXPOSE 8920
 
-# Default environment:
-#   ENDO_ADDR — bind address for the gateway (0.0.0.0 for Docker)
-#   ENDO_STATE_PATH — state directory path
-#   ENDO_GC — enable formula garbage collection
+# Default environment for containerized operation.
+# ENDO_STATE is the root; the entrypoint derives *_PATH vars from it.
+# Users can override individual paths if needed.
+ENV ENDO_STATE=/data/endo
 ENV ENDO_ADDR=0.0.0.0:8920
-ENV ENDO_STATE_PATH=/data/endo
 ENV ENDO_GC=1
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:22-slim
+
+WORKDIR /opt/endo
+
+# Install the Endo CLI globally.  In production, this would be replaced
+# with pre-built bundles copied from the build stage.
+# For now, we install from the local workspace.
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn .yarn
+COPY packages packages
+
+# Install dependencies (production only)
+RUN corepack enable && yarn install --immutable
+
+# State directory — mount a volume here for persistence.
+VOLUME /data/endo
+
+# Gateway port
+EXPOSE 8920
+
+# Default environment:
+#   ENDO_ADDR — bind address for the gateway (0.0.0.0 for Docker)
+#   ENDO_STATE_PATH — state directory path
+#   ENDO_GC — enable formula garbage collection
+ENV ENDO_ADDR=0.0.0.0:8920
+ENV ENDO_STATE_PATH=/data/endo
+ENV ENDO_GC=1
+
+COPY docker/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  endo:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8920:8920"
+    volumes:
+      - endo-state:/data/endo
+    environment:
+      - ENDO_ADDR=0.0.0.0:8920
+      - ENDO_GC=1
+    restart: unless-stopped
+
+volumes:
+  endo-state:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
 set -eu
 
-# Map ENDO_STATE (simple) to ENDO_STATE_PATH (what the daemon reads).
-export ENDO_STATE_PATH="${ENDO_STATE_PATH:-${ENDO_STATE:-/data/endo}}"
+# Resolve a single ENDO_STATE root to the four path env vars that
+# daemon-node.js reads in foreground mode.
+ENDO_STATE="${ENDO_STATE:-/data/endo}"
 
-# Ensure the state directory exists.
-mkdir -p "${ENDO_STATE_PATH}"
+export ENDO_STATE_PATH="${ENDO_STATE_PATH:-${ENDO_STATE}/state}"
+export ENDO_EPHEMERAL_STATE_PATH="${ENDO_EPHEMERAL_STATE_PATH:-/tmp/endo}"
+export ENDO_SOCK_PATH="${ENDO_SOCK_PATH:-/tmp/endo/endo.sock}"
+export ENDO_CACHE_PATH="${ENDO_CACHE_PATH:-${ENDO_STATE}/cache}"
+export ENDO_ADDR="${ENDO_ADDR:-0.0.0.0:8920}"
 
-echo "[endo-docker] Starting daemon at ${ENDO_ADDR:-0.0.0.0:8920}"
+# Ensure directories exist.
+mkdir -p "${ENDO_STATE_PATH}" "${ENDO_EPHEMERAL_STATE_PATH}" "${ENDO_CACHE_PATH}"
+
+echo "[endo-docker] Starting daemon (foreground, PID 1)"
 echo "[endo-docker] State: ${ENDO_STATE_PATH}"
+echo "[endo-docker] Address: ${ENDO_ADDR}"
 echo "[endo-docker] GC: ${ENDO_GC:-0}"
 
-# Run daemon in foreground (no fork).
-# run-daemon calls the daemon's main() which reads ENDO_STATE_PATH,
-# ENDO_ADDR, ENDO_GC, etc. from the environment.
-exec yarn endo run-daemon
+# Run daemon-node.js directly as PID 1 (no fork).
+# daemon-node.js reads paths from ENDO_*_PATH env vars when no
+# positional args are provided.
+exec node packages/daemon/src/daemon-node.js

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -14,10 +14,18 @@ export ENDO_ADDR="${ENDO_ADDR:-0.0.0.0:8920}"
 # Ensure directories exist.
 mkdir -p "${ENDO_STATE_PATH}" "${ENDO_EPHEMERAL_STATE_PATH}" "${ENDO_CACHE_PATH}"
 
+# Serve Chat UI if the bundle directory exists.
+if [ -d "${ENDO_STATIC_DIR:-}" ]; then
+  export ENDO_STATIC_DIR
+elif [ -d "/opt/endo/bundles/endo-chat" ]; then
+  export ENDO_STATIC_DIR="/opt/endo/bundles/endo-chat"
+fi
+
 echo "[endo-docker] Starting daemon (foreground, PID 1)"
 echo "[endo-docker] State: ${ENDO_STATE_PATH}"
 echo "[endo-docker] Address: ${ENDO_ADDR}"
 echo "[endo-docker] GC: ${ENDO_GC:-0}"
+echo "[endo-docker] Static: ${ENDO_STATIC_DIR:-none}"
 
 # Run daemon-node.js directly as PID 1 (no fork).
 # daemon-node.js reads paths from ENDO_*_PATH env vars when no

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eu
+
+# Map ENDO_STATE (simple) to ENDO_STATE_PATH (what the daemon reads).
+export ENDO_STATE_PATH="${ENDO_STATE_PATH:-${ENDO_STATE:-/data/endo}}"
+
+# Ensure the state directory exists.
+mkdir -p "${ENDO_STATE_PATH}"
+
+echo "[endo-docker] Starting daemon at ${ENDO_ADDR:-0.0.0.0:8920}"
+echo "[endo-docker] State: ${ENDO_STATE_PATH}"
+echo "[endo-docker] GC: ${ENDO_GC:-0}"
+
+# Run daemon in foreground (no fork).
+# run-daemon calls the daemon's main() which reads ENDO_STATE_PATH,
+# ENDO_ADDR, ENDO_GC, etc. from the environment.
+exec yarn endo run-daemon

--- a/packages/daemon/src/daemon-node.js
+++ b/packages/daemon/src/daemon-node.js
@@ -200,6 +200,7 @@ const main = async () => {
     port: gatewayPort,
     cancelled,
     addressChecker,
+    staticDir: process.env.ENDO_STATIC_DIR || undefined,
   });
 
   const services = [privatePathService, wsGateway];

--- a/packages/daemon/src/daemon-node.js
+++ b/packages/daemon/src/daemon-node.js
@@ -31,15 +31,40 @@ const fsp = { access: fs.promises.access };
 /** @import { Config } from './types.js' */
 
 const args = process.argv.slice(2);
-if (args.length < 4) {
+
+/** @type {string} */
+let sockPath;
+/** @type {string} */
+let statePath;
+/** @type {string} */
+let ephemeralStatePath;
+/** @type {string} */
+let cachePath;
+
+if (args.length >= 4) {
+  // Spawned by CLI: paths passed as positional arguments.
+  [sockPath, statePath, ephemeralStatePath, cachePath] = args;
+} else if (
+  process.env.ENDO_SOCK_PATH &&
+  process.env.ENDO_STATE_PATH &&
+  process.env.ENDO_EPHEMERAL_STATE_PATH &&
+  process.env.ENDO_CACHE_PATH
+) {
+  // Foreground / Docker mode: paths from environment variables.
+  // These match the variables set by configToEnv() in the daemon package.
+  sockPath = process.env.ENDO_SOCK_PATH;
+  statePath = process.env.ENDO_STATE_PATH;
+  ephemeralStatePath = process.env.ENDO_EPHEMERAL_STATE_PATH;
+  cachePath = process.env.ENDO_CACHE_PATH;
+} else {
   throw new Error(
-    `daemon.js requires arguments [sockPath] [statePath] [ephemeralStatePath] [cachePath], got ${process.argv.join(
-      ', ',
-    )}`,
+    `daemon-node.js requires either 4 positional arguments ` +
+      `[sockPath] [statePath] [ephemeralStatePath] [cachePath], ` +
+      `or environment variables ENDO_SOCK_PATH, ENDO_STATE_PATH, ` +
+      `ENDO_EPHEMERAL_STATE_PATH, ENDO_CACHE_PATH. ` +
+      `Got args: ${process.argv.join(', ')}`,
   );
 }
-
-const [sockPath, statePath, ephemeralStatePath, cachePath] = args;
 
 const gcEnabled = process.env.ENDO_GC === '1';
 
@@ -129,9 +154,12 @@ const killStaleWorkers = async () => {
   );
 };
 
+const foreground = !process.send;
+
 const main = async () => {
   const daemonLabel = `daemon on PID ${pid}`;
-  console.log(`Endo daemon starting on PID ${pid}`);
+  const modeLabel = foreground ? ' (foreground)' : '';
+  console.log(`Endo daemon starting on PID ${pid}${modeLabel}`);
   cancelled.catch(err => {
     console.log(`Endo daemon stopping on PID ${pid} (caught: ${err})`);
   });

--- a/packages/daemon/src/daemon-node.js
+++ b/packages/daemon/src/daemon-node.js
@@ -23,6 +23,7 @@ import {
   makeCryptoPowers,
 } from './daemon-node-powers.js';
 import { startWsGateway } from './ws-gateway.js';
+import { makeAddressChecker } from './cidr.js';
 
 const fsp = { access: fs.promises.access };
 
@@ -161,11 +162,16 @@ const main = async () => {
   );
   const gatewayHost = addrUrl.hostname;
   const gatewayPort = addrUrl.port !== '' ? Number(addrUrl.port) : 8920;
+  const addressChecker = makeAddressChecker({
+    allowRemote: process.env.ENDO_GATEWAY_REMOTE === '1',
+    allowedCIDRs: process.env.ENDO_ALLOWED_CIDRS || '',
+  });
   const wsGateway = startWsGateway({
     endoBootstrap,
     host: gatewayHost,
     port: gatewayPort,
     cancelled,
+    addressChecker,
   });
 
   const services = [privatePathService, wsGateway];

--- a/packages/daemon/src/ws-gateway.js
+++ b/packages/daemon/src/ws-gateway.js
@@ -1,6 +1,8 @@
 // @ts-check
 
 import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
 import { WebSocketServer } from 'ws';
 
 import { E } from '@endo/far';
@@ -75,6 +77,8 @@ harden(makeRateLimiter);
  * @param {((addr: string) => boolean)} [opts.addressChecker] - Optional
  *   predicate that returns true if a remote address is allowed to connect.
  *   Defaults to allowing all connections.
+ * @param {string} [opts.staticDir] - Optional directory of static files
+ *   to serve for HTTP requests (e.g., the Chat UI bundle).
  * @returns {{ started: Promise<string>, stopped: Promise<void> }}
  */
 export const startWsGateway = ({
@@ -83,6 +87,7 @@ export const startWsGateway = ({
   port,
   cancelled,
   addressChecker = _addr => true,
+  staticDir = undefined,
 }) => {
   const fetchLimiter = makeRateLimiter(1000);
   const gatewayP = E(endoBootstrap).gateway();
@@ -98,9 +103,73 @@ export const startWsGateway = ({
     }
   })();
 
-  const server = http.createServer((_req, res) => {
-    res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end('Endo Gateway');
+  /** @type {Record<string, string>} */
+  const mimeTypes = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.mjs': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.ico': 'image/x-icon',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+  };
+
+  const server = http.createServer((req, res) => {
+    if (!staticDir) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('Endo Gateway');
+      return;
+    }
+
+    const url = new URL(req.url || '/', `http://${req.headers.host}`);
+    let filePath = path.join(staticDir, url.pathname);
+
+    // Default to index.html for directory requests.
+    if (filePath.endsWith('/') || filePath === staticDir) {
+      filePath = path.join(filePath, 'index.html');
+    }
+
+    // Prevent path traversal: resolved path must be inside staticDir.
+    const resolved = path.resolve(filePath);
+    const resolvedDir = path.resolve(staticDir);
+    if (!resolved.startsWith(`${resolvedDir}/`) && resolved !== resolvedDir) {
+      // Also allow resolvedDir/index.html
+      if (!resolved.startsWith(resolvedDir)) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
+      }
+    }
+
+    const ext = path.extname(resolved);
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+    fs.readFile(resolved, (err, data) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          // SPA fallback: serve index.html for missing files.
+          const indexPath = path.join(staticDir, 'index.html');
+          fs.readFile(indexPath, (indexErr, indexData) => {
+            if (indexErr) {
+              res.writeHead(404);
+              res.end('Not Found');
+            } else {
+              res.writeHead(200, { 'Content-Type': 'text/html' });
+              res.end(indexData);
+            }
+          });
+        } else {
+          res.writeHead(500);
+          res.end('Internal Server Error');
+        }
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(data);
+    });
   });
 
   const wss = new WebSocketServer({ server });

--- a/packages/daemon/src/ws-gateway.js
+++ b/packages/daemon/src/ws-gateway.js
@@ -72,9 +72,18 @@ harden(makeRateLimiter);
  * @param {string} opts.host
  * @param {number} opts.port
  * @param {Promise<never>} opts.cancelled
+ * @param {((addr: string) => boolean)} [opts.addressChecker] - Optional
+ *   predicate that returns true if a remote address is allowed to connect.
+ *   Defaults to allowing all connections.
  * @returns {{ started: Promise<string>, stopped: Promise<void> }}
  */
-export const startWsGateway = ({ endoBootstrap, host, port, cancelled }) => {
+export const startWsGateway = ({
+  endoBootstrap,
+  host,
+  port,
+  cancelled,
+  addressChecker = _addr => true,
+}) => {
   const fetchLimiter = makeRateLimiter(1000);
   const gatewayP = E(endoBootstrap).gateway();
 
@@ -98,6 +107,14 @@ export const startWsGateway = ({ endoBootstrap, host, port, cancelled }) => {
 
   wss.on('connection', (socket, req) => {
     const remoteAddress = req.socket.remoteAddress || '';
+
+    if (!addressChecker(remoteAddress)) {
+      console.warn(
+        `[Gateway] Rejected connection from ${remoteAddress} (address not allowed)`,
+      );
+      socket.close(1008, 'Address not allowed');
+      return;
+    }
 
     const { promise: closed, resolve: close, reject: abort } = makePromiseKit();
 

--- a/packages/daemon/test/cidr.test.js
+++ b/packages/daemon/test/cidr.test.js
@@ -47,6 +47,46 @@ test('parseCIDR rejects invalid input', t => {
   t.is(parseCIDR('10.0.0.256/8'), undefined);
 });
 
+test('parseCIDR rejects multiple :: in IPv6', t => {
+  t.is(parseCIDR('1::2::3'), undefined);
+});
+
+test('parseCIDR rejects IPv6 with too many groups', t => {
+  t.is(parseCIDR('1:2:3:4:5:6:7:8:9'), undefined);
+  // Too many groups around :: (left + right > 8)
+  t.is(parseCIDR('1:2:3:4:5:6::7:8:9'), undefined);
+});
+
+test('parseCIDR rejects IPv6 prefix > 128', t => {
+  t.is(parseCIDR('::1/129'), undefined);
+});
+
+test('parseCIDR rejects negative prefix', t => {
+  t.is(parseCIDR('10.0.0.0/-1'), undefined);
+});
+
+test('parseCIDR rejects non-integer prefix', t => {
+  t.is(parseCIDR('10.0.0.0/abc'), undefined);
+});
+
+test('parseCIDR rejects IPv6 with invalid hex group', t => {
+  t.is(parseCIDR('zzzz:0:0:0:0:0:0:1'), undefined);
+});
+
+test('parseCIDR parses IPv6 without :: shorthand', t => {
+  const result = parseCIDR('2001:0db8:0000:0000:0000:0000:0000:0001');
+  t.not(result, undefined);
+  t.is(/** @type {NonNullable<typeof result>} */ (result).type, 'ipv6');
+  t.is(/** @type {NonNullable<typeof result>} */ (result).prefixLen, 128);
+});
+
+test('addressMatchesCIDR does not match IPv4 addr against IPv6 CIDR', t => {
+  const cidr = /** @type {NonNullable<ReturnType<typeof parseCIDR>>} */ (
+    parseCIDR('::1/128')
+  );
+  t.false(addressMatchesCIDR('127.0.0.1', cidr));
+});
+
 // --- addressMatchesCIDR ---
 
 test('addressMatchesCIDR matches IPv4 within /8', t => {

--- a/packages/daemon/test/ws-gateway-static.test.js
+++ b/packages/daemon/test/ws-gateway-static.test.js
@@ -1,0 +1,208 @@
+// @ts-check
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import http from 'node:http';
+
+import { Far } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+
+import { startWsGateway } from '../src/ws-gateway.js';
+
+/**
+ * @param {string} url
+ * @returns {Promise<{ status: number, headers: http.IncomingHttpHeaders, body: string }>}
+ */
+const httpGet = url =>
+  new Promise((resolve, reject) => {
+    http.get(url, res => {
+      let body = '';
+      res.on('data', chunk => {
+        body += chunk;
+      });
+      res.on('end', () => {
+        resolve({
+          status: /** @type {number} */ (res.statusCode),
+          headers: res.headers,
+          body,
+        });
+      });
+      res.on('error', reject);
+    });
+  });
+
+/**
+ * Create a temp directory with test files and start a gateway serving them.
+ *
+ * @param {import('ava').ExecutionContext} t
+ */
+const setupStaticGateway = async t => {
+  const tmpDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'endo-gw-test-'),
+  );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'index.html'),
+    '<html><body>Hello</body></html>',
+    'utf-8',
+  );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'app.js'),
+    'console.log("app")',
+    'utf-8',
+  );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'style.css'),
+    'body { color: red; }',
+    'utf-8',
+  );
+  await fs.promises.mkdir(path.join(tmpDir, 'sub'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'sub', 'page.html'),
+    '<html>sub</html>',
+    'utf-8',
+  );
+
+  const { promise: cancelled, reject: cancel } =
+    /** @type {import('@endo/promise-kit').PromiseKit<never>} */ (
+      makePromiseKit()
+    );
+
+  const mockBootstrap = Far('MockBootstrap', {
+    gateway: () => Far('MockGateway', { fetch: () => undefined }),
+  });
+
+  const { started, stopped } = startWsGateway({
+    endoBootstrap: mockBootstrap,
+    host: '127.0.0.1',
+    port: 0,
+    cancelled,
+    staticDir: tmpDir,
+  });
+
+  const address = await started;
+  const url = new URL(address);
+  const baseUrl = `http://127.0.0.1:${url.port}`;
+
+  t.teardown(async () => {
+    cancel(new Error('test done'));
+    await stopped.catch(() => {});
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  return { baseUrl, tmpDir };
+};
+
+test.serial('serves index.html at root', async t => {
+  const { baseUrl } = await setupStaticGateway(t);
+  const res = await httpGet(`${baseUrl}/`);
+  t.is(res.status, 200);
+  t.true(res.headers['content-type']?.includes('text/html'));
+  t.true(res.body.includes('Hello'));
+});
+
+test.serial('serves JS file with correct MIME type', async t => {
+  const { baseUrl } = await setupStaticGateway(t);
+  const res = await httpGet(`${baseUrl}/app.js`);
+  t.is(res.status, 200);
+  t.true(res.headers['content-type']?.includes('javascript'));
+  t.is(res.body, 'console.log("app")');
+});
+
+test.serial('serves CSS file with correct MIME type', async t => {
+  const { baseUrl } = await setupStaticGateway(t);
+  const res = await httpGet(`${baseUrl}/style.css`);
+  t.is(res.status, 200);
+  t.true(res.headers['content-type']?.includes('text/css'));
+});
+
+test.serial('serves files in subdirectories', async t => {
+  const { baseUrl } = await setupStaticGateway(t);
+  const res = await httpGet(`${baseUrl}/sub/page.html`);
+  t.is(res.status, 200);
+  t.true(res.body.includes('sub'));
+});
+
+test.serial('SPA fallback serves index.html for missing files', async t => {
+  const { baseUrl } = await setupStaticGateway(t);
+  const res = await httpGet(`${baseUrl}/nonexistent/route`);
+  t.is(res.status, 200);
+  t.true(res.body.includes('Hello'));
+});
+
+test.serial('returns 404 when no index.html and file missing', async t => {
+  // Create a static dir with NO index.html
+  const tmpDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'endo-gw-noindex-'),
+  );
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'exists.txt'),
+    'data',
+    'utf-8',
+  );
+
+  const { promise: cancelled, reject: cancel } =
+    /** @type {import('@endo/promise-kit').PromiseKit<never>} */ (
+      makePromiseKit()
+    );
+
+  const mockBootstrap = Far('MockBootstrap', {
+    gateway: () => Far('MockGateway', { fetch: () => undefined }),
+  });
+
+  const { started, stopped } = startWsGateway({
+    endoBootstrap: mockBootstrap,
+    host: '127.0.0.1',
+    port: 0,
+    cancelled,
+    staticDir: tmpDir,
+  });
+
+  const address = await started;
+  const url = new URL(address);
+  const baseUrl = `http://127.0.0.1:${url.port}`;
+
+  t.teardown(async () => {
+    cancel(new Error('test done'));
+    await stopped.catch(() => {});
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // Request a missing file — SPA fallback will try index.html which also
+  // doesn't exist, so it should return 404.
+  const res = await httpGet(`${baseUrl}/missing`);
+  t.is(res.status, 404);
+  t.is(res.body, 'Not Found');
+});
+
+test.serial('without staticDir returns plain text', async t => {
+  const { promise: cancelled, reject: cancel } =
+    /** @type {import('@endo/promise-kit').PromiseKit<never>} */ (
+      makePromiseKit()
+    );
+
+  const mockBootstrap = Far('MockBootstrap', {
+    gateway: () => Far('MockGateway', { fetch: () => undefined }),
+  });
+
+  const { started, stopped } = startWsGateway({
+    endoBootstrap: mockBootstrap,
+    host: '127.0.0.1',
+    port: 0,
+    cancelled,
+  });
+
+  const address = await started;
+  const url = new URL(address);
+  const baseUrl = `http://127.0.0.1:${url.port}`;
+
+  t.teardown(async () => {
+    cancel(new Error('test done'));
+    await stopped.catch(() => {});
+  });
+
+  const res = await httpGet(`${baseUrl}/`);
+  t.is(res.status, 200);
+  t.is(res.body, 'Endo Gateway');
+});

--- a/packages/daemon/test/ws-gateway-static.test.js
+++ b/packages/daemon/test/ws-gateway-static.test.js
@@ -136,11 +136,7 @@ test.serial('returns 404 when no index.html and file missing', async t => {
   const tmpDir = await fs.promises.mkdtemp(
     path.join(os.tmpdir(), 'endo-gw-noindex-'),
   );
-  await fs.promises.writeFile(
-    path.join(tmpDir, 'exists.txt'),
-    'data',
-    'utf-8',
-  );
+  await fs.promises.writeFile(path.join(tmpDir, 'exists.txt'), 'data', 'utf-8');
 
   const { promise: cancelled, reject: cancel } =
     /** @type {import('@endo/promise-kit').PromiseKit<never>} */ (


### PR DESCRIPTION
## Summary
- Adds Docker infrastructure: Node 22 slim `Dockerfile` exposing port 8920, `docker-entrypoint.sh` ensuring the state directory and derive env vars from a single `ENDO_STATE` root, `docker-compose.yml` with a named volume for state persistence, and a foreground-mode path in `daemon-node.js` that reads `ENDO_STATE_PATH` / `ENDO_EPHEMERAL_STATE_PATH` / `ENDO_SOCK_PATH` / `ENDO_CACHE_PATH` from the environment so the daemon can run directly as PID 1.
- Wires CIDR address filtering into the WebSocket gateway via the previously-unconnected `cidr.js`. Default: localhost only; `ENDO_GATEWAY_REMOTE=1` allows all; `ENDO_ALLOWED_CIDRS=...` allows explicit ranges. Rejected connections get a 1008 close with "Address not allowed". Closes `cidr.js` branch-coverage gaps.
- Adds static file serving to the gateway for Chat UI hosting: optional `staticDir` parameter / `ENDO_STATIC_DIR` env var with proper MIME types, SPA fallback to `index.html`, and path traversal protection. Docker entrypoint auto-detects `/opt/endo/bundles/endo-chat`. Seven new ws-gateway static-file tests.

## Commits
- feat(docker): add Dockerfile, entrypoint, and compose for self-hosting
- feat(daemon): wire CIDR address filtering into WebSocket gateway
- test(daemon): close cidr.js branch coverage gaps
- feat(daemon): add foreground mode for Docker deployment
- feat(daemon): add static file serving to gateway for Chat UI hosting
- test(daemon): add ws-gateway static file serving tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)