### PR TITLE
docs: design loop scaffolding and unified-weblet-server revisions

### DIFF
--- a/designs/COVERAGE-STATE.md
+++ b/designs/COVERAGE-STATE.md
@@ -1,0 +1,10 @@
+# Coverage Loop State
+
+| | |
+|---|---|
+| **Last Run** | 2026-04-16 |
+| **Package** | @endo/base64 |
+| **Line Coverage** | 95.73% → 96.68% |
+| **Branch Coverage** | 89.18% → 92.10% |
+| **Action Taken** | Added test for `btoa` error path (non-Latin1 characters), bringing `btoa.js` from 88% to 100% lines. Remaining uncovered code is XS-engine-only adapter (`src/decode.js:72-77`) and unreachable defensive assertion (`src/encode.js:60`) — both untestable in Node.js. |
+| **Next Package** | @endo/cache-map |

--- a/designs/LOOP-STATE.md
+++ b/designs/LOOP-STATE.md
@@ -2,10 +2,10 @@
 
 | | |
 |---|---|
-| **Last Run** | 2026-04-16 |
+| **Last Run** | 2026-04-17 |
 | **Task Type** | Design |
-| **Last Design** | chat-rename-dismiss-to-clear.md |
-| **Action Taken** | Audited Proposed design against codebase. Found all three changes already implemented: `/clear` in chat command registry and executor, `endo clear` in CLI, dismiss/dismiss-all prefix collision eliminated. Promoted status from Proposed to **Complete**. Added `## Status` section documenting implementation locations. Updated README totals (22 Complete). |
-| **Next Suggested** | @endo/cache-map (coverage task) |
+| **Last Design** | familiar-unified-weblet-server.md |
+| **Action Taken** | Found previous status section was inaccurate — claimed full implementation in a file that does not exist (`packages/daemon/src/web-server-node.js`). Corrected status to "Partially implemented": Familiar-side localhttp:// protocol handler, exfiltration defense, and navigation guard exist, but daemon-side unified web server, makeWeblet, virtual host routing, and per-weblet CapTP do not. Created QUESTIONS.md with question about the discrepancy. |
+| **Next Suggested** | @endo/exo (coverage task) |
 | **Blockers** | None. |
-| **Assumptions** | None. |
+| **Assumptions** | Previous status was prospective or from another branch. Corrected to reflect origin/llm state. |

--- a/designs/LOOP-STATE.md
+++ b/designs/LOOP-STATE.md
@@ -1,0 +1,11 @@
+# Design Loop State
+
+| | |
+|---|---|
+| **Last Run** | 2026-04-16 |
+| **Task Type** | Design |
+| **Last Design** | chat-rename-dismiss-to-clear.md |
+| **Action Taken** | Audited Proposed design against codebase. Found all three changes already implemented: `/clear` in chat command registry and executor, `endo clear` in CLI, dismiss/dismiss-all prefix collision eliminated. Promoted status from Proposed to **Complete**. Added `## Status` section documenting implementation locations. Updated README totals (22 Complete). |
+| **Next Suggested** | @endo/cache-map (coverage task) |
+| **Blockers** | None. |
+| **Assumptions** | None. |

