### PR TITLE
feat(sandbox): provide default $PATH derived from rootfs

### DIFF
--- a/PLAN/endo_posix_sandbox.md
+++ b/PLAN/endo_posix_sandbox.md
@@ -381,6 +381,51 @@ Powers needed:
   All host-path access is mediated through `Mount` capabilities
   the caller hands in.
 
+### Environment defaults
+
+A slice's `$PATH` (and, by extension, anything else the inner
+shell looks up by short name) is synthesised from the rootfs shape
+when the caller does not supply one explicitly:
+
+- `host-bind` — start with the canonical Debian / Ubuntu order
+  (`/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin`),
+  then append survivors mined from the daemon's own `$PATH`
+  (`/opt/...`, `/snap/bin`, `/var/lib/flatpak/exports/bin`, …).
+  Survivors must be absolute paths, must not contain a `..`
+  segment, and must not begin with `/home`, `/Users`, `/root`,
+  `/tmp`, `/var/tmp`, or `/run/user` — these would either leak
+  the daemon-user's home layout or expose world-writable scratch
+  to the slice.
+  Each survivor is bind-mounted read-only into the slice so the
+  `$PATH` entry actually points at something inside the namespace.
+- `mount` — probe the host rootfs for the canonical bin dirs that
+  exist underneath it; use the slice-internal paths
+  (e.g. `<hostPath>/usr/bin` becomes `/usr/bin`) and fall back to
+  the canonical default when the probe finds nothing.
+- `minimal` — fall back to the canonical default.
+- `oci` (podman driver) — the image's `Config.Env` PATH, probed
+  once via `podman image inspect --format '{{json .Config.Env}}'`
+  and cached per image ref for the driver's lifetime; falls back to
+  the canonical default when the image declares no PATH.  The
+  resolved value is injected at `podman create` time as
+  `-e PATH=…` so the slice's effective PATH is observable from the
+  host regardless of whether the image declared one, and is
+  surfaced through `slice.help()` as a `path: <value> (source:
+  env|image|fallback)` row.
+
+Caller-granted mounts whose `innerPath` ends in `/bin` or `/sbin`
+(or that contain a `bin/` subdirectory) are promoted to the
+synthesised `$PATH`.
+They land **after** the rootfs-derived entries so a hostile mount
+cannot shadow `/usr/bin` with a bin dir of its own.
+A caller-supplied `env.PATH` always wins; the synthesis only fires
+when the slice's `env` does not include `PATH`.
+
+The canonical default lives in
+[`packages/sandbox/src/drivers/path.js`](../packages/sandbox/src/drivers/path.js)
+and is shared between the bwrap and podman drivers so the two
+backends never drift on the user-vs-administrative ordering.
+
 ### Security boundary clarity
 
 Three rules, restated explicitly:

--- a/TADA/21_sandbox_path.md
+++ b/TADA/21_sandbox_path.md
@@ -1,0 +1,49 @@
+
+While reviewing @endo/genie's usage of @endo/sandbox, I refined
+`packages/sandbox/src/drivers/bwrap.js` to manage default `$PATH` especially
+for `host-bind` mode.
+
+- [x] review all of the newly added code around `HOST_BIND_DEFAULT_PATH` and
+  how it's used in `assembleSliceArgv` via `defaultPath`
+  - collect and synthesise all relevant `// TODO` comments into follow-up `TODO/` task(s) for after this session
+  - **Done:** `TODO/22_sandbox_bwrap_path_refinements.md` collects the three
+    in-source `// TODO` markers (host-bind ambient `$PATH` injection,
+    `mount` rootfs probing, caller-mount bin-dir detection) plus a
+    review of `HOST_BIND_DEFAULT_PATH` ordering and the unused
+    constructor `env` parameter.
+
+- [x] analyze `packages/sandbox/src/drivers/podman.js` and plan a similar follow up `TODO/` task to add defautl `$PATH` logic to it
+  - but here it'd be ideal to inspect whatever OCI image is being used to discover its bin paths
+  - falling back to a canonical / classic default path
+  - **Done:** `TODO/23_sandbox_podman_path.md` plans the
+    `podman image inspect`-derived PATH discovery, the canonical
+    fallback, factoring out a shared default into
+    `packages/sandbox/src/drivers/path.js`, and surfacing the chosen
+    PATH via `slice.help()`.
+
+- [x] be sure these follow up tasks, or a final conclusion task, updates
+  `packages/sandbox/README.md` and `PLAN/endo_posix_sandbox.md` to talk about
+  `$PATH` semantics
+  - **Done:** Both follow-up tasks include explicit "Docs" checklist
+    items that add a `## $PATH semantics` section to
+    `packages/sandbox/README.md` and a corresponding subsection under
+    `PLAN/endo_posix_sandbox.md` § "Cross-cutting concerns".
+    Whichever follow-up lands first creates the section; the second
+    extends it.
+
+## Review notes captured (for posterity)
+
+- `assembleSliceArgv` only sets `defaultPath` for `rootfs.kind === 'host-bind'`.
+  `'mount'` and `'minimal'` rootfs slices currently get no `PATH` injection
+  at all unless the caller supplies one.
+- `HOST_BIND_DEFAULT_PATH` ordering puts `sbin` before `bin`
+  (`/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin`) which
+  differs from the Debian / Ubuntu user-default order.
+  Worth a comment + decision in the follow-up.
+- The constructor's `env` parameter is bound as `_env` and discarded.
+  Threading it through is a prerequisite for the ambient-`$PATH`
+  synthesis idea in `TODO/22`.
+- The host-side `cp.spawn` of `bwrap` itself (line 572 in `bwrap.js`)
+  uses `process.env.PATH ?? '/usr/bin:/bin'` for the *bwrap process's*
+  env, separate from what the slice sees.  This is unrelated to the
+  in-slice `defaultPath` and was not flagged for change.

--- a/TADA/22_sandbox_bwrap_path_refinements.md
+++ b/TADA/22_sandbox_bwrap_path_refinements.md
@@ -1,0 +1,106 @@
+
+# Sandbox bwrap driver: refine `$PATH` synthesis
+
+Follow-up to `TODO/21_sandbox_path.md`.
+The `bwrap` driver in `packages/sandbox/src/drivers/bwrap.js` now seeds a
+default `$PATH` for `host-bind` rootfs slices via `HOST_BIND_DEFAULT_PATH`.
+Three call-sites in `assembleSliceArgv` left explicit `// TODO` markers for
+how to extend the synthesis to the other rootfs / mount shapes.
+This task collects them.
+
+**Status: landed.**
+The synthesis logic moved into a shared
+`packages/sandbox/src/drivers/path.js` module so the bwrap and
+(future) podman drivers consume the same canonical default and the
+same set of helpers.
+The bwrap driver now mines the daemon's ambient `$PATH` for
+host-bind slices, probes a `mount` rootfs for canonical bin dirs,
+and promotes caller-granted bin-shaped mounts.
+A unit-test block in `packages/sandbox/test/bwrap.test.js` exercises
+each rootfs shape against `assembleSliceArgv` directly so the
+synthesis is regression-tested without spawning a real bwrap.
+
+## Background
+
+`assembleSliceArgv` (lines ~191–305) accumulates a `defaultPath` string that
+is used to inject `--setenv PATH …` only when the caller did not supply
+their own `PATH` via `spec.env`.
+Today only the `host-bind` branch sets `defaultPath`; the other branches
+leave it empty, so a slice with `rootfs: { kind: 'mount' }` or
+`rootfs: { kind: 'minimal' }` gets no `PATH` at all unless the caller sets
+one.
+
+The driver constructor accepts `env` (currently bound as `_env`, marked
+unused).
+That parameter is the daemon's environment, including the daemon's own
+`$PATH` — useful for some of the synthesis ideas below.
+
+## Tasks
+
+- [x] **Inspect ambient `$PATH` for `host-bind` rootfs.**
+  Implemented via `filterAmbientPathForHostBind` in
+  `packages/sandbox/src/drivers/path.js`.
+  The bwrap driver passes `env.PATH` through to `assembleSliceArgv`,
+  which calls the filter and bind-mounts each survivor with
+  `--ro-bind-try host host` before appending it to the synthesised
+  `$PATH`.
+  The rejection rules match the original spec: drop entries under
+  `/home`, `/Users`, `/root`, `/tmp`, `/var/tmp`, `/run/user`, anything
+  containing `..`, anything not absolute, anything not present on
+  disk (best-effort `fs.existsSync`).
+  Canonical bin dirs already covered by the default are also
+  de-duplicated.
+
+- [x] **Inspect `mount` rootfs for `defaultPath` components.**
+  Implemented via `probeMountRootfsBinPaths` in
+  `packages/sandbox/src/drivers/path.js`.
+  When `rootfs.kind === 'mount'`, the driver probes for
+  `<hostPath>/usr/bin`, `<hostPath>/bin`, etc., and feeds the
+  matching slice-internal paths into the synthesised `$PATH`.
+  When the probe finds nothing, the assembly falls back to the
+  shared `DEFAULT_PATH`.
+
+- [x] **Detect likely bin-dirs among caller-granted mounts.**
+  Implemented via `detectMountBinPaths` in
+  `packages/sandbox/src/drivers/path.js`.
+  A mount whose `innerPath` ends in `/bin` or `/sbin` is promoted
+  directly; mounts with a `bin/` (or `sbin/`) subdirectory under
+  `hostPath` get the corresponding `${innerPath}/bin` /
+  `${innerPath}/sbin` entry.
+  Caller-granted bin-dirs land **after** the rootfs-derived defaults
+  so a hostile caller cannot shadow `/usr/bin`.
+
+- [x] **Review `HOST_BIND_DEFAULT_PATH` ordering.**
+  Flipped to the Debian / Ubuntu default
+  (`/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin`)
+  and renamed `DEFAULT_PATH` because it is now the canonical
+  fall-back across rootfs shapes (and across drivers — the podman
+  driver follow-up consumes the same constant).
+  The choice is documented in a comment block at the top of
+  `packages/sandbox/src/drivers/path.js`.
+
+- [x] **Wire the constructor's `env` parameter through.**
+  `makeBwrapDriver({ env })` now binds `env` (no longer `_env`) and
+  threads `env.PATH` into `assembleSliceArgv` via the new
+  `extras.ambientPath` field.
+  Tests can pass a deterministic `env` to suppress the
+  `process.env.PATH` inheritance; the JSDoc on the constructor
+  documents the new contract.
+
+- [x] **Tests.**
+  `packages/sandbox/test/bwrap.test.js` grew a `PATH synthesis` test
+  block (nine cases) that calls `assembleSliceArgv` directly, with
+  injected `exists` probes, and asserts the `--setenv PATH …` argv
+  slot for each rootfs shape and each precedence rule (caller env
+  wins, rootfs defaults precede caller-mount bin dirs, ambient
+  survivors are filtered, missing host paths are dropped).
+
+- [x] **Docs.**
+  `packages/sandbox/README.md` now has a top-level `## $PATH
+  semantics` section that lays out the per-rootfs default, the
+  `/home`-exclusion rule for ambient PATH mining, and the
+  caller-mount bin-dir promotion rule, plus a cross-link to
+  `TODO/23_sandbox_podman_path.md`.
+  `PLAN/endo_posix_sandbox.md` § "Cross-cutting concerns" gained an
+  "Environment defaults" subsection covering the same policy at the
+  design level.

--- a/TADA/23_sandbox_podman_path.md
+++ b/TADA/23_sandbox_podman_path.md
@@ -1,0 +1,151 @@
+
+# Sandbox podman driver: default `$PATH` synthesis
+
+Follow-up to `TODO/21_sandbox_path.md`.
+The bwrap driver now seeds a sensible default `$PATH` for `host-bind` slices
+(`HOST_BIND_DEFAULT_PATH`).
+The podman driver in `packages/sandbox/src/drivers/podman.js` has no
+equivalent: the slice's `PATH` is whatever the OCI image's
+`Config.Env` happens to set, which works for well-formed images but
+silently drops `PATH` if the caller passes `env: { … }` that does not
+include a `PATH` key (because the per-spawn `-e KEY=VALUE` flags layer
+on top, while the image's `ENV` is consulted only when no override
+clears it).
+
+## Background
+
+In `assembleCreateArgv` (`packages/sandbox/src/drivers/podman.js` ~331–397),
+caller-supplied `spec.env` is passed through as `-e KEY=VALUE` per entry.
+podman does not honour `--clearenv`-style semantics; the image's `ENV` is
+preserved unless the caller's `-e PATH=…` overrides it.
+The bwrap driver's invariant — "if the caller did not set `PATH`, fall back
+to a sensible default" — is therefore not currently mirrored in the podman
+driver.
+For consistency the podman driver should:
+
+1. Discover the OCI image's own `PATH` from `podman image inspect <ref>`.
+2. Use that as the fallback when `spec.env.PATH` is unset.
+3. Fall back to a canonical default (the same
+   `/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin` shape
+   the bwrap driver uses) when the image declares no `PATH` of its own.
+
+## Tasks
+
+- [x] **Probe the image's `PATH`.**
+  Add a helper alongside `ensureImage` that runs
+  `podman image inspect --format '{{json .Config.Env}}' <ref>` and parses
+  the resulting JSON array of `KEY=VALUE` strings.
+  Return the value of the `PATH` key (if any).
+  Cache the result keyed by `ref` for the lifetime of the driver — image
+  refs are immutable enough to make this safe within a daemon run; a
+  retag of the same ref is rare and the worst case is a stale fallback.
+
+- [x] **Apply the fallback in `prepareSlice`.**
+  When `spec.env.PATH === undefined` and an image-derived `PATH` was
+  found, append `-e PATH=<imagePath>` to `assembleCreateArgv`.
+  Otherwise append `-e PATH=<DEFAULT_PATH>` using the same canonical
+  string the bwrap driver uses for `host-bind` (factor it out into a
+  shared constant — see the cross-cutting task below).
+
+  Implemented via `resolveSlicePath(spec, imagePath)` which returns
+  `{ value, source }` with `source ∈ { 'env', 'image', 'fallback' }`.
+  When `source !== 'env'`, `prepareSlice` passes the chosen value as
+  `extras.pathInjection` to `assembleCreateArgv`, which emits the
+  `-e PATH=<value>` flag once the per-key loop confirms the caller's
+  `spec.env` did not already include `PATH`.
+
+- [x] **Spawn-time override.**
+  `spawn` accepts per-call `opts.env`.
+  If `opts.env.PATH` is unset, do **not** re-inject the fallback at exec
+  time — the slice already has it from the create step.
+  If the caller explicitly sets `opts.env.PATH = ''` they are opting out;
+  honour that.
+
+  The `spawn` implementation iterates `opts.env` and emits `-e KEY=VALUE`
+  for each entry without any special-case fallback synthesis, so the
+  semantics described above fall out for free.
+
+- [x] **Surface the chosen `PATH` in `slice.help()`.**
+  Extend `runtimeDetails` with a `path:` row (or fold into an existing
+  `env:` row if one is added) so operators can confirm whether the
+  slice picked up the image's PATH or the fallback.
+  Useful for debugging "why can't my slice find `apk`" cases.
+
+  `PodmanSliceContext.runtimeDetails.path = { value, source }` is
+  populated by `prepareSlice` and rendered by `factory.js`'s
+  `renderSliceRuntimeReport` as
+  `path: <value> (source: env|image|fallback)`.
+
+- [x] **Shared constant.**
+  Move the canonical default
+  `/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin` out of
+  `bwrap.js` into a small shared module (e.g.
+  `packages/sandbox/src/drivers/path.js`) and re-export from both
+  drivers.
+  This avoids the strings drifting out of sync.
+  Coordinate the move with `TODO/22_sandbox_bwrap_path_refinements.md`
+  if it lands first; otherwise the podman patch defines the constant
+  and the bwrap follow-up consumes it.
+
+  `packages/sandbox/src/drivers/path.js` now owns `DEFAULT_PATH` (and
+  related host-bind PATH-mining helpers); both drivers import it.
+  The order was deliberately flipped to user-bin-first to match the
+  Debian / Ubuntu interactive-shell default — see the comment in
+  `path.js`.
+
+- [x] **Tests.**
+  Extend `test/podman.test.js` with two cases:
+  - Image with a known `PATH` in `Config.Env`: assert the slice spawn
+    sees that `PATH` (run `printenv PATH` inside the slice).
+  - Image with no `Config.Env` `PATH`: assert the slice spawn sees the
+    canonical fallback.
+  The existing image-availability skip pattern (`alpine:3.19` not
+  pulled ⇒ `t.pass()`) applies here too.
+
+  `test/podman.test.js` now exercises:
+  - `parseImagePathFromConfigEnv` parser corner cases (extracts PATH,
+    null when absent, null on malformed JSON, tolerates non-string
+    entries, honours empty PATH);
+  - alpine slice spawn sees the image-derived PATH (source: image);
+  - caller `spec.env.PATH` overrides the image-derived PATH
+    (source: env);
+  - image with no `Config.Env` PATH falls back to `DEFAULT_PATH`
+    (source: fallback) — built via a transient `podman commit` of an
+    empty PATH so the parser surfaces `''` and `resolveSlicePath`
+    routes onto the canonical default.
+  Each integration test gracefully passes when the underlying alpine
+  image is not pulled.
+
+- [x] **Docs.**
+  Update `packages/sandbox/README.md` `## $PATH semantics` (added by
+  the bwrap follow-up; create the section here if this task lands
+  first) with the podman behaviour:
+  - default = image's `Config.Env` PATH;
+  - fallback = canonical default (cross-link the bwrap driver);
+  - `slice.help()` reports which was chosen.
+
+  Also update `PLAN/endo_posix_sandbox.md` § "Cross-cutting concerns"
+  to mention image-derived PATH discovery as the podman driver's
+  contract, and the canonical default as the cross-driver fallback.
+  If `TODO/22_sandbox_bwrap_path_refinements.md` already added the
+  subsection, extend it instead of creating a parallel one.
+
+  `packages/sandbox/README.md` § "$PATH semantics" now lists the
+  `oci` row in the per-rootfs default table and carries a
+  "Cross-driver consistency" subsection covering the precedence rule,
+  the `-e PATH=…` injection at create time, and the
+  `path: <value> (source: …)` line in `slice.help()`.
+  `PLAN/endo_posix_sandbox.md` § "Environment defaults" gained an
+  `oci (podman driver)` bullet describing the inspect-and-cache
+  contract and the `slice.help()` surface.
+
+## Status
+
+All tasks complete.
+Verified locally:
+
+- `node --check` on `src/drivers/podman.js`, `src/drivers/path.js`,
+  and `test/podman.test.js`.
+- `npx ava test/podman.test.js -m '*PATH*'` — 8 / 8 tests pass.
+- `yarn lint` shows no sandbox-package errors (unrelated TS noise
+  in other packages predates this change).

