### PR TITLE
fix(lal): preserve tool-call history and types across providers

### DIFF
--- a/packages/lal/providers/anthropic.js
+++ b/packages/lal/providers/anthropic.js
@@ -121,13 +121,17 @@ export const makeAnthropicProvider = ({ apiKey, model }) => {
         console.log('[LAL] Anthropic response received');
       } catch (error) {
         console.error('[LAL] Anthropic API error:', error);
-        const status = error?.status ?? error?.statusCode;
-        const errBody = error?.error ?? error?.body;
+        const err =
+          /** @type {{ status?: number, statusCode?: number, error?: { type?: string, message?: string }, body?: { type?: string, message?: string }, message?: string }} */ (
+            error
+          );
+        const status = err.status ?? err.statusCode;
+        const errBody = err.error ?? err.body;
         const isAuthError =
           status === 401 ||
           errBody?.type === 'authentication_error' ||
           /invalid x-api-key|api key|authentication/i.test(
-            errBody?.message || error?.message || '',
+            errBody?.message || err.message || '',
           );
         if (isAuthError) {
           throw new Error(

--- a/packages/lal/providers/gemini.js
+++ b/packages/lal/providers/gemini.js
@@ -10,6 +10,7 @@
  */
 
 import https from 'node:https';
+import { toOpenAICompatibleMessages } from './openai-compatible-messages.js';
 
 /**
  * @typedef {object} CommonTool
@@ -141,7 +142,7 @@ export const makeGeminiProvider = ({
           model,
           max_tokens: maxTokens,
           tools,
-          messages: sendMessages,
+          messages: toOpenAICompatibleMessages(sendMessages),
         });
       } catch (error) {
         console.error('[LAL] Gemini API error:', error);

--- a/packages/lal/providers/llamacpp.js
+++ b/packages/lal/providers/llamacpp.js
@@ -19,7 +19,7 @@ import { toOpenAICompatibleMessages } from './openai-compatible-messages.js';
  * @typedef {object} CommonChatMessage
  * @property {'system'|'user'|'assistant'|'tool'} role
  * @property {string} content
- * @property {Array<{ id?: string, function: { name: string, arguments: string|object }}>} [tool_calls]
+ * @property {Array<{ id?: string, type?: 'function', function: { name: string, arguments: string|object }}>} [tool_calls]
  * @property {string} [tool_call_id]
  */
 
@@ -86,6 +86,7 @@ export const makeLlamaCppProvider = ({
       ) {
         message.tool_calls = choice.message.tool_calls.map(tc => ({
           id: tc.id,
+          type: 'function',
           function: {
             name: tc.function?.name ?? '',
             arguments: tc.function?.arguments ?? '{}',

--- a/packages/lal/providers/llamacpp.js
+++ b/packages/lal/providers/llamacpp.js
@@ -7,6 +7,7 @@
 
 // eslint-disable-next-line import/no-unresolved
 import OpenAI from 'openai';
+import { toOpenAICompatibleMessages } from './openai-compatible-messages.js';
 
 /**
  * @typedef {object} CommonTool
@@ -64,8 +65,7 @@ export const makeLlamaCppProvider = ({
           model,
           max_tokens: maxTokens,
           tools,
-          // @ts-expect-error - our message format matches OpenAI's for this path
-          messages: sendMessages,
+          messages: toOpenAICompatibleMessages(sendMessages),
         });
       } catch (error) {
         console.error('[LAL] llama.cpp API error:', error);

--- a/packages/lal/providers/openai-compatible-messages.js
+++ b/packages/lal/providers/openai-compatible-messages.js
@@ -1,0 +1,60 @@
+// @ts-check
+
+/** @import { ChatMessage } from '../agent.types.js' */
+/** @import { ChatCompletionMessageParam } from 'openai/resources/chat/completions' */
+
+/**
+ * Convert a common tool-call argument payload to the string shape required by
+ * OpenAI-compatible chat APIs.
+ *
+ * @param {string | object | undefined} args
+ * @returns {string}
+ */
+const stringifyToolArguments = args => {
+  if (typeof args === 'string') {
+    return args;
+  }
+  return JSON.stringify(args ?? {});
+};
+
+/**
+ * Normalize Lal's common message shape to the stricter OpenAI/OpenRouter
+ * history format. Assistant messages with `tool_calls` must preserve each
+ * call's `type: "function"` when they are sent back with tool results.
+ *
+ * @param {ChatMessage[]} messages
+ * @returns {ChatCompletionMessageParam[]}
+ */
+export const toOpenAICompatibleMessages = messages =>
+  messages.map((message, messageIndex) => {
+    if (message.role === 'assistant') {
+      const toolCalls = message.tool_calls?.map((toolCall, toolIndex) => ({
+        id: toolCall.id || `tool_${messageIndex}_${toolIndex}`,
+        type: /** @type {const} */ ('function'),
+        function: {
+          name: toolCall.function.name,
+          arguments: stringifyToolArguments(toolCall.function.arguments),
+        },
+      }));
+
+      if (toolCalls && toolCalls.length > 0) {
+        return {
+          role: 'assistant',
+          content: message.content || null,
+          tool_calls: toolCalls,
+        };
+      }
+      return { role: 'assistant', content: message.content || '' };
+    }
+
+    if (message.role === 'tool') {
+      return {
+        role: 'tool',
+        content: message.content || '',
+        tool_call_id: message.tool_call_id || '',
+      };
+    }
+
+    return { role: message.role, content: message.content || '' };
+  });
+harden(toOpenAICompatibleMessages);

--- a/packages/lal/test/openai-compatible-messages.test.js
+++ b/packages/lal/test/openai-compatible-messages.test.js
@@ -1,0 +1,50 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { toOpenAICompatibleMessages } from '../providers/openai-compatible-messages.js';
+
+test('OpenAI-compatible history preserves tool call type', t => {
+  const messages = toOpenAICompatibleMessages([
+    { role: 'user', content: 'What tools do you have?' },
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        {
+          id: 'call_123',
+          function: {
+            name: 'reply',
+            arguments: { messageNumber: 1, strings: ['hello'] },
+          },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: '"Replied"',
+      tool_call_id: 'call_123',
+    },
+  ]);
+
+  t.deepEqual(messages, [
+    { role: 'user', content: 'What tools do you have?' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call_123',
+          type: 'function',
+          function: {
+            name: 'reply',
+            arguments: '{"messageNumber":1,"strings":["hello"]}',
+          },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: '"Replied"',
+      tool_call_id: 'call_123',
+    },
+  ]);
+});


### PR DESCRIPTION
## Description

Three fixes in `packages/lal` providers:

1. **`fix(lal): preserve OpenAI tool-call history`** — the OpenAI-compatible message normalization was dropping prior tool-call turns when re-assembling history, losing context across multi-turn tool sequences. Includes a direct regression test in `packages/lal/test/openai-compatible-messages.test.js`.
2. **`fix(lal): type Anthropic catch-block error access`** — narrow `err: unknown` before accessing `err.status` in the Anthropic provider's catch block.
3. **`fix(lal): preserve provider tool-call type`** — llama.cpp's normalized tool-call objects were losing their `type` field on round-trip.

Files: 4 providers + 1 test, all under `packages/lal/`.

### Security Considerations

N/A.

### Scaling Considerations

N/A.

### Documentation Considerations

N/A.

### Testing Considerations

OpenAI-compatible message normalization has a direct regression test. The other two fixes are covered by existing provider test surfaces.

### Compatibility Considerations

N/A. `lal` is unpublished, so no changeset required.

### Upgrade Considerations

N/A.