--- a/designs/LOOP.md
+++ b/designs/LOOP.md
@@ -1,0 +1,215 @@
+# Design Progress Loop — Standing Instructions
+
+## Purpose
+
+You are a design-advancement and code-quality agent. Each time you are
+invoked, you either advance a design document or improve test coverage
+in a package, alternating between the two. You then report what you did
+and what should happen next.
+
+## Task Selection
+
+Each invocation does **one** of two things: advance a design, or improve
+test coverage. Alternate between them — check `designs/LOOP-STATE.md` to
+see what the last invocation did and pick the other category. If the last
+action was a design task, do a coverage task, and vice versa.
+
+### Design task selection
+
+Pick the **highest-priority actionable design** using these rules, in order:
+
+1. **In Progress / Active / Draft** designs first — these have momentum.
+   Prefer ones whose dependencies are already Complete.
+2. **Proposed** designs next — they need review and refinement to become
+   actionable.
+3. **Not Started** designs in the current or next incomplete milestone
+   (M1 before M2, etc.), preferring those whose dependencies in the
+   Mermaid graph are already Complete or In Progress.
+4. Skip **Complete**, **Implemented**, **Reference**, and **Deprecated**
+   designs.
+
+Within a tier, rotate: check `designs/LOOP-STATE.md` (if it exists) for the
+last design touched and pick the next eligible one. If `LOOP-STATE.md` does
+not exist, start from the top of the README table.
+
+### Coverage task selection
+
+Pick a package from `packages/` and measure its test coverage. Rotate
+through packages across invocations — check `designs/COVERAGE-STATE.md`
+(if it exists) for the last package measured and pick the next one
+alphabetically. Skip packages with `"test": "exit 0"` (no tests).
+
+**How to measure:** Run `yarn cover` (or `yarn test:c8`) in the package
+directory. If neither script exists, run `c8 ava` directly. Record the
+line/branch/function coverage percentages.
+
+**How to improve:**
+
+1. **Delete dead code first.** If coverage reports reveal functions or
+   branches that are never exercised and inspection confirms they are
+   truly unreachable (not just untested), delete them. Dead code
+   removal is the cheapest way to raise coverage and reduces
+   maintenance burden.
+2. **Write tests for uncovered code.** Focus on uncovered branches and
+   functions that represent real behavior, not just error paths for
+   impossible conditions. Follow the project's existing test patterns
+   and conventions in `CLAUDE.md`.
+3. **Increase coverage thresholds.** If the package has a coverage
+   threshold configured (in `package.json`, `.c8rc`, or `ava` config),
+   raise it to match or slightly exceed the new measured coverage,
+   ratcheting up the minimum over time.
+
+**State file:** After each coverage invocation, write or update
+`designs/COVERAGE-STATE.md` with:
+
+```markdown
+# Coverage Loop State
+
+| | |
+|---|---|
+| **Last Run** | YYYY-MM-DD |
+| **Package** | @endo/package-name |
+| **Line Coverage** | XX% → YY% |
+| **Branch Coverage** | XX% → YY% |
+| **Action Taken** | Brief description |
+| **Next Package** | @endo/next-package |
+```
+
+## What "Making Progress" Means
+
+Each design has a lifecycle. Advance it by one meaningful step:
+
+### For "Not Started" designs
+- Read the full design document.
+- Read the current codebase to understand existing state: what code exists
+  that relates to this design? Have any parts been partially implemented?
+- Update the design's `## Status` section with findings (or add one if
+  missing).
+- Identify the first concrete implementation step and note it.
+- If the design is underspecified, add questions or propose refinements
+  inline.
+- Update the design's metadata status to **Draft** or **In Progress** as
+  appropriate.
+
+### For "Draft" or "Proposed" designs
+- Review the design for completeness, consistency with the codebase, and
+  feasibility.
+- Cross-reference with dependency designs — are prerequisites met?
+- Refine the document: fill gaps, resolve open questions, add code
+  examples if helpful.
+- If ready for implementation, update status to **In Progress** and
+  identify the first implementation phase.
+
+### For "In Progress" designs
+- Read the design and its `## Status` section to understand what's done.
+- Read the relevant source files to verify the status section is accurate.
+- **If the implementation has advanced beyond what the design documents,
+  update the design first.** Add or revise the `## Status` section,
+  correct any stale descriptions, and note deviations from the original
+  plan. Keeping designs in sync with reality is itself meaningful progress.
+- Identify the next unfinished phase or task.
+- If the remaining work is small and well-defined, **implement it**:
+  write or modify code, add tests, update the design's status.
+- If the remaining work is large, break it into a concrete next step and
+  document it in the status section.
+- If all phases are complete, update status to **Complete** and update
+  `designs/README.md` accordingly.
+
+### For "Active" designs
+- Review whether the document is still accurate relative to the codebase.
+- Update any stale information.
+
+## Constraints
+
+- **One design per invocation.** Go deep, not wide.
+- **Always update `designs/README.md`** when you change a design's status
+  or updated date.
+- **Follow `designs/CLAUDE.md`** for document format conventions.
+- **Follow `/CLAUDE.md`** for code conventions when writing implementation.
+- **Do not create PRs or push.** Only make local changes.
+- **Keep designs in sync with the codebase.** If you discover that
+  implementation has outpaced the design document at any status level,
+  update the document to reflect reality. This includes adding or
+  revising `## Status` sections, correcting stale descriptions, and
+  noting deviations from the original plan.
+- **Do not modify Complete/Implemented designs** unless you find an
+  inaccuracy in their status section.
+- **Time-box:** Spend no more than ~10 minutes per invocation. If a task
+  is larger, document what's left and move on.
+- **Don't block on human feedback.** If progress requires a human
+  decision or context you don't have, add the question to
+  `designs/QUESTIONS.md` (create it if it doesn't exist) with the
+  design name, date, and your question. Then proceed with your best
+  educated guess, noting the assumption you made. Collaborators may
+  not respond before the next iteration — don't stall.
+
+## State File
+
+After each invocation, write or update `designs/LOOP-STATE.md` with:
+
+```markdown
+# Design Loop State
+
+| | |
+|---|---|
+| **Last Run** | YYYY-MM-DD |
+| **Task Type** | Design / Coverage |
+| **Last Design** | design-name.md (or N/A for coverage tasks) |
+| **Action Taken** | Brief description |
+| **Next Suggested** | design-name.md or package-name |
+| **Blockers** | None / description |
+| **Assumptions** | None / assumptions made in lieu of human input |
+```
+
+## Questions File
+
+When you encounter a question that needs collaborator input, append it
+to `designs/QUESTIONS.md` in this format:
+
+```markdown
+### design-name.md — YYYY-MM-DD
+
+**Question:** What needs to be decided?
+
+**Context:** Why it matters and what options you see.
+
+**Assumption:** What you chose to proceed with and why.
+
+**Status:** Open / Resolved
+```
+
+If the file doesn't exist, create it with a `# Design Questions` heading.
+Check the file at the start of each iteration — if a collaborator has
+marked a question as Resolved with an answer, incorporate that answer
+and update the relevant design doc.
+
+## Committing Changes
+
+After completing each iteration (design or coverage task), review all
+changes in the working copy and commit them in sensible groups:
+
+1. **Run `git status` and `git diff`** to see everything that changed.
+2. **Group related changes into separate commits.** For example:
+   - Design doc updates (status sections, README sync) in one commit.
+   - New tests or test improvements in another commit.
+   - Implementation code changes in their own commit(s).
+   - Loop state files (`LOOP-STATE.md`, `COVERAGE-STATE.md`) can go
+     with the related design/coverage commit.
+3. **Stage and commit each group** with a clear, descriptive message.
+   Use conventional commit prefixes where appropriate (`docs:`,
+   `test:`, `feat:`, `fix:`, `refactor:`).
+4. **Discard any unwanted changes.** If a change is not worth keeping
+   (e.g., accidental edits, scratch work, failed experiments), revert
+   it with `git checkout -- <file>` before committing.
+5. **Leave `.claude/` alone.** Do not stage, commit, delete, or
+   otherwise touch anything under `.claude/` — these are session
+   artifacts managed externally.
+6. **Do not push.** Commits stay local.
+
+## Reporting
+
+End your response with a brief summary:
+- Which design you worked on
+- What you did (1-3 bullets)
+- What should happen next
+- Any assumptions made (with reference to QUESTIONS.md if applicable)

--- a/designs/QUESTIONS.md
+++ b/designs/QUESTIONS.md
@@ -1,0 +1,11 @@
+# Design Questions
+
+### familiar-unified-weblet-server.md — 2026-04-17
+
+**Question:** The previous status section claimed the unified weblet server was fully implemented in `packages/daemon/src/web-server-node.js`, but this file does not exist on `origin/llm`. Was this work done on a different branch, reverted, or written prospectively?
+
+**Context:** The Familiar-side `localhttp://` protocol handler exists (`packages/familiar/src/protocol-handler.js`), but the daemon-side unified web server — including `webletHandlers`, `makeWeblet`, virtual host routing, and per-weblet CapTP — does not exist. The design status has been corrected to "Partially implemented" to reflect what is actually present.
+
+**Assumption:** The previous status was written prospectively or describes work on a branch not merged to `origin/llm`. Proceeding with the corrected status that only Familiar-side infrastructure is implemented.
+
+**Status:** Open

--- a/designs/README.md
+++ b/designs/README.md
@@ -61,7 +61,7 @@
 | [familiar-electron-shell](familiar-electron-shell.md) | 2026-02-14 | 2026-02-26 | **Complete** |
 | [familiar-gateway-migration](familiar-gateway-migration.md) | 2026-02-14 | 2026-02-26 | **Complete** |
 | [familiar-localhttp-protocol](familiar-localhttp-protocol.md) | 2026-02-24 | 2026-02-25 | In Progress (partially implemented) |
-| [familiar-unified-weblet-server](familiar-unified-weblet-server.md) | 2026-02-14 | 2026-02-26 | In Progress |
+| [familiar-unified-weblet-server](familiar-unified-weblet-server.md) | 2026-02-14 | 2026-04-17 | In Progress |
 | [formula-inspector](formula-inspector.md) | 2026-02-14 | 2026-02-24 | Not Started |
 | [gateway-bearer-token-auth](gateway-bearer-token-auth.md) | 2026-03-02 | 2026-03-06 | **Implemented** |
 | [inventory-cancel-and-liveness](inventory-cancel-and-liveness.md) | 2026-02-14 | 2026-03-13 | Not Started |

--- a/designs/familiar-unified-weblet-server.md
+++ b/designs/familiar-unified-weblet-server.md
@@ -9,19 +9,37 @@
 
 ## Status
 
-**Implemented.** The unified weblet server is in
-`packages/daemon/src/web-server-node.js`. Key implementation details:
+**Partially implemented.** The Familiar-side `localhttp://` protocol handler
+exists, but the daemon-side unified web server does not.
 
-- The `webletHandlers` map is keyed by the bare access token (first 32 chars
-  of the weblet ID), not by `<id>.localhost`. This simplifies the
-  `localhttp://` protocol handler, which sends the bare access token as the
-  `Host` header.
-- Both HTTP requests and WebSocket upgrades are routed by `Host` header.
-- `makeWeblet` supports two modes: unified server (hostname-based routing on
-  the gateway port) and dedicated port (per-weblet server, path-based
-  routing). The unified mode returns `localhttp://{accessToken}` URLs.
-- The `localhttp://` protocol handler in `packages/familiar` proxies to
-  `http://127.0.0.1:{gatewayPort}` with `Host: {accessToken}`.
+### Implemented
+
+- **`localhttp://` protocol handler:** `packages/familiar/src/protocol-handler.js`
+  — registers a privileged scheme, proxies `localhttp://<weblet-id>/` requests
+  to `http://127.0.0.1:{gatewayPort}` with `Host: {accessToken}`, injects CSP
+  headers on every response.
+- **Exfiltration defense:** `packages/familiar/src/exfiltration-defense.js` —
+  DNS poisoning protection, request interception, permission handler.
+- **Navigation guard:** `packages/familiar/src/navigation-guard.js` —
+  `will-navigate` and `setWindowOpenHandler` interception.
+
+### Not implemented
+
+- **Daemon-side unified web server:** The file `packages/daemon/src/web-server-node.js`
+  referenced in the previous status does **not exist** on this branch. The daemon
+  has `packages/daemon/src/ws-gateway.js` for WebSocket gateway connections, but
+  no weblet HTTP routing or `webletHandlers` map.
+- **`makeWeblet` function:** No weblet creation or registration mechanism exists
+  in the daemon.
+- **Virtual host routing:** The gateway does not demultiplex by `Host` header.
+- **Per-weblet CapTP sessions:** No weblet-specific WebSocket handler isolation.
+
+### Previous status note
+
+The previous status section claimed full implementation in
+`packages/daemon/src/web-server-node.js`. This appears to have been written
+prospectively or to describe work on a different branch. The file does not
+exist on `origin/llm` as of 2026-04-17.
 
 ## What is the Problem Being Solved?
 

--- a/designs/familiar-unified-weblet-server.md
+++ b/designs/familiar-unified-weblet-server.md
@@ -3,14 +3,59 @@
 | | |
 |---|---|
 | **Created** | 2026-02-14 |
-| **Updated** | 2026-02-26 |
+| **Updated** | 2026-04-17 |
 | **Author** | Kris Kowal (prompted) |
 | **Status** | In Progress |
 
 ## Status
 
-**Partially implemented.** The Familiar-side `localhttp://` protocol handler
-exists, but the daemon-side unified web server does not.
+**Partially implemented; design under revision.**
+
+Chat weblets have been removed from the current codebase in order to
+regroup on the approach.  The Familiar-side `localhttp://` protocol
+handler remains, but the daemon-side unified web server does not exist.
+
+### Key design revision (2026-04-17)
+
+The original design assumed a single unified HTTP server with
+Host-header-based virtual host routing for all weblets.  This
+assumption must be revised:
+
+- **Familiar weblets** can use the unified server approach (Host-header
+  routing on the gateway port, proxied via `localhttp://`).  The
+  Electron protocol handler provides origin isolation without needing
+  separate ports.
+- **Chat weblets** (standalone browser use without Electron) still need
+  a **separate HTTP port per isolated page**, with the user choosing
+  the port.  Browsers cannot intercept and reroute by scheme like
+  Electron can, so each weblet needs its own `http://` origin on a
+  distinct port.
+
+### Deeper problem: gateway multiplexing and confidentiality
+
+The gateway currently listens on a single port for HTTP and WebSocket
+CapTP.  It acts as a proxy for all users on the system and all personas
+within a single user's daemon.  This creates a problem of:
+
+1. **Hierarchical multiplexing** — the gateway must route connections to
+   the correct user, then to the correct persona/agent within that
+   user's daemon, then to the correct weblet within that agent's scope.
+2. **Session confidentiality** — each CapTP session must be confidential
+   even over plain local HTTP.  Today the gateway trusts that
+   `127.0.0.1` traffic is private, but multi-user scenarios or weblet
+   isolation require per-session encryption or authentication.
+
+These problems are unlikely to be cleanly solved without the OCapN
+Network/Transport separation and the Noise Protocol Network (netlayer).
+Noise would provide per-session confidentiality and mutual
+authentication, which the gateway currently lacks.
+
+### Dependencies added
+
+| Design | Relationship |
+|--------|-------------|
+| [ocapn-network-transport-separation](ocapn-network-transport-separation.md) | The gateway needs a network-level abstraction for session establishment and authentication, not bare WebSocket. |
+| [ocapn-noise-network](ocapn-noise-network.md) | Noise Protocol would provide per-session confidentiality over the shared gateway port, enabling secure multiplexing. |
 
 ### Implemented
 
@@ -25,14 +70,13 @@ exists, but the daemon-side unified web server does not.
 
 ### Not implemented
 
-- **Daemon-side unified web server:** The file `packages/daemon/src/web-server-node.js`
-  referenced in the previous status does **not exist** on this branch. The daemon
-  has `packages/daemon/src/ws-gateway.js` for WebSocket gateway connections, but
-  no weblet HTTP routing or `webletHandlers` map.
-- **`makeWeblet` function:** No weblet creation or registration mechanism exists
-  in the daemon.
+- **Daemon-side unified web server:** No weblet HTTP routing or
+  `webletHandlers` map exists in the daemon.
+- **`makeWeblet` function:** No weblet creation or registration mechanism.
 - **Virtual host routing:** The gateway does not demultiplex by `Host` header.
 - **Per-weblet CapTP sessions:** No weblet-specific WebSocket handler isolation.
+- **Per-port Chat weblets:** Not designed yet; requires user-configurable ports.
+- **Noise-based session confidentiality:** Depends on OCapN networking milestones.
 
 ### Previous status note
 


### PR DESCRIPTION
## Summary
- Adds `designs/LOOP.md` with standing instructions for a recurring agent that alternates between advancing design documents and improving test coverage — covering task selection rules, coverage workflow, commit policy, and question tracking.
- Corrects `familiar-unified-weblet-server` status: previously claimed full implementation in `web-server-node.js`, which does not exist. Updates to partially-implemented (Familiar-side `localhttp://` handler exists; daemon-side unified server does not) and adds a `QUESTIONS.md` tracking the discrepancy.
- Revises the unified-weblet-server design per collaborator feedback: Chat weblets removed to regroup (they need per-port isolation with user-chosen ports), Familiar weblets can still use the unified server. Identifies that gateway multiplexing and per-session confidentiality likely depend on OCapN Noise Protocol, and adds dependencies on `ocapn-network-transport-separation` and `ocapn-noise-network`.

## Commits
- docs: add design loop standing instructions and state files
- docs: correct familiar-unified-weblet-server status
- docs: revise unified-weblet-server design per collaborator feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)