### PR TITLE
feat(fae): deterministic replay + smoke coverage

### DIFF
--- a/packages/fae/.env.example
+++ b/packages/fae/.env.example
@@ -2,3 +2,4 @@ PROVIDER_NAME=default
 LAL_HOST=https://api.anthropic.com
 LAL_MODEL=claude-sonnet-4-6-20250514
 LAL_AUTH_TOKEN=sk-ant-api03-your-key-here
+FAE_CWD=/root-dir-for-list-read-edit-files-tool

--- a/packages/fae/agent.js
+++ b/packages/fae/agent.js
@@ -111,12 +111,24 @@ Example: if a message says "Here is @counter for you", adopt it:
 `;
 
 /**
+ * @typedef {object} ProviderConstructorConfig
+ * @property {string} host - LAL host URL.
+ * @property {string} model - LAL model identifier.
+ * @property {string} authToken - LAL auth token.
+ */
+
+/**
+ * @typedef {object} InjectedProviderConfig
+ * @property {{ chat: (messages: object[], tools: object[]) => Promise<{ message: object }> }} provider - Pre-built provider (e.g. for tests).
+ */
+
+/**
  * Spawn a worker loop that follows a guest's inbox and processes messages
  * using the given LLM provider configuration.
  *
  * @param {any} powers - Guest powers (manager's own or a sub-guest's)
  * @param {Promise<object> | object | undefined} context - Context for cancellation
- * @param {{ host: string, model: string, authToken: string }} providerConfig - LLM provider config
+ * @param {ProviderConstructorConfig | InjectedProviderConfig} providerConfig - LLM provider config. Pass `provider` to inject a pre-built provider (e.g. for tests); otherwise host/model/authToken are used to construct one.
  * @param {string} [systemPrompt] - Override system prompt (defaults to guestSystemPrompt)
  * @returns {Promise<void>}
  */
@@ -139,11 +151,13 @@ export const spawnWorkerLoop = async (
     return null;
   };
 
-  const provider = createProvider({
-    LAL_HOST: providerConfig.host,
-    LAL_MODEL: providerConfig.model,
-    LAL_AUTH_TOKEN: providerConfig.authToken,
-  });
+  const provider =
+    providerConfig.provider ||
+    createProvider({
+      LAL_HOST: providerConfig.host,
+      LAL_MODEL: providerConfig.model,
+      LAL_AUTH_TOKEN: providerConfig.authToken,
+    });
 
   /**
    * @param {object[]} messages

--- a/packages/fae/package.json
+++ b/packages/fae/package.json
@@ -32,7 +32,11 @@
     "setup-tools": "endo run --UNCONFINED setup-tools.js --powers @agent",
     "setup-with-tools": "endo run --UNCONFINED setup-with-tools.js --powers @agent -E PROVIDER_NAME=${PROVIDER_NAME:-default} -E FACTORY_NAME=${FACTORY_NAME:-fae-factory}",
     "setup-fs-tools": "endo run --UNCONFINED setup-fs-tools.js --powers @agent",
+    "debug:llm": "node scripts/debug-llm-logs.js",
+    "debug:llm:tools": "node scripts/debug-llm-logs.js --state=tmp/smoke/state --tools",
     "smoke": "ava --serial --timeout=10m scripts/smoke.test.js",
+    "test": "ava",
+    "test:c8": "c8 ${C8_OPTIONS:-} ses-ava",
     "lint": "yarn lint:eslint",
     "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint '**/*.js'"

--- a/packages/fae/package.json
+++ b/packages/fae/package.json
@@ -36,7 +36,7 @@
     "debug:llm:tools": "node scripts/debug-llm-logs.js --state=tmp/smoke/state --tools",
     "smoke": "ava --serial --timeout=10m scripts/smoke.test.js",
     "test": "ava",
-    "test:c8": "c8 ${C8_OPTIONS:-} ses-ava",
+    "test:c8": "c8 ${C8_OPTIONS:-} ava",
     "lint": "yarn lint:eslint",
     "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint '**/*.js'"
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@endo/cli": "workspace:^",
     "ava": "catalog:dev",
+    "c8": "catalog:dev",
     "eslint": "catalog:dev"
   },
   "eslintConfig": {

--- a/packages/fae/package.json
+++ b/packages/fae/package.json
@@ -36,6 +36,13 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint '**/*.js'"
   },
+  "ava": {
+    "files": [
+      "test/**/*.test.*",
+      "!test/channel-mention.test.js"
+    ],
+    "timeout": "2m"
+  },
   "dependencies": {
     "@endo/conversation-tree": "workspace:^",
     "@endo/daemon": "workspace:^",

--- a/packages/fae/package.json
+++ b/packages/fae/package.json
@@ -32,6 +32,7 @@
     "setup-tools": "endo run --UNCONFINED setup-tools.js --powers @agent",
     "setup-with-tools": "endo run --UNCONFINED setup-with-tools.js --powers @agent -E PROVIDER_NAME=${PROVIDER_NAME:-default} -E FACTORY_NAME=${FACTORY_NAME:-fae-factory}",
     "setup-fs-tools": "endo run --UNCONFINED setup-fs-tools.js --powers @agent",
+    "smoke": "ava --serial --timeout=10m scripts/smoke.test.js",
     "lint": "yarn lint:eslint",
     "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint '**/*.js'"

--- a/packages/fae/scripts/debug-llm-logs.js
+++ b/packages/fae/scripts/debug-llm-logs.js
@@ -1,0 +1,1297 @@
+#!/usr/bin/env node
+// @ts-check
+/* global process, Buffer */
+/* eslint-disable no-await-in-loop, no-console, no-continue */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const PROVIDER_ERROR_PATTERNS = [
+  /Provider returned error/i,
+  /\b4\d\d\b/,
+  /\b5\d\d\b/,
+  /API error/i,
+  /Bad Request/i,
+  /LLM error/i,
+  /Temporary logging of sent error/i,
+];
+
+const SES_ERROR_PATTERNS = [
+  /SES_UNHANDLED_REJECTION/,
+  /CapTP .* exception/i,
+  /TypeError#/i,
+  /Error#/i,
+];
+
+const FAE_ERROR_PATTERNS = [
+  /\[fae\] background error:/,
+  /\[fae\] empty-content fallthrough/,
+  /\[tool\] \S+ error:/,
+];
+
+const ERROR_PATTERNS = [
+  ...PROVIDER_ERROR_PATTERNS,
+  ...SES_ERROR_PATTERNS,
+  ...FAE_ERROR_PATTERNS,
+];
+
+const SIGNAL_PATTERNS = [
+  /\[LAL\] Using /,
+  /\[LAL\] Calling /,
+  /\[fae\] New message/,
+  /\[fae\] context has /,
+  /\[fae\] chat messages:/,
+  /\[fae\] sent:/,
+  /\[fae\] tool results:/,
+  ...ERROR_PATTERNS,
+];
+
+// Categories used by --summary to bucket and tally error lines. Tool errors
+// are tracked per-tool elsewhere, so they are deliberately omitted here.
+const ERROR_CATEGORIES = [
+  { name: 'SES_UNHANDLED_REJECTION', pattern: /SES_UNHANDLED_REJECTION/ },
+  { name: 'CapTP exception', pattern: /CapTP .* exception/i },
+  { name: 'provider HTTP error', pattern: /\b[45]\d\d\b/ },
+  { name: 'provider returned error', pattern: /Provider returned error/i },
+  { name: 'fae background error', pattern: /\[fae\] background error:/ },
+  {
+    name: 'fae empty-content fallthrough',
+    pattern: /\[fae\] empty-content fallthrough/,
+  },
+];
+
+const usage = `Usage: yarn debug:llm [options]
+
+Inspect Endo Application Support logs for Fae/Lal LLM provider issues.
+
+Options:
+  --state=<path>       Endo state directory (default: platform Endo state path)
+  --worker=<filter>    Worker id/label substring, or "active"/"most-recent"
+  --agent=<filter>     Slice the log to a single agent's section by label substring
+  --since=<offset>     Skip the first N bytes of the chosen log file
+  --context=<n>        Lines of context around matched log lines (default: 4)
+  --last=<n>           Maximum signal windows per log file (default: 20)
+  --summary            One-screen post-mortem; skip raw window dump
+  --tools              List each [tool] invocation paired with its result/error
+  --chat               Print the latest full chat message snapshot
+  --all                Include workers with no obvious LLM/error signal
+  --json               Emit machine-readable JSON
+  --help               Show this help
+
+Both --key=value and --key value forms are accepted.
+`;
+
+/**
+ * @param {string[]} argv
+ */
+const parseArgs = argv => {
+  const options = {
+    state: '',
+    worker: '',
+    agent: '',
+    since: 0,
+    context: 4,
+    last: 20,
+    summary: false,
+    tools: false,
+    chat: false,
+    all: false,
+    json: false,
+    help: false,
+  };
+
+  /**
+   * Read the value attached to a flag, supporting both `--key=value` and
+   * `--key value` syntax. Returns the value plus how many additional argv
+   * tokens were consumed.
+   *
+   * @param {string} arg
+   * @param {number} index
+   * @returns {{ value: string, advance: number }}
+   */
+  const valueFor = (arg, index) => {
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex >= 0) {
+      return { value: arg.slice(eqIndex + 1), advance: 0 };
+    }
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith('-')) {
+      return { value: '', advance: 0 };
+    }
+    return { value: next, advance: 1 };
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const head = arg.split('=', 1)[0];
+    if (head === '--state') {
+      const { value, advance } = valueFor(arg, i);
+      options.state = value;
+      i += advance;
+    } else if (head === '--worker') {
+      const { value, advance } = valueFor(arg, i);
+      options.worker = value;
+      i += advance;
+    } else if (head === '--agent') {
+      const { value, advance } = valueFor(arg, i);
+      options.agent = value;
+      i += advance;
+    } else if (head === '--since') {
+      const { value, advance } = valueFor(arg, i);
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new Error(
+          `--since must be a non-negative integer, got: ${value}`,
+        );
+      }
+      options.since = parsed;
+      i += advance;
+    } else if (head === '--context') {
+      const { value, advance } = valueFor(arg, i);
+      options.context = Number(value || options.context);
+      i += advance;
+    } else if (head === '--last') {
+      const { value, advance } = valueFor(arg, i);
+      options.last = Number(value || options.last);
+      i += advance;
+    } else if (head === '--summary') {
+      options.summary = true;
+    } else if (head === '--tools') {
+      options.tools = true;
+    } else if (head === '--chat') {
+      options.chat = true;
+    } else if (head === '--all') {
+      options.all = true;
+    } else if (head === '--json') {
+      options.json = true;
+    } else if (head === '--help' || head === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}\n${usage}`);
+    }
+  }
+
+  return options;
+};
+
+/**
+ * Mirrors `@endo/where` state path selection closely enough for a standalone
+ * debug script.
+ */
+const defaultStatePath = () => {
+  if (process.env.XDG_STATE_HOME) {
+    return path.join(process.env.XDG_STATE_HOME, 'endo');
+  }
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'Endo');
+  }
+  if (process.platform === 'win32') {
+    const appData =
+      process.env.LOCALAPPDATA ||
+      (process.env.APPDATA ? path.join(process.env.APPDATA, 'Local') : '');
+    return path.join(appData || os.homedir(), 'Endo');
+  }
+  return path.join(os.homedir(), '.local', 'state', 'endo');
+};
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<string>}
+ */
+const readTextIfPresent = async filePath => {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if (/** @type {NodeJS.ErrnoException} */ (error).code === 'ENOENT') {
+      return '';
+    }
+    throw error;
+  }
+};
+
+/**
+ * @param {string} filePath
+ */
+const readJsonIfPresent = async filePath => {
+  const text = await readTextIfPresent(filePath);
+  if (text === '') {
+    return {};
+  }
+  return JSON.parse(text);
+};
+
+/**
+ * Read the file as a Buffer plus the UTF-8 decoding of the slice starting at
+ * `since` bytes. Returns the line offset (count of newlines in the prefix)
+ * so callers can report absolute line numbers even after slicing.
+ *
+ * @param {string} filePath
+ * @param {number} since
+ * @returns {Promise<{ buffer: Buffer, text: string, lineOffset: number, totalSize: number }>}
+ */
+const readSliced = async (filePath, since) => {
+  let buffer;
+  try {
+    buffer = await fs.readFile(filePath);
+  } catch (error) {
+    if (/** @type {NodeJS.ErrnoException} */ (error).code === 'ENOENT') {
+      return { buffer: Buffer.alloc(0), text: '', lineOffset: 0, totalSize: 0 };
+    }
+    throw error;
+  }
+  const totalSize = buffer.length;
+  if (since <= 0) {
+    return { buffer, text: buffer.toString('utf8'), lineOffset: 0, totalSize };
+  }
+  if (since >= totalSize) {
+    let lineOffset = 0;
+    for (let i = 0; i < totalSize; i += 1) {
+      if (buffer[i] === 0x0a) lineOffset += 1;
+    }
+    return { buffer, text: '', lineOffset, totalSize };
+  }
+  let lineOffset = 0;
+  for (let i = 0; i < since; i += 1) {
+    if (buffer[i] === 0x0a) lineOffset += 1;
+  }
+  const slice = buffer.subarray(since);
+  return { buffer, text: slice.toString('utf8'), lineOffset, totalSize };
+};
+
+/**
+ * @param {string} text
+ */
+const splitLines = text => text.split(/\r?\n/);
+
+/**
+ * @param {string | object | undefined} args
+ * @returns {string}
+ */
+const stringifyToolArguments = args => {
+  if (typeof args === 'string') {
+    return args;
+  }
+  return JSON.stringify(args ?? {});
+};
+
+/**
+ * Mirror the OpenAI-compatible message normalization used by the provider.
+ *
+ * @param {Array<Record<string, any>>} messages
+ * @returns {object[]}
+ */
+const toOpenAICompatibleMessages = messages =>
+  messages.map((message, messageIndex) => {
+    if (message.role === 'assistant') {
+      const toolCalls = Array.isArray(message.tool_calls)
+        ? message.tool_calls.map((toolCall, toolIndex) => ({
+            id: toolCall.id || `tool_${messageIndex}_${toolIndex}`,
+            type: 'function',
+            function: {
+              name: toolCall.function?.name || '',
+              arguments: stringifyToolArguments(toolCall.function?.arguments),
+            },
+          }))
+        : undefined;
+
+      if (toolCalls && toolCalls.length > 0) {
+        return {
+          role: 'assistant',
+          content: message.content || null,
+          tool_calls: toolCalls,
+        };
+      }
+      return { role: 'assistant', content: message.content || '' };
+    }
+
+    if (message.role === 'tool') {
+      return {
+        role: 'tool',
+        content: message.content || '',
+        tool_call_id: message.tool_call_id || '',
+      };
+    }
+
+    return { role: message.role, content: message.content || '' };
+  });
+
+/**
+ * @param {string} text
+ */
+const hasCompleteJson = text => {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let started = false;
+
+  for (const char of text) {
+    if (!started && /\s/.test(char)) {
+      continue;
+    }
+    started = true;
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+    } else if (char === '"') {
+      inString = true;
+    } else if (char === '{' || char === '[') {
+      depth += 1;
+    } else if (char === '}' || char === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        return true;
+      }
+    }
+  }
+
+  return started && depth === 0 && !inString;
+};
+
+/**
+ * @param {string[]} lines
+ * @param {number} startIndex
+ * @param {string} firstText
+ */
+const parseJsonBlock = (lines, startIndex, firstText) => {
+  let text = firstText.trim();
+  let endIndex = startIndex;
+
+  for (
+    let i = startIndex + 1;
+    i < lines.length && i < startIndex + 250;
+    i += 1
+  ) {
+    if (text !== '' && hasCompleteJson(text)) {
+      break;
+    }
+    text = `${text}\n${lines[i]}`;
+    endIndex = i;
+  }
+
+  if (!hasCompleteJson(text)) {
+    return undefined;
+  }
+
+  try {
+    return { value: JSON.parse(text), endIndex };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * @param {string[]} lines
+ */
+const parseFaeJsonEvents = lines => {
+  const events = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const sentAt = lines[i].indexOf('[fae] sent:');
+    const toolResultsAt = lines[i].indexOf('[fae] tool results:');
+    const chatMessagesAt = lines[i].indexOf('[fae] chat messages:');
+    const kind =
+      sentAt >= 0
+        ? 'assistant'
+        : toolResultsAt >= 0
+          ? 'toolResults'
+          : chatMessagesAt >= 0
+            ? 'chatMessages'
+            : '';
+    const markerAt =
+      sentAt >= 0
+        ? sentAt
+        : toolResultsAt >= 0
+          ? toolResultsAt
+          : chatMessagesAt;
+    if (kind === '') {
+      continue;
+    }
+
+    const marker =
+      kind === 'assistant'
+        ? '[fae] sent:'
+        : kind === 'toolResults'
+          ? '[fae] tool results:'
+          : '[fae] chat messages:';
+    const firstText = lines[i].slice(markerAt + marker.length);
+    const parsed = parseJsonBlock(lines, i, firstText);
+    if (parsed === undefined) {
+      continue;
+    }
+
+    events.push({
+      kind,
+      line: i + 1,
+      endLine: parsed.endIndex + 1,
+      value: parsed.value,
+    });
+    i = parsed.endIndex;
+  }
+
+  return events;
+};
+
+/**
+ * @param {unknown} message
+ */
+const toolCallsOf = message => {
+  if (
+    message &&
+    typeof message === 'object' &&
+    Array.isArray(/** @type {{ tool_calls?: unknown }} */ (message).tool_calls)
+  ) {
+    return /** @type {{ tool_calls: unknown[] }} */ (message).tool_calls;
+  }
+  return [];
+};
+
+/**
+ * @param {ReturnType<typeof parseFaeJsonEvents>} events
+ */
+const analyzeToolHistory = events => {
+  const findings = [];
+
+  for (let i = 0; i < events.length; i += 1) {
+    const event = events[i];
+    if (event.kind !== 'assistant') {
+      continue;
+    }
+
+    const calls = toolCallsOf(event.value);
+    if (calls.length === 0) {
+      continue;
+    }
+
+    const missingType = calls.filter(
+      call =>
+        !call ||
+        typeof call !== 'object' ||
+        /** @type {{ type?: unknown }} */ (call).type !== 'function',
+    );
+    if (missingType.length > 0) {
+      findings.push({
+        severity: 'high',
+        line: event.line,
+        message:
+          'assistant tool_calls are missing type: "function"; OpenAI-compatible providers can reject the next request',
+      });
+    }
+
+    const ids = calls
+      .map(call =>
+        call && typeof call === 'object'
+          ? /** @type {{ id?: unknown }} */ (call).id
+          : undefined,
+      )
+      .filter(id => typeof id === 'string');
+    if (ids.length !== calls.length) {
+      findings.push({
+        severity: 'high',
+        line: event.line,
+        message:
+          'one or more assistant tool_calls have no id; matching tool results may fail',
+      });
+    }
+
+    const next = events.slice(i + 1).find(candidate => {
+      if (candidate.kind === 'toolResults') {
+        return true;
+      }
+      return candidate.kind === 'assistant';
+    });
+
+    if (!next || next.kind !== 'toolResults') {
+      findings.push({
+        severity: 'medium',
+        line: event.line,
+        message:
+          'assistant tool_calls were not followed by logged tool results',
+      });
+      continue;
+    }
+
+    const toolResults = Array.isArray(next.value) ? next.value : [];
+    const resultIds = new Set(
+      toolResults
+        .map(result =>
+          result && typeof result === 'object'
+            ? /** @type {{ tool_call_id?: unknown }} */ (result).tool_call_id
+            : undefined,
+        )
+        .filter(id => typeof id === 'string'),
+    );
+    const missingResults = ids.filter(id => !resultIds.has(id));
+    if (missingResults.length > 0) {
+      findings.push({
+        severity: 'high',
+        line: next.line,
+        message: `tool results missing tool_call_id(s): ${missingResults.join(
+          ', ',
+        )}`,
+      });
+    }
+
+    const normalized = toOpenAICompatibleMessages([
+      /** @type {Record<string, any>} */ (event.value),
+      ...toolResults,
+    ]);
+    const normalizedAssistant = normalized[0];
+    if (
+      normalizedAssistant &&
+      typeof normalizedAssistant === 'object' &&
+      Array.isArray(
+        /** @type {{ tool_calls?: unknown }} */ (normalizedAssistant)
+          .tool_calls,
+      )
+    ) {
+      const normalizedCalls =
+        /** @type {{ tool_calls: Array<{ type?: string }> }} */ (
+          normalizedAssistant
+        ).tool_calls;
+      if (normalizedCalls.every(call => call.type === 'function')) {
+        findings.push({
+          severity: 'info',
+          line: event.line,
+          message:
+            'normalizer can repair this assistant/tool result pair for OpenAI-compatible APIs',
+        });
+      }
+    }
+  }
+
+  return findings;
+};
+
+/**
+ * Slice `lines` down to a single agent's section using the
+ * `[fae-factory] Created agent "<label>"` markers as boundaries.
+ * The matched marker is the start of the slice (inclusive); the next marker
+ * (or end of file) is the end.
+ *
+ * Returns the full marker list regardless of match so callers can report
+ * the available labels when no match is found.
+ *
+ * @param {string[]} lines
+ * @param {number} lineOffset
+ * @param {string} agentFilter
+ * @returns {{
+ *   lines: string[],
+ *   lineOffset: number,
+ *   agentLabels: string[],
+ *   matchedLabel: string,
+ * }}
+ */
+const sliceLinesByAgent = (lines, lineOffset, agentFilter) => {
+  const markers = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i].match(/^\[fae-factory\] Created agent "([^"]+)"/);
+    if (match) {
+      markers.push({ index: i, label: match[1] });
+    }
+  }
+  const agentLabels = markers.map(m => m.label);
+  if (agentFilter === '') {
+    return { lines, lineOffset, agentLabels, matchedLabel: '' };
+  }
+  if (markers.length === 0) {
+    return { lines: [], lineOffset, agentLabels, matchedLabel: '' };
+  }
+  const lower = agentFilter.toLowerCase();
+  const matched = markers.filter(m => m.label.toLowerCase().includes(lower));
+  if (matched.length === 0) {
+    return { lines: [], lineOffset, agentLabels, matchedLabel: '' };
+  }
+  if (matched.length > 1) {
+    const labels = matched.map(m => m.label).join(', ');
+    throw new Error(
+      `--agent=${agentFilter} matched multiple agents: ${labels} (narrow your filter)`,
+    );
+  }
+  const start = matched[0].index;
+  const next = markers.find(m => m.index > start);
+  const end = next ? next.index : lines.length;
+  return {
+    lines: lines.slice(start, end),
+    lineOffset: lineOffset + start,
+    agentLabels,
+    matchedLabel: matched[0].label,
+  };
+};
+
+/**
+ * Collect raw `[tool] name(args)` invocation lines paired in chronological
+ * order with their `-> result` or `error:` follow-up. These are the actual
+ * dispatcher events, not the normalized assistant tool_calls — useful for
+ * tracing how the agent arrived at a reply.
+ *
+ * @param {string[]} lines
+ * @param {number} lineOffset
+ */
+const collectToolInvocations = (lines, lineOffset) => {
+  const entries = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const text = lines[i];
+    const callMatch = text.match(/^\[tool\] (\S+)\(/);
+    if (callMatch) {
+      entries.push({
+        kind: 'call',
+        name: callMatch[1],
+        line: i + 1 + lineOffset,
+        text,
+      });
+      continue;
+    }
+    const okMatch = text.match(/^\[tool\] (\S+) -> /);
+    if (okMatch) {
+      entries.push({
+        kind: 'ok',
+        name: okMatch[1],
+        line: i + 1 + lineOffset,
+        text,
+      });
+      continue;
+    }
+    const errMatch = text.match(/^\[tool\] (\S+) error:/);
+    if (errMatch) {
+      entries.push({
+        kind: 'error',
+        name: errMatch[1],
+        line: i + 1 + lineOffset,
+        text,
+      });
+    }
+  }
+  return entries;
+};
+
+/**
+ * @param {string[]} lines
+ * @param {RegExp[]} patterns
+ */
+const matchingLineIndexes = (lines, patterns) => {
+  const indexes = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (patterns.some(pattern => pattern.test(lines[i]))) {
+      indexes.push(i);
+    }
+  }
+  return indexes;
+};
+
+/**
+ * @param {string[]} lines
+ * @param {number[]} indexes
+ * @param {number} context
+ * @param {number} last
+ * @param {number} lineOffset
+ * @param {ReturnType<typeof parseFaeJsonEvents>} events
+ */
+const makeWindows = (lines, indexes, context, last, lineOffset, events) => {
+  const chosen = indexes.slice(Math.max(0, indexes.length - last));
+  const windows = [];
+
+  for (const index of chosen) {
+    const event = events.find(candidate => {
+      const startIndex = candidate.line - 1;
+      const endIndex = candidate.endLine - 1;
+      return startIndex <= index && index <= endIndex;
+    });
+    const eventStartIndex = event ? event.line - 1 : index;
+    const eventEndIndex = event ? event.endLine - 1 : index;
+    const start = Math.max(0, eventStartIndex - context);
+    const end = Math.min(lines.length - 1, eventEndIndex + context);
+    const previous = windows[windows.length - 1];
+    if (previous && start <= previous.end + 1) {
+      previous.end = Math.max(previous.end, end);
+    } else {
+      windows.push({ start, end });
+    }
+  }
+
+  return windows.map(window => ({
+    startLine: window.start + 1 + lineOffset,
+    endLine: window.end + 1 + lineOffset,
+    lines: lines.slice(window.start, window.end + 1).map((text, offset) => ({
+      line: window.start + offset + 1 + lineOffset,
+      text,
+    })),
+  }));
+};
+
+/**
+ * @param {string} statePath
+ */
+const listWorkerLogs = async statePath => {
+  const workerRoot = path.join(statePath, 'worker');
+  let entries;
+  try {
+    entries = await fs.readdir(workerRoot, { withFileTypes: true });
+  } catch (error) {
+    if (/** @type {NodeJS.ErrnoException} */ (error).code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+
+  const workers = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const id = entry.name;
+    const dir = path.join(workerRoot, id);
+    const logPath = path.join(dir, 'worker.log');
+    const metaPath = path.join(dir, 'worker.meta.json');
+    const [meta, stat] = await Promise.all([
+      readJsonIfPresent(metaPath),
+      fs.stat(logPath).catch(error => {
+        if (/** @type {NodeJS.ErrnoException} */ (error).code === 'ENOENT') {
+          return undefined;
+        }
+        throw error;
+      }),
+    ]);
+    if (stat === undefined) {
+      continue;
+    }
+    workers.push({
+      id,
+      dir,
+      logPath,
+      label:
+        typeof (/** @type {{ label?: unknown }} */ (meta).label) === 'string'
+          ? /** @type {{ label: string }} */ (meta).label
+          : '',
+      createdAt:
+        typeof (/** @type {{ createdAt?: unknown }} */ (meta).createdAt) ===
+        'string'
+          ? /** @type {{ createdAt: string }} */ (meta).createdAt
+          : '',
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    });
+  }
+
+  workers.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return workers;
+};
+
+/**
+ * Resolve a `--worker=<filter>` value against the discovered worker list.
+ * The reserved keywords `active` / `most-recent` pick the freshest log;
+ * any other non-empty value matches by id or label substring (case-insensitive).
+ *
+ * @param {Awaited<ReturnType<typeof listWorkerLogs>>} workers
+ * @param {string} filter
+ */
+const filterWorkers = (workers, filter) => {
+  if (filter === '') {
+    return workers;
+  }
+  const lower = filter.toLowerCase();
+  if (lower === 'active' || lower === 'most-recent') {
+    return workers.length === 0 ? [] : [workers[0]];
+  }
+  return workers.filter(
+    worker =>
+      worker.id.toLowerCase().includes(lower) ||
+      worker.label.toLowerCase().includes(lower),
+  );
+};
+
+/**
+ * @param {string} logPath
+ * @param {ReturnType<typeof parseArgs>} options
+ */
+const analyzeLogFile = async (logPath, options) => {
+  const {
+    text,
+    lineOffset: baseLineOffset,
+    totalSize,
+  } = await readSliced(logPath, options.since);
+  const allLines = splitLines(text);
+  const sliced = sliceLinesByAgent(allLines, baseLineOffset, options.agent);
+  const { lines, lineOffset, agentLabels, matchedLabel } = sliced;
+  const signalIndexes = matchingLineIndexes(lines, SIGNAL_PATTERNS);
+  const errorIndexes = matchingLineIndexes(lines, ERROR_PATTERNS);
+  const events = parseFaeJsonEvents(lines);
+  const toolFindings = analyzeToolHistory(events).map(finding => ({
+    ...finding,
+    line: finding.line + lineOffset,
+  }));
+
+  return {
+    logPath,
+    lineCount: lines.length,
+    signalCount: signalIndexes.length,
+    errorCount: errorIndexes.length,
+    rangeStart: options.since,
+    rangeEnd: totalSize,
+    lineOffset,
+    lines,
+    events,
+    eventSummary: events.map(event => ({
+      kind: event.kind,
+      line: event.line + lineOffset,
+      endLine: event.endLine + lineOffset,
+    })),
+    toolFindings,
+    toolInvocations: collectToolInvocations(lines, lineOffset),
+    agentLabels,
+    matchedAgent: matchedLabel,
+    windows: makeWindows(
+      lines,
+      signalIndexes,
+      options.context,
+      options.last,
+      lineOffset,
+      events,
+    ),
+  };
+};
+
+/**
+ * @param {ReturnType<typeof parseArgs>} options
+ */
+const run = async options => {
+  const explicitState = options.state !== '';
+  const statePath = path.resolve(options.state || defaultStatePath());
+
+  let stateExists = false;
+  try {
+    const stat = await fs.stat(statePath);
+    stateExists = stat.isDirectory();
+  } catch (error) {
+    if (/** @type {NodeJS.ErrnoException} */ (error).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+  if (!stateExists) {
+    const hint = explicitState
+      ? `state path does not exist or is not a directory: ${statePath}`
+      : `default Endo state path does not exist: ${statePath} (pass --state=<path> to override)`;
+    throw new Error(hint);
+  }
+
+  const endoLogPath = path.join(statePath, 'endo.log');
+  const workers = await listWorkerLogs(statePath);
+  const filteredWorkers = filterWorkers(workers, options.worker);
+
+  if (
+    options.worker !== '' &&
+    filteredWorkers.length === 0 &&
+    workers.length > 0
+  ) {
+    throw new Error(
+      `--worker=${options.worker} matched no worker logs (workers found: ${workers.length}).`,
+    );
+  }
+
+  const logs = [];
+  /** @type {Set<string>} */
+  const allAgentLabels = new Set();
+
+  // Skip endo.log when narrowing to a specific worker — the daemon log only
+  // adds noise once the operator already knows which worker to inspect.
+  if (options.worker === '') {
+    const endoLog = await analyzeLogFile(endoLogPath, options);
+    for (const label of endoLog.agentLabels) allAgentLabels.add(label);
+    if (options.all || endoLog.signalCount > 0 || endoLog.errorCount > 0) {
+      logs.push({
+        id: 'endo',
+        label: 'daemon',
+        createdAt: '',
+        mtimeMs: 0,
+        size: 0,
+        ...endoLog,
+      });
+    }
+  }
+
+  for (const worker of filteredWorkers) {
+    const analysis = await analyzeLogFile(worker.logPath, options);
+    for (const label of analysis.agentLabels) allAgentLabels.add(label);
+    if (
+      options.all ||
+      options.worker !== '' ||
+      analysis.signalCount > 0 ||
+      analysis.errorCount > 0 ||
+      analysis.toolFindings.length > 0 ||
+      analysis.toolInvocations.length > 0
+    ) {
+      logs.push({ ...worker, ...analysis });
+    }
+  }
+
+  if (options.agent !== '' && !logs.some(log => log.matchedAgent)) {
+    const sorted = [...allAgentLabels].sort();
+    const available = sorted.length === 0 ? '<none found>' : sorted.join(', ');
+    throw new Error(
+      `--agent=${options.agent} matched no agent (available: ${available})`,
+    );
+  }
+
+  return {
+    statePath,
+    workerCount: workers.length,
+    includedLogCount: logs.length,
+    logs,
+  };
+};
+
+/**
+ * @param {number} ms
+ */
+const formatDuration = ms => {
+  if (!Number.isFinite(ms) || ms < 0) return 'unknown';
+  const totalSec = Math.round(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const minutes = Math.floor(totalSec / 60);
+  const seconds = totalSec % 60;
+  if (minutes < 60) return `${minutes}m${String(seconds).padStart(2, '0')}s`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return `${hours}h${String(remMinutes).padStart(2, '0')}m`;
+};
+
+/**
+ * @param {string} value
+ * @param {number} maxLength
+ */
+const truncateOneLine = (value, maxLength) => {
+  const flat = value.replace(/\s+/g, ' ').trim();
+  if (flat.length <= maxLength) return flat;
+  return `${flat.slice(0, maxLength - 1)}…`;
+};
+
+/**
+ * @param {string} prefix
+ * @param {number} maxLength
+ */
+const homeRelative = (prefix, maxLength) => {
+  const home = os.homedir();
+  if (prefix.startsWith(home)) {
+    return `~${prefix.slice(home.length)}`;
+  }
+  return maxLength > 0 ? truncateOneLine(prefix, maxLength) : prefix;
+};
+
+/**
+ * Build a one-screen post-mortem summary of a single worker log.
+ *
+ * @param {Awaited<ReturnType<typeof analyzeLogFile>> & {
+ *   id?: string,
+ *   label?: string,
+ *   mtimeMs?: number,
+ *   size?: number,
+ * }} log
+ */
+const summarizeLog = log => {
+  /** @type {Map<string, { calls: number, ok: number, error: number }>} */
+  const toolCounts = new Map();
+  /** @type {Map<string, { count: number, last: string }>} */
+  const errorBuckets = new Map();
+  let lastReplyArgsLine = '';
+
+  const bumpTool = (
+    /** @type {string} */ name,
+    /** @type {keyof {calls:0,ok:0,error:0}} */ key,
+  ) => {
+    let entry = toolCounts.get(name);
+    if (!entry) {
+      entry = { calls: 0, ok: 0, error: 0 };
+      toolCounts.set(name, entry);
+    }
+    entry[key] += 1;
+  };
+
+  for (const line of log.lines) {
+    const callMatch = line.match(/^\[tool\] (\S+)\(/);
+    if (callMatch) {
+      bumpTool(callMatch[1], 'calls');
+      if (callMatch[1] === 'reply') {
+        lastReplyArgsLine = line;
+      }
+      continue;
+    }
+    const okMatch = line.match(/^\[tool\] (\S+) -> /);
+    if (okMatch) {
+      bumpTool(okMatch[1], 'ok');
+      continue;
+    }
+    const errMatch = line.match(/^\[tool\] (\S+) error:/);
+    if (errMatch) {
+      bumpTool(errMatch[1], 'error');
+      continue;
+    }
+    for (const category of ERROR_CATEGORIES) {
+      if (category.pattern.test(line)) {
+        const bucket = errorBuckets.get(category.name) || {
+          count: 0,
+          last: '',
+        };
+        bucket.count += 1;
+        bucket.last = line;
+        errorBuckets.set(category.name, bucket);
+      }
+    }
+  }
+
+  const llmRoundTrips = log.events.filter(e => e.kind === 'assistant').length;
+  const chatSnapshots = log.events.filter(e => e.kind === 'chatMessages');
+  const latestChatSnapshot = chatSnapshots.at(-1);
+  const latestChatMessageCount = Array.isArray(latestChatSnapshot?.value)
+    ? latestChatSnapshot.value.length
+    : 0;
+  const totalToolInvocations = [...toolCounts.values()].reduce(
+    (acc, entry) => acc + entry.calls,
+    0,
+  );
+
+  const lastAssistant = [...log.events]
+    .reverse()
+    .find(e => e.kind === 'assistant');
+  /** @type {string} */
+  let lastAssistantContent = '<none>';
+  if (lastAssistant) {
+    const value = /** @type {any} */ (lastAssistant.value);
+    if (value && typeof value.content === 'string' && value.content !== '') {
+      lastAssistantContent = truncateOneLine(value.content, 120);
+    } else if (
+      Array.isArray(value?.tool_calls) &&
+      Number(value.tool_calls.length) > 0
+    ) {
+      const names = value.tool_calls
+        .map(/** @type {any} */ tc => tc?.function?.name)
+        .filter(/** @type {any} */ n => typeof n === 'string')
+        .join(', ');
+      lastAssistantContent = `<tool_calls: ${names || 'unnamed'}>`;
+    } else {
+      lastAssistantContent = '<empty>';
+    }
+  }
+
+  /** @type {string} */
+  let lastReply = '<none sent>';
+  if (lastReplyArgsLine) {
+    const argMatch = lastReplyArgsLine.match(/^\[tool\] reply\((.*)\)\s*$/);
+    if (argMatch) {
+      lastReply = truncateOneLine(argMatch[1], 120);
+    } else {
+      lastReply = truncateOneLine(lastReplyArgsLine, 120);
+    }
+  }
+
+  return {
+    id: log.id || '',
+    label: log.label || '',
+    logPath: log.logPath,
+    rangeStart: log.rangeStart,
+    rangeEnd: log.rangeEnd,
+    ageMs:
+      typeof log.mtimeMs === 'number' && log.mtimeMs > 0
+        ? Date.now() - log.mtimeMs
+        : Number.NaN,
+    llmRoundTrips,
+    chatSnapshotCount: chatSnapshots.length,
+    latestChatMessageCount,
+    totalToolInvocations,
+    toolCounts: [...toolCounts.entries()].map(([name, counts]) => ({
+      name,
+      ...counts,
+    })),
+    errors: [...errorBuckets.entries()].map(([name, bucket]) => ({
+      name,
+      ...bucket,
+    })),
+    lastAssistantContent,
+    lastReply,
+  };
+};
+
+/**
+ * @param {ReturnType<typeof summarizeLog>} summary
+ */
+const printSummary = summary => {
+  const idDisplay = summary.id ? `${summary.id.slice(0, 8)}...` : '<unknown>';
+  const labelDisplay = summary.label ? `  label=${summary.label}` : '';
+  const ageDisplay = Number.isNaN(summary.ageMs)
+    ? ''
+    : `  age=${formatDuration(summary.ageMs)}`;
+  console.log(`worker: ${idDisplay}${labelDisplay}${ageDisplay}`);
+  console.log(`log:    ${homeRelative(summary.logPath, 0)}`);
+  const rangeNote = summary.rangeStart > 0 ? ' (since-offset)' : ' (full file)';
+  console.log(
+    `range:  bytes ${summary.rangeStart}..${summary.rangeEnd}${rangeNote}`,
+  );
+  console.log('');
+
+  console.log(
+    `chat:   ${summary.latestChatMessageCount} message(s) in latest context (${summary.chatSnapshotCount} snapshot(s))`,
+  );
+  console.log(`LLM:    ${summary.llmRoundTrips} round-trip(s)`);
+  console.log(`tools:  ${summary.totalToolInvocations} invocation(s)`);
+  if (summary.toolCounts.length > 0) {
+    const namePad = Math.max(
+      ...summary.toolCounts.map(entry => entry.name.length),
+      8,
+    );
+    for (const entry of summary.toolCounts) {
+      console.log(
+        `        ${entry.name.padEnd(namePad)}  ${entry.calls} call(s) (${entry.ok} ok, ${entry.error} error)`,
+      );
+    }
+  }
+  console.log('');
+
+  if (summary.errors.length === 0) {
+    console.log('errors: <none>');
+  } else {
+    const total = summary.errors.reduce((acc, e) => acc + e.count, 0);
+    console.log(`errors: ${total}`);
+    const namePad = Math.max(...summary.errors.map(e => e.name.length), 8);
+    for (const entry of summary.errors) {
+      console.log(
+        `        ${String(entry.count).padStart(3, ' ')} ${entry.name.padEnd(namePad)}  ${truncateOneLine(entry.last, 80)}`,
+      );
+    }
+  }
+  console.log('');
+
+  console.log(`last assistant: ${summary.lastAssistantContent}`);
+  console.log(`last reply:     ${summary.lastReply}`);
+};
+
+/**
+ * @param {Awaited<ReturnType<typeof analyzeLogFile>>} log
+ */
+const printToolInvocations = log => {
+  console.log('');
+  if (log.toolInvocations.length === 0) {
+    console.log('tool invocations: <none>');
+    return;
+  }
+  console.log(`tool invocations (${log.toolInvocations.length}):`);
+  for (const entry of log.toolInvocations) {
+    console.log(`  ${String(entry.line).padStart(5, ' ')}  ${entry.text}`);
+  }
+};
+
+/**
+ * @param {Awaited<ReturnType<typeof analyzeLogFile>>} log
+ */
+const printLatestChatSnapshot = log => {
+  const latestChatSnapshot = [...log.events]
+    .reverse()
+    .find(event => event.kind === 'chatMessages');
+  console.log('');
+  console.log('latest chat messages:');
+  if (!latestChatSnapshot) {
+    console.log('<none logged>');
+    return;
+  }
+  console.log(JSON.stringify(latestChatSnapshot.value, null, 2));
+};
+
+/**
+ * @param {Awaited<ReturnType<typeof run>>} report
+ * @param {ReturnType<typeof parseArgs>} options
+ */
+const printReport = (report, options) => {
+  console.log(`Endo state: ${report.statePath}`);
+  console.log(`Workers found: ${report.workerCount}`);
+  console.log(`Logs included: ${report.includedLogCount}`);
+
+  for (const log of report.logs) {
+    console.log('');
+    console.log(`== ${log.label || log.id} (${log.id}) ==\n${log.logPath}`);
+    if (log.createdAt) {
+      console.log(`createdAt: ${log.createdAt}`);
+    }
+    console.log(
+      `signals: ${log.signalCount}, errors: ${log.errorCount}, parsed JSON events: ${log.events.length}`,
+    );
+    if (log.matchedAgent) {
+      const sliceStart = log.lineOffset + 1;
+      const sliceEnd = log.lineOffset + log.lineCount;
+      console.log(
+        `agent slice: ${log.matchedAgent} (lines ${sliceStart}-${sliceEnd})`,
+      );
+    }
+
+    if (options.summary) {
+      console.log('');
+      printSummary(summarizeLog(log));
+      if (options.tools) {
+        printToolInvocations(log);
+      }
+      if (options.chat) {
+        printLatestChatSnapshot(log);
+      }
+      continue;
+    }
+
+    if (options.tools) {
+      printToolInvocations(log);
+      if (options.chat) {
+        printLatestChatSnapshot(log);
+      }
+      continue;
+    }
+
+    for (const finding of log.toolFindings) {
+      console.log(`[${finding.severity}] L${finding.line}: ${finding.message}`);
+    }
+
+    for (const window of log.windows) {
+      console.log(`-- lines ${window.startLine}-${window.endLine}`);
+      for (const line of window.lines) {
+        console.log(`${String(line.line).padStart(5, ' ')} ${line.text}`);
+      }
+    }
+    if (options.chat) {
+      printLatestChatSnapshot(log);
+    }
+  }
+};
+
+/**
+ * Strip large in-memory fields before serializing to JSON. Keeps the output
+ * machine-readable but prevents the multi-megabyte LLM payloads from
+ * dominating the dump.
+ *
+ * @param {Awaited<ReturnType<typeof run>>} report
+ */
+const toJsonSafe = report => ({
+  ...report,
+  logs: report.logs.map(log => {
+    const { lines: _lines, events: _events, eventSummary, ...rest } = log;
+    return { ...rest, events: eventSummary };
+  }),
+});
+
+const main = async () => {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage);
+    return;
+  }
+
+  const report = await run(options);
+  if (options.json) {
+    console.log(JSON.stringify(toJsonSafe(report), null, 2));
+  } else {
+    printReport(report, options);
+  }
+};
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/fae/scripts/smoke.test.js
+++ b/packages/fae/scripts/smoke.test.js
@@ -1,0 +1,1132 @@
+// @ts-check
+/* global process, setTimeout, Buffer */
+/* eslint-disable no-await-in-loop, no-console */
+
+/**
+ * End-to-end smoke test (manual; not in CI) for the `@endo/fae`
+ * agent's tool-calling pipeline.  One shared Endo daemon per test
+ * file, one factory (and provider record) per model under test,
+ * per-test fae agent, per-test `FAE_CWD`, no provider-error cascade,
+ * and a postmortem emitted from `test.afterEach.always`.
+ *
+ * The five test bodies (basic-chat, reply-tool, timestamp, math,
+ * read-file) are each registered as a `test.macro` and replayed once
+ * per entry in `LAL_MODELS` (default: `[LAL_MODEL]`), so a
+ * multi-model run yields one AVA row per `(test, model)` pair.
+ *
+ * # Why this file is under `scripts/` rather than `test/`
+ *
+ * AVA's default file globs do not match `scripts/*.test.js` because
+ * the package's `ava.files` config restricts auto-discovery to
+ * `test/**\/*.test.*`. That keeps `yarn test` — including the CI
+ * `turbo run test` invocation — from picking the smoke test up.  The
+ * smoke runner is invoked explicitly via `yarn smoke`, which passes
+ * this file as a positional argument to AVA.
+ *
+ * # CI gate
+ *
+ * Even invoked explicitly, the suite skips itself when `LAL_AUTH_TOKEN`
+ * is unset (the typical CI condition), so the file can be safely run
+ * under `ava` in environments without LLM credentials.
+ *
+ * # Prerequisites
+ *
+ * - `.env` in `packages/fae/` with `LAL_HOST`, `LAL_AUTH_TOKEN`, and
+ *   either `LAL_MODEL` (single-model run, today's default) or
+ *   `LAL_MODELS` (comma-separated list, multi-model matrix).  When
+ *   both are set, `LAL_MODELS` wins.
+ * - `SMOKE_REPLY_TIMEOUT_MS=<ms>` overrides the per-reply wait
+ *   (default 30 s).
+ */
+
+import '@endo/init/debug.js';
+
+import anyTest from 'ava';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+import { E } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+import { start, stop, purge, makeEndoClient } from '@endo/daemon';
+
+/**
+ * Per-test mutable context populated by `test.beforeEach` and consumed
+ * by `sendAndAwaitReply` / `test.afterEach.always`.
+ *
+ * `workerLog` is cached at agent-creation time so that parallel tests
+ * each track their own driver worker's log rather than racing on
+ * "most recently modified" heuristics.  May start out empty if the
+ * driver worker has not yet written its log; lookup is retried lazily
+ * inside `sendAndAwaitReply`.
+ *
+ * @typedef {{
+ *   agentName: string,
+ *   fromId: string,
+ *   cwd: string,
+ *   workerLog: string,
+ *   postmortem: null | { logPath: string, baseline: number, logTail: string },
+ * }} TestCtx
+ */
+
+const test = /** @type {import('ava').TestFn<TestCtx>} */ (anyTest);
+
+const dirname = url.fileURLToPath(new URL('..', import.meta.url));
+const factorySpecifier = new URL('../agent.js', import.meta.url).href;
+const readFileSpecifier = new URL('../tools/read-file.js', import.meta.url)
+  .href;
+const greetSpecifier = new URL('../tools/greet.js', import.meta.url).href;
+const mathSpecifier = new URL('../tools/math.js', import.meta.url).href;
+const timestampSpecifier = new URL('../tools/timestamp.js', import.meta.url)
+  .href;
+
+// ---------------------------------------------------------------------------
+// Paths and constants
+// ---------------------------------------------------------------------------
+
+const SMOKE_TMP = path.join(dirname, 'tmp', 'smoke');
+const SMOKE_STATE = path.join(SMOKE_TMP, 'state');
+const SMOKE_RUN = path.join(SMOKE_TMP, 'run');
+const SMOKE_CACHE = path.join(SMOKE_TMP, 'cache');
+const SMOKE_SOCK =
+  process.platform === 'win32'
+    ? String.raw`\\?\pipe\endo-fae-smoke.sock`
+    : path.join(SMOKE_RUN, 'endo.sock');
+// `STATE_PATH` is the directory the daemon writes worker state into.
+// `start()` lays out `<statePath>/worker/<sha>/worker.log` directly
+// under the configured `statePath`, with no intermediate `endo/` segment.
+// The postmortem command pastes `STATE_PATH` verbatim into
+// `yarn debug:llm --state=…`, so it has to match what the daemon uses.
+const STATE_PATH = SMOKE_STATE;
+const WORKER_ROOT = path.join(STATE_PATH, 'worker');
+
+// Default 90s per reply.  Free-tier providers can take more than 30s
+// on attachment-driven multi-turn flows even when the tool sequence is
+// healthy, so keep enough room for provider variance while still
+// failing real stalls in finite time.  Override `SMOKE_REPLY_TIMEOUT_MS`
+// when a lane needs a different budget.
+const REPLY_TIMEOUT_MS =
+  Number(process.env.SMOKE_REPLY_TIMEOUT_MS) > 0
+    ? Number(process.env.SMOKE_REPLY_TIMEOUT_MS)
+    : 90_000;
+const POLL_INTERVAL_MS = 500;
+
+// ---------------------------------------------------------------------------
+// Env preflight
+// ---------------------------------------------------------------------------
+//
+// Mirror `provider-setup.sh`'s `set -a; source .env` so any shared config
+// (FAE_CWD, etc.) is visible to this process.  Read synchronously at module
+// load so the skip decision below can use the result.
+
+const loadEnvSync = () => {
+  const envPath = path.join(dirname, '.env');
+  let text;
+  try {
+    text = fsSync.readFileSync(envPath, 'utf8');
+  } catch {
+    return;
+  }
+  for (const line of text.split('\n')) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m && !process.env[m[1]]) {
+      process.env[m[1]] = m[2].trim();
+    }
+  }
+};
+loadEnvSync();
+
+/**
+ * Models under test, in registration order.  `LAL_MODELS=a,b,c` opts
+ * into the matrix; otherwise the single `LAL_MODEL` is used (today's
+ * default).  Empty / whitespace-only entries are dropped.
+ */
+const MODELS = (() => {
+  const raw = process.env.LAL_MODELS;
+  if (raw) {
+    return raw
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+  }
+  return process.env.LAL_MODEL ? [process.env.LAL_MODEL] : [];
+})();
+
+const HAS_LLM_CONFIG = !!(
+  process.env.LAL_AUTH_TOKEN &&
+  process.env.LAL_HOST &&
+  MODELS.length > 0
+);
+
+if (!HAS_LLM_CONFIG) {
+  console.error(
+    '[smoke] LAL_AUTH_TOKEN/LAL_HOST/(LAL_MODEL or LAL_MODELS) not set ' +
+      '— skipping smoke suite',
+  );
+}
+
+/**
+ * Reduce a model identifier (e.g. `anthropic/claude-haiku-4-5`) to a
+ * pet-name-safe slug.  Used to disambiguate the provider value and
+ * factory caplet that each model gets in the daemon's host petstore.
+ *
+ * @param {string} modelName
+ * @returns {string}
+ */
+const modelSlug = modelName =>
+  modelName
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase() || 'model';
+
+// Tests within an AVA file run concurrently by default; this file
+// relies on per-test agent isolation (`createAgent` + per-test
+// `fromId` filter + per-test `FAE_CWD`) and on the retry helper
+// below to absorb provider rate-limit hits without serialising.
+// `test.skip` registers the test as skipped at module load when no
+// LLM credentials are configured (CI gate).  Hooks below also bail
+// out when `HAS_LLM_CONFIG` is false so the daemon never starts.
+const smokeTest = HAS_LLM_CONFIG ? test : test.skip;
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers (postmortem worker-log tailing)
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} metaText
+ * @returns {string}
+ */
+const parseLabel = metaText => {
+  try {
+    const { label } = /** @type {{ label?: string }} */ (JSON.parse(metaText));
+    return typeof label === 'string' ? label : '';
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * Locate the `worker.log` that captures every agent's `[fae]` /
+ * `[tool]` / `[LAL]` chat output.  Fae's `createAgent` launches the
+ * driver caplet via `makeUnconfined` (`agent.js:661`), which runs in
+ * the daemon's `host` worker — so every test's chat events land in
+ * the same `host`-labelled worker log rather than the per-agent guest
+ * profile workers.  Tests baseline by file offset and read only the
+ * bytes written after their send, which keeps the per-test postmortem
+ * clean despite the shared backing file (the suite is `--serial`,
+ * so no interleaving).
+ *
+ * The agentName argument is unused now but kept for call-site
+ * compatibility — future per-agent workers would still be discovered
+ * here.
+ *
+ * @param {string} agentName
+ * @returns {Promise<string | undefined>}
+ */
+// eslint-disable-next-line no-unused-vars
+const findDriverWorkerLog = async agentName => {
+  const targetLabel = 'host';
+  let entries;
+  try {
+    entries = await fs.readdir(WORKER_ROOT, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const dir = path.join(WORKER_ROOT, entry.name);
+      const metaPath = path.join(dir, 'worker.meta.json');
+      const metaText = await fs.readFile(metaPath, 'utf8').catch(() => '');
+      if (metaText) {
+        const label = parseLabel(metaText);
+        if (label === targetLabel) {
+          return path.join(dir, 'worker.log');
+        }
+      }
+    }
+  }
+  return undefined;
+};
+
+/** @param {string} filePath */
+const offsetOf = async filePath => {
+  try {
+    return (await fs.stat(filePath)).size;
+  } catch {
+    return 0;
+  }
+};
+
+/**
+ * @param {string} filePath
+ * @param {number} fromOffset
+ * @returns {Promise<string>}
+ */
+const readSince = async (filePath, fromOffset) => {
+  const stat = await fs.stat(filePath);
+  if (stat.size <= fromOffset) return '';
+  const fh = await fs.open(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(stat.size - fromOffset);
+    await fh.read(buf, 0, buf.length, fromOffset);
+    return buf.toString('utf8');
+  } finally {
+    await fh.close();
+  }
+};
+
+/**
+ * Shell-quote `value` for safe inclusion in a single-line command.
+ * @param value
+ */
+const shellQuote = (/** @type {string} */ value) =>
+  `'${value.replace(/'/g, "'\\''")}'`;
+
+/**
+ * Build the shared `yarn debug:llm ...` prefix that slices the host
+ * worker log to one test's agent. Append a view flag (`--tools`,
+ * `--summary`, `--chat`) to get a complete command.
+ *
+ * @param {string} logPath
+ * @param {string} agentName
+ */
+const formatDebugBaseCommand = (logPath, agentName) => {
+  const sha = path.basename(path.dirname(logPath));
+  return [
+    'yarn debug:llm',
+    `--state=${shellQuote(STATE_PATH)}`,
+    `--worker=${sha}`,
+    `--agent=${agentName}`,
+  ].join(' ');
+};
+
+/**
+ * Build the debug commands suggested in the postmortem, one per useful
+ * view (tool calls, summary, chat). Each line is independently
+ * copy-pasteable.
+ *
+ * @param {string} logPath
+ * @param {string} agentName
+ */
+const formatPostmortemCommands = (logPath, agentName) => {
+  const base = formatDebugBaseCommand(logPath, agentName);
+  return [
+    `[smoke] postmortem for agent "${agentName}":`,
+    `  tool calls:  ${base} --tools`,
+    `  summary:     ${base} --summary`,
+    `  chat:        ${base} --chat`,
+  ].join('\n');
+};
+
+// ---------------------------------------------------------------------------
+// Inbox helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of `StampedMessage` that this file inspects. The daemon
+ * exposes a richer type, but it is not exported in a way that's
+ * convenient to import here.
+ *
+ * @typedef {{
+ *   number: bigint,
+ *   type: string,
+ *   from: string,
+ *   messageId?: string,
+ *   replyTo?: string,
+ *   names?: string[],
+ *   strings?: string[],
+ * }} InboxMessage
+ */
+
+/** @param {number} ms */
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+/**
+ * Reconstruct the internal `<formulaNumber>:<nodeNumber>` formula id
+ * from a message's externalized `from` locator
+ * (`endo://<nodeNumber>/?id=<formulaNumber>&type=<formulaType>`).
+ * `host.identify(name)` returns the internal form (see
+ * `formula-identifier.js:94`'s `formatId`), and `mail.js:160-162`
+ * externalizes `from`/`to` to URL form before `listMessages` returns
+ * them, so a direct `m.from === fromId` comparison can never match.
+ *
+ * Mirrors `daemon/src/locator.js`'s `internalizeLocator` without
+ * pulling its non-public export into the test.
+ *
+ * @param {string} fromUrl
+ * @returns {string | undefined}
+ */
+const extractFormulaId = fromUrl => {
+  if (typeof fromUrl !== 'string') return undefined;
+  try {
+    const parsed = new URL(fromUrl);
+    const number = parsed.searchParams.get('id');
+    const node = parsed.host;
+    if (!number || !node) return undefined;
+    return `${number}:${node}`;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Split a prompt around `@<kebab-name>` markers into the
+ * `(strings, edgeNames)` shape `host.send` expects.  The recipient's
+ * inbox renderer (`src/inbox-message-format.js`) interleaves
+ * `strings[i]` with `@${names[i]}` and appends an "Attached references"
+ * block listing each edge name with the exact `adoptTool(...)` call to
+ * use; without it the agent sees the `@petname` as bare prose and
+ * loops on `No reference named "X" in message` errors.
+ *
+ * Edge names are reused verbatim as pet-name lookups in the sender's
+ * namespace — the smoke harness registers every tool under its own
+ * kebab-case pet name, so the same identifier works on both sides.
+ *
+ * @param {string} prompt
+ * @returns {{ strings: string[], edgeNames: string[] }}
+ */
+const parsePromptForEdgeNames = prompt => {
+  const re = /@([a-z][a-z0-9-]*)/g;
+  const strings = [];
+  const edgeNames = [];
+  let cursor = 0;
+  let m = re.exec(prompt);
+  while (m !== null) {
+    strings.push(prompt.slice(cursor, m.index));
+    edgeNames.push(m[1]);
+    cursor = re.lastIndex;
+    m = re.exec(prompt);
+  }
+  strings.push(prompt.slice(cursor));
+  return { strings, edgeNames };
+};
+
+class SmokeReplyTimeoutError extends Error {}
+
+/**
+ * Resolve when a message satisfying `predicate` lands in HOST's inbox,
+ * or reject after `timeoutMs`.
+ *
+ * @param {object} host
+ * @param {(msg: InboxMessage) => boolean} predicate
+ * @param {number} timeoutMs
+ */
+const waitForMessage = async (host, predicate, timeoutMs) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const messages = /** @type {InboxMessage[]} */ (
+      await E(host).listMessages()
+    );
+    const hit = messages.find(predicate);
+    if (hit) return hit;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new SmokeReplyTimeoutError(
+    `Timed out after ${timeoutMs}ms waiting for inbox message`,
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Shared daemon + factory state
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {{
+ *   host: any,
+ *   factoriesByModel: Map<string, any>,
+ *   cancel: (e: Error) => void,
+ *   cancelled: Promise<unknown>,
+ * }} SharedCtx
+ */
+
+/** @type {SharedCtx | null} */
+let shared = null;
+
+const daemonConfig = {
+  statePath: SMOKE_STATE,
+  ephemeralStatePath: SMOKE_RUN,
+  cachePath: SMOKE_CACHE,
+  sockPath: SMOKE_SOCK,
+  pets: new Map(),
+  values: new Map(),
+};
+
+const setupDaemon = async () => {
+  await fs.mkdir(SMOKE_TMP, { recursive: true });
+  await fs.mkdir(SMOKE_STATE, { recursive: true });
+  await fs.mkdir(SMOKE_RUN, { recursive: true });
+  await fs.mkdir(SMOKE_CACHE, { recursive: true });
+  console.log(`[smoke] state path: ${STATE_PATH}`);
+
+  // Bind the gateway to an OS-assigned port so it cannot collide with
+  // the user's main daemon (which usually holds 8920).
+  process.env.ENDO_ADDR = '127.0.0.1:0';
+  await purge(daemonConfig);
+  await start(daemonConfig);
+
+  const { reject: cancel, promise: cancelled } = makePromiseKit();
+  const { getBootstrap } = await makeEndoClient(
+    'fae-smoke',
+    daemonConfig.sockPath,
+    cancelled,
+    undefined,
+    {
+      // Two `console.error` lines fire during a clean teardown that
+      // the default `onReject` in `daemon/src/connection.js` would
+      // otherwise log unconditionally:
+      //
+      //   1. `stop()` calls `terminate()` on the daemon, which
+      //      rejects the daemon-side cancellation with
+      //      `Error('Termination requested')` (`daemon.js:2810`).
+      //      The error message rides back over CapTP and our
+      //      client's `onReject` fires with it.
+      //   2. Our own `shared.cancel(Error('teardown'))` in
+      //      `test.after.always` similarly trips `onReject`.
+      //
+      // The `onReject` callback is a local JS function (CapTP
+      // invokes it in-process; it never crosses the wire), so a
+      // text-match on the rejection's message is enough to filter
+      // those two shutdown signals.  Errors that cross CapTP arrive
+      // as passable records (`{ '@@error': true, message, ... }`),
+      // not native `Error` instances, so the filter checks
+      // `.message` on either shape.  Other CapTP-level errors that
+      // occur during a live test still log via the `else` branch.
+      onReject: err => {
+        const msg =
+          err && typeof err === 'object' && typeof err.message === 'string'
+            ? err.message
+            : String(err);
+        if (msg === 'Termination requested' || msg === 'teardown') {
+          return;
+        }
+        console.error('CapTP fae-smoke exception:', err);
+      },
+    },
+  );
+  const bootstrap = getBootstrap();
+  const host = /** @type {any} */ (E(bootstrap).host());
+
+  // Build one provider value + factory caplet per model under test.
+  // Each factory binds to its own `llm-provider` reference (set in the
+  // factory's petstore via `storeIdentifier`), so agents created
+  // through `factoriesByModel.get(modelName)` chat against that model.
+  // The shape stored at each provider name matches what
+  // `llm-provider-factory.js` would have stored after a form submit.
+  const factoriesByModel = new Map();
+  for (const modelName of MODELS) {
+    const slug = modelSlug(modelName);
+    const providerName = `provider-${slug}`;
+    const factoryName = `fae-factory-${slug}`;
+    const factoryGuestName = `${factoryName}-handle`;
+    const factoryAgentName = `profile-for-${factoryGuestName}`;
+
+    await E(host).storeValue(
+      harden({
+        host: process.env.LAL_HOST,
+        model: modelName,
+        authToken: process.env.LAL_AUTH_TOKEN,
+      }),
+      providerName,
+    );
+
+    const providerId = /** @type {string} */ (
+      await E(host).identify(providerName)
+    );
+    await E(host).provideGuest(factoryGuestName, {
+      introducedNames: harden({ '@agent': 'host-agent' }),
+      agentName: factoryAgentName,
+    });
+    const factoryPowers = await E(host).lookup(factoryAgentName);
+    await E(factoryPowers).storeIdentifier('llm-provider', providerId);
+    await E(host).makeUnconfined('@main', factorySpecifier, {
+      powersName: factoryAgentName,
+      resultName: factoryName,
+    });
+    const factory = await E(host).lookup(factoryName);
+    factoriesByModel.set(modelName, factory);
+    console.log(`[smoke] factory ready for model "${modelName}"`);
+  }
+
+  // Shared tools — every per-test agent reaches them via `@tool-name`
+  // adoption, so we only register them once.  The filesystem-rooted
+  // `read-file` tool is created per-test (it needs a per-test FAE_CWD).
+  await E(host).makeUnconfined('@main', greetSpecifier, {
+    resultName: 'greet-tool',
+  });
+  await E(host).makeUnconfined('@main', mathSpecifier, {
+    resultName: 'math-tool',
+  });
+  await E(host).makeUnconfined('@main', timestampSpecifier, {
+    resultName: 'timestamp-tool',
+  });
+
+  shared = { host, factoriesByModel, cancel, cancelled };
+};
+
+// ---------------------------------------------------------------------------
+// AVA hooks
+// ---------------------------------------------------------------------------
+
+test.before(async t => {
+  if (!HAS_LLM_CONFIG) return;
+  await setupDaemon();
+  t.log(`smoke daemon ready at ${SMOKE_SOCK}`);
+});
+
+test.after.always(async () => {
+  if (!HAS_LLM_CONFIG) return;
+  // Order matches `daemon/test/gateway.test.js`'s teardown: stop the
+  // daemon first, then cancel the client.  Cancelling before the
+  // daemon has shut down races with CapTP teardown.  Pre-attaching
+  // `.catch` on `cancelled` keeps Node's unhandled-rejection handler
+  // quiet for the teardown rejection itself; the client's custom
+  // `onReject` (set in `setupDaemon`) filters the matching CapTP
+  // shutdown-noise lines.
+  await stop(daemonConfig).catch(() => undefined);
+  if (shared) {
+    shared.cancelled.catch(() => {});
+    shared.cancel(Error('teardown'));
+  }
+  delete process.env.ENDO_ADDR;
+});
+
+/**
+ * Per-test setup: mkdtemp a scratch FAE_CWD and initialise the test's
+ * `t.context` shell.  Agent creation is deferred to `provisionAgent`,
+ * which the macro body calls once it knows which model to bind to.
+ *
+ * The temp dir is created here (not in `provisionAgent`) so that
+ * `test.afterEach.always` can rm it even if a macro throws before
+ * provisioning.
+ */
+test.beforeEach(async t => {
+  if (!HAS_LLM_CONFIG) return;
+
+  const slug = t.title
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+    .slice(0, 60);
+  const cwd = await fs.mkdtemp(path.join(SMOKE_TMP, `cwd-${slug}-`));
+  t.context = {
+    agentName: '',
+    fromId: '',
+    cwd,
+    workerLog: '',
+    postmortem: null,
+  };
+});
+
+/**
+ * Create a fresh fae agent against the factory bound to `modelName`,
+ * populate `t.context.{agentName, fromId, workerLog}`, and drain the
+ * agent's `Fae agent ready.` boot announcement so it is not mistaken
+ * for the reply to the macro's first send.
+ *
+ * @param {import('ava').ExecutionContext<TestCtx>} t
+ * @param {string} modelName
+ */
+const provisionAgent = async (t, modelName) => {
+  if (!shared) throw new Error('shared daemon ctx not initialised');
+  const factory = shared.factoriesByModel.get(modelName);
+  if (!factory) {
+    throw new Error(
+      `No factory registered for model "${modelName}". ` +
+        `Available: ${[...shared.factoriesByModel.keys()].join(', ') || '(none)'}`,
+    );
+  }
+
+  const slug = t.title
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+    .slice(0, 60);
+  const agentName = `fae-${slug}-${Date.now().toString(36)}`;
+  t.context.agentName = agentName;
+
+  await E(factory).createAgent(agentName, harden({}));
+
+  // The host stores the agent's guest under `agentName` (`agent.js:621,
+  // 632-634`), so `identify` returns the guest's formula id — the same
+  // value the agent stamps as `from` on outbound messages (mailbox
+  // `selfId`).  Determining it deterministically here lets parallel
+  // tests filter their replies without racing over "Fae agent ready."
+  // announcements landing in HOST's shared inbox.
+  t.context.fromId = /** @type {string} */ (
+    await E(shared.host).identify(agentName)
+  );
+  t.context.workerLog = (await findDriverWorkerLog(agentName)) ?? '';
+
+  await waitForMessage(
+    shared.host,
+    m =>
+      m.type === 'package' &&
+      extractFormulaId(m.from) === t.context.fromId &&
+      Array.isArray(m.strings) &&
+      m.strings.some(s => /Fae agent ready\./i.test(s)),
+    REPLY_TIMEOUT_MS,
+  );
+
+  t.log(
+    `created agent "${agentName}" model=${modelName} ` +
+      `fromId=${t.context.fromId.slice(0, 12)}…`,
+  );
+};
+
+const FRESH_AGENT_ATTEMPTS = 2;
+
+/**
+ * Re-run one smoke scenario on a fresh agent when a live provider call
+ * never returns.  A wedged agent cannot process a second prompt, so
+ * retrying the send alone is ineffective.
+ *
+ * @template T
+ * @param {import('ava').ExecutionContext<TestCtx>} t
+ * @param {string} modelName
+ * @param {() => Promise<T>} run
+ */
+const runWithFreshAgentRetries = async (t, modelName, run) => {
+  for (let attempt = 1; attempt <= FRESH_AGENT_ATTEMPTS; attempt += 1) {
+    await provisionAgent(t, modelName);
+    try {
+      return await run();
+    } catch (error) {
+      if (
+        !(error instanceof SmokeReplyTimeoutError) ||
+        attempt === FRESH_AGENT_ATTEMPTS
+      ) {
+        throw error;
+      }
+      t.log(
+        `reply timeout on attempt ${attempt}/${FRESH_AGENT_ATTEMPTS}; ` +
+          'retrying the smoke case with a fresh agent',
+      );
+    }
+  }
+  throw new Error('unreachable');
+};
+
+test.afterEach.always(async t => {
+  if (!HAS_LLM_CONFIG) return;
+  const { cwd, postmortem, agentName } = t.context;
+  if (cwd) {
+    await fs.rm(cwd, { recursive: true, force: true });
+  }
+  if (!postmortem) return;
+  const { logPath, logTail } = postmortem;
+
+  if (t.passed) {
+    if (logPath && agentName) {
+      t.log(`log: ${logPath}`);
+      t.log(
+        `tool calls: ${formatDebugBaseCommand(logPath, agentName)} --tools`,
+      );
+    }
+    return;
+  }
+
+  if (logTail) {
+    console.error('--- worker.log tail (last 4 KB) ---');
+    console.error(logTail.slice(-4096));
+    console.error('--- end worker.log tail ---');
+  }
+  if (logPath && agentName) {
+    console.error(formatPostmortemCommands(logPath, agentName));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// sendAndAwaitReply
+// ---------------------------------------------------------------------------
+
+/**
+ * Send `prompt` to the test's agent and resolve to its next reply.
+ * Filters on `t.context.fromId` so parallel tests don't pick up each
+ * other's replies from HOST's shared inbox.
+ *
+ * @param {import('ava').ExecutionContext<TestCtx>} t
+ * @param {string} prompt
+ */
+const sendOnce = async (t, prompt) => {
+  if (!shared) throw new Error('shared daemon ctx not initialised');
+  const { agentName, fromId } = t.context;
+
+  // Resolve the driver worker's log path lazily on the first send: a
+  // freshly-created driver may not yet have written `worker.log` when
+  // `beforeEach` ran.  Once resolved, the path is stable across the
+  // test's remaining sends.
+  if (!t.context.workerLog) {
+    t.context.workerLog = (await findDriverWorkerLog(agentName)) ?? '';
+  }
+  const { workerLog } = t.context;
+  const logBaseline = workerLog ? await offsetOf(workerLog) : 0;
+  t.context.postmortem = {
+    logPath: workerLog,
+    baseline: logBaseline,
+    logTail: '',
+  };
+
+  const before = /** @type {InboxMessage[]} */ (
+    await E(shared.host).listMessages()
+  );
+  const inboxBaseline = before.length ? before[before.length - 1].number : 0n;
+
+  const { strings, edgeNames } = parsePromptForEdgeNames(prompt);
+  t.log(
+    `send to ${agentName} (workerLog=${workerLog ? 'found' : 'missing'}) ` +
+      `strings=${strings.length} edgeNames=${
+        edgeNames.length ? edgeNames.join(',') : '(none)'
+      } fromId=${fromId.slice(0, 12)}…`,
+  );
+  await E(shared.host).send(agentName, strings, edgeNames, edgeNames);
+  const afterSend = /** @type {InboxMessage[]} */ (
+    await E(shared.host).listMessages()
+  );
+  const sentPackage = afterSend.find(
+    m =>
+      m.number > inboxBaseline &&
+      m.type === 'package' &&
+      m.replyTo === undefined &&
+      JSON.stringify(m.strings ?? []) === JSON.stringify(strings) &&
+      JSON.stringify(m.names ?? []) === JSON.stringify(edgeNames),
+  );
+  if (!sentPackage?.messageId) {
+    throw new Error('Could not identify sent smoke package in host inbox');
+  }
+
+  let reply;
+  try {
+    reply = await waitForMessage(
+      shared.host,
+      m =>
+        m.number > sentPackage.number &&
+        m.type === 'package' &&
+        m.replyTo === sentPackage.messageId,
+      REPLY_TIMEOUT_MS,
+    );
+  } catch (err) {
+    const after = /** @type {InboxMessage[]} */ (
+      await E(shared.host).listMessages()
+    );
+    const candidates = after.filter(m => m.number > inboxBaseline);
+    t.log(
+      `waitForMessage timed out after ${REPLY_TIMEOUT_MS}ms; ` +
+        `${candidates.length} new inbox message(s) since baseline ${inboxBaseline}; ` +
+        `none matched replyTo=${sentPackage.messageId.slice(0, 12)}…`,
+    );
+    for (const m of candidates.slice(-5)) {
+      t.log(
+        `  · #${m.number} type=${m.type} from=${String(m.from).slice(0, 20)}… ` +
+          `strings=${JSON.stringify((m.strings ?? []).map(s => s.slice(0, 60)))}`,
+      );
+    }
+    throw err;
+  }
+
+  const logTail =
+    workerLog && (await offsetOf(workerLog)) > logBaseline
+      ? await readSince(workerLog, logBaseline)
+      : '';
+  t.context.postmortem = { logPath: workerLog, baseline: logBaseline, logTail };
+
+  const text = Array.isArray(reply.strings)
+    ? reply.strings.join('')
+    : String(reply);
+  return { text, logTail };
+};
+
+// ---------------------------------------------------------------------------
+// Provider-error classification + retry
+// ---------------------------------------------------------------------------
+//
+// Tests run in parallel within the file, which can briefly push past
+// the LLM provider's per-second / per-minute rate-limit bucket
+// (e.g. ≈ 1 req/s on free-tier OpenRouter, 50 req/min on Anthropic
+// free tier).  Provider clients in `packages/lal/providers/` do not
+// retry on 429 — the error propagates straight into the reply text.
+// We classify the reply and retry transient hits with exponential
+// backoff + jitter; permanent errors (auth, invalid key) fail
+// immediately without burning the retry budget.
+
+const PROVIDER_PERMANENT_RE = /invalid_api_key|authentication_error|\b401\b/i;
+const PROVIDER_TRANSIENT_RE =
+  /\b429\b|Rate limit exceeded|insufficient_quota|temporar(y|ily)/i;
+
+/** @param {string} replyText */
+const isPermanentProviderError = replyText =>
+  PROVIDER_PERMANENT_RE.test(replyText);
+
+/** @param {string} replyText */
+const isTransientProviderError = replyText =>
+  !isPermanentProviderError(replyText) && PROVIDER_TRANSIENT_RE.test(replyText);
+
+const RETRY_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 1500;
+const RETRY_JITTER_MS = 500;
+
+/**
+ * Send `prompt` and retry the send when the reply looks like a
+ * transient provider error (429 / quota / rate-limit / temporary).
+ * Permanent errors are returned to the caller so the test fails fast.
+ *
+ * @param {import('ava').ExecutionContext<TestCtx>} t
+ * @param {string} prompt
+ */
+const sendAndAwaitReply = async (t, prompt) => {
+  /** @type {{ text: string, logTail: string }} */
+  let last = { text: '', logTail: '' };
+  for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt += 1) {
+    last = await sendOnce(t, prompt);
+    if (!isTransientProviderError(last.text)) return last;
+    if (attempt < RETRY_ATTEMPTS - 1) {
+      const wait =
+        RETRY_BASE_DELAY_MS * 2 ** attempt +
+        Math.floor(Math.random() * RETRY_JITTER_MS);
+      t.log(
+        `transient provider error (attempt ${attempt + 1}/${RETRY_ATTEMPTS}); ` +
+          `backing off ${wait}ms: ${last.text.slice(0, 120)}`,
+      );
+      await sleep(wait);
+    }
+  }
+  return last;
+};
+
+/**
+ * Fail the current test if the reply is a provider error that the
+ * retry loop above could not recover from — either an auth/permanent
+ * error or a transient error that survived all retries.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} replyText
+ */
+const failOnProviderError = (t, replyText) => {
+  if (isPermanentProviderError(replyText)) {
+    t.fail(`provider auth error: ${replyText.slice(0, 200)}`);
+  } else if (isTransientProviderError(replyText)) {
+    t.fail(
+      `provider rate-limit / quota error survived ${RETRY_ATTEMPTS} retries: ${replyText.slice(
+        0,
+        200,
+      )}`,
+    );
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Test macros (replayed once per model in `REGISTRATION_MODELS`)
+// ---------------------------------------------------------------------------
+//
+// Each macro:
+//   1. Calls `provisionAgent(t, modelName)` to bind `t.context` to a
+//      fresh agent against the factory for `modelName`.
+//   2. Runs the test body.
+//   3. Renders its AVA row title as `<test-name> [<modelName>]` so each
+//      `(test, model)` pair is a distinct row in `--list-tests` and in
+//      the TAP / postmortem output.
+
+const basicChatMacro = test.macro({
+  /**
+   * @param {import('ava').ExecutionContext<TestCtx>} t
+   * @param {string} modelName
+   */
+  exec: async (t, modelName) => {
+    await runWithFreshAgentRetries(t, modelName, async () => {
+      const { text, logTail } = await sendAndAwaitReply(
+        t,
+        'Smoke test: please reply with the single word "ack" and nothing else.',
+      );
+      t.log(`reply: ${text.slice(0, 200)}`);
+      failOnProviderError(t, text);
+      t.regex(text.toLowerCase(), /ack/, 'reply should contain "ack"');
+      t.truthy(logTail, 'worker.log tail should be captured');
+    });
+  },
+  title: (provided, modelName) => `basic-chat [${modelName}]`,
+});
+
+const replyToolMacro = test.macro({
+  /**
+   * @param {import('ava').ExecutionContext<TestCtx>} t
+   * @param {string} modelName
+   */
+  exec: async (t, modelName) => {
+    await runWithFreshAgentRetries(t, modelName, async () => {
+      const { text, logTail } = await sendAndAwaitReply(
+        t,
+        'Smoke test: please respond with a brief hello.',
+      );
+      t.log(`reply: ${text.slice(0, 200)}`);
+      failOnProviderError(t, text);
+      t.truthy(logTail, 'worker.log tail should be captured');
+      t.regex(
+        logTail,
+        /\[tool\] reply\(/,
+        'worker.log should show `[tool] reply(...)`',
+      );
+    });
+  },
+  title: (provided, modelName) => `reply-tool [${modelName}]`,
+});
+
+const timestampMacro = test.macro({
+  /**
+   * @param {import('ava').ExecutionContext<TestCtx>} t
+   * @param {string} modelName
+   */
+  exec: async (t, modelName) => {
+    await runWithFreshAgentRetries(t, modelName, async () => {
+      const { text, logTail } = await sendAndAwaitReply(
+        t,
+        'Here is a timestamp tool @timestamp-tool. ' +
+          'Adopt it, then call it and tell me the current ISO time in your reply.',
+      );
+      t.log(`reply: ${text.slice(0, 200)}`);
+      failOnProviderError(t, text);
+      t.truthy(logTail, 'worker.log tail should be captured');
+      const usedTimestampCapability =
+        /\[tool\] timestampTool\(/.test(logTail) ||
+        /\[tool\] exec\(\{code:".*timestamp-tool/s.test(logTail);
+      t.true(
+        usedTimestampCapability,
+        'worker.log should show timestamp-tool capability use',
+      );
+      // The daemon-side `[tool] X -> "…"` line is emitted by `agent.js`
+      // when the tool returns; the model cannot fabricate it.  The exact
+      // format the tool returns depends on the `timezone` argument the
+      // model passes — under SES, `Date.prototype.toLocaleString` falls
+      // back to `Date.prototype.toString()` output because `Intl` is
+      // unavailable, so the result is not necessarily ISO.  Asserting on
+      // the model's ISO-formatted reply (below) covers the end-to-end
+      // requirement without coupling to the tool's per-arg output shape.
+      const sawTimestampResult =
+        /\[tool\] timestampTool -> "[^"]*\d{4}[^"]*"/.test(logTail) ||
+        /\[tool\] exec -> .*?\d{4}/.test(logTail);
+      t.true(
+        sawTimestampResult,
+        'worker.log should show a timestamp result containing a year',
+      );
+      t.regex(
+        logTail,
+        /\[tool\] adoptTool\([^\n]*timestamp-tool/,
+        'worker.log should show `[tool] adoptTool(...)` for timestamp-tool',
+      );
+      t.regex(
+        text,
+        /\d{4}-\d{2}-\d{2}/,
+        'reply should contain an ISO-ish date',
+      );
+    });
+  },
+  title: (provided, modelName) => `timestamp [${modelName}]`,
+});
+
+const mathMacro = test.macro({
+  /**
+   * @param {import('ava').ExecutionContext<TestCtx>} t
+   * @param {string} modelName
+   */
+  exec: async (t, modelName) => {
+    await runWithFreshAgentRetries(t, modelName, async () => {
+      const { text, logTail } = await sendAndAwaitReply(
+        t,
+        'Here is a math tool @math-tool. ' +
+          'Adopt it, then use it to compute 7 * 6 and reply with just the number.',
+      );
+      t.log(`reply: ${text.slice(0, 200)}`);
+      failOnProviderError(t, text);
+      t.truthy(logTail, 'worker.log tail should be captured');
+      const usedMathCapability =
+        /\[tool\] mathTool\(/.test(logTail) ||
+        /\[tool\] exec\(\{code:".*math-tool/s.test(logTail);
+      t.true(
+        usedMathCapability,
+        'worker.log should show math-tool capability use',
+      );
+      t.regex(text, /\b42\b/, 'reply should contain "42"');
+    });
+  },
+  title: (provided, modelName) => `math [${modelName}]`,
+});
+
+const readFileMacro = test.macro({
+  /**
+   * @param {import('ava').ExecutionContext<TestCtx>} t
+   * @param {string} modelName
+   */
+  exec: async (t, modelName) => {
+    await runWithFreshAgentRetries(t, modelName, async () => {
+      if (!shared) throw new Error('shared daemon ctx not initialised');
+      // The read-file tool's root is fixed at creation, so for per-test
+      // isolation we create one rooted at this test's mkdtemp FAE_CWD.
+      // The tool's petname is unique per test so adoption picks it up by
+      // name rather than colliding with siblings.
+      const toolName = `read-file-${t.context.agentName}`;
+      await E(shared.host).makeUnconfined('@main', readFileSpecifier, {
+        resultName: toolName,
+        env: harden({ FAE_CWD: t.context.cwd }),
+      });
+
+      const sentinelName = 'fae-smoke-sentinel.json';
+      const sentinelToken = `FAE_SMOKE_${Date.now().toString(36)}`;
+      await fs.writeFile(
+        path.join(t.context.cwd, sentinelName),
+        JSON.stringify({ token: sentinelToken }, null, 2),
+      );
+
+      const adoption = await sendAndAwaitReply(
+        t,
+        `Here is a read-file tool @${toolName}. ` +
+          `Adopt it, then reply with the single word "adopted".`,
+      );
+      t.log(`adoption reply: ${adoption.text.slice(0, 200)}`);
+      failOnProviderError(t, adoption.text);
+      t.regex(
+        adoption.logTail,
+        /\[tool\] adoptTool\(/,
+        'worker.log should show `[tool] adoptTool(...)`',
+      );
+
+      const reply = await sendAndAwaitReply(
+        t,
+        `Read "${sentinelName}" and tell me the value of ` +
+          `the "token" field exactly as it appears.`,
+      );
+      t.log(`reply: ${reply.text.slice(0, 200)}`);
+      failOnProviderError(t, reply.text);
+      const usedReadFileCapability =
+        /\[tool\] readFile\S*\(/.test(reply.logTail) ||
+        new RegExp(String.raw`\[tool\] exec\(\{code:".*${toolName}`, 's').test(
+          reply.logTail,
+        );
+      t.true(
+        usedReadFileCapability,
+        'worker.log should show read-file capability use',
+      );
+      t.true(
+        reply.text.includes(sentinelToken),
+        `reply should contain the sentinel token "${sentinelToken}"`,
+      );
+    });
+  },
+  title: (provided, modelName) => `read-file [${modelName}]`,
+});
+
+// ---------------------------------------------------------------------------
+// Macro registration
+// ---------------------------------------------------------------------------
+//
+// One AVA row per `(macro, modelName)` pair.  When `HAS_LLM_CONFIG`
+// is false `smokeTest === test.skip`, so the rows register but never
+// run.  If neither `LAL_MODEL` nor `LAL_MODELS` is set `MODELS` is
+// empty and the loop registers nothing — AVA will note the file as
+// "no tests", which is the right answer for a fully unconfigured run.
+
+for (const modelName of MODELS) {
+  smokeTest(basicChatMacro, modelName);
+  smokeTest(replyToolMacro, modelName);
+  smokeTest(timestampMacro, modelName);
+  smokeTest(mathMacro, modelName);
+  smokeTest(readFileMacro, modelName);
+}

--- a/packages/fae/test/channel-mention.test.js
+++ b/packages/fae/test/channel-mention.test.js
@@ -7,7 +7,8 @@
  * replies in the channel (not to inbox).
  *
  * Requires a running LLM — reads config from packages/lal/.env or
- * the environment.  NOT part of the automated suite; run manually:
+ * the environment. Excluded from the default `yarn test` glob in
+ * packages/fae/package.json; run manually:
  *
  *   cd packages/fae && npx ava test/channel-mention.test.js --timeout=120s
  */

--- a/packages/fae/test/mock-provider-fixtures.test.js
+++ b/packages/fae/test/mock-provider-fixtures.test.js
@@ -1,0 +1,145 @@
+// @ts-check
+
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import fs from 'node:fs';
+import url from 'node:url';
+
+import { findMockTrace, makeMockProvider } from '@endo/lal/providers/index.js';
+import { makeMockPowers } from '@endo/lal/tools/mock-powers.js';
+
+import { spawnWorkerLoop } from '../agent.js';
+import { make as makeRealMathTool } from '../tools/math.js';
+
+const fixturePath = url.fileURLToPath(
+  new URL('../../lal/test/fixtures/llm-provider-traces.json', import.meta.url),
+);
+
+const loadFixtures = () => JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+/**
+ * Derive the ordered list of tool names actually invoked across all
+ * rounds of a fixture trace. Used to check that the static
+ * `expectedToolNames` declaration stays in sync with the trace data.
+ *
+ * @param {ReturnType<typeof findMockTrace>} trace
+ * @returns {string[]}
+ */
+const actualToolCallNames = trace =>
+  (trace.rounds || []).flatMap(round => {
+    const toolCalls =
+      /** @type {{ function: { name: string } }[]} */ (
+        /** @type {any} */ (round.response.message).tool_calls
+      ) || [];
+    return toolCalls.map(call => call.function.name);
+  });
+
+// Wrap the real math tool (packages/fae/tools/math.js) so a change to its
+// schema or arithmetic actually surfaces here. Wrapping is only to capture
+// each execute() call for assertions; semantics come from the real tool.
+const makeTrackedMathTool = executions => {
+  const realTool = makeRealMathTool(undefined);
+  return harden({
+    schema: () => realTool.schema(),
+    async execute(args) {
+      executions.push(args);
+      return realTool.execute(args);
+    },
+    help: () => realTool.help(),
+  });
+};
+
+// Marked test.failing because the fixture's adoption + tool-turn flow
+// is fully wired only by endojs/endo-but-for-bots#298's attachment-driven
+// tool-turn hardening; on this PR the worker loop does not yet drive the
+// replayed trace to completion.
+test.failing(
+  'current fixture replays Fae attachment adoption through mock provider',
+  async t => {
+    const trace = findMockTrace(loadFixtures(), 'fae.current.math-tool');
+    t.deepEqual(
+      actualToolCallNames(trace),
+      trace.expectedToolNames,
+      'fixture rounds should invoke exactly the declared expectedToolNames',
+    );
+
+    /** @type {Array<Record<string, unknown>>} */
+    const toolExecutions = [];
+    const mathTool = makeTrackedMathTool(toolExecutions);
+    const attachments = new Map([['math-tool-id', mathTool]]);
+
+    const initialMessage = harden({
+      number: 1,
+      type: 'package',
+      from: '@host',
+      to: 'lal-self-id',
+      messageId: 'mock-fae-msg-1',
+      strings: [
+        'Here is a math tool ',
+        '. Adopt it, then use it to compute 7 * 6 and reply with just the number.',
+      ],
+      names: ['math-tool'],
+      ids: ['math-tool-id'],
+    });
+
+    const { powers, sent, adoptions } = makeMockPowers({
+      initialMessage,
+      attachments,
+    });
+
+    await spawnWorkerLoop(powers, null, {
+      provider: makeMockProvider({ trace }),
+    });
+
+    t.deepEqual(adoptions, [
+      { messageNumber: '1', edgeName: 'math-tool', petName: 'tools/math-tool' },
+    ]);
+    t.deepEqual(toolExecutions, [{ b: 6, a: 7, operation: 'multiply' }]);
+
+    const replies = sent.filter(record => record.replyTo !== undefined);
+    t.true(
+      replies.some(reply =>
+        /** @type {string[]} */ (reply.strings).join('').includes('42'),
+      ),
+      'fixture should drive Fae to reply with the math result',
+    );
+  },
+);
+
+test('fixtures capture current prompt improvement over llm tip', async t => {
+  const fixtures = loadFixtures();
+  const before = findMockTrace(fixtures, 'fae.llm-tip.math-tool');
+  const after = findMockTrace(fixtures, 'fae.current.math-tool');
+
+  const beforeRounds = before.rounds || [];
+  const afterRounds = after.rounds || [];
+  const beforeCall = /** @type {any} */ (beforeRounds[0].response.message)
+    .tool_calls[0];
+  const afterCall = /** @type {any} */ (afterRounds[0].response.message)
+    .tool_calls[0];
+  t.is(beforeCall.function.name, 'adoptTool');
+  t.is(afterCall.function.name, 'adoptTool');
+  t.is(JSON.parse(beforeCall.function.arguments).edgeName, 'math');
+  t.is(JSON.parse(afterCall.function.arguments).edgeName, 'math-tool');
+});
+
+// Marked test.failing because the assertion targets the *intended*
+// behavior: with a sufficiently descriptive prompt the model should
+// adopt the actual attachment edge ("math-tool"), not guess at a
+// shorter name ("math"). The fae.llm-tip.math-tool fixture captures
+// what the older prompt actually produced, so this assertion will
+// fail until somebody re-captures the trace against a newer model or
+// prompt. Keeping it as test.failing documents the prompt fix that
+// landed in the fae.current.math-tool fixture without forcing a
+// hidden skip.
+test.failing(
+  'older prompt without attached-references block adopts the right edge',
+  async t => {
+    const before = findMockTrace(loadFixtures(), 'fae.llm-tip.math-tool');
+    const beforeRounds = before.rounds || [];
+    const beforeCall = /** @type {any} */ (beforeRounds[0].response.message)
+      .tool_calls[0];
+    t.is(JSON.parse(beforeCall.function.arguments).edgeName, 'math-tool');
+  },
+);

--- a/packages/fae/tsconfig.json
+++ b/packages/fae/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "*.js",
+    "scripts",
     "src",
     "tools",
     "test"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1948,6 +1948,7 @@ __metadata:
     "@endo/patterns": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     ava: "catalog:dev"
+    c8: "catalog:dev"
     eslint: "catalog:dev"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Five commits on `packages/fae`:

1. `test(fae): exclude live channel-mention test from default ava glob` — separates the always-live test from the default `yarn test` glob; run manually via `npx ava test/channel-mention.test.js`.
2. `feat(fae): support deterministic provider replay via DI` — `spawnWorkerLoop` accepts an injected provider.
3. `test(fae): add provider fixture replay test` — uses the lal `MockProvider` to replay fixture traces. The full attachment-adoption case is `test.failing` here; passes after the attachment-driven tool-turn hardening lands.
4. `test(fae): add end-to-end smoke coverage` — `scripts/smoke.test.js` against a real LLM provider.
5. `feat(fae): add smoke postmortem tooling` — `scripts/debug-llm-logs.js`.

### Security Considerations

Smoke scripts hit external LLM APIs when run live; excluded from the default `yarn test` glob.

### Scaling Considerations

N/A.

### Documentation Considerations

`.env.example` documents the API keys the live smoke runs require.

### Testing Considerations

Default `yarn test` stays self-contained. Smoke runs via `yarn test scripts/smoke.test.js` with credentials.

### Compatibility Considerations

DI hook on `spawnWorkerLoop` is additive.

### Upgrade Considerations

N/A. `fae` is unpublished.