### PR TITLE
fix(lal): remove vestigial notification queue references

### DIFF
--- a/packages/lal/agent.js
+++ b/packages/lal/agent.js
@@ -11,7 +11,7 @@ import { makeLocalTree } from '@endo/platform/fs/node';
 import { createProvider } from './providers/index.js';
 
 /** @import { FarRef } from '@endo/eventual-send' */
-/** @import { GuestPowers, NameOrPath, ToolParameterProperty, ToolParameters, ToolFunction, Tool, ToolCall, ChatMessage, ToolResult, ToolCallArgs, InboxMessage, LalContext } from './agent.types' */
+/** @import { GuestPowers, NameOrPath, ToolParameterProperty, ToolParameters, ToolFunction, Tool, ToolCall, ChatMessage, ToolResult, ToolCallArgs, InboxMessage, LalContext } from './agent.types.js' */
 
 // ============================================================================
 // Interface Definition
@@ -822,7 +822,7 @@ export const spawnWorkerLoop = async (powers, context, workerEnv) => {
   // messages appended at that step, plus a pointer to the parent node.
   // The full transcript is assembled by walking the chain when calling the LLM.
 
-  /** @import { TranscriptNode } from './agent.types' */
+  /** @import { TranscriptNode } from './agent.types.js' */
 
   /** @type {Map<string, TranscriptNode>} */
   const nodeCache = new Map();
@@ -1381,30 +1381,7 @@ export const spawnWorkerLoop = async (powers, context, workerEnv) => {
         );
         leafNode.messages.push(...toolResults);
         await putNode(leafNode);
-        // After processing tools, loop again (notifications will be picked up
-        // at the top of the next iteration by processNotifications).
-        // eslint-disable-next-line no-undef, @endo/restrict-comparison-operands
-      } else if (notificationQueue.length > 0) {
-        // No tool calls, but there are notifications to process — loop again.
-        // eslint-disable-next-line no-undef, @endo/restrict-comparison-operands
-      } else if (pendingProposals.size > 0) {
-        // Check if we have pending proposals - wait for them to settle
-        console.log(
-          // eslint-disable-next-line no-undef
-          `[lal] Waiting for ${pendingProposals.size} pending proposal(s) to settle...`,
-        );
-        // Wait for any pending proposal to settle
-        // eslint-disable-next-line no-undef
-        const pendingPromises = [...pendingProposals.values()].map(p =>
-          p.promise.then(
-            () => {},
-            () => {},
-          ),
-        );
-        await Promise.race(pendingPromises);
-        // Loop again to process the notification.
       } else {
-        // Really done
         continueLoop = false;
         await putNode(leafNode);
         activeLeafNode = null;
@@ -1419,7 +1396,7 @@ export const spawnWorkerLoop = async (powers, context, workerEnv) => {
 
   /**
    * Build the user-role message content for an inbound message.
-   * @param {InboxMessage & {type?: string}} message
+   * @param {InboxMessage & {type?: string}} _message
    * @param _message
    * @returns {string}
    */


### PR DESCRIPTION
## Description

When the LLM returned no tool calls (e.g., a final response), the worker loop fell into an `else if (notificationQueue.length > 0)` branch that threw `ReferenceError`.
The proposal/notification subsystem was removed in 90f8e910f when `evaluate()` switched from host-mediated approval to direct execution, but the dangling reads on `notificationQueue` and `pendingProposals` survived.
A later lint cleanup (7487d28ce) silenced `no-undef` rather than recognizing the branches as dead.

This PR deletes those two dead `else if` branches in `packages/lal/agent.js`, removing the runtime `ReferenceError` on the no-tool-call path and the `// eslint-disable no-undef` lines that were papering over it.

Also aligns two `@import` specifiers for `./agent.types` to include the `.js` extension, per repo convention.

Most critical file to review: `packages/lal/agent.js`.

### Security Considerations

None.
The change removes unreachable code paths and an unreachable `Promise.race` over a `Map` that no longer exists; no authorities, capabilities, or trust boundaries are affected.

### Scaling Considerations

None.
Removing dead branches has no runtime cost implication.

### Documentation Considerations

None.
No public API change; no user-visible behavior change beyond the bug fix (the LLM-final-response path no longer throws).

### Testing Considerations

This restores the intended `continueLoop = false` exit on the no-tool-call path, which was previously reached only via the `ReferenceError` being swallowed upstream.
No new tests are added; the change is the deletion of unreachable code that referenced removed identifiers.

### Compatibility Considerations

None.
The deleted branches could not execute (the identifiers they referenced no longer exist), so no caller behavior changes.

### Upgrade Considerations

None.