### PR TITLE
feat(lal): add OpenRouter provider and share OpenAI Chat shape

### DIFF
--- a/packages/lal/LAL-ARCHITECTURE.md
+++ b/packages/lal/LAL-ARCHITECTURE.md
@@ -362,6 +362,7 @@ Based on the `LAL_HOST` environment variable:
 | Host URL pattern | Provider | SDK | Default model |
 |------------------|----------|-----|---------------|
 | Contains `anthropic.com` | `makeAnthropicProvider` | `@anthropic-ai/sdk` | `claude-opus-4-5-20251101` |
+| Contains `openrouter.ai` | `makeOpenRouterProvider` | `openai` | `anthropic/claude-sonnet-4-5` |
 | Contains `/v1` | `makeLlamaCppProvider` | `openai` | `qwen3` |
 | Other | `makeOllamaProvider` | `ollama` | `qwen3` |
 

--- a/packages/lal/README.md
+++ b/packages/lal/README.md
@@ -13,21 +13,26 @@ The LLM agent uses tool calls to interact with the Endo daemon, enabling it to:
 ## Configuration
 
 The agent is configured via environment variables.
-If `LAL_HOST` contains `anthropic.com`, the Anthropic provider is used;
+The provider is selected from `LAL_HOST`:
+if it contains `anthropic.com`, the Anthropic provider is used;
+if it contains `openrouter.ai`, the OpenRouter provider is used;
 otherwise the llama.cpp (OpenAI-compatible) provider is used.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `LAL_HOST` | API base URL (Ollama, llama.cpp, or Anthropic) | `http://localhost:11434/v1` |
-| `LAL_MODEL` | Model name | `qwen3` (llama.cpp) or `claude-opus-4-5-20251101` (Anthropic) |
+| `LAL_HOST` | API base URL (Ollama, llama.cpp, OpenRouter, or Anthropic) | `http://localhost:11434/v1` |
+| `LAL_MODEL` | Model name | `qwen3` (llama.cpp), `anthropic/claude-sonnet-4-5` (OpenRouter), or `claude-opus-4-5-20251101` (Anthropic) |
 | `LAL_AUTH_TOKEN` | API key (optional for local servers) | - |
 | `LAL_MAX_TOKENS` | Max completion tokens (llama.cpp provider) | `4096` |
 | `LAL_MAX_MESSAGES` | Truncate to last N messages before sending (avoids context-size errors) | - |
+| `LAL_OPENROUTER_REFERER` | Optional `HTTP-Referer` header for OpenRouter dashboard attribution | - |
+| `LAL_OPENROUTER_TITLE` | Optional `X-Title` header for OpenRouter dashboard attribution | - |
 
 Example configuration files are provided:
 - `local.env.example` - Local Ollama instance
 - `cloud.env.example` - Remote Ollama with authentication
 - `openai.env.example` - OpenAI API (OpenAI-compatible provider)
+- `openrouter.env.example` - OpenRouter (multi-vendor LLM gateway)
 - `opus.env.example` - Anthropic Claude (Opus)
 
 For a llama.cpp server that returns "context size" errors, set `LAL_MAX_MESSAGES`

