### PR TITLE
feat(lal): deterministic provider replay (DI, mock-powers)

### DIFF
--- a/packages/lal/agent.js
+++ b/packages/lal/agent.js
@@ -791,7 +791,7 @@ before resorting to \`evaluate()\`. For unfamiliar capabilities, use
  *
  * @param {any} powers - Guest powers (manager's own or a sub-guest's)
  * @param {Promise<object> | object | null | undefined} context - Context for cancellation
- * @param {{ LAL_HOST?: string, LAL_MODEL?: string, LAL_AUTH_TOKEN?: string }} workerEnv - LLM provider config
+ * @param {{ LAL_HOST?: string, LAL_MODEL?: string, LAL_AUTH_TOKEN?: string, provider?: { chat: (messages: object[], tools: object[]) => Promise<{ message: object }> } }} workerEnv - LLM provider config. Pass `provider` to inject a pre-built provider (e.g. for tests); otherwise the LAL_* env vars are used to construct one.
  * @returns {Promise<void>}
  */
 export const spawnWorkerLoop = async (powers, context, workerEnv) => {
@@ -808,7 +808,7 @@ export const spawnWorkerLoop = async (powers, context, workerEnv) => {
     return null;
   };
 
-  const provider = createProvider(workerEnv);
+  const provider = workerEnv.provider || createProvider(workerEnv);
 
   /**
    * Chat with the LLM.

--- a/packages/lal/package.json
+++ b/packages/lal/package.json
@@ -18,6 +18,7 @@
   "type": "module",
   "exports": {
     "./providers/index.js": "./providers/index.js",
+    "./tools/mock-powers.js": "./tools/mock-powers.js",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -41,6 +42,7 @@
     "@endo/marshal": "workspace:^",
     "@endo/patterns": "workspace:^",
     "@endo/platform": "workspace:^",
+    "@endo/promise-kit": "workspace:^",
     "ollama": "^0.6.3",
     "openai": "^4.77.0"
   },
@@ -48,7 +50,6 @@
     "@endo/cli": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/lockdown": "workspace:^",
-    "@endo/promise-kit": "workspace:^",
     "@endo/ses-ava": "workspace:^",
     "ava": "catalog:dev",
     "c8": "catalog:dev",

--- a/packages/lal/providers/anthropic.js
+++ b/packages/lal/providers/anthropic.js
@@ -4,7 +4,8 @@
  * Converts our common message/tool format to Anthropic's API and back.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
+/** @import { Anthropic } from '@anthropic-ai/sdk' */
+/** @typedef {import('@anthropic-ai/sdk').default} AnthropicClient */
 
 /**
  * @typedef {object} CommonTool
@@ -98,10 +99,22 @@ const toAnthropicMessages = messages => {
  * @returns {{ chat: (messages: CommonChatMessage[], tools: CommonTool[]) => Promise<{ message: CommonChatMessage }> }}
  */
 export const makeAnthropicProvider = ({ apiKey, model }) => {
-  const client = new Anthropic({ apiKey });
+  /** @type {Promise<AnthropicClient> | undefined} */
+  let clientP;
+
+  /** @returns {Promise<AnthropicClient>} */
+  const getClient = async () => {
+    if (clientP === undefined) {
+      clientP = import('@anthropic-ai/sdk').then(
+        ({ default: AnthropicClient }) => new AnthropicClient({ apiKey }),
+      );
+    }
+    return clientP;
+  };
 
   return {
     async chat(messages, tools) {
+      const client = await getClient();
       const { system, messages: anthropicMessages } =
         toAnthropicMessages(messages);
       console.log('[LAL] Calling Anthropic API...');
@@ -109,6 +122,7 @@ export const makeAnthropicProvider = ({ apiKey, model }) => {
         '[LAL] Messages:',
         JSON.stringify(anthropicMessages, null, 2),
       );
+      /** @type {Anthropic.Message} */
       let response;
       try {
         response = await client.messages.create({

--- a/packages/lal/providers/index.js
+++ b/packages/lal/providers/index.js
@@ -110,4 +110,5 @@ export const createProvider = env => {
 export { makeAnthropicProvider } from './anthropic.js';
 export { makeGeminiProvider } from './gemini.js';
 export { makeLlamaCppProvider } from './llamacpp.js';
+export { findMockTrace, makeMockProvider } from './mock.js';
 export { makeOllamaProvider } from './ollama.js';

--- a/packages/lal/providers/llamacpp.js
+++ b/packages/lal/providers/llamacpp.js
@@ -5,8 +5,6 @@
  * Supports context-size and request options that differ from Anthropic.
  */
 
-// eslint-disable-next-line import/no-unresolved
-import OpenAI from 'openai';
 import { toOpenAICompatibleMessages } from './openai-compatible-messages.js';
 
 /**
@@ -40,13 +38,24 @@ export const makeLlamaCppProvider = ({
   maxTokens = 4096,
   maxMessages = undefined,
 }) => {
-  const client = new OpenAI({
-    apiKey,
-    baseURL,
-  });
+  let clientP;
+
+  const getClient = async () => {
+    if (clientP === undefined) {
+      clientP = import('openai').then(
+        ({ default: OpenAI }) =>
+          new OpenAI({
+            apiKey,
+            baseURL,
+          }),
+      );
+    }
+    return clientP;
+  };
 
   return {
     async chat(messages, tools) {
+      const client = await getClient();
       let sendMessages = messages;
       if (
         typeof maxMessages === 'number' &&

--- a/packages/lal/providers/mock.js
+++ b/packages/lal/providers/mock.js
@@ -1,0 +1,73 @@
+// @ts-check
+
+/**
+ * @typedef {object} MockTraceRound
+ * @property {{ message: object }} response
+ */
+
+/**
+ * @typedef {object} MockTrace
+ * @property {string} id
+ * @property {string[]} [expectedToolNames]
+ * @property {{ messages: object[] }} [providerRequest]
+ * @property {{ ok: boolean, status?: number, message?: object | string }} [providerResult]
+ * @property {MockTraceRound[]} [rounds]
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+const cloneJson = value => JSON.parse(JSON.stringify(value));
+
+/**
+ * Look up a trace by id in a parsed fixture file. The fixture file is
+ * authored alongside tests, so we trust its shape rather than guarding
+ * defensively.
+ *
+ * @param {{ traces: MockTrace[] }} fixtures
+ * @param {string} fixtureId
+ * @returns {MockTrace}
+ */
+export const findMockTrace = (fixtures, fixtureId) => {
+  const trace = fixtures.traces.find(entry => entry.id === fixtureId);
+  if (!trace) {
+    throw new Error(`Mock LLM fixture not found: ${fixtureId}`);
+  }
+  return trace;
+};
+harden(findMockTrace);
+
+/**
+ * Create a deterministic provider that replays assistant messages from a
+ * captured trace. The `calls` array is intentionally mutable so tests can
+ * inspect the harness-to-provider requests after replay.
+ *
+ * @param {{ trace: MockTrace }} options
+ * @returns {{ calls: Array<{ messages: object[], tools: object[] }>, chat: (messages: object[], tools: object[]) => Promise<{ message: object }> }}
+ */
+export const makeMockProvider = ({ trace }) => {
+  const rounds = trace.rounds || [];
+  let index = 0;
+  /** @type {Array<{ messages: object[], tools: object[] }>} */
+  const calls = [];
+
+  return {
+    calls,
+    async chat(messages, tools) {
+      calls.push({
+        messages: /** @type {object[]} */ (cloneJson(messages)),
+        tools: /** @type {object[]} */ (cloneJson(tools)),
+      });
+      const round = rounds[index];
+      index += 1;
+      if (!round) {
+        throw new Error(
+          `Mock LLM fixture "${trace.id}" exhausted after ${rounds.length} round(s)`,
+        );
+      }
+      return /** @type {{ message: object }} */ (cloneJson(round.response));
+    },
+  };
+};
+harden(makeMockProvider);

--- a/packages/lal/providers/ollama.js
+++ b/packages/lal/providers/ollama.js
@@ -5,8 +5,6 @@
  * Adapted from llamadrome/ollama-backend.js.
  */
 
-import { Ollama } from 'ollama';
-
 /**
  * @typedef {object} CommonTool
  * @property {'function'} type
@@ -86,15 +84,26 @@ const toOllamaMessages = messages => {
  * @returns {{ chat: (messages: CommonChatMessage[], tools: CommonTool[]) => Promise<{ message: CommonChatMessage }> }}
  */
 export const makeOllamaProvider = ({ host, model, apiKey }) => {
-  const ollama = new Ollama({
-    ...(host && { host }),
-    headers: {
-      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
-    },
-  });
+  let clientP;
+
+  const getClient = async () => {
+    if (clientP === undefined) {
+      clientP = import('ollama').then(
+        ({ Ollama }) =>
+          new Ollama({
+            ...(host && { host }),
+            headers: {
+              ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+            },
+          }),
+      );
+    }
+    return clientP;
+  };
 
   return {
     async chat(messages, tools) {
+      const ollama = await getClient();
       console.log(
         `[LAL] Calling Ollama at ${host || 'localhost:11434'} with model: ${model}`,
       );
@@ -121,7 +130,7 @@ export const makeOllamaProvider = ({ host, model, apiKey }) => {
 
       // Handle tool calls if present
       const { tool_calls: toolCalls } = response.message || {};
-      if (toolCalls && toolCalls.length > 0) {
+      if (Array.isArray(toolCalls) && toolCalls.length > 0) {
         const idBase = `ollama_tool_${Date.now()}_`;
         message.tool_calls = toolCalls.map(
           (

--- a/packages/lal/test/fixtures/llm-provider-traces.json
+++ b/packages/lal/test/fixtures/llm-provider-traces.json
@@ -1,0 +1,346 @@
+{
+  "schemaVersion": 1,
+  "captured": {
+    "date": "2026-05-18",
+    "host": "https://openrouter.ai/api/v1",
+    "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+    "note": "Token-free, deterministic subsets of real provider responses captured from the free-tier model configured in packages/fae/.env. Random provider call ids are preserved only as opaque fixture ids."
+  },
+  "traces": [
+    {
+      "id": "fae.current.math-tool",
+      "package": "fae",
+      "gitRef": "438b4f889",
+      "description": "Current Fae attachment prompt leads the model to adopt the exact math-tool edge, call the adopted camelCase tool, then reply.",
+      "expectedToolNames": ["adoptTool", "mathTool", "reply"],
+      "rounds": [
+        {
+          "request": {
+            "messageCount": 2,
+            "lastRole": "user",
+            "lastContentIncludes": [
+              "Attached references",
+              "edgeName=\"math-tool\"",
+              "toolName=\"math-tool\""
+            ]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call_b81a44bcac284ab79b21ba1e",
+                  "type": "function",
+                  "function": {
+                    "name": "adoptTool",
+                    "arguments": "{\"messageNumber\": 1, \"edgeName\": \"math-tool\", \"toolName\": \"math-tool\"}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "request": {
+            "messageCount": 4,
+            "lastRole": "tool",
+            "lastContentIncludes": ["Adopted tool from message #1"]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call_374ac718a48842daba823b4b",
+                  "type": "function",
+                  "function": {
+                    "name": "mathTool",
+                    "arguments": "{\"b\": 6, \"a\": 7, \"operation\": \"multiply\"}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "request": {
+            "messageCount": 6,
+            "lastRole": "tool",
+            "lastContentIncludes": ["42"]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call_48f37af9a28141fe978b63ce",
+                  "type": "function",
+                  "function": {
+                    "name": "reply",
+                    "arguments": "{\"messageNumber\": 1, \"strings\": [\"42\"]}"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "fae.llm-tip.math-tool",
+      "package": "fae",
+      "gitRef": "llm",
+      "description": "The older Fae prompt did not include an attachment block. The same real model guessed edgeName=math instead of the actual math-tool edge.",
+      "expectedFirstToolName": "adoptTool",
+      "expectedFirstEdgeName": "math",
+      "rounds": [
+        {
+          "request": {
+            "messageCount": 2,
+            "lastRole": "user",
+            "lastContentIncludes": [
+              "Here is a math tool @math-tool",
+              "Use reply(messageNumber: 1, ...)"
+            ],
+            "lastContentExcludes": ["Attached references"]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call_345cc4be048d46ada59480c0",
+                  "type": "function",
+                  "function": {
+                    "name": "adoptTool",
+                    "arguments": "{\"messageNumber\": 1, \"edgeName\": \"math\", \"toolName\": \"math-tool\"}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "request": {
+            "messageCount": 4,
+            "lastRole": "tool",
+            "lastContentIncludes": ["Adopted tool from message #1"]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call_047bcabb4aa54a50a6b95c8a",
+                  "type": "function",
+                  "function": {
+                    "name": "mathTool",
+                    "arguments": "{\"a\": 7, \"operation\": \"multiply\", \"b\": 6}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "request": {
+            "messageCount": 6,
+            "lastRole": "tool",
+            "lastContentIncludes": ["42"]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call_0347633211a949c1b93ca85f",
+                  "type": "function",
+                  "function": {
+                    "name": "reply",
+                    "arguments": "{\"messageNumber\": 1, \"strings\": [\"42\"]}"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "lal.current.inbox-reply",
+      "package": "lal",
+      "gitRef": "438b4f889",
+      "description": "Current Lal agent flow against the real model: inspect inbox, reply OK, then dismiss.",
+      "expectedToolNames": ["listMessages", "reply", "dismiss"],
+      "rounds": [
+        {
+          "request": {
+            "messageCount": 2,
+            "lastRole": "user",
+            "lastContentIncludes": [
+              "You have new mail. Check your messages and respond appropriately."
+            ]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "chatcmpl-tool-80347c761438c3d8",
+                  "type": "function",
+                  "function": {
+                    "name": "listMessages",
+                    "arguments": "{}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "request": {
+            "messageCount": 4,
+            "lastRole": "tool",
+            "lastContentIncludes": [
+              "Reply with exactly: OK then dismiss this message"
+            ]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call_499bb843b32a4ce4b378105d",
+                  "type": "function",
+                  "function": {
+                    "name": "reply",
+                    "arguments": "{\"messageNumber\": \"+1\", \"strings\": [\"OK\"], \"edgeNames\": [], \"petNames\": []}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "request": {
+            "messageCount": 6,
+            "lastRole": "tool",
+            "lastContentIncludes": ["undefined"]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                {
+                  "id": "call_efd17f5076714139aee670ff",
+                  "type": "function",
+                  "function": {
+                    "name": "dismiss",
+                    "arguments": "{\"messageNumber\": \"+1\"}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "request": {
+            "messageCount": 8,
+            "lastRole": "tool",
+            "lastContentIncludes": ["undefined"]
+          },
+          "response": {
+            "message": {
+              "role": "assistant",
+              "content": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "lal.llm-tip.openai-compatible-missing-type",
+      "package": "lal",
+      "gitRef": "llm",
+      "description": "The provider-facing history shape from llm tip omitted type=function on assistant tool calls and OpenRouter rejected it.",
+      "providerRequest": {
+        "messages": [
+          { "role": "system", "content": "You are Lal." },
+          { "role": "user", "content": "Reply with OK." },
+          {
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [
+              {
+                "id": "call_fixture_reply",
+                "function": {
+                  "name": "reply",
+                  "arguments": "{\"messageNumber\":\"+1\",\"strings\":[\"OK\"],\"edgeNames\":[],\"petNames\":[]}"
+                }
+              }
+            ]
+          },
+          {
+            "role": "tool",
+            "content": "undefined",
+            "tool_call_id": "call_fixture_reply"
+          },
+          { "role": "user", "content": "Continue." }
+        ]
+      },
+      "providerResult": {
+        "ok": false,
+        "status": 400,
+        "message": "400 Provider returned error"
+      }
+    },
+    {
+      "id": "lal.current.openai-compatible-with-type",
+      "package": "lal",
+      "gitRef": "438b4f889",
+      "description": "The normalized current provider-facing history includes type=function and OpenRouter accepted it.",
+      "providerRequest": {
+        "messages": [
+          { "role": "system", "content": "You are Lal." },
+          { "role": "user", "content": "Reply with OK." },
+          {
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [
+              {
+                "id": "call_fixture_reply",
+                "type": "function",
+                "function": {
+                  "name": "reply",
+                  "arguments": "{\"messageNumber\":\"+1\",\"strings\":[\"OK\"],\"edgeNames\":[],\"petNames\":[]}"
+                }
+              }
+            ]
+          },
+          {
+            "role": "tool",
+            "content": "undefined",
+            "tool_call_id": "call_fixture_reply"
+          },
+          { "role": "user", "content": "Continue." }
+        ]
+      },
+      "providerResult": {
+        "ok": true,
+        "message": {
+          "role": "assistant",
+          "content": null
+        }
+      }
+    }
+  ]
+}

--- a/packages/lal/test/mock-provider-fixtures.test.js
+++ b/packages/lal/test/mock-provider-fixtures.test.js
@@ -1,0 +1,70 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import fs from 'node:fs';
+import url from 'node:url';
+
+import { spawnWorkerLoop } from '../agent.js';
+import { findMockTrace, makeMockProvider } from '../providers/index.js';
+import { makeMockPowers } from '../tools/mock-powers.js';
+
+const fixturePath = url.fileURLToPath(
+  new URL('fixtures/llm-provider-traces.json', import.meta.url),
+);
+
+const loadFixtures = () => JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+/**
+ * Derive the ordered list of tool names actually invoked across all
+ * rounds of a fixture trace. Used to check that the static
+ * `expectedToolNames` declaration stays in sync with the trace data.
+ *
+ * @param {ReturnType<typeof findMockTrace>} trace
+ * @returns {string[]}
+ */
+const actualToolCallNames = trace =>
+  (trace.rounds || []).flatMap(round => {
+    const toolCalls =
+      /** @type {{ function: { name: string } }[]} */ (
+        /** @type {any} */ (round.response.message).tool_calls
+      ) || [];
+    return toolCalls.map(call => call.function.name);
+  });
+
+test('mock provider fixture replays Lal inbox reply and dismiss flow', async t => {
+  const trace = findMockTrace(loadFixtures(), 'lal.current.inbox-reply');
+  t.deepEqual(
+    actualToolCallNames(trace),
+    trace.expectedToolNames,
+    'fixture rounds should invoke exactly the declared expectedToolNames',
+  );
+
+  const { powers, whenDismissed, sent } = makeMockPowers({
+    initialMessage: harden({
+      number: 1,
+      from: '@host',
+      to: 'lal-self-id',
+      messageId: 'mock-msg-1',
+      strings: [
+        'Reply with exactly: OK then dismiss this message (dismiss message 1).',
+      ],
+      names: [],
+      ids: [],
+    }),
+  });
+
+  const dismissed = whenDismissed(1);
+  await spawnWorkerLoop(powers, null, {
+    provider: makeMockProvider({ trace }),
+  });
+  await dismissed;
+
+  const reply = sent.find(record =>
+    record.strings.some(text => text.includes('OK')),
+  );
+  t.truthy(reply, 'fixture should drive Lal to reply with OK');
+  t.true(
+    reply?.strings[0].startsWith('[depth:'),
+    'Lal reply tool should still add transcript depth',
+  );
+});

--- a/packages/lal/test/openai-compatible-messages.test.js
+++ b/packages/lal/test/openai-compatible-messages.test.js
@@ -1,6 +1,15 @@
 import test from '@endo/ses-ava/prepare-endo.js';
+import fs from 'node:fs';
+import url from 'node:url';
 
+import { findMockTrace } from '../providers/index.js';
 import { toOpenAICompatibleMessages } from '../providers/openai-compatible-messages.js';
+
+const fixturePath = url.fileURLToPath(
+  new URL('fixtures/llm-provider-traces.json', import.meta.url),
+);
+
+const loadFixtures = () => JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
 
 test('OpenAI-compatible history preserves tool call type', t => {
   const messages = toOpenAICompatibleMessages([
@@ -47,4 +56,40 @@ test('OpenAI-compatible history preserves tool call type', t => {
       tool_call_id: 'call_123',
     },
   ]);
+});
+
+test('fixture documents provider rejection before tool-call type normalization', t => {
+  const fixtures = loadFixtures();
+  const before = findMockTrace(
+    fixtures,
+    'lal.llm-tip.openai-compatible-missing-type',
+  );
+  const after = findMockTrace(
+    fixtures,
+    'lal.current.openai-compatible-with-type',
+  );
+  const beforeProviderResult = before.providerResult;
+  const afterProviderResult = after.providerResult;
+  const beforeProviderRequest = before.providerRequest;
+  const afterProviderRequest = after.providerRequest;
+
+  if (
+    beforeProviderResult === undefined ||
+    afterProviderResult === undefined ||
+    beforeProviderRequest === undefined ||
+    afterProviderRequest === undefined
+  ) {
+    throw new Error('fixture is missing provider request/result data');
+  }
+
+  t.is(beforeProviderResult.ok, false);
+  t.is(beforeProviderResult.status, 400);
+  t.is(afterProviderResult.ok, true);
+
+  const normalized = toOpenAICompatibleMessages(beforeProviderRequest.messages);
+  t.deepEqual(
+    normalized,
+    afterProviderRequest.messages,
+    'current Lal provider history matches the accepted provider-facing fixture',
+  );
 });

--- a/packages/lal/test/simulator/run-simulator.js
+++ b/packages/lal/test/simulator/run-simulator.js
@@ -20,7 +20,7 @@ import '@endo/init';
 import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import { spawnWorkerLoop } from '../../agent.js';
-import { makeMockPowers } from './mock-powers.js';
+import { makeMockPowers } from '../../tools/mock-powers.js';
 
 const TIMEOUT_MS = 120_000;
 

--- a/packages/lal/test/simulator/run-simulator.test.js
+++ b/packages/lal/test/simulator/run-simulator.test.js
@@ -10,7 +10,7 @@
  */
 
 import test from '@endo/ses-ava/prepare-endo.js';
-import { makeMockPowers } from './mock-powers.js';
+import { makeMockPowers } from '../../tools/mock-powers.js';
 
 const TIMEOUT_MS = 120_000;
 

--- a/packages/lal/tools/mock-powers.js
+++ b/packages/lal/tools/mock-powers.js
@@ -1,9 +1,10 @@
 // @ts-check
 /**
- * Mock guest powers for the Lal agent simulator.
+ * Mock guest powers for the Lal/Fae agent loops.
  * Implements the GuestPowers interface the agent expects from Endo,
  * with an in-memory directory and mailbox so we can run the agent
- * without a real daemon. Used to debug LLM providers (Anthropic, etc.).
+ * without a real daemon. Used by the simulator runner, by deterministic
+ * provider-fixture tests, and reused from Fae's test suite.
  */
 
 import { makePromiseKit } from '@endo/promise-kit';
@@ -11,13 +12,43 @@ import { makePromiseKit } from '@endo/promise-kit';
 const SELF_ID = 'lal-self-id';
 
 /**
- * Create mock guest powers for the Lal agent.
+ * @param {number | bigint | string} value
+ * @returns {bigint}
+ */
+const normalizeMessageNumber = value => {
+  if (typeof value === 'string' && value.startsWith('+')) {
+    return BigInt(value.slice(1));
+  }
+  return BigInt(value);
+};
+
+/**
+ * @param {number | bigint | string} left
+ * @param {number | bigint | string} right
+ */
+const sameMessageNumber = (left, right) =>
+  normalizeMessageNumber(left) === normalizeMessageNumber(right);
+
+/** @param {number | bigint | string} value */
+const messageNumberKey = value => String(normalizeMessageNumber(value));
+
+/**
+ * Create mock guest powers for the Lal or Fae agent.
+ *
+ * Pass `attachments` to make `lookupById` resolve to real refs and let
+ * `adopt(messageNumber, edgeName, ...)` install the actual capability
+ * (e.g. a FaeTool) into the directory by walking the message's
+ * names/ids arrays. Without attachments, `adopt` falls back to a
+ * placeholder string (suitable for tests that only care that adoption
+ * happened, not what was adopted).
+ *
  * @param {object} [options]
  * @param {object} [options.initialMessage] - Optional first inbox message to deliver (default: one from HOST)
- * @returns {{ powers: object, whenDismissed: (n: number) => Promise<void>, whenSend: () => Promise<{ recipient: string, strings: string[] }>, sent: Array<{ recipient: string, strings: string[], edgeNames: string[], petNames: string[] }> }}
+ * @param {Map<string, unknown>} [options.attachments] - id -> ref map for lookupById and adopt
+ * @returns {{ powers: object, whenDismissed: (n: number) => Promise<void>, whenSend: () => Promise<{ recipient: string, strings: string[] }>, sent: Array<{ recipient: string, strings: string[], edgeNames: string[], petNames: string[], replyTo?: string }>, adoptions: Array<{ messageNumber: string, edgeName: string, petName: string }> }}
  */
 export function makeMockPowers(options = {}) {
-  const { initialMessage } = options;
+  const { initialMessage, attachments } = options;
 
   /** @type {Map<string, unknown>} directory: path key -> value */
   const directory = new Map();
@@ -26,11 +57,13 @@ export function makeMockPowers(options = {}) {
 
   /** @type {Array<{ number: number, from: string, to: string, type?: string, strings?: string[], names?: string[], ids?: string[], messageId?: string, replyTo?: string }>} */
   const messages = [];
-  /** @type {Map<number, { promise: Promise<unknown>, resolve: (value?: unknown) => void }>} */
+  /** @type {Map<string, { promise: Promise<unknown>, resolve: (value?: unknown) => void }>} */
   const dismissWaiters = new Map();
 
-  /** @type {Array<{ recipient: string, strings: string[], edgeNames: string[], petNames: string[] }>} */
+  /** @type {Array<{ recipient: string, strings: string[], edgeNames: string[], petNames: string[], replyTo?: string }>} */
   const sent = [];
+  /** @type {Array<{ messageNumber: string, edgeName: string, petName: string }>} */
+  const adoptions = [];
   const { promise: nextSendPromise, resolve: resolveNextSend } =
     makePromiseKit();
 
@@ -40,14 +73,15 @@ export function makeMockPowers(options = {}) {
    * @returns {Promise<void>}
    */
   function whenDismissed(n) {
-    if (!dismissWaiters.has(n)) {
+    const key = messageNumberKey(n);
+    if (!dismissWaiters.has(key)) {
       const { promise, resolve } = makePromiseKit();
-      dismissWaiters.set(n, { promise, resolve });
+      dismissWaiters.set(key, { promise, resolve });
       return /** @type {Promise<void>} */ (promise);
     }
     return /** @type {Promise<void>} */ (
       /** @type {{ promise: Promise<unknown>, resolve: (value?: unknown) => void }} */ (
-        dismissWaiters.get(n)
+        dismissWaiters.get(key)
       ).promise
     );
   }
@@ -105,7 +139,7 @@ export function makeMockPowers(options = {}) {
     },
 
     list(...petNamePath) {
-      const prefix = petNamePath.length ? `${petNamePath.join('/')}.` : '';
+      const prefix = petNamePath.length ? `${petNamePath.join('/')}/` : '';
       const names = new Set();
       for (const k of directory.keys()) {
         if (prefix ? k.startsWith(prefix) && k !== prefix : true) {
@@ -185,22 +219,60 @@ export function makeMockPowers(options = {}) {
       return Promise.resolve();
     },
 
-    adopt(messageNumber, _edgeName, petNameOrPath) {
+    adopt(messageNumber, edgeName, petNameOrPath) {
       const path = Array.isArray(petNameOrPath)
         ? petNameOrPath
         : [petNameOrPath];
       const key = path.join('/');
-      directory.set(key, `adopted-from-msg-${messageNumber}`);
+      // If we have a real ref for this edge, install it; otherwise
+      // fall back to a placeholder so tests that don't care about the
+      // adopted value still see "something" at the key.
+      /** @type {unknown} */
+      let value = `adopted-from-msg-${messageNumber}`;
+      if (attachments) {
+        const parent = messages.find(m =>
+          sameMessageNumber(m.number, messageNumber),
+        );
+        if (
+          parent &&
+          Array.isArray(parent.names) &&
+          Array.isArray(parent.ids)
+        ) {
+          const edgeIndex = parent.names.indexOf(edgeName);
+          if (edgeIndex >= 0) {
+            const id = parent.ids[edgeIndex];
+            if (attachments.has(id)) {
+              value = attachments.get(id);
+            }
+          }
+        }
+      }
+      directory.set(key, value);
+      adoptions.push({
+        messageNumber: messageNumberKey(messageNumber),
+        edgeName,
+        petName: key,
+      });
       return Promise.resolve();
     },
 
+    lookupById(id) {
+      if (!attachments || !attachments.has(id)) {
+        return Promise.reject(new Error(`Unknown id: ${id}`));
+      }
+      return Promise.resolve(attachments.get(id));
+    },
+
     dismiss(messageNumber) {
-      const idx = messages.findIndex(m => m.number === messageNumber);
+      const idx = messages.findIndex(m =>
+        sameMessageNumber(m.number, messageNumber),
+      );
       if (idx >= 0) messages.splice(idx, 1);
-      const waiter = dismissWaiters.get(messageNumber);
+      const key = messageNumberKey(messageNumber);
+      const waiter = dismissWaiters.get(key);
       if (waiter) {
         waiter.resolve();
-        dismissWaiters.delete(messageNumber);
+        dismissWaiters.delete(key);
       }
       return Promise.resolve();
     },
@@ -229,7 +301,9 @@ export function makeMockPowers(options = {}) {
 
     reply(messageNumber, strings, edgeNames, petNames) {
       // Find the parent message to determine the other party
-      const parent = messages.find(m => m.number === messageNumber);
+      const parent = messages.find(m =>
+        sameMessageNumber(m.number, messageNumber),
+      );
       const recipientName = parent
         ? parent.from === SELF_ID
           ? parent.to
@@ -292,5 +366,6 @@ export function makeMockPowers(options = {}) {
     whenDismissed,
     whenSend,
     sent,
+    adoptions,
   };
 }


### PR DESCRIPTION
## Description

Three commits adding deterministic provider replay support to `packages/lal`:

1. **fix(lal): lazy-load LLM SDKs to defer SES-incompatible imports** — provider factory imports SDK modules lazily so SES lockdown completes before their top-level init runs.
2. **feat(lal): expose reusable mock powers** — moves mock powers to the published tools surface and adds reusable attachment-backed lookup/adopt support for Lal/Fae tests.
3. **feat(lal): add deterministic provider replay fixtures** — adds injectable mock provider replay, captured fixture traces, and deterministic replay coverage.

Files: 13, all under `packages/lal/`.

### Security Considerations
N/A. Mock provider and fixtures are test-only.

### Scaling Considerations
N/A.

### Documentation Considerations
N/A.

### Testing Considerations
Fixture-driven replay tests make provider-behavior regressions catchable deterministically without network or live SDK calls.

### Compatibility Considerations
Additive. Existing provider construction paths unchanged.

### Upgrade Considerations
N/A. `lal` is unpublished.