--- a/TADA/24_sandbox_paths_review_round1.md
+++ b/TADA/24_sandbox_paths_review_round1.md
@@ -1,0 +1,108 @@
+# Address the below feedback from review
+
+- [x] update `filterAmbientPathForHostBind` to use `realpath` ; I'd mildly
+  prefer to use an async/promise-returning realpath resolver, rather than
+  `realpathSync` if one's available
+  - Done in `packages/sandbox/src/drivers/path.js`.
+    `filterAmbientPathForHostBind` is now async and accepts a
+    `realpath: (p) => Promise<string|null>` option.  After the textual
+    block-prefix check passes, the entry is canonicalised through the
+    resolver and the prefix / `..` / canonical-bin-dir checks are
+    re-applied to the resolved value.  An `ENOENT`/`EACCES`/`ELOOP`
+    from the resolver drops the entry.
+  - The bwrap driver wires `fs.promises.realpath` through
+    `prepareSlice`; `assembleSliceArgv` is now async accordingly.
+  - Tests added to `packages/sandbox/test/bwrap.test.js`:
+    - "drops ambient entries whose realpath lands in a blocked
+      prefix" — covers the `/opt/eve → /tmp/attacker` symlink trick.
+    - "drops ambient entries whose realpath fails" — covers the
+      ENOENT/EACCES path.
+
+- [x] update `joinPathEntries` so that it sanitizes `innerPath` input:
+  - newlines should be a fatal error, raise an exception
+  - for colons, just split and process parts, so that for an input like we'd get `/foo/bin:/bin/bin`
+  - Done in `joinPathEntries` (path.js).  Any control character
+    (`\x00..\x1f`) raises `makeError(X\`PATH entry must not contain
+    control characters: ${q(entry)}\`)`.  Embedded `:` separators are
+    split and each part is processed as an independent entry, so a
+    caller-granted `innerPath = '/foo:/bin'` produces a clean
+    `…:/foo:/bin` rather than smuggling `/foo` in by concatenation.
+  - Tests added: "innerPath with embedded colon is split, not
+    smuggled" and "innerPath with newline is fatal".
+
+- [x] detect and prune/skip any relative `hostPath`s in `probeMountRootfsBinPaths`
+  - Done.  The helper short-circuits to `[]` when `hostPath` is not a
+    string starting with `/`, so probes never resolve against the
+    daemon's CWD.  Test added: "relative mount rootfs hostPath is
+    skipped" — also asserts the `exists` probe is never called.
+
+- [x] fallback to the empty string for `mount`-rootfs that lacks canonical bin dirs
+  - we're doing the probe anyhow, so the fallback should only include directories that actually exist inside a given OCI image
+  - Done in `assembleSliceArgv` (bwrap.js) step 9.  When the synthesis
+    yields an empty string and the rootfs is `kind: 'mount'`, the
+    slice gets `--setenv PATH ''` rather than `DEFAULT_PATH`.  The
+    pre-existing `DEFAULT_PATH` fallback is preserved for `host-bind`
+    and `minimal` rootfs shapes (where the canonical bin dirs are
+    actually mounted in or expected to be).  Test renamed: "mount
+    rootfs with empty probe yields empty PATH".
+
+## Verification
+
+- `npx corepack yarn lint:eslint` clean (0 errors, 0 warnings on the
+  changed files).
+- `tsc --build` reports no new errors in the sandbox package; the
+  unrelated upstream errors in `base64`, `harden`, etc. are
+  pre-existing.
+- `npx corepack yarn workspace @endo/sandbox test` — all 80 tests
+  pass across the four lockdown configs (lockdown, unsafe, endo,
+  noop-harden).
+
+## Saboteur findings (PR 119: sandbox $PATH derivation)
+
+cc @jcorbin, @kriskowal
+
+Reviewed `drivers/path.js`, the bwrap and podman synthesis call sites, and the
+spec-resolution chain in `factory.js`. The threat model in
+`TADA/22_sandbox_bwrap_path_refinements.md` is sound and the precedence
+(rootfs-defaults → ambient-survivors → caller-mounts) does prevent shadowing of
+`/usr/bin` for the obvious case. A handful of attack surfaces remain.
+
+### Real concerns
+
+1. **No `realpath` on ambient `$PATH` survivors (host-bind).**
+   `filterAmbientPathForHostBind` rejects literal `/tmp/`, `/home/`, `..`,
+   etc., but it does **not** call `fs.realpathSync`.  An operator-installed
+   `/opt/eve` that is itself a symlink to `/tmp/attacker` survives the textual
+   prefix check, gets `--ro-bind-try`'d into the slice, and ends up on the
+   slice's `$PATH`.  The whole point of the `/tmp` block list is to keep
+   world-writable scratch out of the slice; symlink-via-`/opt` defeats it.
+   Suggest resolving each survivor with `fs.realpathSync` and re-applying the
+   prefix check to the resolved value (drop on `EACCES`/`ENOENT`).
+
+2. **No validation of `mount.hostPath` / `mount.innerPath` characters.**
+   `joinPathEntries` blindly does `entries.join(':')`.  A caller-granted mount
+   with `innerPath = '/foo:/bin'` produces a `detectMountBinPaths` result of
+   `'/foo:/bin/bin'`, which when joined silently inserts `/foo` into `$PATH`.
+   Newlines in `innerPath` corrupt the `--setenv PATH …` argv slot in a
+   different but equally surprising way.  The cap mechanism is the trust
+   boundary today, but a defensive `if (entry.includes(':') ||
+   /[\x00-\x1f]/.test(entry)) continue;` in `joinPathEntries` would close it.
+
+3. **`probeMountRootfsBinPaths` works on a relative path when `hostPath` lacks
+   a leading `/`.** If `mountSpec.hostPath = 'srv/foo'` (or `..`), the probe
+   does `existsSync('srv/foo/usr/bin')` against the daemon's CWD.  That is not
+   a sandbox escape — bwrap will reject the `--ro-bind ../  /` invocation
+   downstream — but the synthesised `$PATH` ends up reflecting CWD-shaped
+   probes that have nothing to do with the slice.  An early `if
+   (!hostPath.startsWith('/')) return [];` would localise the failure mode.
+
+4. **`mount`-rootfs with no canonical bin dirs falls back to host-shaped
+   DEFAULT_PATH.** When the probe returns `[]`, the slice's `$PATH` is
+   `/usr/local/bin:/usr/bin:/bin:…` — i.e., paths that **do not exist inside
+   the slice**.  Not a sandbox escape, but the comment in `bwrap.js` says the
+   fallback is "so the slice can at least find sh/echo if the caller bound a
+   standard userland tree" — which is exactly the case the probe just
+   disproved.  The fallback should be the empty string for `mount` rootfs whose
+   probe came up empty, or it should be documented that the caller is
+   responsible for setting `spec.env.PATH` themselves.
+

--- a/TADA/25_sandbox_path_prefixs.md
+++ b/TADA/25_sandbox_path_prefixs.md
@@ -1,0 +1,53 @@
+# Sandbox bin path mounts
+
+
+- read `packages/sandbox/src/drivers/bwrap.js` circa lines 297-313
+- read `packages/sandbox/src/drivers/path.js` circa lines 45-61 wrt `CANONICAL_BIN_PATHS`
+
+- [x] we need to convert survivor bin paths into functional mount prefixes as describe inline
+  - and those mounts need to be deduplicated ; in general, all mounts passed as
+    flags like `--ro-bind-try` need to be dedeuplicated in that entire section
+    of argv assembling
+  - Done: added `elevateSurvivorToMountRoot` in
+    `packages/sandbox/src/drivers/path.js`.
+    Strips a trailing `/bin` or `/sbin` segment to get the package
+    root (`/opt/rocm/bin` → `/opt/rocm`, `/snap/bin` → `/snap`),
+    then strips a further trailing `/exports` so flatpak-shaped
+    paths reach the right level
+    (`/var/lib/flatpak/exports/bin` → `/var/lib/flatpak`).
+  - Done: dedup is applied in `assembleSliceArgv` via a local
+    `tryAddRoBindTry` helper that tracks seen host paths and drops
+    a request when an earlier entry already covers it (identical or
+    strict ancestor).  The host-bind branch now routes both
+    `HOST_BIND_ROOTFS_PATHS` and the elevated survivors through this
+    helper, so e.g. `/usr/bin/site_perl` survivors never emit a
+    second `--ro-bind-try` under `/usr`.
+  - Note: PATH entries still record the original survivor path so
+    commands resolve at the directory the operator placed on
+    `$PATH`; only the *mount* widens to the package root.
+
+- [x] this also brings up that our canonical mounts are insufficient
+  - `/bin` needs `/lib` (maybe also `/lib64` or `/lib32`) to function,
+    classically these binaries are not statically linked
+  - similarly `/usr/bin` needs all of `/usr` to function, not just dynamic
+    libraries, but also data in places like `/usr/share`
+  - Done: `HOST_BIND_ROOTFS_PATHS` already covered `/usr`, `/lib`,
+    `/lib64`, `/etc`; added `/lib32` for multilib hosts.  `/usr/share`
+    and friends are reachable through the existing `/usr` bind, and
+    the comment on `HOST_BIND_ROOTFS_PATHS` now spells out why we
+    bind the parent roots wholesale.
+
+- Tests:
+  - Updated `PATH synthesis: host-bind appends ambient survivors after canonical bins`
+    to assert `/snap/bin` lands as a `/snap` bind (elevated) and the
+    raw `/opt/local/bin` is no longer bound separately.
+  - Added `mount dedup: survivors under canonical roots do not emit redundant binds`
+    pinning that `/usr/*` survivors never produce a second `/usr`
+    bind, while their PATH entries still appear.
+  - Added `mount dedup: flatpak survivor elevates past /exports`
+    pinning the two-level strip for `/var/lib/flatpak/exports/bin`.
+  - Added `mount dedup: HOST_BIND_ROOTFS_PATHS entries deduplicate against /usr`
+    pinning that the legitimate top-level siblings (`/lib`, `/lib32`,
+    `/lib64`, `/bin`, `/sbin`, `/etc`) still each emit their own
+    bind alongside `/usr` (guard against an over-eager dedup).
+

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -246,6 +246,93 @@ feed into `firewalld` / `ufw` / `nftables` rules on the host.
   (placeholder in `prepareSlice`); a future patch will memfd-write
   the blob and pass `--seccomp <fd>`.
 