--- a/packages/lal/agent.types.d.ts
+++ b/packages/lal/agent.types.d.ts
@@ -45,6 +45,12 @@ export type ChatMessage = {
   content: string;
   tool_calls?: ToolCall[];
   tool_call_id?: string;
+  /** Plaintext reasoning trace (OpenRouter extension). */
+  reasoning?: string;
+  /** Structured reasoning blocks; carries encrypted/signed thinking traces
+   *  for upstream providers and must be forwarded verbatim on the next
+   *  assistant turn. */
+  reasoning_details?: object[];
 };
 
 export type ToolResult = {

--- a/packages/lal/openrouter.env.example
+++ b/packages/lal/openrouter.env.example
@@ -1,0 +1,13 @@
+# OpenRouter (https://openrouter.ai)
+# Get an API key from https://openrouter.ai/keys
+# LAL_MODEL: vendor-prefixed slug, e.g. anthropic/claude-sonnet-4-5, openai/gpt-4o,
+# google/gemini-2.5-pro, meta-llama/llama-3.3-70b-instruct
+# (see https://openrouter.ai/models)
+
+export LAL_HOST=https://openrouter.ai/api/v1
+export LAL_MODEL=anthropic/claude-sonnet-4-5
+export LAL_AUTH_TOKEN=
+
+# Optional attribution headers shown on the OpenRouter dashboard.
+# export LAL_OPENROUTER_REFERER=https://example.com
+# export LAL_OPENROUTER_TITLE=Lal

--- a/packages/lal/providers/anthropic.js
+++ b/packages/lal/providers/anthropic.js
@@ -112,10 +112,7 @@ export const makeAnthropicProvider = ({ apiKey, model, logger = console }) => {
       const { system, messages: anthropicMessages } =
         toAnthropicMessages(messages);
       logger.log('[LAL] Calling Anthropic API...');
-      logger.log(
-        '[LAL] Messages:',
-        JSON.stringify(anthropicMessages, null, 2),
-      );
+      logger.log('[LAL] Messages:', JSON.stringify(anthropicMessages, null, 2));
       let response;
       try {
         response = await client.messages.create({

--- a/packages/lal/providers/anthropic.js
+++ b/packages/lal/providers/anthropic.js
@@ -125,13 +125,17 @@ export const makeAnthropicProvider = ({ apiKey, model, logger = console }) => {
         logger.log('[LAL] Anthropic response received');
       } catch (error) {
         logger.error('[LAL] Anthropic API error:', error);
-        const status = error?.status ?? error?.statusCode;
-        const errBody = error?.error ?? error?.body;
+        const e =
+          /** @type {{ status?: number, statusCode?: number, error?: { type?: string, message?: string }, body?: { type?: string, message?: string }, message?: string }} */ (
+            error
+          );
+        const status = e.status ?? e.statusCode;
+        const errBody = e.error ?? e.body;
         const isAuthError =
           status === 401 ||
           errBody?.type === 'authentication_error' ||
           /invalid x-api-key|api key|authentication/i.test(
-            errBody?.message || error?.message || '',
+            errBody?.message || e.message || '',
           );
         if (isAuthError) {
           throw new Error(

--- a/packages/lal/providers/anthropic.js
+++ b/packages/lal/providers/anthropic.js
@@ -7,6 +7,13 @@
 import Anthropic from '@anthropic-ai/sdk';
 
 /**
+ * @typedef {object} Logger
+ * @property {(...args: unknown[]) => void} log
+ * @property {(...args: unknown[]) => void} error
+ * @property {(...args: unknown[]) => void} warn
+ */
+
+/**
  * @typedef {object} CommonTool
  * @property {'function'} type
  * @property {{ name: string, description: string, parameters: object }} function
@@ -94,18 +101,18 @@ const toAnthropicMessages = messages => {
 
 /**
  * Create an Anthropic-backed chat provider.
- * @param {{ apiKey: string, model: string }} options
+ * @param {{ apiKey: string, model: string, logger?: Logger }} options
  * @returns {{ chat: (messages: CommonChatMessage[], tools: CommonTool[]) => Promise<{ message: CommonChatMessage }> }}
  */
-export const makeAnthropicProvider = ({ apiKey, model }) => {
+export const makeAnthropicProvider = ({ apiKey, model, logger = console }) => {
   const client = new Anthropic({ apiKey });
 
   return {
     async chat(messages, tools) {
       const { system, messages: anthropicMessages } =
         toAnthropicMessages(messages);
-      console.log('[LAL] Calling Anthropic API...');
-      console.log(
+      logger.log('[LAL] Calling Anthropic API...');
+      logger.log(
         '[LAL] Messages:',
         JSON.stringify(anthropicMessages, null, 2),
       );
@@ -118,9 +125,9 @@ export const makeAnthropicProvider = ({ apiKey, model }) => {
           tools: toAnthropicTools(tools),
           messages: anthropicMessages,
         });
-        console.log('[LAL] Anthropic response received');
+        logger.log('[LAL] Anthropic response received');
       } catch (error) {
-        console.error('[LAL] Anthropic API error:', error);
+        logger.error('[LAL] Anthropic API error:', error);
         const status = error?.status ?? error?.statusCode;
         const errBody = error?.error ?? error?.body;
         const isAuthError =

--- a/packages/lal/providers/config.js
+++ b/packages/lal/providers/config.js
@@ -6,8 +6,12 @@
 /**
  * Detect the provider kind from a base URL.
  *
+ * Matches vendor-specific domains first; the trailing `/v1` check is the
+ * generic OpenAI-compatible catchall (typically a localhost or private
+ * server such as llama.cpp / vLLM).
+ *
  * @param {string} baseURL
- * @returns {'anthropic' | 'gemini' | 'openai-compatible' | 'ollama'}
+ * @returns {'anthropic' | 'gemini' | 'openrouter' | 'openai-compatible' | 'ollama'}
  */
 export const detectProviderKind = baseURL => {
   if (baseURL.includes('anthropic.com')) {
@@ -18,6 +22,9 @@ export const detectProviderKind = baseURL => {
     baseURL.includes('generativelanguage')
   ) {
     return 'gemini';
+  }
+  if (baseURL.includes('openrouter.ai')) {
+    return 'openrouter';
   }
   if (baseURL.includes('/v1')) {
     return 'openai-compatible';
@@ -30,6 +37,7 @@ harden(detectProviderKind);
 const defaultModels = {
   anthropic: 'claude-sonnet-4-6-20250514',
   gemini: 'gemini-2.5-pro',
+  openrouter: 'anthropic/claude-sonnet-4-5',
   'openai-compatible': 'qwen3',
   ollama: 'qwen3',
 };

--- a/packages/lal/providers/gemini.js
+++ b/packages/lal/providers/gemini.js
@@ -11,26 +11,14 @@
 
 import https from 'node:https';
 
-/**
- * @typedef {object} Logger
- * @property {(...args: unknown[]) => void} log
- * @property {(...args: unknown[]) => void} error
- * @property {(...args: unknown[]) => void} warn
- */
+import {
+  toOpenAIChatMessages,
+  toOpenAIChatTools,
+  parseOpenAIChatChoice,
+  truncateMessages,
+} from './openai-chat.js';
 
-/**
- * @typedef {object} CommonTool
- * @property {'function'} type
- * @property {{ name: string, description: string, parameters: object }} function
- */
-
-/**
- * @typedef {object} CommonChatMessage
- * @property {'system'|'user'|'assistant'|'tool'} role
- * @property {string} content
- * @property {Array<{ id?: string, function: { name: string, arguments: string|object }}>} [tool_calls]
- * @property {string} [tool_call_id]
- */
+/** @import { Logger, CommonTool, CommonChatMessage } from './openai-chat.js' */
 
 /**
  * @param {string} baseURL
@@ -129,17 +117,7 @@ export const makeGeminiProvider = ({
 
   return {
     async chat(messages, tools) {
-      let sendMessages = messages;
-      if (
-        typeof maxMessages === 'number' &&
-        maxMessages > 0 &&
-        messages.length > maxMessages
-      ) {
-        sendMessages = messages.slice(-maxMessages);
-        logger.log(
-          `[LAL] Truncated to last ${maxMessages} messages (was ${messages.length})`,
-        );
-      }
+      const sendMessages = truncateMessages(messages, maxMessages, logger);
       logger.log(
         `[LAL] Calling Gemini at ${url.origin}${url.pathname} with model: ${model}`,
       );
@@ -148,35 +126,14 @@ export const makeGeminiProvider = ({
         response = await postJson(url, apiKey, {
           model,
           max_tokens: maxTokens,
-          tools,
-          messages: sendMessages,
+          tools: toOpenAIChatTools(tools),
+          messages: toOpenAIChatMessages(sendMessages),
         });
       } catch (error) {
         logger.error('[LAL] Gemini API error:', error);
         throw error;
       }
-      const choice = response.choices?.[0];
-      if (!choice) {
-        return { message: { role: 'assistant', content: '' } };
-      }
-      /** @type {CommonChatMessage} */
-      const message = {
-        role: 'assistant',
-        content: choice.message?.content ?? '',
-      };
-      if (
-        choice.message?.tool_calls &&
-        /** @type {unknown[]} */ (choice.message.tool_calls).length > 0
-      ) {
-        message.tool_calls = choice.message.tool_calls.map(tc => ({
-          id: tc.id,
-          function: {
-            name: tc.function?.name ?? '',
-            arguments: tc.function?.arguments ?? '{}',
-          },
-        }));
-      }
-      return { message };
+      return { message: parseOpenAIChatChoice(response.choices?.[0]) };
     },
   };
 };

--- a/packages/lal/providers/gemini.js
+++ b/packages/lal/providers/gemini.js
@@ -12,6 +12,13 @@
 import https from 'node:https';
 
 /**
+ * @typedef {object} Logger
+ * @property {(...args: unknown[]) => void} log
+ * @property {(...args: unknown[]) => void} error
+ * @property {(...args: unknown[]) => void} warn
+ */
+
+/**
  * @typedef {object} CommonTool
  * @property {'function'} type
  * @property {{ name: string, description: string, parameters: object }} function
@@ -107,7 +114,7 @@ const postJson = (url, apiKey, payload) =>
 /**
  * Create a Gemini-backed chat provider via the Google OpenAI-compatible API.
  *
- * @param {{ baseURL: string, model: string, apiKey: string, maxTokens?: number, maxMessages?: number }} options
+ * @param {{ baseURL: string, model: string, apiKey: string, maxTokens?: number, maxMessages?: number, logger?: Logger }} options
  * @returns {{ chat: (messages: CommonChatMessage[], tools: CommonTool[]) => Promise<{ message: CommonChatMessage }> }}
  */
 export const makeGeminiProvider = ({
@@ -116,6 +123,7 @@ export const makeGeminiProvider = ({
   apiKey,
   maxTokens = 4096,
   maxMessages = undefined,
+  logger = console,
 }) => {
   const url = makeChatCompletionsUrl(baseURL);
 
@@ -128,11 +136,11 @@ export const makeGeminiProvider = ({
         messages.length > maxMessages
       ) {
         sendMessages = messages.slice(-maxMessages);
-        console.log(
+        logger.log(
           `[LAL] Truncated to last ${maxMessages} messages (was ${messages.length})`,
         );
       }
-      console.log(
+      logger.log(
         `[LAL] Calling Gemini at ${url.origin}${url.pathname} with model: ${model}`,
       );
       let response;
@@ -144,7 +152,7 @@ export const makeGeminiProvider = ({
           messages: sendMessages,
         });
       } catch (error) {
-        console.error('[LAL] Gemini API error:', error);
+        logger.error('[LAL] Gemini API error:', error);
         throw error;
       }
       const choice = response.choices?.[0];

--- a/packages/lal/providers/index.js
+++ b/packages/lal/providers/index.js
@@ -8,6 +8,7 @@ import { makeAnthropicProvider } from './anthropic.js';
 import { makeGeminiProvider } from './gemini.js';
 import { makeLlamaCppProvider } from './llamacpp.js';
 import { makeOllamaProvider } from './ollama.js';
+import { makeOpenRouterProvider } from './openrouter.js';
 import { detectProviderKind, resolveModelForHost } from './config.js';
 
 /**
@@ -27,6 +28,7 @@ import { detectProviderKind, resolveModelForHost } from './config.js';
  *
  * Provider selection based on LAL_HOST:
  * - Contains 'anthropic.com' -> Anthropic provider
+ * - Contains 'openrouter.ai' -> OpenRouter provider
  * - Contains '/v1' suffix -> llama.cpp (OpenAI-compatible) provider
  * - Otherwise (e.g., 'http://localhost:11434') -> Native Ollama provider
  *
@@ -34,10 +36,20 @@ import { detectProviderKind, resolveModelForHost } from './config.js';
  * - LAL_HOST: Base URL for the LLM service (default: http://localhost:11434)
  * - LAL_MODEL: Model name (defaults vary by provider)
  * - LAL_AUTH_TOKEN: API key for authentication
- * - LAL_MAX_TOKENS: Max tokens for completion (llama.cpp only)
- * - LAL_MAX_MESSAGES: Truncate to last N messages (llama.cpp only)
+ * - LAL_MAX_TOKENS: Max tokens for completion (llama.cpp / OpenRouter)
+ * - LAL_MAX_MESSAGES: Truncate to last N messages (llama.cpp / OpenRouter)
+ * - LAL_OPENROUTER_REFERER / LAL_OPENROUTER_TITLE: optional attribution
+ *   headers shown on OpenRouter's request dashboard
  *
- * @param {{ LAL_HOST?: string, LAL_MODEL?: string, LAL_AUTH_TOKEN?: string, LAL_MAX_TOKENS?: string, LAL_MAX_MESSAGES?: string }} env
+ * @param {{
+ *   LAL_HOST?: string,
+ *   LAL_MODEL?: string,
+ *   LAL_AUTH_TOKEN?: string,
+ *   LAL_MAX_TOKENS?: string,
+ *   LAL_MAX_MESSAGES?: string,
+ *   LAL_OPENROUTER_REFERER?: string,
+ *   LAL_OPENROUTER_TITLE?: string,
+ * }} env
  * @param {{ logger?: Logger }} [options]
  * @returns {Provider}
  */
@@ -83,6 +95,34 @@ export const createProvider = (env, { logger = console } = {}) => {
     });
   }
 
+  if (providerKind === 'openrouter') {
+    const apiKey = env.LAL_AUTH_TOKEN;
+    if (!apiKey || apiKey === '') {
+      throw new Error(
+        'LAL_AUTH_TOKEN is required for OpenRouter. Set it to your API key.',
+      );
+    }
+    const maxTokens = env.LAL_MAX_TOKENS
+      ? parseInt(env.LAL_MAX_TOKENS, 10)
+      : 4096;
+    const maxMessages = env.LAL_MAX_MESSAGES
+      ? parseInt(env.LAL_MAX_MESSAGES, 10)
+      : undefined;
+    logger.log(
+      `[LAL] Using OpenRouter provider at ${baseURL} with model: ${model}`,
+    );
+    return makeOpenRouterProvider({
+      baseURL,
+      model,
+      apiKey,
+      maxTokens,
+      maxMessages,
+      referer: env.LAL_OPENROUTER_REFERER,
+      title: env.LAL_OPENROUTER_TITLE,
+      logger,
+    });
+  }
+
   if (providerKind === 'openai-compatible') {
     // Use llama.cpp (OpenAI-compatible) provider when URL contains /v1
     const apiKey = env.LAL_AUTH_TOKEN || 'ollama';
@@ -122,3 +162,4 @@ export { makeAnthropicProvider } from './anthropic.js';
 export { makeGeminiProvider } from './gemini.js';
 export { makeLlamaCppProvider } from './llamacpp.js';
 export { makeOllamaProvider } from './ollama.js';
+export { makeOpenRouterProvider } from './openrouter.js';

--- a/packages/lal/providers/index.js
+++ b/packages/lal/providers/index.js
@@ -11,6 +11,13 @@ import { makeOllamaProvider } from './ollama.js';
 import { detectProviderKind, resolveModelForHost } from './config.js';
 
 /**
+ * @typedef {object} Logger
+ * @property {(...args: unknown[]) => void} log
+ * @property {(...args: unknown[]) => void} error
+ * @property {(...args: unknown[]) => void} warn
+ */
+
+/**
  * @typedef {object} Provider
  * @property {(messages: object[], tools: object[]) => Promise<{ message: object }>} chat
  */
@@ -31,9 +38,10 @@ import { detectProviderKind, resolveModelForHost } from './config.js';
  * - LAL_MAX_MESSAGES: Truncate to last N messages (llama.cpp only)
  *
  * @param {{ LAL_HOST?: string, LAL_MODEL?: string, LAL_AUTH_TOKEN?: string, LAL_MAX_TOKENS?: string, LAL_MAX_MESSAGES?: string }} env
+ * @param {{ logger?: Logger }} [options]
  * @returns {Provider}
  */
-export const createProvider = env => {
+export const createProvider = (env, { logger = console } = {}) => {
   const baseURL = env.LAL_HOST || 'http://localhost:11434';
   const providerKind = detectProviderKind(baseURL);
   const model = resolveModelForHost(baseURL, env.LAL_MODEL);
@@ -45,8 +53,8 @@ export const createProvider = env => {
         'LAL_AUTH_TOKEN is required for Anthropic. Set it to your API key.',
       );
     }
-    console.log(`[LAL] Using Anthropic provider with model: ${model}`);
-    return makeAnthropicProvider({ apiKey, model });
+    logger.log(`[LAL] Using Anthropic provider with model: ${model}`);
+    return makeAnthropicProvider({ apiKey, model, logger });
   }
 
   if (providerKind === 'gemini') {
@@ -62,7 +70,7 @@ export const createProvider = env => {
     const maxMessages = env.LAL_MAX_MESSAGES
       ? parseInt(env.LAL_MAX_MESSAGES, 10)
       : undefined;
-    console.log(
+    logger.log(
       `[LAL] Using Gemini provider at ${baseURL} with model: ${model}`,
     );
     return makeGeminiProvider({
@@ -71,6 +79,7 @@ export const createProvider = env => {
       apiKey,
       maxTokens,
       maxMessages,
+      logger,
     });
   }
 
@@ -83,7 +92,7 @@ export const createProvider = env => {
     const maxMessages = env.LAL_MAX_MESSAGES
       ? parseInt(env.LAL_MAX_MESSAGES, 10)
       : undefined;
-    console.log(
+    logger.log(
       `[LAL] Using llama.cpp provider at ${baseURL} with model: ${model}`,
     );
     return makeLlamaCppProvider({
@@ -92,18 +101,20 @@ export const createProvider = env => {
       apiKey,
       maxTokens,
       maxMessages,
+      logger,
     });
   }
 
   // Default: Use native Ollama provider
   const apiKey = env.LAL_AUTH_TOKEN;
-  console.log(
+  logger.log(
     `[LAL] Using native Ollama provider at ${baseURL} with model: ${model}`,
   );
   return makeOllamaProvider({
     host: baseURL,
     model,
     apiKey,
+    logger,
   });
 };
 

--- a/packages/lal/providers/llamacpp.js
+++ b/packages/lal/providers/llamacpp.js
@@ -1,33 +1,22 @@
 // @ts-check
 /**
  * llama.cpp server provider for the Lal agent.
- * Uses the OpenAI-compatible API that many llama.cpp servers expose.
- * Supports context-size and request options that differ from Anthropic.
+ * Thin wrapper over the shared OpenAI Chat Completions shape that
+ * injects llama.cpp-typical defaults (e.g. a placeholder API key for
+ * servers that don't require auth).
  */
 
 // eslint-disable-next-line import/no-unresolved
 import OpenAI from 'openai';
 
-/**
- * @typedef {object} Logger
- * @property {(...args: unknown[]) => void} log
- * @property {(...args: unknown[]) => void} error
- * @property {(...args: unknown[]) => void} warn
- */
+import {
+  toOpenAIChatMessages,
+  toOpenAIChatTools,
+  parseOpenAIChatChoice,
+  truncateMessages,
+} from './openai-chat.js';
 
-/**
- * @typedef {object} CommonTool
- * @property {'function'} type
- * @property {{ name: string, description: string, parameters: object }} function
- */
-
-/**
- * @typedef {object} CommonChatMessage
- * @property {'system'|'user'|'assistant'|'tool'} role
- * @property {string} content
- * @property {Array<{ id?: string, function: { name: string, arguments: string|object }}>} [tool_calls]
- * @property {string} [tool_call_id]
- */
+/** @import { Logger, CommonTool, CommonChatMessage } from './openai-chat.js' */
 
 /**
  * Create a llama.cpp-backed chat provider (OpenAI-compatible API).
@@ -54,53 +43,21 @@ export const makeLlamaCppProvider = ({
 
   return {
     async chat(messages, tools) {
-      let sendMessages = messages;
-      if (
-        typeof maxMessages === 'number' &&
-        maxMessages > 0 &&
-        messages.length > maxMessages
-      ) {
-        sendMessages = messages.slice(-maxMessages);
-        logger.log(
-          `[LAL] Truncated to last ${maxMessages} messages (was ${messages.length})`,
-        );
-      }
+      const sendMessages = truncateMessages(messages, maxMessages, logger);
       logger.log(`[LAL] Calling llama.cpp at ${baseURL} with model: ${model}`);
       let response;
       try {
         response = await client.chat.completions.create({
           model,
           max_tokens: maxTokens,
-          tools,
-          // @ts-expect-error - our message format matches OpenAI's for this path
-          messages: sendMessages,
+          tools: toOpenAIChatTools(tools),
+          messages: toOpenAIChatMessages(sendMessages),
         });
       } catch (error) {
         logger.error('[LAL] llama.cpp API error:', error);
         throw error;
       }
-      const choice = response.choices?.[0];
-      if (!choice) {
-        return { message: { role: 'assistant', content: '' } };
-      }
-      /** @type {CommonChatMessage} */
-      const message = {
-        role: 'assistant',
-        content: choice.message?.content ?? '',
-      };
-      if (
-        choice.message?.tool_calls &&
-        /** @type {unknown[]} */ (choice.message.tool_calls).length > 0
-      ) {
-        message.tool_calls = choice.message.tool_calls.map(tc => ({
-          id: tc.id,
-          function: {
-            name: tc.function?.name ?? '',
-            arguments: tc.function?.arguments ?? '{}',
-          },
-        }));
-      }
-      return { message };
+      return { message: parseOpenAIChatChoice(response.choices?.[0]) };
     },
   };
 };

--- a/packages/lal/providers/llamacpp.js
+++ b/packages/lal/providers/llamacpp.js
@@ -9,6 +9,13 @@
 import OpenAI from 'openai';
 
 /**
+ * @typedef {object} Logger
+ * @property {(...args: unknown[]) => void} log
+ * @property {(...args: unknown[]) => void} error
+ * @property {(...args: unknown[]) => void} warn
+ */
+
+/**
  * @typedef {object} CommonTool
  * @property {'function'} type
  * @property {{ name: string, description: string, parameters: object }} function
@@ -29,7 +36,7 @@ import OpenAI from 'openai';
  * If the server returns "context size" errors, increase the server's n_ctx
  * or set LAL_MAX_MESSAGES to truncate to the last N messages before sending.
  *
- * @param {{ baseURL: string, model: string, apiKey?: string, maxTokens?: number, maxMessages?: number }} options
+ * @param {{ baseURL: string, model: string, apiKey?: string, maxTokens?: number, maxMessages?: number, logger?: Logger }} options
  * @returns {{ chat: (messages: CommonChatMessage[], tools: CommonTool[]) => Promise<{ message: CommonChatMessage }> }}
  */
 export const makeLlamaCppProvider = ({
@@ -38,6 +45,7 @@ export const makeLlamaCppProvider = ({
   apiKey = 'ollama',
   maxTokens = 4096,
   maxMessages = undefined,
+  logger = console,
 }) => {
   const client = new OpenAI({
     apiKey,
@@ -53,11 +61,11 @@ export const makeLlamaCppProvider = ({
         messages.length > maxMessages
       ) {
         sendMessages = messages.slice(-maxMessages);
-        console.log(
+        logger.log(
           `[LAL] Truncated to last ${maxMessages} messages (was ${messages.length})`,
         );
       }
-      console.log(`[LAL] Calling llama.cpp at ${baseURL} with model: ${model}`);
+      logger.log(`[LAL] Calling llama.cpp at ${baseURL} with model: ${model}`);
       let response;
       try {
         response = await client.chat.completions.create({
@@ -68,7 +76,7 @@ export const makeLlamaCppProvider = ({
           messages: sendMessages,
         });
       } catch (error) {
-        console.error('[LAL] llama.cpp API error:', error);
+        logger.error('[LAL] llama.cpp API error:', error);
         throw error;
       }
       const choice = response.choices?.[0];

--- a/packages/lal/providers/ollama.js
+++ b/packages/lal/providers/ollama.js
@@ -8,6 +8,13 @@
 import { Ollama } from 'ollama';
 
 /**
+ * @typedef {object} Logger
+ * @property {(...args: unknown[]) => void} log
+ * @property {(...args: unknown[]) => void} error
+ * @property {(...args: unknown[]) => void} warn
+ */
+
+/**
  * @typedef {object} CommonTool
  * @property {'function'} type
  * @property {{ name: string, description: string, parameters: object }} function
@@ -82,10 +89,15 @@ const toOllamaMessages = messages => {
  * Uses OLLAMA_HOST for the Ollama server URL (defaults to http://localhost:11434).
  * Uses OLLAMA_API_KEY for authentication if required.
  *
- * @param {{ host?: string, model: string, apiKey?: string }} options
+ * @param {{ host?: string, model: string, apiKey?: string, logger?: Logger }} options
  * @returns {{ chat: (messages: CommonChatMessage[], tools: CommonTool[]) => Promise<{ message: CommonChatMessage }> }}
  */
-export const makeOllamaProvider = ({ host, model, apiKey }) => {
+export const makeOllamaProvider = ({
+  host,
+  model,
+  apiKey,
+  logger = console,
+}) => {
   const ollama = new Ollama({
     ...(host && { host }),
     headers: {
@@ -95,7 +107,7 @@ export const makeOllamaProvider = ({ host, model, apiKey }) => {
 
   return {
     async chat(messages, tools) {
-      console.log(
+      logger.log(
         `[LAL] Calling Ollama at ${host || 'localhost:11434'} with model: ${model}`,
       );
 
@@ -107,7 +119,7 @@ export const makeOllamaProvider = ({ host, model, apiKey }) => {
           tools: toOllamaTools(tools),
         });
       } catch (error) {
-        console.error('[LAL] Ollama API error:', error);
+        logger.error('[LAL] Ollama API error:', error);
         throw error;
       }
 

--- a/packages/lal/providers/openai-chat.js
+++ b/packages/lal/providers/openai-chat.js
@@ -157,11 +157,7 @@ harden(parseOpenAIChatChoice);
  * @param {Logger} [logger]
  * @returns {CommonChatMessage[]}
  */
-export const truncateMessages = (
-  messages,
-  maxMessages,
-  logger = console,
-) => {
+export const truncateMessages = (messages, maxMessages, logger = console) => {
   if (
     typeof maxMessages !== 'number' ||
     maxMessages <= 0 ||

--- a/packages/lal/providers/openai-chat.js
+++ b/packages/lal/providers/openai-chat.js
@@ -37,6 +37,10 @@
  * @property {string} content
  * @property {Array<{ id?: string, function: { name: string, arguments: string|object }}>} [tool_calls]
  * @property {string} [tool_call_id]
+ * @property {string} [reasoning] Plaintext reasoning trace (OpenRouter extension).
+ * @property {object[]} [reasoning_details] Structured reasoning blocks. Carries
+ *   encrypted/signed thinking traces for upstream providers (notably Anthropic
+ *   via OpenRouter) and must be forwarded verbatim on the next assistant turn.
  */
 
 /**
@@ -75,6 +79,9 @@ export const toOpenAIChatMessages = messages =>
                 : JSON.stringify(tc.function.arguments ?? {}),
           },
         }));
+      }
+      if (msg.reasoning_details) {
+        /** @type {any} */ (out).reasoning_details = msg.reasoning_details;
       }
       return out;
     }
@@ -122,6 +129,21 @@ export const parseOpenAIChatChoice = choice => {
         arguments: tc.function?.arguments ?? '{}',
       },
     }));
+  }
+  // OpenRouter (and some other proxies) extend the response with reasoning
+  // fields not present in the OpenAI Chat Completions schema. Read them via
+  // an ad-hoc cast so the parser can preserve them when present.
+  const extended =
+    /** @type {{ reasoning?: unknown, reasoning_details?: unknown }} */ (
+      choiceMsg ?? {}
+    );
+  if (typeof extended.reasoning === 'string') {
+    message.reasoning = extended.reasoning;
+  }
+  if (Array.isArray(extended.reasoning_details)) {
+    message.reasoning_details = /** @type {object[]} */ (
+      extended.reasoning_details
+    );
   }
   return message;
 };

--- a/packages/lal/providers/openai-chat.js
+++ b/packages/lal/providers/openai-chat.js
@@ -1,0 +1,153 @@
+// @ts-check
+/**
+ * Shared converters for the OpenAI Chat Completions API shape.
+ *
+ * Used by every provider whose upstream speaks Chat Completions:
+ * llama.cpp, OpenRouter, Google's OpenAI-compatible Gemini endpoint,
+ * and (when wired) OpenAI itself.
+ *
+ * This module is API-shape code, not a provider — it does not know about
+ * any specific vendor and never opens an HTTP connection.
+ */
+
+/**
+ * @import {
+ *   ChatCompletion,
+ *   ChatCompletionMessageParam,
+ *   ChatCompletionTool,
+ * } from 'openai/resources/chat/completions'
+ */
+
+/**
+ * @typedef {object} Logger
+ * @property {(...args: unknown[]) => void} log
+ * @property {(...args: unknown[]) => void} error
+ * @property {(...args: unknown[]) => void} warn
+ */
+
+/**
+ * @typedef {object} CommonTool
+ * @property {'function'} type
+ * @property {{ name: string, description: string, parameters: object }} function
+ */
+
+/**
+ * @typedef {object} CommonChatMessage
+ * @property {'system'|'user'|'assistant'|'tool'} role
+ * @property {string} content
+ * @property {Array<{ id?: string, function: { name: string, arguments: string|object }}>} [tool_calls]
+ * @property {string} [tool_call_id]
+ */
+
+/**
+ * Convert common tools to the OpenAI Chat Completions tools array.
+ * `CommonTool` is structurally identical to `ChatCompletionTool`, so this
+ * is currently a pass-through cast. Kept as a named seam so future
+ * tool-shape adjustments can land in one place.
+ *
+ * @param {CommonTool[]} tools
+ * @returns {ChatCompletionTool[]}
+ */
+export const toOpenAIChatTools = tools =>
+  /** @type {ChatCompletionTool[]} */ (tools);
+harden(toOpenAIChatTools);
+
+/**
+ * Convert common messages to OpenAI Chat Completions request messages.
+ *
+ * @param {CommonChatMessage[]} messages
+ * @returns {ChatCompletionMessageParam[]}
+ */
+export const toOpenAIChatMessages = messages =>
+  messages.map(msg => {
+    if (msg.role === 'assistant') {
+      const out = { role: 'assistant', content: msg.content || '' };
+      if (msg.tool_calls && msg.tool_calls.length > 0) {
+        // @ts-expect-error tool_calls lacks the `type: 'function'`
+        // discriminator until a follow-up commit; the OpenAI server
+        // tolerates the omission today.
+        out.tool_calls = msg.tool_calls.map(tc => ({
+          id: tc.id,
+          function: {
+            name: tc.function.name,
+            arguments: tc.function.arguments,
+          },
+        }));
+      }
+      return /** @type {ChatCompletionMessageParam} */ (out);
+    }
+    if (msg.role === 'tool') {
+      return {
+        role: 'tool',
+        tool_call_id: msg.tool_call_id ?? '',
+        content: msg.content,
+      };
+    }
+    return { role: msg.role, content: msg.content };
+  });
+harden(toOpenAIChatMessages);
+
+/**
+ * Convert an OpenAI Chat Completions response choice to a CommonChatMessage.
+ *
+ * Note for debuggers: OpenAI-Chat-shape providers (llama.cpp, OpenRouter,
+ * Gemini's compat endpoint, etc.) sometimes return a "choice" that silently
+ * omits `message.content` and `message.tool_calls` — e.g. when the upstream
+ * model truncates mid-stream or returns an unfamiliar `finish_reason`. In that
+ * case this function returns an empty assistant message rather than throwing,
+ * so the agent loop sees a no-op turn instead of a crash. If you are chasing
+ * "the agent suddenly went silent," check the raw upstream response first.
+ *
+ * @param {ChatCompletion.Choice | undefined} choice
+ * @returns {CommonChatMessage}
+ */
+export const parseOpenAIChatChoice = choice => {
+  if (!choice) {
+    return { role: 'assistant', content: '' };
+  }
+  const choiceMsg = choice.message;
+  /** @type {CommonChatMessage} */
+  const message = {
+    role: 'assistant',
+    content: choiceMsg?.content ?? '',
+  };
+  const toolCalls = choiceMsg?.tool_calls;
+  if (toolCalls && toolCalls.length > 0) {
+    message.tool_calls = toolCalls.map(tc => ({
+      id: tc.id,
+      function: {
+        name: tc.function?.name ?? '',
+        arguments: tc.function?.arguments ?? '{}',
+      },
+    }));
+  }
+  return message;
+};
+harden(parseOpenAIChatChoice);
+
+/**
+ * Truncate to the last N messages when `maxMessages` is set.
+ *
+ * @param {CommonChatMessage[]} messages
+ * @param {number} [maxMessages]
+ * @param {Logger} [logger]
+ * @returns {CommonChatMessage[]}
+ */
+export const truncateMessages = (
+  messages,
+  maxMessages,
+  logger = console,
+) => {
+  if (
+    typeof maxMessages !== 'number' ||
+    maxMessages <= 0 ||
+    messages.length <= maxMessages
+  ) {
+    return messages;
+  }
+  logger.log(
+    `[LAL] Truncated to last ${maxMessages} messages (was ${messages.length})`,
+  );
+  return messages.slice(-maxMessages);
+};
+harden(truncateMessages);

--- a/packages/lal/providers/openai-chat.js
+++ b/packages/lal/providers/openai-chat.js
@@ -61,20 +61,22 @@ harden(toOpenAIChatTools);
 export const toOpenAIChatMessages = messages =>
   messages.map(msg => {
     if (msg.role === 'assistant') {
+      /** @type {import('openai/resources/chat/completions').ChatCompletionAssistantMessageParam} */
       const out = { role: 'assistant', content: msg.content || '' };
       if (msg.tool_calls && msg.tool_calls.length > 0) {
-        // @ts-expect-error tool_calls lacks the `type: 'function'`
-        // discriminator until a follow-up commit; the OpenAI server
-        // tolerates the omission today.
         out.tool_calls = msg.tool_calls.map(tc => ({
-          id: tc.id,
+          id: tc.id ?? '',
+          type: 'function',
           function: {
             name: tc.function.name,
-            arguments: tc.function.arguments,
+            arguments:
+              typeof tc.function.arguments === 'string'
+                ? tc.function.arguments
+                : JSON.stringify(tc.function.arguments ?? {}),
           },
         }));
       }
-      return /** @type {ChatCompletionMessageParam} */ (out);
+      return out;
     }
     if (msg.role === 'tool') {
       return {

--- a/packages/lal/providers/openrouter.js
+++ b/packages/lal/providers/openrouter.js
@@ -1,0 +1,117 @@
+// @ts-check
+/**
+ * OpenRouter provider for the Lal agent.
+ * Thin wrapper over the shared OpenAI Chat Completions shape that adds:
+ *  - optional `HTTP-Referer` / `X-Title` headers for OpenRouter's
+ *    request-attribution dashboard
+ *  - an optional `reasoning` request-body parameter
+ *  - a clearer 401 error message
+ *
+ * Models are namespaced by upstream vendor (e.g.
+ * `anthropic/claude-sonnet-4-5`, `openai/gpt-4o`).
+ */
+
+// eslint-disable-next-line import/no-unresolved
+import OpenAI from 'openai';
+
+import {
+  toOpenAIChatMessages,
+  toOpenAIChatTools,
+  parseOpenAIChatChoice,
+  truncateMessages,
+} from './openai-chat.js';
+
+/** @import { Logger, CommonTool, CommonChatMessage } from './openai-chat.js' */
+/** @import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions' */
+
+/**
+ * @typedef {object} ReasoningConfig
+ * @property {'minimal'|'low'|'medium'|'high'|'xhigh'} [effort]
+ * @property {number} [max_tokens]
+ * @property {boolean} [exclude]
+ * @property {boolean} [enabled]
+ */
+
+/**
+ * Chat Completions request body with the OpenRouter-specific `reasoning`
+ * extension. Lets the request shape stay type-checked even though the upstream
+ * OpenAI types do not know about `reasoning`.
+ *
+ * @typedef {ChatCompletionCreateParamsNonStreaming & { reasoning?: ReasoningConfig }} OpenRouterChatBody
+ */
+
+/**
+ * Create an OpenRouter-backed chat provider.
+ *
+ * @param {{
+ *   baseURL?: string,
+ *   model: string,
+ *   apiKey: string,
+ *   maxTokens?: number,
+ *   maxMessages?: number,
+ *   referer?: string,
+ *   title?: string,
+ *   reasoning?: ReasoningConfig,
+ *   logger?: Logger,
+ * }} options
+ * @returns {{ chat: (messages: CommonChatMessage[], tools: CommonTool[]) => Promise<{ message: CommonChatMessage }> }}
+ */
+export const makeOpenRouterProvider = ({
+  baseURL = 'https://openrouter.ai/api/v1',
+  model,
+  apiKey,
+  maxTokens = 4096,
+  maxMessages = undefined,
+  referer,
+  title,
+  reasoning,
+  logger = console,
+}) => {
+  /** @type {Record<string, string>} */
+  const defaultHeaders = {};
+  if (referer) defaultHeaders['HTTP-Referer'] = referer;
+  if (title) defaultHeaders['X-Title'] = title;
+
+  const client = new OpenAI({
+    apiKey,
+    baseURL,
+    ...(Object.keys(defaultHeaders).length > 0 && { defaultHeaders }),
+  });
+
+  return {
+    async chat(messages, tools) {
+      const sendMessages = truncateMessages(messages, maxMessages, logger);
+      logger.log(`[LAL] Calling OpenRouter at ${baseURL} with model: ${model}`);
+
+      /** @type {OpenRouterChatBody} */
+      const body = {
+        model,
+        max_tokens: maxTokens,
+        messages: toOpenAIChatMessages(sendMessages),
+        tools: toOpenAIChatTools(tools),
+        ...(reasoning && { reasoning }),
+      };
+
+      let response;
+      try {
+        response = await client.chat.completions.create(body);
+      } catch (error) {
+        logger.error('[LAL] OpenRouter API error:', error);
+        const status =
+          /** @type {{ status?: number, statusCode?: number }} */ (error)
+            .status ??
+          /** @type {{ status?: number, statusCode?: number }} */ (error)
+            .statusCode;
+        if (status === 401) {
+          throw new Error(
+            'OpenRouter authentication failed (invalid or expired API key). Check LAL_AUTH_TOKEN.',
+          );
+        }
+        throw error;
+      }
+
+      return { message: parseOpenAIChatChoice(response.choices?.[0]) };
+    },
+  };
+};
+harden(makeOpenRouterProvider);

--- a/packages/lal/test/openai-chat.test.js
+++ b/packages/lal/test/openai-chat.test.js
@@ -1,0 +1,122 @@
+// @ts-check
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import {
+  toOpenAIChatMessages,
+  toOpenAIChatTools,
+  parseOpenAIChatChoice,
+  truncateMessages,
+} from '../providers/openai-chat.js';
+
+/** @import { CommonChatMessage } from '../providers/openai-chat.js' */
+
+test('toOpenAIChatTools passes tools through unchanged', t => {
+  const tools = harden([
+    {
+      type: 'function',
+      function: { name: 'foo', description: 'd', parameters: {} },
+    },
+  ]);
+  t.is(toOpenAIChatTools(tools), tools);
+});
+
+test('toOpenAIChatMessages converts system/user/tool/assistant roles', t => {
+  /** @type {CommonChatMessage[]} */
+  const input = [
+    { role: 'system', content: 'sys' },
+    { role: 'user', content: 'hi' },
+    { role: 'assistant', content: 'hello' },
+    { role: 'tool', content: 'result', tool_call_id: 'call_1' },
+  ];
+  const result = toOpenAIChatMessages(input);
+  t.deepEqual(result, [
+    { role: 'system', content: 'sys' },
+    { role: 'user', content: 'hi' },
+    { role: 'assistant', content: 'hello' },
+    { role: 'tool', tool_call_id: 'call_1', content: 'result' },
+  ]);
+});
+
+test('toOpenAIChatMessages preserves assistant tool_calls', t => {
+  /** @type {CommonChatMessage[]} */
+  const input = [
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        { id: 'call_1', function: { name: 'foo', arguments: '{"x":1}' } },
+      ],
+    },
+  ];
+  const result = toOpenAIChatMessages(input);
+  t.deepEqual(result, [
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        { id: 'call_1', function: { name: 'foo', arguments: '{"x":1}' } },
+      ],
+    },
+  ]);
+});
+
+test('parseOpenAIChatChoice returns empty assistant message for missing choice', t => {
+  t.deepEqual(parseOpenAIChatChoice(undefined), {
+    role: 'assistant',
+    content: '',
+  });
+});
+
+test('parseOpenAIChatChoice extracts content', t => {
+  t.deepEqual(
+    parseOpenAIChatChoice({ message: { role: 'assistant', content: 'hi' } }),
+    { role: 'assistant', content: 'hi' },
+  );
+});
+
+test('parseOpenAIChatChoice extracts tool_calls', t => {
+  const result = parseOpenAIChatChoice({
+    message: {
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        {
+          id: 'call_1',
+          function: { name: 'foo', arguments: '{"x":1}' },
+        },
+      ],
+    },
+  });
+  t.deepEqual(result, {
+    role: 'assistant',
+    content: '',
+    tool_calls: [
+      { id: 'call_1', function: { name: 'foo', arguments: '{"x":1}' } },
+    ],
+  });
+});
+
+test('truncateMessages no-ops below threshold', t => {
+  /** @type {CommonChatMessage[]} */
+  const msgs = [
+    { role: 'user', content: 'a' },
+    { role: 'user', content: 'b' },
+  ];
+  t.is(truncateMessages(msgs, 5), msgs);
+  t.is(truncateMessages(msgs, undefined), msgs);
+  t.is(truncateMessages(msgs, 0), msgs);
+});
+
+test('truncateMessages slices to last N when over threshold', t => {
+  /** @type {CommonChatMessage[]} */
+  const msgs = [
+    { role: 'user', content: 'a' },
+    { role: 'user', content: 'b' },
+    { role: 'user', content: 'c' },
+  ];
+  const silent = harden({ log: () => {}, error: () => {}, warn: () => {} });
+  t.deepEqual(truncateMessages(msgs, 2, silent), [
+    { role: 'user', content: 'b' },
+    { role: 'user', content: 'c' },
+  ]);
+});

--- a/packages/lal/test/openai-chat.test.js
+++ b/packages/lal/test/openai-chat.test.js
@@ -120,6 +120,38 @@ test('parseOpenAIChatChoice extracts tool_calls', t => {
   });
 });
 
+test('toOpenAIChatMessages forwards reasoning_details on assistant turns', t => {
+  /** @type {CommonChatMessage[]} */
+  const input = [
+    {
+      role: 'assistant',
+      content: 'thought',
+      reasoning_details: [{ type: 'reasoning.encrypted', data: 'xyz' }],
+    },
+  ];
+  const result = toOpenAIChatMessages(input);
+  t.deepEqual(/** @type {any} */ (result[0]).reasoning_details, [
+    { type: 'reasoning.encrypted', data: 'xyz' },
+  ]);
+});
+
+test('parseOpenAIChatChoice extracts reasoning and reasoning_details', t => {
+  const result = parseOpenAIChatChoice(
+    /** @type {any} */ ({
+      message: {
+        role: 'assistant',
+        content: 'answer',
+        reasoning: 'plain trace',
+        reasoning_details: [{ type: 'reasoning.encrypted', data: 'xyz' }],
+      },
+    }),
+  );
+  t.is(result.reasoning, 'plain trace');
+  t.deepEqual(result.reasoning_details, [
+    { type: 'reasoning.encrypted', data: 'xyz' },
+  ]);
+});
+
 test('truncateMessages no-ops below threshold', t => {
   /** @type {CommonChatMessage[]} */
   const msgs = [

--- a/packages/lal/test/openai-chat.test.js
+++ b/packages/lal/test/openai-chat.test.js
@@ -8,9 +8,10 @@ import {
   truncateMessages,
 } from '../providers/openai-chat.js';
 
-/** @import { CommonChatMessage } from '../providers/openai-chat.js' */
+/** @import { CommonChatMessage, CommonTool } from '../providers/openai-chat.js' */
 
 test('toOpenAIChatTools passes tools through unchanged', t => {
+  /** @type {CommonTool[]} */
   const tools = harden([
     {
       type: 'function',
@@ -78,10 +79,7 @@ test('toOpenAIChatMessages stringifies object arguments', t => {
   const result = toOpenAIChatMessages(input);
   const [msg] = result;
   t.is(msg.role, 'assistant');
-  t.is(
-    /** @type {any} */ (msg).tool_calls[0].function.arguments,
-    '{"x":1}',
-  );
+  t.is(/** @type {any} */ (msg).tool_calls[0].function.arguments, '{"x":1}');
 });
 
 test('parseOpenAIChatChoice returns empty assistant message for missing choice', t => {
@@ -93,19 +91,29 @@ test('parseOpenAIChatChoice returns empty assistant message for missing choice',
 
 test('parseOpenAIChatChoice extracts content', t => {
   t.deepEqual(
-    parseOpenAIChatChoice({ message: { role: 'assistant', content: 'hi' } }),
+    parseOpenAIChatChoice({
+      finish_reason: 'stop',
+      index: 0,
+      logprobs: null,
+      message: { role: 'assistant', content: 'hi', refusal: null },
+    }),
     { role: 'assistant', content: 'hi' },
   );
 });
 
 test('parseOpenAIChatChoice extracts tool_calls', t => {
   const result = parseOpenAIChatChoice({
+    finish_reason: 'tool_calls',
+    index: 0,
+    logprobs: null,
     message: {
       role: 'assistant',
       content: '',
+      refusal: null,
       tool_calls: [
         {
           id: 'call_1',
+          type: 'function',
           function: { name: 'foo', arguments: '{"x":1}' },
         },
       ],

--- a/packages/lal/test/openai-chat.test.js
+++ b/packages/lal/test/openai-chat.test.js
@@ -37,7 +37,7 @@ test('toOpenAIChatMessages converts system/user/tool/assistant roles', t => {
   ]);
 });
 
-test('toOpenAIChatMessages preserves assistant tool_calls', t => {
+test('toOpenAIChatMessages emits tool_calls with type: function', t => {
   /** @type {CommonChatMessage[]} */
   const input = [
     {
@@ -54,10 +54,34 @@ test('toOpenAIChatMessages preserves assistant tool_calls', t => {
       role: 'assistant',
       content: '',
       tool_calls: [
-        { id: 'call_1', function: { name: 'foo', arguments: '{"x":1}' } },
+        {
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'foo', arguments: '{"x":1}' },
+        },
       ],
     },
   ]);
+});
+
+test('toOpenAIChatMessages stringifies object arguments', t => {
+  /** @type {CommonChatMessage[]} */
+  const input = [
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        { id: 'call_1', function: { name: 'foo', arguments: { x: 1 } } },
+      ],
+    },
+  ];
+  const result = toOpenAIChatMessages(input);
+  const [msg] = result;
+  t.is(msg.role, 'assistant');
+  t.is(
+    /** @type {any} */ (msg).tool_calls[0].function.arguments,
+    '{"x":1}',
+  );
 });
 
 test('parseOpenAIChatChoice returns empty assistant message for missing choice', t => {

--- a/packages/lal/test/provider-config.test.js
+++ b/packages/lal/test/provider-config.test.js
@@ -37,3 +37,28 @@ test('resolveModelForHost upgrades legacy qwen3 placeholder for Gemini', t => {
 test('resolveModelForHost preserves explicit non-default OpenAI-compatible models', t => {
   t.is(resolveModelForHost('https://api.openai.com/v1', 'gpt-4o'), 'gpt-4o');
 });
+
+test('detectProviderKind recognizes OpenRouter', t => {
+  t.is(detectProviderKind('https://openrouter.ai/api/v1'), 'openrouter');
+});
+
+test('getDefaultModelForHost returns the OpenRouter default model', t => {
+  t.is(
+    getDefaultModelForHost('https://openrouter.ai/api/v1'),
+    'anthropic/claude-sonnet-4-5',
+  );
+});
+
+test('resolveModelForHost upgrades legacy qwen3 placeholder for OpenRouter', t => {
+  t.is(
+    resolveModelForHost('https://openrouter.ai/api/v1', 'qwen3'),
+    'anthropic/claude-sonnet-4-5',
+  );
+});
+
+test('resolveModelForHost preserves an explicit OpenRouter model slug', t => {
+  t.is(
+    resolveModelForHost('https://openrouter.ai/api/v1', 'openai/gpt-4o'),
+    'openai/gpt-4o',
+  );
+});


### PR DESCRIPTION
Closes: #XXXX
Refs: #XXXX

## Description

Adds an OpenRouter provider and consolidates the OpenAI-Chat-Completions request/response shape into one module shared by `llamacpp`, `gemini`, and the new `openrouter` factory. Two related fixes (`type: 'function'` on `tool_calls`, round-tripping `reasoning_details`) are needed for OpenRouter compatibility but apply to the shared shape generally. Also makes the provider `logger` an injectable optional capability.

Review in commit order. Key files: `providers/openai-chat.js` (new shared shape), `providers/index.js` (host routing), `providers/openrouter.js`.

### Security Considerations

`openrouter.ai` joins the existing list of routable hosts; same trust model as OpenAI/Anthropic/Gemini (auth from env-supplied config). `reasoning_details` must be forwarded verbatim — those blocks may carry signed/encrypted upstream traces and modifying them invalidates upstream signature checks.

### Scaling Considerations

None. Same per-request shape work as before, deduplicated across providers.

### Documentation Considerations

`openrouter.env.example` covers the new env vars (`LAL_OPENROUTER_API_KEY` / `_REFERER` / `_TITLE`). No saved-data migration.

### Testing Considerations

New unit coverage in `test/openai-chat.test.js` and `test/provider-config.test.js`. End-to-end OpenRouter validation needs a real API key and is not in CI. This was tested manually with the `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` model.

### Compatibility Considerations

Backwards compatible. Provider factories gain an optional `{ logger }` arg defaulting to `console`. The shape changes are spec-compliant supersets that existing OpenAI/llamacpp/gemini servers already accept.

### Upgrade Considerations

None