### PR TITLE
fix(fae): bind provider via storeIdentifier in setup scripts

### DIFF
--- a/packages/fae/fae-factory-setup.js
+++ b/packages/fae/fae-factory-setup.js
@@ -63,8 +63,10 @@ export const main = async agent => {
   }
 
   // Write the provider reference into the factory's petstore.
+  // E(agent).identify(...) returns a bare formula id, so use
+  // storeIdentifier rather than storeLocator (which requires endo://).
   const factoryPowers = await E(agent).lookup(agentName);
-  await E(factoryPowers).storeLocator('llm-provider', providerId);
+  await E(factoryPowers).storeIdentifier('llm-provider', providerId);
 
   // Launch the fae-factory caplet.
   await E(agent).makeUnconfined('@main', faeFactorySpecifier, {

--- a/packages/fae/setup-with-tools.js
+++ b/packages/fae/setup-with-tools.js
@@ -86,7 +86,9 @@ export const main = async agent => {
     }
 
     const factoryPowers = await E(agent).lookup(factoryAgent);
-    await E(factoryPowers).storeLocator('llm-provider', providerId);
+    // E(agent).identify(...) returns a bare formula id, so use
+    // storeIdentifier rather than storeLocator (which requires endo://).
+    await E(factoryPowers).storeIdentifier('llm-provider', providerId);
 
     await E(agent).makeUnconfined('@main', faeFactorySpecifier, {
       powersName: factoryAgent,


### PR DESCRIPTION
## Description

Fixes observed error during `yarn setup-factory` in `packages/fae`:
```sh
CapTP cli exception: (RemoteError(error:captp:Endo#20001)#1)
RemoteError(error:captp:Endo#20001)#1: storeLocator requires an endo:// locator, got "a50...cba:c7b...617"
```

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Ensures `packages/fae/README` instructions work - specifically the `yarn setup-factory` step.

### Testing Considerations

Manually tested

### Compatibility Considerations

I don't believe so.

### Upgrade Considerations

None, bug fix