+## $PATH semantics
+
+A slice's `$PATH` is synthesised at slice construction so that
+unqualified commands (`echo`, `sh`, `apk`, …) resolve under the
+configured rootfs without the caller having to spell out the path
+explicitly.
+A caller-supplied `env.PATH` always wins; the synthesis only fires
+when the slice spec's `env` does not already include `PATH`.
+
+The default is constructed per-rootfs:
+
+| Rootfs       | Default `$PATH`                                                                                     |
+| ------------ | --------------------------------------------------------------------------------------------------- |
+| `host-bind`  | `/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin` plus operator-installed survivors    |
+| `mount`      | the subset of the canonical bin dirs that exist under the host rootfs, falling back to the default  |
+| `minimal`    | the canonical default                                                                               |
+| `oci`        | the image's `Config.Env` PATH (Phase 2 podman driver), falling back to the canonical default        |
+
+The canonical default is sourced from
+[`src/drivers/path.js`](./src/drivers/path.js) and is shared between
+the bwrap and podman drivers so the two backends do not drift.
+The order is the Debian / Ubuntu interactive-shell order
+(user bin dirs first, administrative dirs last) — flipped from the
+Phase 1 order, which put `/sbin` first.
+
+### Ambient `$PATH` mining (host-bind)
+
+The bwrap driver also mines the daemon's own `process.env.PATH`
+(or the constructor's `env.PATH` if one was passed) for distro-shaped
+extras such as `/opt/...`, `/snap/bin`, or
+`/var/lib/flatpak/exports/bin`.
+A survivor must:
+
+- be an absolute path,
+- not contain a `..` segment,
+- not begin with one of `/home`, `/Users`, `/root`, `/tmp`,
+  `/var/tmp`, or `/run/user` — these would either point at
+  user-private state or world-writable scratch where another local
+  user could plant a binary,
+- not be one of the canonical bin dirs already covered by the
+  default,
+- exist on disk (best-effort `fs.existsSync` probe — the
+  `--ro-bind-try` mount itself tolerates a missing path).
+
+Survivors are bind-mounted read-only into the slice and appended
+to `$PATH` in their daemon-PATH order.
+**`/home`-prefixed entries are deliberately dropped** so a daemon
+running out of an operator's home directory does not leak the home
+layout into the slice.
+
+### Caller-mount bin-dir promotion
+
+When the caller grants a mount whose `innerPath` ends in `/bin` or
+`/sbin`, or whose host directory contains a `bin/` (or `sbin/`)
+subdirectory, the inner-side bin path is appended to `$PATH`.
+These promoted entries land **after** the rootfs-derived defaults so
+a hostile caller cannot shadow `/usr/bin` with a bin dir of their
+own.
+
+### Cross-driver consistency
+
+The podman driver (Phase 2) follows the same precedence rule the
+bwrap driver uses for `host-bind`:
+
+1. caller-supplied `spec.env.PATH` always wins,
+2. otherwise the OCI image's declared `PATH` from `Config.Env`
+   (probed once via `podman image inspect --format '{{json .Config.Env}}'`
+   and cached per ref for the driver's lifetime),
+3. otherwise the shared canonical default.
+
+The injection happens at `podman create` time as `-e PATH=…`, so the
+slice's effective `PATH` is observable from the host even when the
+image declared one of its own.  The chosen value and its source
+(`env` / `image` / `fallback`) are surfaced via the `slice.help()`
+"Hardening layers in effect" report:
+
+```text
+  path: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin (source: image)
+```
+
+This makes "why can't my slice find `apk`" debuggable without having
+to spawn `printenv PATH` inside the container.
+
+The shared canonical default lives in `src/drivers/path.js` so the
+podman driver's fall-back and the bwrap driver's `minimal`-rootfs
+fall-back stay aligned.
+
 ## Hardening layers
 
 Phase 1.5 surfaces three additional confinement knobs the slice

--- a/packages/sandbox/src/drivers/bwrap.js
+++ b/packages/sandbox/src/drivers/bwrap.js
@@ -349,7 +349,7 @@ export const assembleSliceArgv = async (spec, extras) => {
     argv.push(flag, mount.hostPath, mount.innerPath);
     // Caller-mount bin-dirs land **after** rootfs-derived defaults so
     // a hostile mount cannot shadow `/usr/bin` with `bin/foo` of its
-    // own.  See `TODO/22_sandbox_bwrap_path_refinements.md` for the
+    // own.  See `TADA/22_sandbox_bwrap_path_refinements.md` for the
     // threat model.
     for (const innerPath of detectMountBinPaths(mount, {
       exists: extras.exists,

--- a/packages/sandbox/src/drivers/bwrap.js
+++ b/packages/sandbox/src/drivers/bwrap.js
@@ -15,6 +15,14 @@ import {
   makeCgroup2Probe,
   resolveLimits,
 } from '../limits.js';
+import {
+  CANONICAL_BIN_PATHS,
+  DEFAULT_PATH,
+  detectMountBinPaths,
+  filterAmbientPathForHostBind,
+  joinPathEntries,
+  probeMountRootfsBinPaths,
+} from './path.js';
 
 /** @import { SandboxDriver, SliceSpec, SpawnOpts, DriverProcess, BackendProbe, BackendProbeDetails } from '../types.js' */
 
@@ -49,6 +57,11 @@ const ROOTFS_BASE_FLAGS = harden([
  * Host paths bind-mounted read-only when `rootfs.kind === 'host-bind'`.
  * Each entry is tried with `--ro-bind-try` so a missing host path is
  * skipped rather than failing the slice.
+ *
+ * The bin-dir entries here mirror `CANONICAL_BIN_PATHS` from
+ * `./path.js`; the rootfs binds also include `/usr`, `/lib`,
+ * `/lib64`, and `/etc` so dynamic linkers and configuration files
+ * are reachable.
  */
 const HOST_BIND_ROOTFS_PATHS = harden([
   '/usr',
@@ -183,10 +196,25 @@ harden(readableToAsyncIterable);
  *  10. Initial `--chdir` (when `cwd` is set).
  *
  * @param {SliceSpec} spec
- * @param {{ seccompFd: number | null }} extras
- * @returns {string[]}
+ * @param {{
+ *   seccompFd: number | null,
+ *   ambientPath?: string,
+ *   exists?: (path: string) => boolean,
+ *   realpath?: (path: string) => Promise<string | null>,
+ * }} extras  `ambientPath` is the daemon-side `$PATH` mined for
+ *            host-bind PATH synthesis; defaults to `process.env.PATH`.
+ *            `exists` is the host-disk probe used by the synthesis
+ *            helpers; defaults to `fs.existsSync`.  `realpath` is the
+ *            symlink-resolving canonicaliser applied to ambient PATH
+ *            survivors; defaults to identity (no resolution) so test
+ *            harnesses without a filesystem can call this directly.
+ * @returns {Promise<string[]>}
  */
-const assembleSliceArgv = (spec, extras) => {
+export const assembleSliceArgv = async (spec, extras) => {
+  // Hoisted `await null` so the `safe-await-separator` rule sees a
+  // top-level await before the conditional `await
+  // filterAmbientPathForHostBind(...)` further down.
+  await null;
   /** @type {string[]} */
   const argv = [];
 
@@ -214,6 +242,7 @@ const assembleSliceArgv = (spec, extras) => {
 
   // 2. Lifecycle.
   argv.push('--die-with-parent');
+  argv.push('--new-session');
 
   // 3. Drop all capabilities.
   argv.push('--cap-drop', 'ALL');
@@ -226,6 +255,21 @@ const assembleSliceArgv = (spec, extras) => {
   }
 
   // 5. Rootfs.
+  //
+  // `defaultPathEntries` accumulates the slice-internal directories
+  // we believe should be on `$PATH` if the caller did not supply one.
+  // We compose the final string at the bottom of step 9 so the
+  // entries observe the documented precedence:
+  //
+  //   1. Rootfs-derived defaults (host-bind canonical bin dirs, mount
+  //      rootfs probed bin dirs, or `DEFAULT_PATH` for `minimal`).
+  //   2. Daemon-side ambient `$PATH` survivors (host-bind only;
+  //      `/opt`, `/snap/bin`, etc. that the operator added to the
+  //      daemon's environment).
+  //   3. Caller-granted mount bin-dirs (a hostile caller cannot
+  //      shadow `/usr/bin` because their entries land last).
+  /** @type {string[]} */
+  const defaultPathEntries = [];
   if (
     typeof spec.rootfs === 'object' &&
     spec.rootfs !== null &&
@@ -237,10 +281,33 @@ const assembleSliceArgv = (spec, extras) => {
         // 32-bit hosts) instead of failing the slice.
         argv.push('--ro-bind-try', path, path);
       }
+      // Canonical bin dirs first — these are the same paths we just
+      // bound above and they end up in `DEFAULT_PATH` order.
+      for (const binPath of CANONICAL_BIN_PATHS) {
+        defaultPathEntries.push(binPath);
+      }
+      // Then mine the daemon's `$PATH` for distro-shaped extras
+      // (`/opt/...`, `/snap/bin`, `/var/lib/flatpak/exports/bin`, …).
+      // The filter rejects user-private and world-writable entries,
+      // canonicalises through `realpath` to defeat the
+      // `/opt/eve → /tmp/attacker` symlink trick, and drops any
+      // non-existent host paths; survivors are bound read-only into
+      // the slice and appended to the path string in their
+      // daemon-PATH order.
+      const ambientSurvivors = await filterAmbientPathForHostBind(
+        extras.ambientPath,
+        { exists: extras.exists, realpath: extras.realpath },
+      );
+      for (const path of ambientSurvivors) {
+        argv.push('--ro-bind-try', path, path);
+        defaultPathEntries.push(path);
+      }
     } else if (spec.rootfs.kind === 'minimal') {
       // Nothing — caller is expected to bind their own rootfs via
       // `mounts`.  We still get /proc, /dev, /tmp from the base
-      // rootfs flags below.
+      // rootfs flags below.  Caller-mount bin-dirs (step 6 below)
+      // and the `DEFAULT_PATH` fallback at the end of step 9 cover
+      // the env-PATH side.
     } else if (spec.rootfs.kind === 'mount') {
       const mountSpec =
         /** @type {{ kind: 'mount'; hostPath: string; mode: 'ro' | 'rw' }} */ (
@@ -248,6 +315,23 @@ const assembleSliceArgv = (spec, extras) => {
         );
       const flag = mountSpec.mode === 'rw' ? '--bind' : '--ro-bind';
       argv.push(flag, mountSpec.hostPath, '/');
+      // Probe the host directory for the canonical bin dirs.  The
+      // mount is rooted at `/`, so `<hostPath>/usr/bin` becomes
+      // `/usr/bin` inside the slice.  When the probe finds nothing —
+      // either because `hostPath` is relative (the helper bails out)
+      // or because the rootfs genuinely lacks any of the canonical
+      // bin layouts — we synthesise an empty `$PATH` rather than
+      // falling back to `DEFAULT_PATH`: those default paths point at
+      // directories the slice has just demonstrated it does not
+      // contain, so claiming they exist would produce confusing
+      // `command not found` failures inside the slice.  Callers with
+      // an unconventional rootfs are expected to set `spec.env.PATH`
+      // explicitly.
+      for (const innerPath of probeMountRootfsBinPaths(mountSpec.hostPath, {
+        exists: extras.exists,
+      })) {
+        defaultPathEntries.push(innerPath);
+      }
     } else if (spec.rootfs.kind === 'oci') {
       // OCI image refs are the podman driver's surface; bwrap has no
       // way to materialise an OCI image without an external store.
@@ -263,6 +347,15 @@ const assembleSliceArgv = (spec, extras) => {
   for (const mount of spec.mounts) {
     const flag = mount.mode === 'rw' ? '--bind' : '--ro-bind';
     argv.push(flag, mount.hostPath, mount.innerPath);
+    // Caller-mount bin-dirs land **after** rootfs-derived defaults so
+    // a hostile mount cannot shadow `/usr/bin` with `bin/foo` of its
+    // own.  See `TODO/22_sandbox_bwrap_path_refinements.md` for the
+    // threat model.
+    for (const innerPath of detectMountBinPaths(mount, {
+      exists: extras.exists,
+    })) {
+      defaultPathEntries.push(innerPath);
+    }
   }
 
   // 7. Writable scratch upper layer.  Mounted as `/scratch` so it is
@@ -279,8 +372,40 @@ const assembleSliceArgv = (spec, extras) => {
 
   // 9. Environment.
   argv.push('--clearenv');
+  let hadPath = false;
   for (const [key, value] of Object.entries(spec.env)) {
     argv.push('--setenv', key, value);
+    if (key === 'PATH') hadPath = true;
+  }
+  if (!hadPath) {
+    // Caller did not set `PATH`.  Use the synthesised entries; if
+    // synthesis turned up nothing the fallback depends on the rootfs
+    // shape:
+    //   - `host-bind` and `minimal` fall back to `DEFAULT_PATH` so the
+    //     slice can find `sh`/`echo` against the host bin dirs that
+    //     `host-bind` always binds (or that a `minimal` caller is
+    //     expected to bind explicitly via `mounts`).
+    //   - `mount`-rootfs slices fall back to the empty string: the
+    //     probe just demonstrated that none of the canonical bin
+    //     layouts exist inside the rootfs, so `DEFAULT_PATH` would
+    //     point at directories the slice does not contain.  A caller
+    //     who knows their rootfs uses an unusual layout is expected
+    //     to set `spec.env.PATH` explicitly.
+    const synthesised = joinPathEntries(defaultPathEntries);
+    const isMountRootfs =
+      typeof spec.rootfs === 'object' &&
+      spec.rootfs !== null &&
+      'kind' in spec.rootfs &&
+      spec.rootfs.kind === 'mount';
+    let pathValue;
+    if (synthesised !== '') {
+      pathValue = synthesised;
+    } else if (isMountRootfs) {
+      pathValue = '';
+    } else {
+      pathValue = DEFAULT_PATH;
+    }
+    argv.push('--setenv', 'PATH', pathValue);
   }
 
   // 10. Cwd inside the slice.
@@ -297,19 +422,58 @@ harden(assembleSliceArgv);
  *
  * @param {object} [input]
  * @param {Record<string, string>} [input.env]                Daemon env
- *                                                            (PATH etc.)
+ *                                                            (PATH etc.).
+ *                                                            The `PATH`
+ *                                                            field, when
+ *                                                            present, is
+ *                                                            mined for
+ *                                                            host-bind
+ *                                                            slices so a
+ *                                                            slice can
+ *                                                            see operator-
+ *                                                            installed
+ *                                                            bin dirs
+ *                                                            like `/opt`
+ *                                                            and `/snap/bin`.
+ *                                                            Defaults to
+ *                                                            an empty
+ *                                                            object — a
+ *                                                            test that
+ *                                                            wants
+ *                                                            deterministic
+ *                                                            argv shape
+ *                                                            should pass
+ *                                                            `env: {}`
+ *                                                            explicitly
+ *                                                            so the driver
+ *                                                            does not
+ *                                                            inherit the
+ *                                                            ambient
+ *                                                            `process.env.PATH`.
  * @param {typeof import('child_process')} [input.childProcess] Child-
  *                                                            process module
  *                                                            override
  *                                                            (tests).
  * @param {typeof import('fs')} [input.fs]                    fs module
- *                                                            override.
+ *                                                            override.  Used
+ *                                                            for the
+ *                                                            `existsSync`
+ *                                                            probe and the
+ *                                                            `promises.realpath`
+ *                                                            canonicaliser
+ *                                                            that back the
+ *                                                            ambient-PATH
+ *                                                            and mount-bin
+ *                                                            synthesis;
+ *                                                            tests can
+ *                                                            inject a
+ *                                                            stub.
  * @returns {SandboxDriver}
  */
 export const makeBwrapDriver = ({
-  env: _env = {},
+  env = {},
   childProcess: childProcessModule,
-  fs: _fs,
+  fs: fsModule,
 } = {}) => {
   // Lazy-resolve `child_process` so callers in test environments can
   // inject a stub without paying the import cost up front.
@@ -436,7 +600,52 @@ export const makeBwrapDriver = ({
     /** @type {string | null} */
     const seccompTempPath = null;
 
-    const sliceArgv = assembleSliceArgv(spec, { seccompFd });
+    // Lazy-resolve `fs` for the existsSync probe and the
+    // promise-returning `realpath` resolver used by the PATH
+    // synthesis helpers.  We require fs only when the slice has
+    // either a `host-bind` rootfs (ambient `$PATH` mining +
+    // realpath) or a `mount` rootfs / caller-granted mounts
+    // (canonical bin-dir probing).  When `fs` cannot be loaded, fall
+    // back to a "always exists" probe and an identity realpath —
+    // `--ro-bind-try` already tolerates missing host paths, so the
+    // worst case is a `$PATH` entry that points at a directory the
+    // slice cannot reach.
+    await null;
+    /** @type {(p: string) => boolean} */
+    let exists = () => true;
+    /** @type {(p: string) => Promise<string | null>} */
+    let realpath = async p => p;
+    try {
+      const fs = fsModule ?? (await import('fs'));
+      exists = p => {
+        try {
+          return fs.existsSync(p);
+        } catch {
+          return false;
+        }
+      };
+      realpath = async p => {
+        // Hoisted `await null` to satisfy `safe-await-separator`.
+        await null;
+        try {
+          return await fs.promises.realpath(p);
+        } catch {
+          // ENOENT / EACCES / EIO / ELOOP — the filter treats this as
+          // a drop signal rather than a hard failure so a single
+          // unreadable PATH entry does not poison the whole slice.
+          return null;
+        }
+      };
+    } catch {
+      // best-effort
+    }
+
+    const sliceArgv = await assembleSliceArgv(spec, {
+      seccompFd,
+      ambientPath: env.PATH,
+      exists,
+      realpath,
+    });
 
     // Phase 1.5 resource caps.  The factory passes a fully-resolved
     // limits dictionary in `spec.limits`; the driver maps it onto a

--- a/packages/sandbox/src/drivers/bwrap.js
+++ b/packages/sandbox/src/drivers/bwrap.js
@@ -19,6 +19,7 @@ import {
   CANONICAL_BIN_PATHS,
   DEFAULT_PATH,
   detectMountBinPaths,
+  elevateSurvivorToMountRoot,
   filterAmbientPathForHostBind,
   joinPathEntries,
   probeMountRootfsBinPaths,
@@ -60,12 +61,18 @@ const ROOTFS_BASE_FLAGS = harden([
  *
  * The bin-dir entries here mirror `CANONICAL_BIN_PATHS` from
  * `./path.js`; the rootfs binds also include `/usr`, `/lib`,
- * `/lib64`, and `/etc` so dynamic linkers and configuration files
- * are reachable.
+ * `/lib32`, `/lib64`, and `/etc` so dynamic linkers, multilib
+ * runtimes, and configuration files are reachable.  The bin dirs
+ * by themselves are not enough: classically the binaries under
+ * `/bin` and `/sbin` are dynamically linked against `/lib*`, and
+ * tools under `/usr/bin` reach into `/usr/share` for data files.
+ * Mounting the parent roots wholesale lets those references
+ * resolve inside the slice without piecemeal probing.
  */
 const HOST_BIND_ROOTFS_PATHS = harden([
   '/usr',
   '/lib',
+  '/lib32',
   '/lib64',
   '/bin',
   '/sbin',
@@ -270,6 +277,29 @@ export const assembleSliceArgv = async (spec, extras) => {
   //      shadow `/usr/bin` because their entries land last).
   /** @type {string[]} */
   const defaultPathEntries = [];
+  // Track every host path requested via `--ro-bind-try` in the rootfs
+  // section so we never emit a duplicate or a strictly redundant child
+  // bind.  A new request is dropped when the path is identical to a
+  // prior bind or lives underneath one (the parent already covers it).
+  // The `--ro-bind-try` flavour tolerates missing paths, so the dedup
+  // scope is just bookkeeping; we are not promising the directory
+  // exists, only that we will not ask for it twice.
+  /** @type {Set<string>} */
+  const roBindTrySeen = new Set();
+  /**
+   * Append a `--ro-bind-try host host` pair unless an earlier entry
+   * already covers `hostPath`.
+   *
+   * @param {string} hostPath
+   */
+  const tryAddRoBindTry = hostPath => {
+    if (roBindTrySeen.has(hostPath)) return;
+    for (const seen of roBindTrySeen) {
+      if (hostPath.startsWith(`${seen}/`)) return;
+    }
+    roBindTrySeen.add(hostPath);
+    argv.push('--ro-bind-try', hostPath, hostPath);
+  };
   if (
     typeof spec.rootfs === 'object' &&
     spec.rootfs !== null &&
@@ -279,7 +309,7 @@ export const assembleSliceArgv = async (spec, extras) => {
       for (const path of HOST_BIND_ROOTFS_PATHS) {
         // `--ro-bind-try` skips missing paths (e.g. /lib64 on pure
         // 32-bit hosts) instead of failing the slice.
-        argv.push('--ro-bind-try', path, path);
+        tryAddRoBindTry(path);
       }
       // Canonical bin dirs first — these are the same paths we just
       // bound above and they end up in `DEFAULT_PATH` order.
@@ -291,16 +321,27 @@ export const assembleSliceArgv = async (spec, extras) => {
       // The filter rejects user-private and world-writable entries,
       // canonicalises through `realpath` to defeat the
       // `/opt/eve → /tmp/attacker` symlink trick, and drops any
-      // non-existent host paths; survivors are bound read-only into
-      // the slice and appended to the path string in their
-      // daemon-PATH order.
+      // non-existent host paths; survivors are elevated to a package
+      // root and bound read-only into the slice, then appended to the
+      // path string in their daemon-PATH order.
+      //
+      // Elevation is needed because binding only the bin dir leaves
+      // dangling symlinks: `/snap/bin/foo` is a symlink to
+      // `/snap/foo/current/...`, `/opt/rocm/bin/foo` links against
+      // `/opt/rocm/lib`, and `/var/lib/flatpak/exports/bin/foo` execs
+      // into `/var/lib/flatpak/app/...`.  See
+      // `elevateSurvivorToMountRoot` in `./path.js` for the heuristic.
+      // The PATH entry stays at the original survivor path so commands
+      // resolve at the directory the operator actually placed on
+      // `$PATH`; only the *mount* widens to the package root.
       const ambientSurvivors = await filterAmbientPathForHostBind(
         extras.ambientPath,
         { exists: extras.exists, realpath: extras.realpath },
       );
-      for (const path of ambientSurvivors) {
-        argv.push('--ro-bind-try', path, path);
-        defaultPathEntries.push(path);
+      for (const survivor of ambientSurvivors) {
+        const mountRoot = elevateSurvivorToMountRoot(survivor);
+        tryAddRoBindTry(mountRoot);
+        defaultPathEntries.push(survivor);
       }
     } else if (spec.rootfs.kind === 'minimal') {
       // Nothing — caller is expected to bind their own rootfs via

--- a/packages/sandbox/src/drivers/path.js
+++ b/packages/sandbox/src/drivers/path.js
@@ -12,8 +12,8 @@ import { makeError, q, X } from '@endo/errors';
  * the security rules that govern which host paths are allowed to leak
  * into the slice.
  *
- * See `TODO/22_sandbox_bwrap_path_refinements.md` and
- * `TODO/23_sandbox_podman_path.md` for the motivating discussion.
+ * See `TADA/22_sandbox_bwrap_path_refinements.md` and
+ * `TADA/23_sandbox_podman_path.md` for the motivating discussion.
  */
 
 /**
@@ -297,7 +297,7 @@ harden(probeMountRootfsBinPaths);
  * children gets both inner paths).  The caller is responsible for
  * appending the result **after** the rootfs-derived defaults so a
  * hostile caller cannot shadow `/usr/bin` with a bin dir of their
- * own — see `TODO/22_sandbox_bwrap_path_refinements.md` for the
+ * own — see `TADA/22_sandbox_bwrap_path_refinements.md` for the
  * threat model.
  *
  * @param {{ hostPath: string, innerPath: string }} mount

--- a/packages/sandbox/src/drivers/path.js
+++ b/packages/sandbox/src/drivers/path.js
@@ -324,6 +324,56 @@ export const detectMountBinPaths = (mount, options = {}) => {
 harden(detectMountBinPaths);
 
 /**
+ * Elevate a daemon-PATH survivor to a host directory whose contents
+ * the slice will need on top of the bin entry itself.
+ *
+ * Survivors arrive here as the operator-installed `$PATH` entries
+ * that passed `filterAmbientPathForHostBind`: paths shaped like
+ * `/opt/rocm/bin`, `/snap/bin`, or `/var/lib/flatpak/exports/bin`.
+ * Bind-mounting only the bin directory exposes dangling symlinks: a
+ * snap binary at `/snap/bin/foo` is a symlink to
+ * `/snap/foo/current/usr/bin/foo`, a rocm tool wraps shared
+ * libraries under `/opt/rocm/lib`, and a flatpak wrapper under
+ * `/var/lib/flatpak/exports/bin/foo` execs into `/var/lib/flatpak/app/...`.
+ * The slice needs the broader package root, not just the bin dir.
+ *
+ * Heuristic, in order:
+ *   1. Strip a trailing `/bin` or `/sbin` segment to get the package
+ *      root (`/opt/rocm/bin` → `/opt/rocm`, `/snap/bin` → `/snap`).
+ *   2. If the resulting path then ends in `/exports`, strip that
+ *      suffix as well — flatpak nests its bin dir one extra level
+ *      under the package root (`/var/lib/flatpak/exports` →
+ *      `/var/lib/flatpak`).
+ *   3. If neither suffix matches, return the entry unchanged — there
+ *      is no obvious elevation, and the caller's dedup logic will
+ *      collapse it against any canonical mount that already covers
+ *      it (e.g. `/usr/bin/site_perl` is preserved verbatim and then
+ *      dropped because `/usr` is already mounted).
+ *
+ * Stripping never returns the empty string: a survivor that reduces
+ * to `/` after the suffix strip is left alone, since the upstream
+ * filter already rejects every `CANONICAL_BIN_PATH` (which is the
+ * only way to hit that case).
+ *
+ * @param {string} entry  Absolute, post-realpath PATH entry.
+ * @returns {string}      Host path the bwrap driver should bind in
+ *                        place of `entry`.
+ */
+export const elevateSurvivorToMountRoot = entry => {
+  let candidate = entry;
+  if (candidate.endsWith('/bin') || candidate.endsWith('/sbin')) {
+    const trimmed = candidate.slice(0, candidate.lastIndexOf('/'));
+    if (trimmed !== '') candidate = trimmed;
+  }
+  if (candidate.endsWith('/exports')) {
+    const trimmed = candidate.slice(0, candidate.lastIndexOf('/'));
+    if (trimmed !== '') candidate = trimmed;
+  }
+  return candidate;
+};
+harden(elevateSurvivorToMountRoot);
+
+/**
  * Join an array of path entries into a `$PATH` string.  Empty input
  * yields the empty string (callers usually fall back to `DEFAULT_PATH`
  * in that case).  Duplicates are removed (first occurrence wins) so

--- a/packages/sandbox/src/drivers/path.js
+++ b/packages/sandbox/src/drivers/path.js
@@ -1,0 +1,374 @@
+// @ts-check
+
+import { makeError, q, X } from '@endo/errors';
+
+/**
+ * Cross-driver `$PATH` defaults and synthesis helpers.
+ *
+ * The bwrap and podman drivers both need to make a sensible choice
+ * about the slice's `$PATH` when the caller does not supply one
+ * explicitly.  The constants and small filters in this module keep
+ * the choice consistent across drivers and provide a single home for
+ * the security rules that govern which host paths are allowed to leak
+ * into the slice.
+ *
+ * See `TODO/22_sandbox_bwrap_path_refinements.md` and
+ * `TODO/23_sandbox_podman_path.md` for the motivating discussion.
+ */
+
+/**
+ * Canonical default `$PATH` for slices that have nothing better to
+ * offer (host-bind without an ambient `$PATH` to mine, mount rootfs
+ * without any of the well-known bin dirs, OCI image without a
+ * `Config.Env` PATH).
+ *
+ * The order matches the Debian / Ubuntu default for an interactive
+ * login shell:
+ *
+ *   /usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
+ *
+ * which puts user-tool dirs ahead of administrative ones.
+ * Some distros (Arch, RHEL) merge `/sbin` → `/usr/bin` symlinks and
+ * the order is moot; on others (older Debian, Alpine) the Debian
+ * order is the least surprising for a generic slice that is not
+ * deliberately running an admin tool by an unqualified name.
+ *
+ * The previous bwrap-only constant put `/sbin` first; we deliberately
+ * flipped to user-first so a slice that runs `sh` and finds both
+ * `/sbin/ifconfig` and `/usr/bin/ifconfig` picks the user variant by
+ * default.
+ */
+export const DEFAULT_PATH =
+  '/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin';
+harden(DEFAULT_PATH);
+
+/**
+ * Canonical bin directories the bwrap driver tries to bind-mount into
+ * a `host-bind` slice and probes for inside a `mount`-rootfs slice.
+ *
+ * Order matches `DEFAULT_PATH`; consumers that build a synthesized
+ * `defaultPath` from the subset of these that exist on disk get the
+ * same user-first ordering for free.
+ */
+export const CANONICAL_BIN_PATHS = harden([
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+  '/usr/local/sbin',
+  '/usr/sbin',
+  '/sbin',
+]);
+harden(CANONICAL_BIN_PATHS);
+
+/**
+ * Prefixes that disqualify an ambient `$PATH` entry from being
+ * inherited into a `host-bind` slice.  Either:
+ *   - they point at user-private state we deliberately keep out
+ *     (`/home`, `/Users`, `/root`),
+ *   - they are world-writable scratch (`/tmp`, `/var/tmp`,
+ *     `/run/user`) where another local user could plant a binary
+ *     that the slice would then prefer over `/usr/bin/foo`.
+ *
+ * The check is on a leading-prefix basis (`startsWith` plus a `/`
+ * boundary) so `/tmproot` does not match `/tmp`.
+ */
+const AMBIENT_PATH_BLOCKED_PREFIXES = harden([
+  '/home/',
+  '/Users/',
+  '/root/',
+  '/tmp/',
+  '/var/tmp/',
+  '/run/user/',
+]);
+
+/**
+ * Exact-match form of `AMBIENT_PATH_BLOCKED_PREFIXES` so `/tmp` (no
+ * trailing slash) is also rejected.  Mirroring entries are needed
+ * because a leading-prefix `startsWith('/tmp/')` does not match the
+ * bare `/tmp`.
+ */
+const AMBIENT_PATH_BLOCKED_EXACT = harden([
+  '/home',
+  '/Users',
+  '/root',
+  '/tmp',
+  '/var/tmp',
+  '/run/user',
+]);
+
+/**
+ * @param {string} entry
+ * @returns {boolean}
+ */
+const isAmbientPathEntryBlocked = entry => {
+  if (AMBIENT_PATH_BLOCKED_EXACT.includes(entry)) return true;
+  for (const prefix of AMBIENT_PATH_BLOCKED_PREFIXES) {
+    if (entry.startsWith(prefix)) return true;
+  }
+  return false;
+};
+
+/**
+ * Filter the daemon-side `$PATH` down to entries that are safe to
+ * surface in a `host-bind` slice.  Survivors are returned in the
+ * caller's order; duplicates are dropped (first occurrence wins).
+ *
+ * Rejection criteria, in order:
+ *   1. Entry is empty or not absolute (`/foo` only — drop `foo`,
+ *      `./foo`, `../foo`).
+ *   2. Entry contains a `..` segment — refuse to chase relative
+ *      escapes that resolve through host symlinks.
+ *   3. Entry begins with one of the user-private / world-writable
+ *      prefixes in `AMBIENT_PATH_BLOCKED_PREFIXES`.
+ *   4. Entry is one of `CANONICAL_BIN_PATHS` — those are already
+ *      bound and present in `DEFAULT_PATH`; including them again
+ *      would just add noise.
+ *   5. Optional `realpath` resolution — when supplied, each surviving
+ *      entry is canonicalised through the host filesystem and the
+ *      block-prefix check is re-applied to the resolved value.  This
+ *      defeats the symlink trick where an operator-installed
+ *      `/opt/eve` is itself a symlink to `/tmp/attacker`: textual
+ *      prefix checks on the literal `/opt/eve` survive, but the
+ *      resolved `/tmp/attacker` does not.
+ *   6. Optional `exists` probe — drop entries that do not exist on
+ *      the host.  The probe is best-effort: `--ro-bind-try` already
+ *      tolerates missing paths, so omitting the probe degrades to
+ *      "bound but empty" rather than a hard error.  When `realpath`
+ *      is supplied, an `ENOENT`/`EACCES` from `realpath` itself also
+ *      drops the entry — a path the daemon cannot canonicalise
+ *      cannot be safely bound.
+ *
+ * The function is async because the preferred `realpath` resolver is
+ * `fs.promises.realpath`; tests that do not need filesystem
+ * canonicalisation can omit the option entirely.
+ *
+ * @param {string | undefined} pathEnv  Value of `process.env.PATH` /
+ *                                      the daemon's `env.PATH`.
+ * @param {object} [options]
+ * @param {(p: string) => boolean} [options.exists]  Existence probe
+ *                                                   (default: a
+ *                                                   no-op `() => true`
+ *                                                   so callers can opt
+ *                                                   out of the probe
+ *                                                   in unit tests).
+ * @param {(p: string) => Promise<string | null>} [options.realpath]
+ *   Promise-returning canonicaliser (typically
+ *   `p => fs.promises.realpath(p).catch(() => null)`).  A resolver
+ *   that returns `null` drops the entry; a resolver that returns a
+ *   string has its result re-checked against the block-prefix list.
+ *   Default is the identity (entry passes through unchanged), which
+ *   preserves the pre-realpath behaviour for tests.
+ * @returns {Promise<readonly string[]>}
+ */
+/**
+ * Predicate form of the textual `$PATH`-entry validity check used by
+ * `filterAmbientPathForHostBind`.  Encapsulating the rules in a
+ * named helper keeps the main loop body free of early-return
+ * `continue` statements that the project's `no-continue` lint rule
+ * forbids.
+ *
+ * @param {string} entry
+ * @returns {boolean}
+ */
+const isTextuallyAcceptableAmbientEntry = entry =>
+  entry !== '' &&
+  entry.startsWith('/') &&
+  !entry.split('/').includes('..') &&
+  !isAmbientPathEntryBlocked(entry);
+
+/**
+ * Predicate form of the post-realpath validity check.
+ *
+ * @param {string | null | undefined} resolved
+ * @returns {resolved is string}
+ */
+const isResolvedPathAcceptable = resolved => {
+  if (typeof resolved !== 'string') return false;
+  if (!resolved.startsWith('/')) return false;
+  if (resolved.split('/').includes('..')) return false;
+  if (isAmbientPathEntryBlocked(resolved)) return false;
+  // Block-list the canonical bin dirs against the resolved path too
+  // — `/usr/bin` resolved through `/bin → usr/bin` would otherwise
+  // re-introduce a duplicate.
+  if (CANONICAL_BIN_PATHS.includes(resolved)) return false;
+  return true;
+};
+
+export const filterAmbientPathForHostBind = async (pathEnv, options = {}) => {
+  // Hoisted `await null` keeps `safe-await-separator` happy: the
+  // function reads as "yield once, then proceed synchronously through
+  // the loop" rather than "first nested await is the realpath call".
+  await null;
+  const exists = options.exists ?? (() => true);
+  /** @type {(p: string) => Promise<string | null>} */
+  const realpath = options.realpath ?? (async p => p);
+  if (typeof pathEnv !== 'string' || pathEnv === '') return harden([]);
+  /** @type {string[]} */
+  const out = [];
+  const seen = new Set();
+  // CANONICAL_BIN_PATHS are already covered by DEFAULT_PATH; treat
+  // them as already-seen so the survivor list never re-introduces them.
+  for (const canonical of CANONICAL_BIN_PATHS) seen.add(canonical);
+  for (const entry of pathEnv.split(':')) {
+    if (isTextuallyAcceptableAmbientEntry(entry) && !seen.has(entry)) {
+      // Canonicalise through the host filesystem and re-apply the
+      // block-prefix check.  An operator-installed `/opt/eve` that
+      // is itself a symlink to `/tmp/attacker` survives the textual
+      // check above; the resolved `/tmp/attacker` does not.
+      /** @type {string | null | undefined} */
+      let resolved;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        resolved = await realpath(entry);
+      } catch {
+        // ENOENT / EACCES / EIO — drop entries the daemon cannot
+        // canonicalise rather than gambling on the textual form.
+        resolved = null;
+      }
+      if (isResolvedPathAcceptable(resolved) && exists(entry)) {
+        seen.add(entry);
+        if (resolved !== entry) seen.add(resolved);
+        // Bind the original (pre-realpath) entry: that is the path
+        // the operator put on `$PATH`, so it is the path the slice
+        // expects to see and the path bwrap's `--ro-bind-try` is
+        // willing to follow through the symlink for.
+        out.push(entry);
+      }
+    }
+  }
+  return harden(out);
+};
+harden(filterAmbientPathForHostBind);
+
+/**
+ * Probe a `mount`-rootfs host directory for the subset of
+ * `CANONICAL_BIN_PATHS` that exist underneath it, and return the
+ * matching slice-internal paths (with the host prefix stripped).
+ *
+ * Example: if `hostPath = /opt/myroot` and `/opt/myroot/usr/bin`
+ * exists, this returns `['/usr/bin']` (the inner path the slice will
+ * see, because the rootfs is mounted at `/`).
+ *
+ * Relative `hostPath`s (anything that is not anchored at `/`) are
+ * skipped: a probe of `srv/foo/usr/bin` would resolve against the
+ * daemon's CWD, which has nothing to do with the slice and is
+ * a footgun if the CWD happens to contain a real `usr/bin/`.  bwrap
+ * itself rejects relative `--ro-bind …  /` operands downstream; the
+ * early bail-out here keeps the synthesised `$PATH` from reflecting
+ * a probe that has no bearing on the slice.
+ *
+ * @param {string} hostPath  Host path of the mount-rootfs.
+ * @param {object} [options]
+ * @param {(p: string) => boolean} [options.exists]  Existence probe
+ *                                                   (default: returns
+ *                                                   true so the helper
+ *                                                   is usable from
+ *                                                   unit tests without
+ *                                                   touching disk).
+ * @returns {readonly string[]}
+ */
+export const probeMountRootfsBinPaths = (hostPath, options = {}) => {
+  const exists = options.exists ?? (() => true);
+  /** @type {string[]} */
+  const out = [];
+  if (typeof hostPath !== 'string' || !hostPath.startsWith('/')) {
+    return harden(out);
+  }
+  const trimmed = hostPath.replace(/\/+$/, '');
+  for (const innerPath of CANONICAL_BIN_PATHS) {
+    if (exists(`${trimmed}${innerPath}`)) {
+      out.push(innerPath);
+    }
+  }
+  return harden(out);
+};
+harden(probeMountRootfsBinPaths);
+
+/**
+ * Inspect a caller-granted mount and return the slice-internal bin
+ * paths it appears to expose.  Three shapes are recognised:
+ *
+ *   - `innerPath` ends in `/bin` or `/sbin` — the mount itself is
+ *     a bin-dir, return `innerPath`.
+ *   - `<hostPath>/bin` exists on disk — return `${innerPath}/bin`.
+ *   - `<hostPath>/sbin` exists on disk — return `${innerPath}/sbin`.
+ *
+ * Multiple matches stack (a mount with both `bin/` and `sbin/`
+ * children gets both inner paths).  The caller is responsible for
+ * appending the result **after** the rootfs-derived defaults so a
+ * hostile caller cannot shadow `/usr/bin` with a bin dir of their
+ * own — see `TODO/22_sandbox_bwrap_path_refinements.md` for the
+ * threat model.
+ *
+ * @param {{ hostPath: string, innerPath: string }} mount
+ * @param {object} [options]
+ * @param {(p: string) => boolean} [options.exists]  Existence probe
+ *                                                   (default: a
+ *                                                   no-op `() => true`).
+ * @returns {string[]}
+ */
+export const detectMountBinPaths = (mount, options = {}) => {
+  const exists = options.exists ?? (() => true);
+  /** @type {string[]} */
+  const out = [];
+  const innerTrimmed = mount.innerPath.replace(/\/+$/, '');
+  if (innerTrimmed.endsWith('/bin') || innerTrimmed.endsWith('/sbin')) {
+    out.push(innerTrimmed);
+    return harden(out);
+  }
+  const hostTrimmed = mount.hostPath.replace(/\/+$/, '');
+  if (exists(`${hostTrimmed}/bin`)) out.push(`${innerTrimmed}/bin`);
+  if (exists(`${hostTrimmed}/sbin`)) out.push(`${innerTrimmed}/sbin`);
+  return harden(out);
+};
+harden(detectMountBinPaths);
+
+/**
+ * Join an array of path entries into a `$PATH` string.  Empty input
+ * yields the empty string (callers usually fall back to `DEFAULT_PATH`
+ * in that case).  Duplicates are removed (first occurrence wins) so
+ * the synthesised string never repeats an entry.
+ *
+ * Sanitisation applied to each entry, in order:
+ *
+ *   1. **Newlines (`\n`, `\r`) and other control characters
+ *      (`\x00..\x1f`) are fatal.**  A newline in a `$PATH` entry
+ *      corrupts the `--setenv PATH …` argv slot in arbitrary,
+ *      surprising ways; rather than silently dropping the bad entry
+ *      we throw so the caller (and reviewer) sees the bug.
+ *   2. **Embedded `:` separators are split, not preserved.**  A
+ *      caller-granted mount with `innerPath = '/foo:/bin'` would
+ *      otherwise produce a `detectMountBinPaths` result of
+ *      `'/foo:/bin/bin'`, smuggling `/foo` onto `$PATH`.  We split
+ *      on `:` and process each part as an independent entry, so the
+ *      output is well-formed regardless of what the caller put in
+ *      `innerPath`.
+ *
+ * @param {readonly string[]} entries
+ * @returns {string}
+ */
+export const joinPathEntries = entries => {
+  /** @type {string[]} */
+  const out = [];
+  const seen = new Set();
+  for (const entry of entries) {
+    // eslint-disable-next-line no-control-regex
+    if (/[\x00-\x1f]/.test(entry)) {
+      throw makeError(
+        X`PATH entry must not contain control characters: ${q(entry)}`,
+      );
+    }
+    // Split embedded `:` into independent parts so a caller-granted
+    // mount cannot smuggle extra segments onto `$PATH`.  An entry
+    // that does not contain `:` falls through the split as a single
+    // part, preserving the previous behaviour.
+    for (const part of entry.split(':')) {
+      if (part !== '' && !seen.has(part)) {
+        seen.add(part);
+        out.push(part);
+      }
+    }
+  }
+  return out.join(':');
+};
+harden(joinPathEntries);

--- a/packages/sandbox/src/drivers/podman.js
+++ b/packages/sandbox/src/drivers/podman.js
@@ -5,6 +5,7 @@
 import { makeError, q, X } from '@endo/errors';
 
 import { makeCgroup2Probe } from '../limits.js';
+import { DEFAULT_PATH } from './path.js';
 
 /** @import { SandboxDriver, SliceSpec, SpawnOpts, DriverProcess, BackendProbe, BackendProbeDetails } from '../types.js' */
 
@@ -52,8 +53,19 @@ const DEFAULT_STOP_GRACE_S = 5;
  * infinity` is portable across both Alpine's busybox and Debian's
  * coreutils, and exits cleanly on SIGTERM.  Subsequent slice work
  * happens via `podman exec`; PID 1 just keeps the namespace alive.
+ *
+ * The path is **absolute** (`/bin/sleep`) so PID 1 starts even when
+ * the slice's `$PATH` is too restrictive to find `sleep` by short
+ * name.  This matters for callers who supply their own
+ * `spec.env.PATH = /opt/myapp/bin` — without an absolute path we
+ * would emit a confusing `crun: executable file `sleep` not found in
+ * $PATH` error from `podman start`.  Both Alpine (busybox) and
+ * Debian / Ubuntu / RHEL (coreutils) ship `sleep` at `/bin/sleep`
+ * (RHEL has it as a `/usr/bin/sleep` symlink target via the usrmerge
+ * symlink farm; the entry point is reachable through `/bin/sleep`
+ * either way).
  */
-const IDLE_PID1 = harden(['sleep', 'infinity']);
+const IDLE_PID1 = harden(['/bin/sleep', 'infinity']);
 
 /**
  * Parse `podman --version` output into a version string.
@@ -311,11 +323,75 @@ harden(probeRootlessNetBackend);
  *                                     or `null` when no profile was
  *                                     materialised.  Unlinked at
  *                                     teardown.
- * @property {{ cgroup2: { available: boolean, controllers: string[], reason?: string }, rootless: { available: boolean, reason?: string }, rootlessNet: { backend: RootlessNetBackend, reason?: string } }} runtimeDetails
+ * @property {{ cgroup2: { available: boolean, controllers: string[], reason?: string }, rootless: { available: boolean, reason?: string }, rootlessNet: { backend: RootlessNetBackend, reason?: string }, path: { value: string, source: 'env' | 'image' | 'fallback' } }} runtimeDetails
  *                                     Hardening-layer report the
  *                                     factory weaves into per-slice
- *                                     `help()` output.
+ *                                     `help()` output.  `path`
+ *                                     records which `PATH` the slice
+ *                                     ended up with and where it came
+ *                                     from (caller env, OCI image,
+ *                                     or canonical fallback).
  */
+
+/**
+ * Resolve which `PATH` value the slice will actually use, and where it
+ * came from.  Mirrors the bwrap driver's "caller wins, then the rootfs
+ * defaults, then the canonical fallback" precedence so the two backends
+ * present a consistent surface.
+ *
+ * Precedence:
+ *   1. Caller-supplied `spec.env.PATH` — `'env'`.  An explicit empty
+ *      string is honoured (the caller is opting out of any PATH).
+ *   2. Image's `Config.Env` `PATH` — `'image'`.
+ *   3. `DEFAULT_PATH` from `./path.js` — `'fallback'`.
+ *
+ * The `source` is surfaced in `slice.help()` so operators can tell
+ * which case fired without inspecting the container's env directly.
+ *
+ * @param {SliceSpec} spec
+ * @param {string | null} imagePath
+ * @returns {{ value: string, source: 'env' | 'image' | 'fallback' }}
+ */
+const resolveSlicePath = (spec, imagePath) => {
+  if (typeof spec.env.PATH === 'string') {
+    return harden({ value: spec.env.PATH, source: 'env' });
+  }
+  if (typeof imagePath === 'string' && imagePath !== '') {
+    return harden({ value: imagePath, source: 'image' });
+  }
+  return harden({ value: DEFAULT_PATH, source: 'fallback' });
+};
+harden(resolveSlicePath);
+
+/**
+ * Parse the JSON array emitted by
+ * `podman image inspect --format '{{json .Config.Env}}'` and return the
+ * value of the `PATH=` entry, if any.  Tolerant of malformed input:
+ * non-array JSON, non-string entries, missing PATH all return `null`.
+ *
+ * Exported for unit testing — the integration path is exercised via
+ * the live podman driver, but isolated parser tests want to drive
+ * pathological shapes without rebuilding an OCI image.
+ *
+ * @param {string} configEnvJson
+ * @returns {string | null}
+ */
+export const parseImagePathFromConfigEnv = configEnvJson => {
+  let parsed;
+  try {
+    parsed = JSON.parse(configEnvJson);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  for (const entry of parsed) {
+    if (typeof entry === 'string' && entry.startsWith('PATH=')) {
+      return entry.slice('PATH='.length);
+    }
+  }
+  return null;
+};
+harden(parseImagePathFromConfigEnv);
 
 /**
  * Assemble the `podman create` argv for a slice.  The image reference
@@ -325,7 +401,13 @@ harden(probeRootlessNetBackend);
  * @param {SliceSpec} spec
  * @param {string} containerName
  * @param {RootlessNetBackend} netBackend
- * @param {{ seccompProfilePath: string | null }} extras
+ * @param {{ seccompProfilePath: string | null, pathInjection: string | null }} extras
+ *   `pathInjection` is the `PATH` value to inject as `-e PATH=…` when
+ *   the caller did not set one.  `null` means "leave the image's
+ *   `Config.Env` PATH alone" — used when the caller's `spec.env`
+ *   already includes a `PATH` (the per-key loop below emits the `-e`
+ *   itself), or when the helper is invoked from a code path that
+ *   does not need the synthesis.
  * @returns {string[]}
  */
 const assembleCreateArgv = (spec, containerName, netBackend, extras) => {
@@ -385,8 +467,18 @@ const assembleCreateArgv = (spec, containerName, netBackend, extras) => {
 
   // Environment.  podman starts its containers with a minimal env
   // already; we override / append the caller-supplied keys via -e.
+  // When the caller did NOT set `PATH`, we inject `extras.pathInjection`
+  // explicitly so the slice's `PATH` is observable from the host and
+  // does not depend on whether the OCI image happened to set
+  // `Config.Env`.  This mirrors the bwrap driver's `--setenv PATH=…`
+  // path-synthesis behaviour.
+  let hadPath = false;
   for (const [key, value] of Object.entries(spec.env)) {
     argv.push('-e', `${key}=${value}`);
+    if (key === 'PATH') hadPath = true;
+  }
+  if (!hadPath && extras.pathInjection !== null) {
+    argv.push('-e', `PATH=${extras.pathInjection}`);
   }
 
   if (spec.cwd !== undefined && spec.cwd !== '') {
@@ -730,6 +822,67 @@ export const makePodmanDriver = ({
   };
 
   /**
+   * Cache of `image ref` → `Config.Env` PATH (or `null` when the
+   * image declares no PATH / inspection failed).  Image refs are
+   * effectively immutable once pulled; caching for the lifetime of
+   * the driver avoids repeating `podman image inspect` for every
+   * slice that reuses the same image, and the worst case under a
+   * concurrent retag is a stale fallback that still produces a
+   * working `PATH`.
+   *
+   * @type {Map<string, string | null>}
+   */
+  const imagePathCache = new Map();
+
+  /**
+   * Probe the OCI image's `Config.Env` for a `PATH=` entry and return
+   * its value (or `null` when the image declares none).  Result is
+   * cached in `imagePathCache` keyed by `ref`.
+   *
+   * Best-effort: any failure (inspect non-zero, malformed JSON, no
+   * `Config.Env` key) is swallowed and surfaces as `null`, which
+   * `resolveSlicePath` then maps onto the canonical `DEFAULT_PATH`.
+   *
+   * @param {typeof import('child_process')} cp
+   * @param {string} ref
+   * @returns {Promise<string | null>}
+   */
+  const inspectImagePath = async (cp, ref) => {
+    if (imagePathCache.has(ref)) {
+      // `Map.get` returns `T | undefined`; the `has` guard guarantees
+      // the value is in the map, so a non-null assertion via cast is
+      // safer than a `??` that would conflate "cached as null" with
+      // "missing".
+      return /** @type {string | null} */ (imagePathCache.get(ref) ?? null);
+    }
+    const runtime = await ensureRuntime(cp);
+    let result;
+    try {
+      result = await spawnAndCollect(
+        cp,
+        'podman',
+        podmanArgs(runtime, [
+          'image',
+          'inspect',
+          '--format',
+          '{{json .Config.Env}}',
+          ref,
+        ]),
+      );
+    } catch {
+      imagePathCache.set(ref, null);
+      return null;
+    }
+    if (result.code !== 0) {
+      imagePathCache.set(ref, null);
+      return null;
+    }
+    const imagePath = parseImagePathFromConfigEnv(result.stdout.trim());
+    imagePathCache.set(ref, imagePath);
+    return imagePath;
+  };
+
+  /**
    * Ensure the OCI image referenced by the slice spec is present in
    * the user's container storage.  No-op when the image is already
    * present (`podman image exists` exits 0).
@@ -787,6 +940,12 @@ export const makePodmanDriver = ({
     const cp = await getCp();
     await ensureImage(cp, ref);
 
+    // Probe the image's `Config.Env` PATH so the slice's `$PATH`
+    // synthesis (below) has an image-derived default available.
+    // The probe is cached per `ref` for the driver's lifetime; the
+    // first slice for a given image pays the cost.
+    const imagePath = await inspectImagePath(cp, ref);
+
     // Pick the rootless network backend up front so the runtime
     // report reflects what the slice actually got.  `none` and
     // `host-*` profiles do not require pasta / slirp4netns; only
@@ -833,9 +992,19 @@ export const makePodmanDriver = ({
 
     const runtime = await ensureRuntime(cp);
     const containerName = makeSliceName();
+    // Resolve the slice's effective `PATH` once so we can both inject
+    // it into the container's create-time env and surface it via
+    // `runtimeDetails.path` for `slice.help()`.  When the caller's
+    // `spec.env` already includes a `PATH` we leave `pathInjection`
+    // null and let the per-key loop in `assembleCreateArgv` emit it
+    // (the resolved record still records `source: 'env'` so the help
+    // line stays accurate).
+    const slicePath = resolveSlicePath(spec, imagePath);
+    const pathInjection = slicePath.source === 'env' ? null : slicePath.value;
     const createArgv = podmanArgs(runtime, [
       ...assembleCreateArgv(spec, containerName, netBackend, {
         seccompProfilePath: seccompTempPath,
+        pathInjection,
       }),
       ref,
       ...IDLE_PID1,
@@ -888,6 +1057,7 @@ export const makePodmanDriver = ({
             }
           : { backend: netBackend },
       ),
+      path: slicePath,
     });
 
     /** @type {PodmanSliceContext} */

--- a/packages/sandbox/src/factory.js
+++ b/packages/sandbox/src/factory.js
@@ -80,11 +80,12 @@ Methods:
  *   - `runtimeDetails.prlimit:    { applied: string[] }` (bwrap)
  *   - `runtimeDetails.rootless:   { available, reason? }` (podman)
  *   - `runtimeDetails.rootlessNet:{ backend, reason? }` (podman)
+ *   - `runtimeDetails.path:       { value, source }`     (podman)
  *
  * Missing fields render as "not detected" so the report stays
  * informative across drivers that do not implement every layer.
  *
- * @param {{ runtimeDetails?: { landlock?: { available: boolean, reason?: string }, cgroup2?: { available: boolean, controllers: string[], reason?: string }, prlimit?: { applied: string[] }, rootless?: { available: boolean, reason?: string }, rootlessNet?: { backend: string | null, reason?: string } } }} driverSlice
+ * @param {{ runtimeDetails?: { landlock?: { available: boolean, reason?: string }, cgroup2?: { available: boolean, controllers: string[], reason?: string }, prlimit?: { applied: string[] }, rootless?: { available: boolean, reason?: string }, rootlessNet?: { backend: string | null, reason?: string }, path?: { value: string, source: 'env' | 'image' | 'fallback' } } }} driverSlice
  * @param {SliceSpec} spec
  * @returns {string}
  */
@@ -151,6 +152,14 @@ const renderSliceRuntimeReport = (driverSlice, spec) => {
           : '';
       lines.push(`  rootless-net: none${why}`);
     }
+  }
+  if (details.path !== undefined) {
+    // `source` distinguishes "caller set this" / "the OCI image set
+    // this" / "we fell back to the cross-driver default" — useful
+    // when debugging "why can't my slice find `apk`" cases.
+    lines.push(
+      `  path: ${details.path.value} (source: ${details.path.source})`,
+    );
   }
   return lines.join('\n');
 };
@@ -312,11 +321,11 @@ export const makeSandboxFactory = ({ drivers, scratchProvider }) => {
         r => harden({ ok: /** @type {const} */ (true), value: r }),
         e => harden({ ok: /** @type {const} */ (false), error: e }),
       );
-      if (result.ok) {
+      if (result.ok === true) {
         probes.push(harden({ name: driver.name, ...result.value }));
       } else {
-        const reason =
-          /** @type {Error} */ (result.error).message || String(result.error);
+        const err = /** @type {{ error: any }} */ (result).error;
+        const reason = /** @type {Error} */ (err).message || String(err);
         probes.push(harden({ name: driver.name, available: false, reason }));
       }
     }

--- a/packages/sandbox/test/bwrap.test.js
+++ b/packages/sandbox/test/bwrap.test.js
@@ -13,7 +13,8 @@ import * as nodeOs from 'node:os';
 import * as nodePath from 'node:path';
 import { setTimeout } from 'node:timers';
 
-import { makeBwrapDriver } from '../src/drivers/bwrap.js';
+import { assembleSliceArgv, makeBwrapDriver } from '../src/drivers/bwrap.js';
+import { DEFAULT_PATH } from '../src/drivers/path.js';
 import { makeSandboxFactory } from '../src/factory.js';
 
 const StubMountInterface = M.interface('Mount', {
@@ -895,4 +896,450 @@ test.serial('fork() throws notImplemented before Phase 3', async t => {
   await t.throwsAsync(() => E(handle).fork(), {
     message: /Phase 3/,
   });
+});
+
+// --- PATH synthesis tests --------------------------------------------------
+//
+// These exercise `assembleSliceArgv` directly without spawning bwrap so
+// they run on every host (including non-Linux CI matrix entries).  They
+// assert the `--setenv PATH …` argv slot reflects the rules in
+// `TODO/22_sandbox_bwrap_path_refinements.md` for each rootfs shape.
+
+/**
+ * Pull the `--setenv PATH …` value out of an argv produced by
+ * `assembleSliceArgv`.  Returns `undefined` when no `PATH` setenv pair
+ * is present.
+ *
+ * @param {string[]} argv
+ * @returns {string | undefined}
+ */
+const extractSetenvPath = argv => {
+  for (let i = 0; i < argv.length - 2; i += 1) {
+    if (argv[i] === '--setenv' && argv[i + 1] === 'PATH') {
+      return argv[i + 2];
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Build a minimal `SliceSpec` for the synthesis tests.  The factory's
+ * defaults (limits, seccomp, scratch) are irrelevant here because we
+ * bypass the factory and call `assembleSliceArgv` directly.
+ *
+ * @param {Partial<import('../src/types.js').SliceSpec> & { rootfs: import('../src/types.js').SliceSpec['rootfs'] }} overrides
+ * @returns {import('../src/types.js').SliceSpec}
+ */
+const makeStubSpec = overrides =>
+  /** @type {any} */ (
+    harden({
+      mounts: [],
+      scratchHostPath: '',
+      network: 'none',
+      seccomp: 'default',
+      env: {},
+      ...overrides,
+    })
+  );
+
+test('PATH synthesis: host-bind seeds the canonical user-first default', async t => {
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath: '',
+      exists: () => true,
+    },
+  );
+  const path = extractSetenvPath(argv);
+  t.is(
+    path,
+    DEFAULT_PATH,
+    'host-bind without ambient PATH should match the canonical default',
+  );
+  // Sanity: the canonical default is user-first.
+  t.true(
+    /** @type {string} */ (path).indexOf('/usr/bin') <
+      /** @type {string} */ (path).indexOf('/sbin'),
+    'user bin dirs should appear before /sbin in the default PATH',
+  );
+});
+
+test('PATH synthesis: host-bind appends ambient survivors after canonical bins', async t => {
+  const ambientPath = [
+    '/opt/local/bin',
+    '/snap/bin',
+    '/var/lib/flatpak/exports/bin',
+    '/home/alice/bin', // dropped — under /home
+    '/tmp/bin', // dropped — under /tmp
+    'relative/bin', // dropped — not absolute
+    '/usr/bin', // dropped — already in canonical set
+    '/opt/foo/../bar', // dropped — contains ..
+  ].join(':');
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath,
+      exists: () => true,
+    },
+  );
+  const path = extractSetenvPath(argv);
+  t.true(
+    /** @type {string} */ (path).startsWith(DEFAULT_PATH),
+    'canonical default should be the prefix',
+  );
+  t.regex(
+    /** @type {string} */ (path),
+    /\/opt\/local\/bin/,
+    '/opt entries should be inherited',
+  );
+  t.regex(/** @type {string} */ (path), /\/snap\/bin/);
+  t.regex(/** @type {string} */ (path), /\/var\/lib\/flatpak\/exports\/bin/);
+  t.notRegex(
+    /** @type {string} */ (path),
+    /\/home\//,
+    '/home entries must be dropped from synthesised PATH',
+  );
+  t.notRegex(
+    /** @type {string} */ (path),
+    /\/tmp\//,
+    '/tmp entries must be dropped from synthesised PATH',
+  );
+  t.notRegex(/** @type {string} */ (path), /\.\./, 'no .. segments survive');
+  // Survivors should also appear as `--ro-bind-try` arguments so the
+  // PATH entries actually point at something inside the slice.
+  t.true(
+    argv.includes('/opt/local/bin'),
+    'survivor /opt/local/bin should be bound into the slice',
+  );
+  // The argv pattern is `--ro-bind-try src dst`; check src AND dst.
+  for (let i = 0; i < argv.length - 2; i += 1) {
+    if (argv[i] === '--ro-bind-try' && argv[i + 1] === '/snap/bin') {
+      t.is(argv[i + 2], '/snap/bin', 'binds host path to itself');
+      return;
+    }
+  }
+  t.fail('/snap/bin survivor should appear in a --ro-bind-try pair');
+});
+
+test('PATH synthesis: host-bind drops ambient entries that do not exist', async t => {
+  // The exists() probe simulates `/opt/extant` present and
+  // `/opt/missing` absent.  Only the extant entry should land in PATH
+  // and the bind list.
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath: '/opt/missing:/opt/extant',
+      exists: p => p === '/opt/extant',
+    },
+  );
+  const path = extractSetenvPath(argv);
+  t.regex(/** @type {string} */ (path), /\/opt\/extant/);
+  t.notRegex(
+    /** @type {string} */ (path),
+    /\/opt\/missing/,
+    'missing host paths should not appear in synthesised PATH',
+  );
+});
+
+test('PATH synthesis: host-bind drops ambient entries whose realpath lands in a blocked prefix', async t => {
+  // `/opt/eve` is a symlink to `/tmp/attacker` — the textual prefix
+  // check passes on the literal `/opt/eve`, but the resolved path is
+  // under `/tmp/` and must be rejected.  `/opt/safe` resolves to
+  // itself and is preserved.
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath: '/opt/eve:/opt/safe',
+      exists: () => true,
+      realpath: async p => {
+        if (p === '/opt/eve') return '/tmp/attacker';
+        return p;
+      },
+    },
+  );
+  const path = /** @type {string} */ (extractSetenvPath(argv));
+  t.notRegex(
+    path,
+    /\/opt\/eve/,
+    'symlink-via-/opt to /tmp/* must be dropped after realpath',
+  );
+  t.notRegex(path, /\/tmp/, 'resolved /tmp target must not appear');
+  t.regex(path, /\/opt\/safe/, 'genuine /opt entries survive realpath');
+  t.false(
+    argv.includes('/opt/eve'),
+    'symlinked entry should not be bound into the slice',
+  );
+});
+
+test('PATH synthesis: host-bind drops ambient entries whose realpath fails', async t => {
+  // A realpath that throws (ENOENT/EACCES) drops the entry — we will
+  // not gamble on the textual form when the daemon cannot
+  // canonicalise.
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath: '/opt/broken:/opt/ok',
+      exists: () => true,
+      realpath: async p => {
+        if (p === '/opt/broken') throw new Error('ENOENT');
+        return p;
+      },
+    },
+  );
+  const path = /** @type {string} */ (extractSetenvPath(argv));
+  t.notRegex(path, /\/opt\/broken/);
+  t.regex(path, /\/opt\/ok/);
+});
+
+test('PATH synthesis: mount rootfs probes for canonical bin dirs', async t => {
+  // Probe says only `/usr/bin` and `/bin` exist under the rootfs.
+  // The synthesised PATH should reflect those slice-internal paths
+  // (NOT the host-prefixed paths).
+  const hostPath = '/srv/myrootfs';
+  const presentInner = new Set(['/usr/bin', '/bin']);
+  const argv = await assembleSliceArgv(
+    makeStubSpec({
+      rootfs: /** @type {any} */ ({ kind: 'mount', hostPath, mode: 'ro' }),
+    }),
+    {
+      seccompFd: null,
+      ambientPath: '',
+      exists: p => {
+        if (!p.startsWith(hostPath)) return false;
+        const inner = p.slice(hostPath.length);
+        return presentInner.has(inner);
+      },
+    },
+  );
+  const path = extractSetenvPath(argv);
+  t.is(
+    path,
+    '/usr/bin:/bin',
+    'mount-rootfs probe should yield slice-internal canonical paths in user-first order',
+  );
+});
+
+test('PATH synthesis: mount rootfs with empty probe yields empty PATH', async t => {
+  // The probe demonstrated that none of the canonical bin dirs exist
+  // inside the rootfs; falling back to `DEFAULT_PATH` would point at
+  // directories the slice does not contain, so we synthesise an
+  // empty `$PATH` and leave it to the caller to set `spec.env.PATH`.
+  const argv = await assembleSliceArgv(
+    makeStubSpec({
+      rootfs: /** @type {any} */ ({
+        kind: 'mount',
+        hostPath: '/srv/empty',
+        mode: 'ro',
+      }),
+    }),
+    {
+      seccompFd: null,
+      ambientPath: '',
+      exists: () => false,
+    },
+  );
+  t.is(
+    extractSetenvPath(argv),
+    '',
+    'empty mount rootfs should not falsely advertise host bin dirs',
+  );
+});
+
+test('PATH synthesis: relative mount rootfs hostPath is skipped', async t => {
+  // A relative `hostPath` would otherwise have its probe resolve
+  // against the daemon CWD; bail out early so the synthesised PATH
+  // does not reflect a probe with no bearing on the slice.
+  const probedPaths = [];
+  const argv = await assembleSliceArgv(
+    makeStubSpec({
+      rootfs: /** @type {any} */ ({
+        kind: 'mount',
+        hostPath: 'srv/relative',
+        mode: 'ro',
+      }),
+    }),
+    {
+      seccompFd: null,
+      ambientPath: '',
+      exists: p => {
+        probedPaths.push(p);
+        return true;
+      },
+    },
+  );
+  t.is(
+    extractSetenvPath(argv),
+    '',
+    'relative hostPath probe is skipped, falls back to empty PATH',
+  );
+  t.deepEqual(probedPaths, [], 'no canonical-bin probes against relative CWD');
+});
+
+test('PATH synthesis: minimal rootfs falls back to DEFAULT_PATH', async t => {
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'minimal' } }),
+    {
+      seccompFd: null,
+      ambientPath: '',
+      exists: () => true,
+    },
+  );
+  t.is(extractSetenvPath(argv), DEFAULT_PATH);
+});
+
+test('PATH synthesis: caller-granted bin-shaped mounts append after rootfs defaults', async t => {
+  const argv = await assembleSliceArgv(
+    makeStubSpec({
+      rootfs: { kind: 'host-bind' },
+      mounts: harden([
+        // Inner path ends in /bin → mount itself is a bin-dir.
+        { hostPath: '/srv/tools', innerPath: '/opt/tools/bin', mode: 'ro' },
+        // Mount with a `bin/` subdir (probed via exists).
+        { hostPath: '/srv/extra', innerPath: '/opt/extra', mode: 'ro' },
+      ]),
+    }),
+    {
+      seccompFd: null,
+      ambientPath: '',
+      // `/srv/extra/bin` is the only existence query that matters
+      // here; other probes can return whatever.
+      exists: p => p === '/srv/extra/bin',
+    },
+  );
+  const path = /** @type {string} */ (extractSetenvPath(argv));
+  // Must START with the canonical default — caller bin dirs cannot
+  // shadow /usr/bin.
+  t.true(
+    path.startsWith(DEFAULT_PATH),
+    'caller bin dirs must not shadow rootfs defaults',
+  );
+  t.regex(path, /\/opt\/tools\/bin/, 'inner-path-suffix /bin recognised');
+  t.regex(
+    path,
+    /\/opt\/extra\/bin/,
+    'bin/ subdir recognised under caller mount',
+  );
+  // /usr/bin must come before /opt/tools/bin in the synthesised string.
+  t.true(
+    path.indexOf('/usr/bin') < path.indexOf('/opt/tools/bin'),
+    'rootfs canonical /usr/bin must come before caller-supplied /opt/tools/bin',
+  );
+});
+
+test('PATH synthesis: caller-mount innerPath with embedded colon is split, not smuggled', async t => {
+  // A caller-granted mount with `innerPath = '/opt/tools/bin:/foo'`
+  // would otherwise feed a `/opt/tools/bin:/foo` segment into
+  // joinPathEntries, smuggling `/foo` onto $PATH.  joinPathEntries
+  // must split the entry and process each part as an independent
+  // segment (which here means `/foo` lands in the synthesised PATH
+  // explicitly — but as a known, separate segment, not as a
+  // smuggle-by-concatenation).
+  const argv = await assembleSliceArgv(
+    makeStubSpec({
+      rootfs: { kind: 'host-bind' },
+      mounts: harden([
+        {
+          hostPath: '/srv/tools',
+          innerPath: '/opt/tools/bin:/foo',
+          mode: 'ro',
+        },
+      ]),
+    }),
+    {
+      seccompFd: null,
+      ambientPath: '',
+      exists: () => true,
+    },
+  );
+  const path = /** @type {string} */ (extractSetenvPath(argv));
+  // Each segment of the synthesised PATH must be a clean, non-empty
+  // path with no embedded `:`.
+  for (const segment of path.split(':')) {
+    t.notRegex(
+      segment,
+      /:/,
+      `segment ${segment} should not contain embedded colons`,
+    );
+  }
+  t.regex(path, /\/opt\/tools\/bin/);
+  t.regex(path, /\/foo/);
+});
+
+test('PATH synthesis: caller-mount innerPath with newline is fatal', async t => {
+  // Newlines in `innerPath` corrupt the `--setenv PATH …` argv slot
+  // in arbitrary ways; `joinPathEntries` raises a structured error so
+  // the bug is visible at slice-prep time rather than at exec time.
+  await t.throwsAsync(
+    () =>
+      assembleSliceArgv(
+        makeStubSpec({
+          rootfs: { kind: 'host-bind' },
+          mounts: harden([
+            {
+              hostPath: '/srv/tools',
+              innerPath: '/opt/tools/bin\ninjected',
+              mode: 'ro',
+            },
+          ]),
+        }),
+        {
+          seccompFd: null,
+          ambientPath: '',
+          exists: () => true,
+        },
+      ),
+    { message: /control characters/ },
+  );
+});
+
+test('PATH synthesis: caller-supplied env.PATH always wins', async t => {
+  const argv = await assembleSliceArgv(
+    makeStubSpec({
+      rootfs: { kind: 'host-bind' },
+      env: harden({ PATH: '/only/this' }),
+    }),
+    {
+      seccompFd: null,
+      // Even with a fat ambient PATH, the caller's explicit value
+      // takes precedence.
+      ambientPath: '/opt/local/bin:/snap/bin',
+      exists: () => true,
+    },
+  );
+  // Find the LAST `--setenv PATH …` pair — caller's env iteration runs
+  // before the synthesis fallback would, but the synthesis fallback
+  // is gated by `hadPath`.  The expected behaviour is exactly one
+  // `--setenv PATH …` pair, with the caller's value.
+  /** @type {string[]} */
+  const pathValues = [];
+  for (let i = 0; i < argv.length - 2; i += 1) {
+    if (argv[i] === '--setenv' && argv[i + 1] === 'PATH') {
+      pathValues.push(argv[i + 2]);
+    }
+  }
+  t.deepEqual(
+    pathValues,
+    ['/only/this'],
+    'caller-supplied PATH must be the only --setenv PATH pair',
+  );
+});
+
+test('PATH synthesis: ambient PATH undefined is not an error', async t => {
+  // The bwrap driver may be constructed without an `env` (or with one
+  // that omits PATH).  The synthesis should degrade gracefully to the
+  // canonical default rather than throwing.
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath: undefined,
+      exists: () => true,
+    },
+  );
+  t.is(extractSetenvPath(argv), DEFAULT_PATH);
 });

--- a/packages/sandbox/test/bwrap.test.js
+++ b/packages/sandbox/test/bwrap.test.js
@@ -903,7 +903,7 @@ test.serial('fork() throws notImplemented before Phase 3', async t => {
 // These exercise `assembleSliceArgv` directly without spawning bwrap so
 // they run on every host (including non-Linux CI matrix entries).  They
 // assert the `--setenv PATH …` argv slot reflects the rules in
-// `TODO/22_sandbox_bwrap_path_refinements.md` for each rootfs shape.
+// `TADA/22_sandbox_bwrap_path_refinements.md` for each rootfs shape.
 
 /**
  * Pull the `--setenv PATH …` value out of an argv produced by

--- a/packages/sandbox/test/bwrap.test.js
+++ b/packages/sandbox/test/bwrap.test.js
@@ -1007,20 +1007,146 @@ test('PATH synthesis: host-bind appends ambient survivors after canonical bins',
     '/tmp entries must be dropped from synthesised PATH',
   );
   t.notRegex(/** @type {string} */ (path), /\.\./, 'no .. segments survive');
-  // Survivors should also appear as `--ro-bind-try` arguments so the
-  // PATH entries actually point at something inside the slice.
+  // Survivors are elevated to a package-root mount (the bin dir alone
+  // exposes dangling symlinks into siblings like `lib/`), so the
+  // `--ro-bind-try` pair binds the parent and the bin-dir entry only
+  // appears on `$PATH`.
   t.true(
-    argv.includes('/opt/local/bin'),
-    'survivor /opt/local/bin should be bound into the slice',
+    argv.includes('/opt/local'),
+    'survivor /opt/local/bin should be elevated to /opt/local for binding',
   );
-  // The argv pattern is `--ro-bind-try src dst`; check src AND dst.
+  t.false(
+    argv.includes('/opt/local/bin'),
+    'the unelevated bin dir should not be bound separately',
+  );
+  // The argv pattern is `--ro-bind-try src dst`; check src AND dst for
+  // the elevated `/snap` mount that covers `/snap/bin`.
   for (let i = 0; i < argv.length - 2; i += 1) {
-    if (argv[i] === '--ro-bind-try' && argv[i + 1] === '/snap/bin') {
-      t.is(argv[i + 2], '/snap/bin', 'binds host path to itself');
+    if (argv[i] === '--ro-bind-try' && argv[i + 1] === '/snap') {
+      t.is(argv[i + 2], '/snap', 'binds elevated host path to itself');
       return;
     }
   }
-  t.fail('/snap/bin survivor should appear in a --ro-bind-try pair');
+  t.fail('/snap/bin survivor should appear as /snap in a --ro-bind-try pair');
+});
+
+test('mount dedup: survivors under canonical roots do not emit redundant binds', async t => {
+  // `/usr/bin/site_perl` and `/usr/lib/jvm/default/bin` are PATH
+  // entries that survive the textual filter (they are not literal
+  // CANONICAL_BIN_PATHS) but live entirely under `/usr`, which the
+  // host-bind rootfs already mounts.  The dedup logic must collapse
+  // them so we never emit a second `--ro-bind-try` for a path the
+  // parent mount already covers.
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath: '/usr/bin/site_perl:/usr/lib/jvm/default/bin:/opt/rocm/bin',
+      exists: () => true,
+    },
+  );
+  // Count `--ro-bind-try` pairs whose host path starts with `/usr`.
+  // The canonical `/usr` bind from HOST_BIND_ROOTFS_PATHS is one; no
+  // survivor under it should add another.
+  let usrBindCount = 0;
+  for (let i = 0; i < argv.length - 2; i += 1) {
+    if (
+      argv[i] === '--ro-bind-try' &&
+      typeof argv[i + 1] === 'string' &&
+      (argv[i + 1] === '/usr' || argv[i + 1].startsWith('/usr/'))
+    ) {
+      usrBindCount += 1;
+    }
+  }
+  t.is(usrBindCount, 1, '/usr bind appears once even with /usr/* survivors');
+  // The PATH entries are still recorded so commands resolve at the
+  // operator-supplied locations.
+  const path = /** @type {string} */ (extractSetenvPath(argv));
+  t.regex(path, /\/usr\/bin\/site_perl/);
+  t.regex(path, /\/usr\/lib\/jvm\/default\/bin/);
+  // /opt/rocm/bin elevates to /opt/rocm; the bin dir is on PATH but
+  // the mount is the package root.
+  t.true(
+    argv.includes('/opt/rocm'),
+    '/opt/rocm/bin survivor elevates to /opt/rocm mount',
+  );
+  t.false(
+    argv.includes('/opt/rocm/bin'),
+    'unelevated /opt/rocm/bin is not bound separately',
+  );
+  t.regex(path, /\/opt\/rocm\/bin/, '/opt/rocm/bin still appears on PATH');
+});
+
+test('mount dedup: flatpak survivor elevates past /exports', async t => {
+  // `/var/lib/flatpak/exports/bin/foo` is a shell wrapper that execs
+  // into `/var/lib/flatpak/app/...`; binding only `/var/lib/flatpak/exports`
+  // would still leave dangling references.  Elevate one extra level
+  // past the trailing `/exports` segment so the slice can resolve the
+  // wrapper's downstream paths.
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath: '/var/lib/flatpak/exports/bin',
+      exists: () => true,
+    },
+  );
+  t.true(
+    argv.includes('/var/lib/flatpak'),
+    'flatpak bin dir elevates to the package root',
+  );
+  t.false(
+    argv.includes('/var/lib/flatpak/exports'),
+    'intermediate /exports parent is not the elevation target',
+  );
+  t.false(
+    argv.includes('/var/lib/flatpak/exports/bin'),
+    'unelevated bin dir is not bound separately',
+  );
+  // PATH still points at the operator-supplied bin dir inside the
+  // elevated mount.
+  const path = /** @type {string} */ (extractSetenvPath(argv));
+  t.regex(path, /\/var\/lib\/flatpak\/exports\/bin/);
+});
+
+test('mount dedup: HOST_BIND_ROOTFS_PATHS entries deduplicate against /usr', async t => {
+  // The default HOST_BIND_ROOTFS_PATHS list is already arranged so
+  // `/usr` precedes `/lib`, `/lib32`, `/lib64`, `/bin`, `/sbin`, and
+  // `/etc`.  Those siblings are NOT redundant against `/usr` (they
+  // are top-level paths, not children), so each gets its own bind.
+  // A subsequent survivor under `/usr` *would* be redundant; this test
+  // pins the non-redundant case to guard against an over-eager dedup
+  // that swallows the legitimate sibling binds.
+  const argv = await assembleSliceArgv(
+    makeStubSpec({ rootfs: { kind: 'host-bind' } }),
+    {
+      seccompFd: null,
+      ambientPath: '',
+      exists: () => true,
+    },
+  );
+  for (const expected of [
+    '/usr',
+    '/lib',
+    '/lib32',
+    '/lib64',
+    '/bin',
+    '/sbin',
+    '/etc',
+  ]) {
+    let found = false;
+    for (let i = 0; i < argv.length - 2; i += 1) {
+      if (
+        argv[i] === '--ro-bind-try' &&
+        argv[i + 1] === expected &&
+        argv[i + 2] === expected
+      ) {
+        found = true;
+        break;
+      }
+    }
+    t.true(found, `${expected} should appear as a --ro-bind-try pair`);
+  }
 });
 
 test('PATH synthesis: host-bind drops ambient entries that do not exist', async t => {

--- a/packages/sandbox/test/podman.test.js
+++ b/packages/sandbox/test/podman.test.js
@@ -7,6 +7,7 @@ import { E } from '@endo/eventual-send';
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';
 
+import assert from 'node:assert';
 import { spawn as nodeSpawn } from 'node:child_process';
 import * as nodeFs from 'node:fs';
 import * as nodeOs from 'node:os';
@@ -15,7 +16,9 @@ import * as nodePath from 'node:path';
 import {
   ENDO_SANDBOX_PREFIX,
   makePodmanDriver,
+  parseImagePathFromConfigEnv,
 } from '../src/drivers/podman.js';
+import { DEFAULT_PATH } from '../src/drivers/path.js';
 import { makeSandboxFactory } from '../src/factory.js';
 
 const StubMountInterface = M.interface('Mount', {
@@ -653,3 +656,257 @@ test.serial('fork() throws notImplemented before Phase 3', async t => {
     message: /Phase 3/,
   });
 });
+
+// ---------------------------------------------------------------------------
+// $PATH synthesis (TODO/23_sandbox_podman_path.md)
+// ---------------------------------------------------------------------------
+
+test('parseImagePathFromConfigEnv: extracts PATH from Config.Env', t => {
+  // Shape mirrors `podman image inspect --format '{{json .Config.Env}}'`.
+  const json = JSON.stringify([
+    'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    'LANG=C.UTF-8',
+  ]);
+  t.is(
+    parseImagePathFromConfigEnv(json),
+    '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+  );
+});
+
+test('parseImagePathFromConfigEnv: returns null when no PATH key', t => {
+  t.is(parseImagePathFromConfigEnv(JSON.stringify(['LANG=C.UTF-8'])), null);
+  // Mapping onto DEFAULT_PATH is `resolveSlicePath`'s job; the parser
+  // just signals "no PATH found" via null.
+});
+
+test('parseImagePathFromConfigEnv: tolerates malformed JSON', t => {
+  t.is(parseImagePathFromConfigEnv('not json'), null);
+  t.is(parseImagePathFromConfigEnv('{}'), null);
+  t.is(parseImagePathFromConfigEnv('null'), null);
+});
+
+test('parseImagePathFromConfigEnv: tolerates non-string entries', t => {
+  // A hostile or buggy image might surface non-string entries; the
+  // parser must skip them rather than throw.
+  t.is(parseImagePathFromConfigEnv(JSON.stringify([null, 42, {}])), null);
+  t.is(parseImagePathFromConfigEnv(JSON.stringify([null, 'PATH=/x'])), '/x');
+});
+
+test('parseImagePathFromConfigEnv: empty PATH is honoured as empty string', t => {
+  // An image that explicitly sets `ENV PATH=` is opting out — surface
+  // the empty string so `resolveSlicePath` can fall back to DEFAULT_PATH
+  // (its `imagePath !== ''` guard treats this case as "no image PATH").
+  t.is(parseImagePathFromConfigEnv(JSON.stringify(['PATH='])), '');
+});
+
+test.serial(
+  'alpine slice spawn sees the image-derived PATH (source: image)',
+  async t => {
+    if (!podmanAvailability.available || !podmanAvailability.imagePresent) {
+      t.pass(
+        `podman or alpine image not available: ${podmanAvailability.reason ?? 'image absent'}`,
+      );
+      return;
+    }
+    // Discover the image's own PATH so the assertion does not bake in
+    // a particular Alpine release's choice; this also exercises the
+    // same `podman image inspect` path the driver uses internally.
+    const inspect = await podmanRun([
+      'image',
+      'inspect',
+      '--format',
+      '{{json .Config.Env}}',
+      ALPINE_REF,
+    ]);
+    if (inspect.code !== 0) {
+      t.pass(`podman image inspect failed: ${inspect.stderr.trim()}`);
+      return;
+    }
+    const expectedPath = parseImagePathFromConfigEnv(inspect.stdout.trim());
+    t.is(
+      typeof expectedPath,
+      'string',
+      'alpine image is expected to declare a PATH in Config.Env',
+    );
+    // node:assert narrows expectedPath from `string | null` to `string`
+    // for the type-checker; ava's t.is above already handled the
+    // user-facing failure case.
+    assert(typeof expectedPath === 'string');
+
+    const driver = makePodmanDriver({ env: {}, reapOrphans: false });
+    const { powers, tmpdirs } = makeStubScratchProvider();
+    const factory = makeSandboxFactory({
+      drivers: harden([driver]),
+      scratchProvider: powers,
+    });
+    const handle = await E(factory).make(
+      harden({
+        rootfs: { kind: 'oci', ref: ALPINE_REF },
+        network: 'none',
+        backend: 'podman',
+      }),
+    );
+    t.teardown(async () => {
+      await E(handle).dispose();
+      cleanupTmpdirs(tmpdirs);
+    });
+
+    const proc = await E(handle).spawn(harden(['/bin/printenv', 'PATH']));
+    const stdout = await drainReader(await E(proc).stdout());
+    const exit = await E(proc).wait();
+    t.is(exit.code, 0, 'printenv PATH should succeed');
+    t.is(stdout.toString('utf8').trimEnd(), expectedPath);
+    // Sanity: the image-derived PATH differs from our canonical
+    // fallback (alpine puts /usr/local/sbin first), so this assertion
+    // also confirms we did not silently slip into the fallback branch.
+    t.not(
+      stdout.toString('utf8').trimEnd(),
+      DEFAULT_PATH,
+      'image PATH should differ from DEFAULT_PATH for alpine',
+    );
+
+    const help = await E(handle).help();
+    t.regex(
+      help,
+      new RegExp(
+        `path: ${expectedPath?.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')} \\(source: image\\)`,
+      ),
+      'help() reports the image-derived PATH',
+    );
+  },
+);
+
+test.serial(
+  'caller spec.env.PATH overrides the image-derived PATH (source: env)',
+  async t => {
+    if (!podmanAvailability.available || !podmanAvailability.imagePresent) {
+      t.pass(
+        `podman or alpine image not available: ${podmanAvailability.reason ?? 'image absent'}`,
+      );
+      return;
+    }
+    const callerPath = '/opt/myapp/bin:/usr/bin';
+    const driver = makePodmanDriver({ env: {}, reapOrphans: false });
+    const { powers, tmpdirs } = makeStubScratchProvider();
+    const factory = makeSandboxFactory({
+      drivers: harden([driver]),
+      scratchProvider: powers,
+    });
+    const handle = await E(factory).make(
+      harden({
+        rootfs: { kind: 'oci', ref: ALPINE_REF },
+        network: 'none',
+        backend: 'podman',
+        env: { PATH: callerPath },
+      }),
+    );
+    t.teardown(async () => {
+      await E(handle).dispose();
+      cleanupTmpdirs(tmpdirs);
+    });
+
+    const proc = await E(handle).spawn(harden(['/bin/printenv', 'PATH']));
+    const stdout = await drainReader(await E(proc).stdout());
+    const exit = await E(proc).wait();
+    t.is(exit.code, 0);
+    t.is(stdout.toString('utf8').trimEnd(), callerPath);
+
+    const help = await E(handle).help();
+    t.regex(
+      help,
+      new RegExp(
+        `path: ${callerPath.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')} \\(source: env\\)`,
+      ),
+      'help() reports the caller-supplied PATH',
+    );
+  },
+);
+
+test.serial(
+  'image with no Config.Env PATH falls back to DEFAULT_PATH (source: fallback)',
+  async t => {
+    // Building a custom OCI image at test time is impractical here, so
+    // we exercise the fallback branch through the driver's
+    // `inspectImagePath` cache: stub the `child_process` module so
+    // `podman image inspect` returns an empty `Config.Env`, then
+    // observe `resolveSlicePath` picking `DEFAULT_PATH`.
+    //
+    // The integration counterpart (a real custom image) is covered in
+    // the parser unit tests above; what matters here is that the
+    // driver's full prepare path honours that branch and surfaces
+    // `source: fallback` to `slice.help()`.
+    if (!podmanAvailability.available || !podmanAvailability.imagePresent) {
+      t.pass(
+        `podman or alpine image not available: ${podmanAvailability.reason ?? 'image absent'}`,
+      );
+      return;
+    }
+    // Use an image whose Config.Env has no PATH by stripping it via a
+    // throw-away tagged image.  `podman tag` is cheap; the new tag
+    // points at the same layers but we override Config.Env via
+    // `--config` on `podman commit`.  When that is unsupported on the
+    // host's podman, fall back to a pass-through skip.
+    const tag = `localhost/endo-sandbox-test-no-path:${Date.now().toString(16)}`;
+    const created = await podmanRun([
+      'create',
+      '--name',
+      `endo-sandbox-test-seed-${Date.now().toString(16)}`,
+      ALPINE_REF,
+      '/bin/true',
+    ]);
+    if (created.code !== 0) {
+      t.pass(`could not seed temp container: ${created.stderr.trim()}`);
+      return;
+    }
+    const seedName = created.stdout.trim();
+    t.teardown(async () => {
+      await podmanRun(['rm', '-f', seedName]);
+      await podmanRun(['rmi', '-f', tag]);
+    });
+    // `podman commit -c "ENV PATH="` would set PATH to the empty
+    // string; `--change "ENV "` is rejected.  The cleanest way to
+    // produce a Config.Env without PATH is `--change-config` JSON
+    // patching, which podman does not support directly.  We sidestep
+    // this by committing with `PATH=` (empty value) — the parser
+    // returns `''` for that, and `resolveSlicePath` then falls back
+    // to DEFAULT_PATH (its `imagePath !== ''` guard).
+    const committed = await podmanRun([
+      'commit',
+      '--change',
+      'ENV PATH=',
+      seedName,
+      tag,
+    ]);
+    if (committed.code !== 0) {
+      t.pass(`podman commit unsupported here: ${committed.stderr.trim()}`);
+      return;
+    }
+
+    const driver = makePodmanDriver({ env: {}, reapOrphans: false });
+    const { powers, tmpdirs } = makeStubScratchProvider();
+    const factory = makeSandboxFactory({
+      drivers: harden([driver]),
+      scratchProvider: powers,
+    });
+    const handle = await E(factory).make(
+      harden({
+        rootfs: { kind: 'oci', ref: tag },
+        network: 'none',
+        backend: 'podman',
+      }),
+    );
+    t.teardown(async () => {
+      await E(handle).dispose();
+      cleanupTmpdirs(tmpdirs);
+    });
+
+    const proc = await E(handle).spawn(harden(['/bin/printenv', 'PATH']));
+    const stdout = await drainReader(await E(proc).stdout());
+    const exit = await E(proc).wait();
+    t.is(exit.code, 0);
+    t.is(stdout.toString('utf8').trimEnd(), DEFAULT_PATH);
+
+    const help = await E(handle).help();
+    t.regex(help, /path: .* \(source: fallback\)/);
+  },
+);

--- a/packages/sandbox/test/podman.test.js
+++ b/packages/sandbox/test/podman.test.js
@@ -658,7 +658,7 @@ test.serial('fork() throws notImplemented before Phase 3', async t => {
 });
 
 // ---------------------------------------------------------------------------
-// $PATH synthesis (TODO/23_sandbox_podman_path.md)
+// $PATH synthesis (TADA/23_sandbox_podman_path.md)
 // ---------------------------------------------------------------------------
 
 test('parseImagePathFromConfigEnv: extracts PATH from Config.Env', t => {


### PR DESCRIPTION
## Summary

Synthesizes a default `$PATH` for sandbox slices from the rootfs's canonical bin dirs, with caller `spec.env.PATH` overriding everything.
The bwrap and podman drivers each get matching path-derivation logic plus tests, and a shared `drivers/path.js` module hosts the canonical default and the security filters that govern which host paths are allowed to leak into a slice.

## Design docs

This PR ships against the following TADA design notes:

- `TADA/21_sandbox_path.md` — overall `$PATH` semantics for sandbox slices.
- `TADA/22_sandbox_bwrap_path_refinements.md` — bwrap-specific rules for ambient-`$PATH` filtering, host-bind detection, and mount-rootfs probing.
- `TADA/23_sandbox_podman_path.md` — podman-specific rules for OCI image `Config.Env` PATH inheritance.

## Audit trail

- Panel review (CHANGES_REQUESTED, dismissed once must-fixes landed): https://github.com/endojs/endo-but-for-bots/pull/119#pullrequestreview-4245100904
- Saboteur findings (realpath survivors, joinPathEntries sanitization, hostPath relative guard, mount-rootfs empty-probe fallback) were addressed in the consolidated `feat(sandbox)` commit and the shepherd typedoc fix `6c2ba40cc5`: https://github.com/endojs/endo-but-for-bots/pull/119#issuecomment-4398264566
