### PR TITLE
docs(designs): daemon mount and git capability plans

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -1,8 +1,23 @@
 # Endo Design Documents
 
-*Last updated: 2026-05-20 (full grooming pass: milestone-totals reconciled to current table contents, calibration round 2026-05-20 added, Summary by Milestone and Gantt re-projected, Progress-as-of refreshed; landed on top of the 2026-05-19 status-only sweep that reconciled Status fields with shipped state on `llm`, M½ project-hygiene milestone extracted from M1, endopi raft added, PR #302 consolidation absorbed, and patterns-diagnostic-feedback added; forge-gap-analysis Reference design added 2026-05-20)*
+*Last updated: 2026-05-20 (daemon mount and git capability plans added — three new design docs revised per design-panel review: structured-result-shape migration deferred to Phase 7, `tree(ref)` and `readOnly()` both live on the `Git` cap, `NativeGitBackend` hardening envelope split off the essential `GitBackend` contract, `EndoMountBacking` pinned to a hidden Exo facet, credential-injection mechanism named, native git pinned to >=2.30, restart-mid-operation tests added, open-question debt reduced from 20 to 2; landed on top of the same-day forge-gap-analysis Reference design and the same-day full grooming pass that reconciled milestone-totals, added the 2026-05-20 calibration round, re-projected the Summary by Milestone and Gantt, and refreshed Progress-as-of; itself landed on top of the 2026-05-19 status-only sweep that reconciled Status fields with shipped state on `llm`, M½ project-hygiene milestone extracted from M1, endopi raft added, PR #302 consolidation absorbed, and patterns-diagnostic-feedback added)*
 
 *Recently added or revised:
+[daemon-mount-capabilities](daemon-mount-capabilities.md) (added
+2026-05-18, revised 2026-05-20; concrete completion plan for
+`EndoMount`, mount-scoped entry descriptors as values, snapshotting,
+and trusted physical-backing provenance as a hidden Exo facet),
+[daemon-git-capability](daemon-git-capability.md) (added 2026-05-18,
+revised 2026-05-20; revised git design over `EndoMount` /
+`EndoMountFile`; `tree(ref)` for historical reads and `readOnly()`
+for attenuation both live on the `Git` cap; `NativeGitBackend`
+hardening envelope split off the essential `GitBackend` contract;
+structured result shapes deferred to Phase 7),
+[daemon-git-remotes](daemon-git-remotes.md) (added 2026-05-18, revised
+2026-05-20; MVP remote-git companion for fetch, pull, push, bounded HTTPS
+transport, phase-conditional endpoint policy (formula-owned in Phase 1;
+controller-owned once Phase 5 lands), and non-extractable
+credentials with a `GIT_ASKPASS`-fed-by-anonymous-pipe injection mechanism),
 [patterns-diagnostic-feedback](patterns-diagnostic-feedback.md) (added
 2026-05-19, revised 2026-05-20; opt-in
 `@endo/patterns/explain-mismatch.js` submodule with a Rust-compiler-style
@@ -85,8 +100,11 @@ LLM-agent stack).*
 | [daemon-checkin-checkout](daemon-checkin-checkout.md) | 2026-03-17 | 2026-05-19 | **Complete** |
 | [daemon-capability-filesystem](daemon-capability-filesystem.md) | 2026-02-15 | 2026-05-19 | Reference |
 | [daemon-content-store-gc](daemon-content-store-gc.md) | 2026-03-20 | 2026-05-08 | **Complete** |
+| [daemon-git-capability](daemon-git-capability.md) | 2026-05-18 | 2026-05-20 | Proposed |
+| [daemon-git-remotes](daemon-git-remotes.md) | 2026-05-18 | 2026-05-21 | Proposed |
 | [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-05-19 | In Progress (PR #287) |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-05-19 | In Progress |
+| [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-05-20 | Proposed |
 | [filesystem-watchers](filesystem-watchers.md) | 2026-05-07 | 2026-05-07 | Not Started |
 | [platform-fs](platform-fs.md) | 2026-03-18 | 2026-05-19 | **Complete** |
 | [daemon-capability-persona](daemon-capability-persona.md) | 2026-02-16 | 2026-02-24 | Not Started |
@@ -179,7 +197,7 @@ LLM-agent stack).*
 | [namehub-interface-unification](namehub-interface-unification.md) | 2026-05-07 | 2026-05-07 | Proposed |
 | [forge-gap-analysis](forge-gap-analysis.md) | 2026-05-20 | 2026-05-20 | Reference (exploratory) |
 
-**Totals:** 39 Complete/Implemented, 18 In Progress, 36 Not Started, 17 Proposed, 2 Active, 7 Reference, 2 Deprecated, 1 Superseded (122 designs). Refreshed 2026-05-19 by a status-only sweep (consolidating the 2026-05-18 sweep with the 2026-05-19 batch update for 11 additional designs from closed PR #302) plus the patterns-diagnostic-feedback and ocapn-noise-session-reconnect Proposed entries; the 12-design jump in Complete/Implemented over the 2026-05-08 snapshot reflects shipped work whose Status field had not previously been updated, not new completions in this pass; see the corresponding "## Status" sections in each design file for evidence pointers (commit SHA or PR number). Totals reflect the 11 design files added on `llm` since the sweep's branch point (the endopi raft of `endopi` + 8 `endopi-*` gap-closing designs plus `hardened-text-codecs-shim` and `hardened-url-shim`) plus namehub-interface-unification (Proposed) added by PR #117 on rebase, plus forge-gap-analysis (Reference) added 2026-05-20.
+**Totals:** 39 Complete/Implemented, 18 In Progress, 36 Not Started, 20 Proposed, 2 Active, 7 Reference, 2 Deprecated, 1 Superseded (125 designs). Refreshed 2026-05-19 by a status-only sweep (consolidating the 2026-05-18 sweep with the 2026-05-19 batch update for 11 additional designs from closed PR #302) plus the patterns-diagnostic-feedback and ocapn-noise-session-reconnect Proposed entries; the 12-design jump in Complete/Implemented over the 2026-05-08 snapshot reflects shipped work whose Status field had not previously been updated, not new completions in this pass; see the corresponding "## Status" sections in each design file for evidence pointers (commit SHA or PR number). Totals reflect the 16 design files added on `llm` since the sweep's branch point (the endopi raft of `endopi` + 8 `endopi-*` gap-closing designs, `hardened-text-codecs-shim`, `hardened-url-shim`, namehub-interface-unification (Proposed) added by PR #117 on rebase, forge-gap-analysis (Reference) added 2026-05-20, and the daemon mount and git capability trio: `daemon-mount-capabilities` + `daemon-git-capability` + `daemon-git-remotes`).
 
 ## Roadmap
 
@@ -300,6 +318,9 @@ flowchart TD
         pfs[platform-fs<br/><i>COMPLETE</i>]
         dfs[daemon-capability-filesystem<br/><i>REFERENCE</i>]
         dmount[daemon-mount<br/><i>IN PROGRESS</i>]
+        dmcap[daemon-mount-capabilities]
+        dgit[daemon-git-capability]
+        dgitremote[daemon-git-remotes]
         dfsw[filesystem-watchers]
         dcsgc[daemon-content-store-gc]
         dpers[daemon-capability-persona]
@@ -307,10 +328,15 @@ flowchart TD
         icancel[inventory-cancel-and-liveness]
         pfs --> dfs
         pfs --> dmount
+        dmount --> dmcap
+        dmcap --> dgit
+        dgit --> dgitremote
         pfs --> dci
         pfs --> dfsw
         dmount --> dfsw
         dmount --> dtools
+        dgitremote --> dtools
+        enetfetch --> dgitremote
         dmount --> dcsgc
         dsand --> dbank
         dfs --> dbank
@@ -401,6 +427,9 @@ capabilities available to agents.
 | daemon-capability-filesystem | Reference | `Dir`/`File` capabilities sketch retained as reference; narrower mount slice ships via daemon-mount |
 | ~~daemon-content-store-gc~~ | **Complete** | Content-store pruning and scratch-mount directory cleanup at GC time; landed in PR #99 |
 | daemon-mount | In Progress | Phases 1-3, 5 on `llm` (commit `e22f71327`); symlink confinement, 20 integration tests; Phase 4 (sub-mounts, snapshot) in PR #135 open, mount extensions in PR #127 open, `followNameChanges` in PR #277 open |
+| daemon-mount-capabilities | Proposed | Complete `EndoMount`: snapshot bridge, mount-scoped descriptors, `makeFile` sibling, entry overloads on `has`/`stat`/`lookup`, trusted backing provenance |
+| daemon-git-capability | Proposed | Revised git design over `EndoMount` / `EndoMountEntry`; `tree(ref)` and `readOnly()` both live on the `Git` cap |
+| daemon-git-remotes | Proposed | MVP remote-git companion: fetch / pull / push composed from local `Git`, bounded HTTPS transport, endpoint policy, and credential caps |
 | filesystem-watchers | Not Started | `EndoMount.followNameChanges` parity with `EndoDirectory`; Node `fs.watch` adapter on `FilePowers` |
 | daemon-locator-terminology | Not Started | Clean locator API; unblocked |
 | daemon-rename-to-manager | Not Started | Rename `daemon.js`/`Daemon`/`MignonicPowers` to `manager.js`/`Manager`/`WorkerPowers` to align JS with Rust `endor` nomenclature |

--- a/designs/daemon-agent-tools.md
+++ b/designs/daemon-agent-tools.md
@@ -3,7 +3,7 @@
 | | |
 |---|---|
 | **Created** | 2026-03-02 |
-| **Updated** | 2026-03-02 |
+| **Updated** | 2026-05-18 |
 | **Author** | Kris Kowal (prompted) |
 | **Status** | Not Started |
 
@@ -27,6 +27,15 @@ This design bridges the capability system designs
 [daemon-capability-bank](daemon-capability-bank.md)) with the concrete
 tools an AI agent uses for coding assistance. It defines the tool
 interface that Lal and Fae register when granted these capabilities.
+
+> **Revision note (2026-05-18):** The later
+> [daemon-mount-capabilities](daemon-mount-capabilities.md),
+> [daemon-git-capability](daemon-git-capability.md), and
+> [daemon-git-remotes](daemon-git-remotes.md) designs refine this sketch:
+> local git authority should derive from `EndoMount`, path authority should
+> flow through mount-scoped descriptors, and remote git should be granted
+> separately through bounded `GitRemote` capabilities rather than omitted
+> from the product model.
 
 ## Design
 
@@ -309,10 +318,10 @@ include capability configuration.
    the same agent code works with or without coding capabilities —
    it simply has fewer tools available.
 
-3. **Git without push.** The `Git` capability deliberately excludes
-   network operations. Pushing requires a separate network capability.
-   This prevents data exfiltration via `git push` to an attacker's
-   remote.
+3. **Git split by authority.** The local `Git` capability deliberately
+   excludes network operations. Fetch / pull / push belong on separately
+   granted remote-git capabilities so product workflows can exist without
+   smuggling network and credential authority into local repository access.
 
 4. **Shell is array-based.** Commands are passed as `(command, args[])`
    tuples, never as shell strings. This prevents shell injection and
@@ -329,6 +338,12 @@ include capability configuration.
   `Dir` and `File` capabilities used by filesystem tools.
 - [daemon-capability-bank](daemon-capability-bank.md) — capability
   framework and category taxonomy.
+- [daemon-mount-capabilities](daemon-mount-capabilities.md) — concrete
+  completion plan for the live mount capability this sketch now builds on.
+- [daemon-git-capability](daemon-git-capability.md) — revised local git
+  design over `EndoMount`.
+- [daemon-git-remotes](daemon-git-remotes.md) — companion remote-git
+  design for fetch, pull, push, and credentialed endpoints.
 - [daemon-os-sandbox-plugin](daemon-os-sandbox-plugin.md) — OS-level
   process confinement for shell execution.
 - [lal-fae-form-provisioning](lal-fae-form-provisioning.md) — form-based

--- a/designs/daemon-git-capability.md
+++ b/designs/daemon-git-capability.md
@@ -1,0 +1,845 @@
+# Daemon Git Capability over EndoMount
+
+| | |
+|---|---|
+| **Created** | 2026-05-18 |
+| **Updated** | 2026-05-20 |
+| **Author** | 0xPatrick (prompted) |
+| **Status** | Proposed |
+
+> **Read in order.**
+> This is doc 2 of 3.
+> It requires [daemon-mount-capabilities](daemon-mount-capabilities.md) (doc 1) as a prerequisite and is required by [daemon-git-remotes](daemon-git-remotes.md) (doc 3).
+
+## Summary
+
+Define a local-git capability `Git` whose authority is derived from an already-authorized `EndoMount` (not from a path string).
+Worktree operations (status / diff / log / add / commit / branch / merge / rebase / stash) and historical tree reads (`tree(ref)`) live on `Git`; `Git.readOnly()` attenuates the cap for read-only auditor agents, matching the `EndoMount.readOnly()` idiom.
+Path-bearing inputs are `EndoMountEntry` values, not free-form strings.
+The first backend is native git (`NativeGitBackend`) on a pinned `git >= 2.30`, with the hardening envelope (sanitized env, askpass-only authentication, allowlist, repo-local-filter rejection) called out separately from the essential `GitBackend` contract so a future JS backend can implement the essential parts without inheriting native-only methods.
+Structured result shapes for diff / show / merge / rebase / stash arrive in a later phase; the first phase returns those as text so consumers can start integrating against the path-bearing inputs immediately.
+
+## What You Should Know First
+
+This document assumes you know the following primitives from [daemon-mount-capabilities](daemon-mount-capabilities.md) (doc 1) in one-line form; the rest of the doc names them without re-introducing them.
+
+- **`EndoMount`** is the daemon's live-mount Exo: confined live access to one physical directory, returns `EndoMountFile` handles, and is structurally compatible with `ReadableTree`.
+- **`EndoMountFile`** is the live mutable-file handle minted by `EndoMount.lookup()`; it is structurally compatible with `ReadableBlob`.
+- **`EndoMountEntry`** is the mount-scoped value-shaped descriptor for a path that may not currently exist on disk; the `Git` capability consumes entries (not free-form path strings) for its path-bearing methods.
+- **`EndoMountBacking`** is the host-private Exo facet on the mount formula that trusted daemon code uses to reach the physical worktree without leaking the path to guests; `provideGit` uses it to verify a mount is physical.
+- **`ReadableTree` / `ReadableBlob`** are the shared read-surface interfaces in [platform-fs](platform-fs.md); `Git.tree(ref)` returns a `ReadableTree`.
+
+## What is the Problem Being Solved?
+
+Agents need useful local git workflows without receiving ambient shell authority, raw host paths, or network authority.
+The earlier [daemon-agent-tools](daemon-agent-tools.md) note sketches a path-scoped `Git` wrapper, and `packages/fae` now has a practical reference implementation of that idea.
+That implementation is useful as a native-git adapter prototype, but its public authority boundary is still a configured repository-root string.
+
+The newer filesystem work changes the right abstraction boundary:
+
+- live worktree authority should come from `EndoMount`;
+- existing live files should be represented by `EndoMountFile`;
+- paths that do not currently have live handles should be represented by mount-scoped descriptors, not ambient strings;
+- immutable commit trees should surface as `ReadableTree` providers inside the broader filesystem model.
+
+This document revises the git design around those facts.
+
+## Goals
+
+1. Define a git capability whose authority is derived from an existing physical worktree mount rather than from an arbitrary path string.
+2. Preserve useful local git workflows without exposing raw git command execution, network operations, or repository configuration mutation.
+3. Make the public API handle-first by using `EndoMount`, `EndoMountFile`, and `EndoMountEntry`.
+4. Distinguish mutable physical-worktree operations from immutable git-tree reads.
+5. Keep the implementation backend swappable so native git, a JS git library, or a future daemon-native backend can share one public capability contract.
+6. Preserve room for bulk native-git data paths, such as `git archive`, so large immutable tree reads do not degenerate into one subprocess or one remote object turn per file.
+
+## Non-Goals
+
+- Defining remote transport, fetch, pull, push, or credential management in this local-worktree document.
+  Those are MVP-relevant, but they require separate network and credential authority and are specified in [daemon-git-remotes](daemon-git-remotes.md).
+- Arbitrary shell access.
+- Raw `git` passthrough.
+- Exposing repository config, hooks, aliases, or arbitrary filters to guests.
+- Making a CAS tree or arbitrary virtual tree behave as a writable git worktree.
+- Replacing the multi-provider filesystem design with git-specific special cases.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [daemon-mount-capabilities](daemon-mount-capabilities.md) | Required prerequisite: snapshot bridge, mount-scoped descriptors, handle-oriented navigation, and trusted backing provenance. |
+| [daemon-mount](daemon-mount.md) | Current physical mount formula implementation. |
+| [platform-fs](platform-fs.md) | Shared `ReadableTree` / `SnapshotTree` vocabulary for git tree exposure. |
+| [daemon-capability-filesystem](daemon-capability-filesystem.md) | Broader multi-provider VFS model including physical and git-tree backends. |
+| [daemon-agent-tools](daemon-agent-tools.md) | Earlier agent-facing sketch to be revised by this design. |
+| [daemon-git-remotes](daemon-git-remotes.md) | Companion MVP design for fetch, pull, push, and credentialed remote use. |
+
+## Current State
+
+### Useful Reference Implementation
+
+The current Fae git tool demonstrates several implementation details worth preserving:
+
+- local-only workflow coverage;
+- explicit operation allowlisting;
+- sanitized git environment;
+- disabled hooks, fsmonitor, external diff, signing, and prompt-based auth;
+- repository-root verification;
+- rejection of repo-local executable filters and merge drivers.
+
+That work should remain useful as a reference for a `NativeGitBackend`.
+
+### What Changes in This Design
+
+| Earlier shape | Revised shape |
+|---|---|
+| Repository root string configured authority | `EndoMount` carries public worktree authority |
+| Path strings were passed into git calls | `EndoMountEntry` values are passed after mount-local resolution |
+| Git only meant commands against a worktree | Git exposes worktree mutation, `tree(ref)` for immutable historical reads, and `readOnly()` for in-place attenuation |
+| Adapter details leaked into the tool design | Public `Git` capability is backend-shaped (native-first), with `NativeGitBackend` named separately |
+
+## Architecture
+
+```mermaid
+flowchart TD
+  host[HOST] -->|provideMount '/repo' 'worktree'| mount[EndoMount]
+  mount -.->|host-private backing grant| gitProvider[Git provider]
+  gitProvider -->|over live worktree| git[Git capability]
+  git -->|tree ref| rt[ReadableTree / ReadableBlob]
+  git -->|readOnly| roGit[Git, attenuated]
+```
+
+The public worktree authority remains the `EndoMount`.
+Trusted daemon code uses a hidden backing grant to prove that the mount is physical and to reach the repository metadata required by the chosen backend.
+
+## Two Git Concerns, Kept Separate
+
+### 1. Physical Worktree Capability
+
+A physical worktree capability is the mutable side:
+
+- status
+- add / restore
+- commit
+- branch switching
+- merge / rebase
+- stash
+
+It requires a real worktree and repository metadata.
+It should be granted only for an `EndoMount` backed by a physical directory that is exactly the repository worktree root.
+
+### 2. Git-Tree Backend
+
+A git-tree backend is the immutable side:
+
+- expose `HEAD^{tree}` or another tree-ish as a read-only filesystem tree;
+- browse source at a commit without mutating the worktree;
+- provide stable inputs for diffs, checkouts, snapshots, or future VFS composition.
+
+The result should implement `ReadableTree`, with blobs implementing `ReadableBlob`.
+Once the VFS compositor exists, git trees become ordinary read-only providers mounted beside physical, memory, and CAS backends.
+
+Keeping these concerns separate avoids forcing immutable commit trees to pretend they can support live worktree mutations.
+
+## Capability Construction
+
+The host flow is capability-derived.
+`provideGit()` takes an `EndoMount` capability as its first argument and a pet name as the second:
+
+```js
+const worktree = await E(host).provideMount('/repo', 'repo-worktree');
+const git = await E(host).provideGit(worktree, 'repo-git');
+```
+
+The `petName` (the second argument, `'repo-git'` in the example above) registers the constructed `Git` capability in the host's name table so the operator can later resolve it back by name (e.g., `await E(host).lookup('repo-git')`).  It is purely a host-side handle for later lookup; the `Git`-deriving authority is the mount cap, not the name.
+
+Cap-passing is the only normative form on `provideGit`.
+Pet-name lookup is not part of this API: an agent-facing CLI or tool adapter that needs to look up a mount by name uses a separate `E(host).lookup(name)` capability (or whatever convenience method the harness layer provides) to resolve the name to a mount cap *before* calling `provideGit`.
+
+`provideGit()`:
+
+1. takes a mount capability;
+2. uses the host-private mount backing grant (see [daemon-mount-capabilities](daemon-mount-capabilities.md) § Host-Private Physical Backing) to prove the mount is physical;
+3. verifies that the physical mount root is exactly a git worktree root;
+4. constructs a `Git` formula / Exo tied to that mount identity;
+5. stores only the formula references required to reconstitute the capability, not a guest-visible free-form path.
+
+The required invariant is that git authority can only be derived from an already-authorized mount.
+There must be no parallel host API that mints local `Git` from a raw path string once the mount model exists; that would reintroduce an independent filesystem authority path beside `EndoMount`.
+
+### Read-only construction paths
+
+`provideGit` accepts either a writable mount or a read-only mount.
+Both construction paths are valid; the invariant the formula enforces is that both produce the **same authority shape internally**:
+
+```js
+const git = await E(host).provideGit(writableMount, 'repo-git');
+// mutable Git
+
+const roGit1 = await E(git).readOnly();
+// read-only Git
+
+const roGit2 = await E(host).provideGit(readOnlyMount, 'repo-git-ro');
+// also read-only Git
+```
+
+Those two read-only `Git` caps expose the same read surface and reject the same mutation methods.
+Read-only state is part of the `Git` capability / formula itself, not just a wrapper convention: `provideGit(readOnlyMount)` constructs a `Git` whose mutability flag is already false; it does **not** briefly mint a writable `Git` and wrap it.
+
+The same backing invariants — same repository-root verification, same backing-storage check — apply on both construction paths.
+Git authority is bounded by the mount it was derived from, and `Git.readOnly()` can only attenuate further; it can never widen.
+
+The same-authority-shape invariant is what makes the repository-identity pin (Design Decision 7) construct-able on a read-only mount in the first place: pinning needs read access to `.git/config` and `git rev-parse` output, and the read-only mount grants exactly that historical-contents read access at construction time.
+See Design Decision 8 § *Two additional boundaries on a read-only `Git`* for the explicit cross-link between read-only mount authority and historical-contents grant, and for the inverse note (callers handing out a read-only `Git` derived from a read-only mount are simultaneously granting historical-contents read access, not just present-worktree read access).
+
+Behavioral boundaries that follow from this same-authority-shape invariant are catalogued in § Design Decision 8 (allowed and rejected operations on a read-only `Git`) and § Design Decision 9 (`Git.readOnly()` idempotence and attenuation semantics).
+`GitRemote` construction from a read-only `Git` is rejected for now, even for `fetch`, because fetching mutates `.git` object and ref state (see `daemon-git-remotes.md` § Capability Construction).
+
+Remote repository use composes later without changing that root:
+
+```mermaid
+flowchart LR
+  mount[EndoMount] --> git[Git]
+  transport[HTTPS transport cap] --> remote[GitRemote]
+  cred[credential cap] --> remote
+  git --> remote
+```
+
+## Proposed Public Vocabulary
+
+### `GitRef`
+
+```ts
+type GitRef = {
+  name: string;
+  kind: 'branch' | 'tag' | 'commit' | 'detached';
+  oid?: string;
+};
+```
+
+### `GitStatusEntry`
+
+```ts
+type GitStatusEntry = {
+  entry: EndoMountEntry;
+  path: string; // mount-relative display copy
+  index:
+    | 'clean'
+    | 'added'
+    | 'modified'
+    | 'deleted'
+    | 'renamed'
+    | 'copied'
+    | 'conflicted';
+  worktree:
+    | 'clean'
+    | 'modified'
+    | 'deleted'
+    | 'untracked'
+    | 'ignored'
+    | 'conflicted';
+  node?: EndoMountFile | EndoMount;
+};
+```
+
+`entry` is the authority-bearing reference.
+`path` is only presentation data.
+`node` is present only when a live worktree object currently exists.
+
+### `GitCommit`
+
+```ts
+type GitCommit = {
+  oid: string;
+  summary: string;
+  author?: string;
+  committedAt?: number;
+};
+```
+
+### `Git`
+
+```ts
+interface Git {
+  // The public filesystem authority this Git capability is tied to.
+  worktree(): EndoMount;
+
+  // Repository inspection.
+  status(): Promise<GitStatusEntry[]>;
+  diff(options?: {
+    cached?: boolean;
+    base?: GitRef | string;
+    head?: GitRef | string;
+    entries?: EndoMountEntry[];
+  }): Promise<string>;
+  log(options?: {
+    maxCount?: number;
+    ref?: GitRef | string;
+  }): Promise<GitCommit[]>;
+  show(ref: GitRef | string): Promise<string>;
+  revParse(ref: GitRef | string): Promise<GitRef>;
+
+  // Worktree and index mutation.
+  add(entries: EndoMountEntry[]): Promise<void>;
+  restore(entries: EndoMountEntry[], options?: { staged?: boolean }):
+    Promise<void>;
+  commit(message: string): Promise<GitCommit>;
+
+  // Branching.
+  currentBranch(): Promise<GitRef | undefined>;
+  branches(): Promise<GitRef[]>;
+  createBranch(name: string, options?: {
+    startPoint?: GitRef | string;
+    switchAfterCreate?: boolean;
+  }): Promise<GitRef>;
+  deleteBranch(name: string, options?: { force?: boolean }): Promise<void>;
+  renameBranch(from: string, to: string): Promise<void>;
+  // Branch checkout and detached-HEAD checkout are separate methods so
+  // the `*Branch` family stays coherent.  switchBranch(name) checks out
+  // a branch by name (matches `git switch <branch>`); detach(ref)
+  // performs a detached-HEAD checkout of any other ref — tag, commit
+  // oid, or arbitrary tree-ish — and matches `git switch --detach
+  // <ref>` / `git checkout --detach <ref>`.
+  switchBranch(name: string): Promise<void>;
+  detach(ref: GitRef | string): Promise<void>;
+
+  // History editing and integration.
+  merge(ref: GitRef | string, options?: { noFastForward?: boolean }):
+    Promise<string>;
+  rebase(input:
+    | { mode: 'start'; upstream: GitRef | string }
+    | { mode: 'continue' }
+    | { mode: 'abort' }
+    | { mode: 'skip' }): Promise<string>;
+
+  // Local stash state.
+  stashPush(options?: {
+    message?: string;
+    entries?: EndoMountEntry[];
+    includeUntracked?: boolean;
+  }): Promise<string>;
+  stashList(): Promise<string[]>;
+  stashShow(index?: number): Promise<string>;
+  stashApply(index?: number): Promise<void>;
+  stashPop(index?: number): Promise<void>;
+  stashDrop(index?: number): Promise<void>;
+
+  // Immutable tree access (one-turn read on the same capability).
+  tree(ref: GitRef | string): Promise<ReadableTree>;
+
+  // Attenuation to a read-only posture.  Mutation methods on the returned
+  // cap throw at runtime in the first implementation phase; the type
+  // narrows to drop them when structured shapes land in Phase 7.
+  readOnly(): Git;
+}
+```
+
+`tree(ref)` returns the read surface defined by `GitTreeProvider` below; the interface name remains as the documented shape of the returned read capability even though tree access lives as a method on `Git` itself.
+
+`readOnly()` mirrors the `EndoMount.readOnly()` attenuation idiom ([daemon-mount-capabilities](daemon-mount-capabilities.md) § Design Decision 6): the returned `Git` exposes the same methods, but the mutation methods (`add`, `restore`, `commit`, `createBranch`, `deleteBranch`, `renameBranch`, `switchBranch`, `detach`, `merge`, `rebase`, `stashPush`, `stashApply`, `stashPop`, `stashDrop`) throw at runtime initially and are narrowed out of the type when structured shapes land (Phase 7).
+A read-only auditor agent holds the attenuated `Git`; the operator hands it `await E(git).readOnly()` rather than the unattenuated cap.
+
+### Alternatives Considered for Tree Access Shape
+
+The design panel recommended splitting tree access off `Git` into a separately-grantable `GitTreeProvider` capability obtained via `git.trees()`.
+Two further shapes were considered.
+The chosen shape (tree on `Git` plus `Git.readOnly()`) was picked for consistency with the existing `EndoMount.readOnly()` idiom and for the one-turn cost on the common case.
+
+| Shape | Pros | Cons |
+|---|---|---|
+| **Chosen: `Git.tree(ref)` plus `Git.readOnly()`** | One-turn read on the common case (caller holds `Git`, wants `tree`).  Matches `EndoMount.readOnly()` idiom.  Read-only auditor is `await E(git).readOnly()` — no new cap shape. | No standalone "tree-only" grant shape: a caller who should only read historical trees still holds an attenuated `Git`, which advertises the read methods it does not care about. |
+| **Considered: split-only (`git.trees() → GitTreeProvider.tree(ref)`)** | Cleanest decomposition: tree-only callers hold a different cap type, not an attenuated parent.  Matches decomplector's "different concerns → different caps" lens. | Two-turn cost on every read (`await E(git).trees()` then `await E(provider).tree(ref)`), unless the holder caches the provider.  No in-place attenuation pattern for the rest of `Git`. |
+| **Considered: both axes (`Git.tree(ref)` + `Git.readOnly()` + separately-grantable `GitTreeProvider` via host shortcut)** | Covers every use case: one-turn tree access for `Git` holders, read-only attenuation posture, and tree-only grants for build systems / archivers that should never see worktree state. | Widest public surface.  Two ways to obtain a tree-reading capability (via `Git.tree(ref)` and via the separately-granted provider) is the kind of accidental complexity creep an implementation later regrets. |
+
+If a real build-system or code-archiver use case surfaces that wants a genuinely tree-only grant (without worktree-method advertisement at all), the implementation can revisit and add the separately-grantable `GitTreeProvider` shape.
+Until then, an attenuated `Git` plus `tree(ref)` covers the auditor case without inventing a new cap type.
+
+The initial implementation can keep some result types textual where the stable structure is not yet worth committing to.
+The path-bearing inputs should not regress back to arbitrary strings.
+
+### Sample Use
+
+```js
+// status the worktree
+const entries = await E(git).status();
+for (const entry of entries) {
+  if (entry.worktree !== 'clean') {
+    console.error(entry.path, entry.worktree);
+  }
+}
+
+// stage a file, commit it
+const readme = await E(worktree).entry('README.md');
+await E(git).add([readme]);
+const commit = await E(git).commit('docs: update README');
+
+// browse a historical tree without touching the worktree
+const headTree = await E(git).tree('HEAD');
+const oldReadme = await E(headTree).lookup('README.md');
+const text = await E(oldReadme).text();
+
+// hand a read-only attenuated Git to an auditor agent
+const auditor = await E(git).readOnly();
+await E(auditor).status();          // ok — read method
+await E(auditor).commit('nope');    // throws — mutation method on read-only
+```
+
+### Structured Result Shapes (Phase 7)
+
+The text-returning methods (`diff`, `show`, `merge`, `rebase`, `stashList`, `stashShow`) ship as `Promise<string>` in the first implementation phase and gain structured-shape siblings in Phase 7 of the Implementation Plan.
+Naming the eventual shapes here lets first-phase consumers plan a clean migration instead of writing a parser they will have to throw away.
+
+```ts
+type GitDiffHunk = {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: Array<{ kind: 'context' | 'add' | 'remove'; text: string }>;
+};
+
+type GitFileDiff = {
+  oldEntry?: EndoMountEntry;
+  newEntry?: EndoMountEntry;
+  oldMode?: number;
+  newMode?: number;
+  status: 'added' | 'modified' | 'deleted' | 'renamed' | 'copied';
+  hunks: GitDiffHunk[];
+  binary?: { oldSizeBytes?: number; newSizeBytes?: number };
+};
+
+type GitDiff = { files: GitFileDiff[] };
+
+type GitShow = {
+  commit: GitCommit;
+  parents: string[];
+  diff: GitDiff;
+};
+
+type GitConflict = {
+  entry: EndoMountEntry;
+  base?: { oid: string };
+  ours: { oid: string };
+  theirs: { oid: string };
+  markerStyle: 'merge' | 'diff3';
+};
+
+type GitMergeResult =
+  | { status: 'up-to-date'; head: GitRef }
+  | { status: 'fast-forward'; head: GitRef }
+  | { status: 'merged'; head: GitRef; merged: GitCommit }
+  | { status: 'conflicts'; conflicts: GitConflict[] };
+
+type GitRebaseResult =
+  | { status: 'completed'; head: GitRef; replayed: GitCommit[] }
+  | { status: 'conflicts'; current: GitCommit; conflicts: GitConflict[] }
+  | { status: 'aborted'; head: GitRef }
+  | { status: 'in-progress'; current: GitCommit };
+```
+
+Phase 7 upgrades the `Git` interface in place; the first phase's text-returning methods move under `*Text()` siblings (`diffText`, `showText`, …) so callers that still want the porcelain output for display can keep it.
+The migration is named in `## Migration Strategy` as a discrete step rather than an ambient "we'll structurally-improve later"; consumers who write against the first phase can flip to the structured shapes by replacing one method call per site.
+
+`stashList`'s structured shape, in the same vein, becomes `Promise<Array<{ index: number; ref: GitRef; message: string; created: GitCommit }>>`.
+It ships as part of the same Phase 7 cut.
+
+## Why `EndoMountEntry` Is Required
+
+`EndoMountFile` is correct for an existing file, but git routinely needs to talk about entries that are not live file handles:
+
+- a tracked file deleted from the worktree;
+- an untracked path before it is created or staged;
+- an index entry absent from the filesystem;
+- a conflict path;
+- a historical path in another tree.
+
+The git API therefore needs mount-relative entry descriptors in addition to live handles.
+Without them, the design inevitably falls back to free-form relative strings and loses the provenance supplied by the mount.
+
+## Git-Tree Backend
+
+### Read Surface
+
+The git-tree backend's read surface is `ReadableTree` (with blobs as `ReadableBlob`).
+`Git.tree(ref)` returns it directly:
+
+```ts
+interface GitTreeProvider {
+  // Documented name for the shape Git.tree(ref) returns when factored
+  // out conceptually; tree access is a method on Git itself, not a
+  // separately-grantable cap.  See § Alternatives Considered for Tree
+  // Access Shape for the trade-off.
+  tree(ref: GitRef | string): Promise<ReadableTree>;
+}
+```
+
+The returned tree should:
+
+- resolve the ref in the repository object database;
+- expose directories as `ReadableTree`;
+- expose blobs as `ReadableBlob`;
+- never expose mutation methods;
+- be usable anywhere a `ReadableTree` is accepted today, including checkin, checkout, staging, and later VFS mounting.
+
+### VFS Integration
+
+When the VFS namespace exists, a host could compose:
+
+```mermaid
+flowchart LR
+  vfs((VFS namespace))
+  vfs --> w["/worktree (physical EndoMount, read-write)"]
+  vfs --> rm["/ref/main (git-tree backend, read-only)"]
+  vfs --> rr["/ref/review (git-tree backend, read-only)"]
+  vfs --> sc["/scratch (memory backend, read-write)"]
+```
+
+The guest sees ordinary filesystem trees.
+Git remains the provider of the immutable revision-backed trees, not a special path syntax inside the VFS.
+
+### Bulk Tree Data Plane
+
+The public read surface should stay `ReadableTree` / `ReadableBlob`, but the native backend should not be limited to the smallest possible git primitive for every use case.
+Lazy browsing can reasonably use commands such as `git ls-tree` and `git cat-file` because an agent may only inspect a handful of entries.
+Whole-tree materialization is different: `storeTree()`, `stageTree()`, checkout-like flows, caplet source import, and future VFS composition may need hundreds or thousands of files from one commit.
+
+For those bulk paths, a native backend should be allowed to amortize the cost of shelling out by streaming a subtree in one operation:
+
+```sh
+git archive --format=tar HASH path/to/thing
+```
+
+or equivalently by resolving the subtree first and archiving that tree-ish.
+Trusted daemon code can then parse the tar stream and feed the content store or scratch-mount writer directly.
+The important point is that the tar stream is a private backend data plane.
+The guest still receives object capabilities and structured results, not host paths, tar bytes, or raw git command authority.
+
+This optimization matters whenever many files from one revision flow into a single sink: importing a commit subtree into content-addressed storage, staging a git tree into a scratch mount, constructing a source archive, indexing many files at once.
+For one-off interactive reads, lazy `lookup()` and blob reads keep latency low and avoid loading data the agent will not use.
+
+The archive path must obey the same authority and validation rules as the rest of the git-tree backend:
+
+- the ref is resolved inside the already-authorized repository;
+- subtree paths are normalized git-tree path segments, not host paths;
+- archive entry names are treated as untrusted input and checked for absolute paths, `..`, NUL bytes, duplicate entries, and unsupported modes;
+- symlink, executable-bit, and directory mode handling is explicit rather than inherited from a host `tar` command;
+- extraction is performed by trusted code into CAS formulas or an authorized scratch mount, never by giving the guest a destination path;
+- archive generation uses argument arrays, not shell interpolation.
+
+Compression is a secondary concern.
+`git archive --format=tar` is already valuable because it batches traversal and file transfer.
+A compressed variant may be useful for storage or network hops, but the first optimization target is reducing process and object-call overhead while preserving the same public capability boundary.
+
+## Backend Boundary
+
+The public `Git` capability is shaped for the native-git backend in [`packages/fae`](../packages/fae)'s existing reference implementation.
+A later JS backend (`isomorphic-git`, an Endo-native HTTP git smart-protocol client, a daemon-local object-database walker) may require contract revisions in a later phase.
+The contract below is best-effort backend-pluggable, not contractually backend-replaceable; methods that turn out to leak native-git assumptions (sanitization, askpass, allowlist rejection) move to a `NativeGitBackend` sub-interface in a later phase if and when that swap actually happens.
+
+```ts
+// Essential backend contract (every backend must satisfy):
+interface GitBackend {
+  assertRepositoryRoot(): Promise<void>;
+  status(): Promise<BackendStatusEntry[]>;
+  diff(...): Promise<string>;
+  add(...): Promise<void>;
+  // ...
+  tree(ref: string): Promise<ReadableTree>;
+}
+
+// Native-git-shaped contract; carries the hardening envelope:
+interface NativeGitBackend extends GitBackend {
+  sanitizeChildEnv(env: Record<string, string>): Record<string, string>;
+  rejectRepoLocalExecutables(): Promise<void>;
+  // …native-only operational surface
+}
+```
+
+The split is deliberate: it names the parts of today's implementation that are accidentally specific to shelling-out, so a future JS backend can implement the essential contract without inheriting hooks that do not apply to it.
+Until that swap actually happens, the only backend in flight is the native one.
+
+### Initial Backend: Native Git
+
+Start with a `NativeGitBackend` because the existing reference tool already proves the hardening envelope and local workflow shape:
+
+- exact worktree-root verification;
+- no shell interpolation;
+- sanitized environment;
+- disabled hooks and external execution paths;
+- explicit operation allowlist;
+- rejection of repo-local executable filters and merge drivers.
+
+This backend uses the host-private physical mount backing, not a path granted to the guest.
+
+#### Native Git Version Pin
+
+The backend pins **`git >= 2.30`** as its minimum supported version (ships with Ubuntu 22.04 LTS, macOS Monterey's git-installable, Homebrew's default, RHEL 9, and Debian 12).
+The load-bearing features that motivate the 2.30 floor — and that a future maintainer considering lowering the floor must replace or work without — are `git status --porcelain=v2` (introduced in 2.11, the stable machine-readable status format the `status()` parser depends on) and `git rev-parse --end-of-options` (introduced in 2.24, the explicit option/positional separator the `revParse()` invocation uses to refuse ref strings that begin with `--`).
+The chosen parsing surfaces are stable across that floor:
+
+- `git status --porcelain=v2 --branch` for `status()` (NUL-terminated with `-z`);
+- `git log --pretty=format:%H%x1f%s%x1f%aN%x1f%aI%x1e` for `log()`;
+- `git diff --raw -z` plus `git diff` (text) for the first `diff()` phase; `git diff --no-color --no-ext-diff` invariants for the structured-shape hunk parser ([§ Structured Result Shapes (Phase 7)](#structured-result-shapes-phase-7));
+- `git for-each-ref --format=...` for `branches()`;
+- `git rev-parse --verify --end-of-options` for `revParse()`;
+- `git ls-tree -z --long` and `git cat-file --batch` for lazy tree reads;
+- `git archive --format=tar` for bulk tree reads.
+
+The startup check runs `git --version` once per daemon instance and refuses to construct a `NativeGitBackend` on hosts whose git is older than the pinned floor.
+Parsers assume the pinned formats; they reject and surface a structured error if a future host's git emits a format the parser does not recognize, rather than degrading silently.
+
+For immutable tree reads, the native backend may expose both a lazy object view and a bulk archive reader internally.
+Callers should not observe which strategy was used except through performance.
+A small `lookup('README.md')` can use `cat-file`; a `storeTree()` over the same revision can use a single archive stream.
+
+### Future Backends
+
+A JS implementation such as an `isomorphic-git`-style backend remains a valid future experiment, especially for commit-tree reads or alternate storage backends.
+Adopting one will sharpen the line between `GitBackend` (essential) and `NativeGitBackend` (native-only) and may surface methods that should move from one to the other.
+Plan for the contract to evolve across phases rather than treating it as frozen.
+
+Evaluation criteria for any future backend:
+
+- support for the required local workflow surface;
+- ability to honor the same confinement and filter/hook restrictions;
+- ability to operate through mount / backend abstractions rather than ambient host paths;
+- ability to provide an efficient bulk tree data plane for large immutable reads, whether by native `git archive`, batched object APIs, or direct object-database traversal;
+- fidelity with native git behavior for merges, rebases, stashes, and index semantics where those operations are exposed.
+
+## Security Model
+
+### Authority Separation
+
+| Capability | Allows |
+|---|---|
+| `EndoMount` | Live worktree filesystem access within one confined root |
+| `Git` | Local repository operations over that worktree |
+| network capability | Remote repository interaction, if separately granted |
+| shell capability | Process execution, if separately granted |
+
+Granting git does not imply shell or network authority.
+
+Remote repository interaction is still required for an agent MVP; it is specified separately in [daemon-git-remotes](daemon-git-remotes.md) so that the extra network and credential authority remains explicit.
+
+### Required Restrictions
+
+- No raw git command passthrough; no public config mutation.
+- No push, pull, fetch, clone, remote mutation, or credential helpers (those live separately on [daemon-git-remotes](daemon-git-remotes.md)).
+- No hooks, aliases, external diff, fsmonitor, textconv, custom filters, merge drivers, or signing helpers unless a future explicit capability design authorizes them.
+- No accepting arbitrary host paths; all path-bearing operations consume `EndoMountEntry` values from the same worktree mount.
+
+### Read-Only and Snapshot Interactions
+
+- A read-only worktree mount may support inspection and immutable tree reads but must reject mutating git operations.
+- `git.tree(ref)` returns immutable read capabilities (a `ReadableTree`); the returned tree never exposes mutation.
+- `git.readOnly()` returns a `Git` whose mutation methods throw; use it to grant an auditor agent inspection authority without the worktree mutation surface.
+- `worktree.snapshot()` remains the way to capture the live worktree into content-addressed snapshot storage.
+
+## Agent-Facing Tool Adapters
+
+`Git` is a capability, not necessarily the exact LLM tool schema.
+Lal, Fae, or Genie can adapt it into tool calls:
+
+- resolve user-entered relative paths through the granted worktree mount;
+- convert those paths immediately into `EndoMountEntry` values;
+- call the git capability with entries;
+- present copied relative paths and structured status data back to the LLM.
+
+The existing Fae git tool can survive as a transitional reference branch and later be replaced by a thin adapter over the proper `Git` capability.
+
+## Implementation Plan
+
+### Phase 0: Mount Prerequisites
+
+Complete the required phases from [daemon-mount-capabilities](daemon-mount-capabilities.md):
+
+- [ ] `snapshot()`;
+- [ ] `EndoMountEntry`;
+- [ ] handle-oriented open/create APIs;
+- [ ] metadata;
+- [ ] host-private physical backing provenance.
+
+### Phase 1: Backend Contract and Formula Skeleton
+
+- [ ] Add `GitBackend` abstraction.
+- [ ] Add `Git` interface guards and types.
+- [ ] Add `git` formula type tying a git capability to a mount formula identity.
+- [ ] Add host method to derive git from an existing physical worktree mount.
+- [ ] Add exact-repository-root verification.
+
+### Phase 2: Local Inspection Surface
+
+- [ ] Implement `worktree`, `status`, `diff`, `log`, `show`, and `revParse`.
+- [ ] Convert backend path results into `EndoMountEntry` values minted from the worktree mount.
+- [ ] Return structured status entries with optional live nodes when available.
+
+### Phase 3: Local Mutation Surface
+
+- [ ] Implement `add`, `restore`, and `commit`.
+- [ ] Implement branch listing / create / delete / rename / `switchBranch` / `detach`.
+- [ ] Enforce read-only mount rejection on all mutation calls.
+- [ ] Port the native hardening checks from the reference implementation into backend tests.
+
+### Phase 4: Integration Workflows
+
+- [ ] Implement merge, rebase, and stash operations.
+- [ ] Define conflict-state reporting and ensure conflict entries are represented by `EndoMountEntry`, not path strings.
+- [ ] Add restart / persistence tests for long-lived git capabilities.
+
+### Phase 5: Git-Tree Reads and Read-Only Attenuation
+
+- [ ] Implement `Git.tree(ref) -> ReadableTree` directly on the `Git` cap (the `GitTreeProvider` shape names the returned read surface).
+- [ ] Implement `Git.readOnly()` returning an attenuated `Git`; mutation methods throw at runtime in this phase and are dropped from the type in Phase 7 alongside the structured-result-shape migration.
+- [ ] Add tests for browsing blobs and subtrees at specific refs.
+- [ ] Add tests for read-only attenuation: every mutation method on a `readOnly()` cap throws; every read method still works.
+- [ ] Verify compatibility with existing checkin / checkout / stage-tree flows.
+- [ ] Add a backend-private bulk tree path for large materialization operations, initially using `git archive --format=tar` if the native backend remains the practical implementation.
+- [ ] Keep the read surface separable enough that, if a build-system or archiver use case surfaces a need for a tree-only-grant cap, the separately-grantable `GitTreeProvider` shape can be added without breaking `Git.tree(ref)` consumers (see § Alternatives Considered for Tree Access Shape).
+
+### Phase 6: Agent Adapters and Migration
+
+- [ ] Replace path-root Fae git provisioning with a thin adapter over granted `Git`.
+- [ ] Add Lal / Genie registration over the capability rather than over process wrappers.
+- [ ] Deprecate direct path-string git tool creation once capability-based provisioning exists.
+- [ ] Update [daemon-agent-tools](daemon-agent-tools.md) to point at the revised model.
+
+### Phase 7: Structured Result Shapes
+
+- [ ] Land the structured shapes named in § Structured Result Shapes (`GitDiff`, `GitFileDiff`, `GitDiffHunk`, `GitShow`, `GitConflict`, `GitMergeResult`, `GitRebaseResult`, structured `stashList`).
+- [ ] Rename the text-returning methods to `*Text` siblings (`diffText`, `showText`, `mergeText`, `rebaseText`, `stashListText`, `stashShowText`) so display consumers can keep the porcelain output.
+- [ ] Drop mutation methods from the type of `readOnly()` cap returns; the runtime-throws behavior from Phase 5 stays as a defense-in-depth check.
+- [ ] Migrate every in-tree consumer of the text methods to the structured shape in the same window; the `*Text` siblings remain available for consumers that still need porcelain.
+
+## Testing Plan
+
+### Capability Tests
+
+- git can only be derived from a physical mount;
+- mount root must equal the actual worktree root;
+- entries from another mount are rejected;
+- read-only mounts reject mutation;
+- no guest-visible method leaks the physical path;
+- **same-authority-shape invariant**: a read-only `Git` obtained via `await E(writableGit).readOnly()` exposes the same read surface and the same throw-on-mutation behavior as a read-only `Git` obtained via `provideGit(readOnlyMount)` — `__getMethodNames__()` returns the same set, and the same mutation methods reject;
+- **`Git.readOnly()` is idempotent**: invoking `readOnly()` on an already-read-only `Git` returns the same cap (or an equivalent read-only cap with the same surface); composing it does not produce nested or differently-attenuated wrappers;
+- **`GitRemote` construction from a read-only `Git` is rejected**: `provideGitRemote({ git: readOnlyGit, ... })` throws with a structured error citing the read-only posture;
+- **`Git.tree(ref)` is allowed on a read-only `Git`** and reads historical repository contents reachable from `ref` (matching the read-only mount's historical-contents grant).
+
+### Workflow Tests
+
+- clean / modified / added / deleted / untracked / conflicted status;
+- add / restore / commit;
+- branch create / `switchBranch` / `detach` / rename / delete;
+- merge, rebase, and stash happy paths plus conflicts;
+- exact behavior after daemon restart;
+- **daemon-restart mid-operation**: kill the daemon during `rebase` (between commits), restart, and confirm `rebase --continue` resumes cleanly from the recorded `.git/rebase-merge` state without orphaning the index;
+- **`.git` replaced under the mount mid-operation**: swap the `.git` directory while a long `merge` is mid-conflict, confirm the next git call rejects the operation with a structured error rather than silently completing against the new repository;
+- **mount-formula identity preserved across restart**: confirm `provideGit()` after restart re-derives the same `Git` cap as before the restart, with the same backing-facet identity check holding.
+
+### Hardening Tests
+
+- reject executable filters;
+- reject merge drivers;
+- ignore hooks and global/system config;
+- disable network-facing operations;
+- reject arbitrary unsupported operations.
+
+### Tree Provider Tests
+
+- browse commit trees;
+- load blobs from historical refs;
+- use git trees as `ReadableTree` inputs to existing snapshot and staging flows;
+- materialize a large subtree through the bulk archive path and confirm it produces the same CAS / scratch-mount result as the lazy tree walk;
+- reject malicious or malformed archive entries during trusted extraction;
+- confirm immutability.
+
+## Migration Strategy
+
+1. Preserve the current Fae implementation as a reference branch and test corpus.
+2. Build the mount prerequisites.
+3. Introduce `Git` (text-returning `diff` / `show` / `merge` / `rebase` / `stashList` / `stashShow`) without removing any existing ad hoc tool immediately.
+4. Move agent adapters onto `Git`.
+5. Retire path-configured wrappers after the capability path is exercised in real workflows.
+6. Land the structured-shape phase (Phase 7 of the Implementation Plan) alongside `*Text` siblings; migrate in-tree consumers to the structured shapes.
+
+## Open Questions
+
+This trio's open-question debt has been resolved into the Design Decisions below.
+No open questions remain on this document; revisit if real implementation surfaces new ones.
+
+### Resolved (recorded as Design Decisions)
+
+- Tree-access shape (`tree(ref)` on `Git` plus `readOnly()` attenuation; separately-grantable `GitTreeProvider` is a documented alternative for future use cases) — decision 3 and § Alternatives Considered for Tree Access Shape.
+- Structured `diff()` shape — decision 6.
+- Structured conflict state in phase 4 — decision 6.
+- Pinning repository identity separately from worktree mount — decision 7.
+- Operations valid over a read-only worktree mount — decision 8.
+- Read-only audit grant shape — decision 9; bulk-path exposure is a backend-private optimization, see decision 10.
+
+## Design Decisions
+
+1. **Git derives from `EndoMount`, by cap-passing.**
+   `provideGit(mountCap, petName)` is the only normative entry point; cap-passing is the only form accepted.
+   Pet-name lookup is not part of `provideGit` itself: agent-facing CLI / tool adapters that need it use a separate `E(host).lookup` capability (or whatever convenience the harness layer provides) to resolve a name to a mount cap before calling `provideGit`.
+   No host API mints local `Git` from a raw path string once the mount model exists.
+2. **Entries, not strings, carry path authority.**
+   Path strings may appear at UI boundaries, but git operations consume mount-minted descriptors.
+3. **Live worktree and immutable trees are separate methods, not separate capabilities.**
+   Mutable worktree operations and `tree(ref)` both live on `Git`; read-only attenuation comes via `Git.readOnly()`, matching the `EndoMount.readOnly()` idiom.
+   An audit-grant for a read-only auditor agent is `await E(git).readOnly()`; the auditor holds an attenuated `Git`.
+   See § Alternatives Considered for Tree Access Shape for the split-capability variant the design panel originally recommended and the rationale for picking attenuation instead.
+4. **Backend choice is best-effort pluggable, not contractually swappable.**
+   The first-phase contract is shaped for the `NativeGitBackend` extracted from `packages/fae`.
+   A future JS backend may force the essential `GitBackend` contract to narrow as native-only methods migrate to `NativeGitBackend`.
+   The contract is allowed to evolve at backend-swap time rather than being treated as frozen.
+5. **No hidden authority expansion.**
+   Git does not imply network or shell access, and a read-only mount does not become writable through git.
+6. **Text first, then structured shapes.**
+   `diff` / `show` / `merge` / `rebase` / `stashList` / `stashShow` return `Promise<string>` in the first implementation phase; the structured-shapes phase (Implementation Plan § Phase 7) introduces the shapes named in § Structured Result Shapes (Phase 7) alongside `*Text` siblings for the porcelain output.
+   Conflict state is modeled structurally from the structured-shapes phase onward (`GitConflict`).
+7. **Pin repository identity separately from the worktree mount.**
+   The git formula records (a) the worktree mount identity AND (b) a repository-identity pin captured at construction time, then verifies the pin before acting on every subsequent operation.
+   This defends against `.git` being replaced under the mount (Open Question #4 in the early draft).
+   Read-only inspection methods log a structured warning and fail-closed if the pin no longer matches.
+
+   **Pin algorithm.**
+   The pin is computed at construction time by reading `git rev-parse --git-common-dir --git-path config --git-path HEAD` inside the worktree, then hashing a canonical tuple of:
+
+   - the absolute `--git-common-dir` (canonicalized, symlinks resolved);
+   - the contents of `<common-dir>/config` at the moment of the pin, excluding mutable-by-design sections (`remote.*.url`, `branch.*.merge`, and similar settings the operator may legitimately edit post-pin without changing repository identity);
+   - the OID of the first commit reachable from HEAD if the repo has commits (`git rev-list --max-count=1 HEAD`), or the sentinel `EMPTY` if the repo is unborn or empty.
+
+   **Edge cases.**
+
+   - **Linked worktrees** (`git worktree add`): the pin uses the `--git-common-dir`, not the `.git`-file's pointer.
+     A worktree-add against the same parent repo therefore pins to the same identity, which is correct: the same git object database serves both worktrees.
+   - **Detached HEAD**: the first-commit OID is used (HEAD's own OID for a detached single-commit case, the rev-list root otherwise); the pin is stable so long as that OID remains reachable.
+   - **Submodules**: the pin is the submodule's own `--git-common-dir`, not the parent repo's.
+     Swapping a submodule's `.git` indirection re-pins (correctly: it is a different repository as far as the submodule's local `Git` cap is concerned).
+   - **Empty / unborn repos**: the `EMPTY` sentinel pins the repository identity to the unborn state.
+     The first guest-initiated `commit` creates a first-commit OID that does not match the `EMPTY` sentinel, so the next pin-verification call fails closed with a structured warning naming the new first-commit OID.
+     The host then re-derives `Git` against the now-non-empty repo to refresh the pin; the guest does not implicitly re-pin by committing.
+     Fail-closed preserves the "guests cannot mutate the pin" invariant unconditionally (Design Decision 5): a guest-initiated commit must not silently widen the repository-identity authority a pin was minted to bound.
+
+   **Re-pinning** is a host-side operation: the host can re-derive `Git` with a refreshed pin.
+   Guests cannot mutate the pin under any path, including the unborn-to-non-empty transition above.
+8. **Read-only worktree mounts permit inspection + immutable trees + `worktree.snapshot()`; reject everything else.**
+   A read-only `Git` can be obtained two ways and the two paths produce the same authority shape (see § Read-only construction paths):
+   - **Writable→readOnly path:** `await E(git).readOnly()` returns a read-only attenuation of a `Git` constructed from a writable mount.
+   - **Read-only-mount-derived path:** `provideGit(readOnlyMount)` constructs a `Git` whose mutability flag is already false; the formula does not briefly mint a writable `Git` and wrap it.
+
+   Allowed on a read-only `Git`: `status`, `diff`, `log`, `show`, `revParse`, `branches`, `currentBranch`, `tree(ref)`, `readOnly()` (idempotent — see Design Decision 9), and `worktree.snapshot()`.
+   Rejected: `add`, `restore`, `commit`, `createBranch`, `deleteBranch`, `renameBranch`, `switchBranch`, `detach`, `merge`, `rebase`, `stashPush`, `stashApply`, `stashPop`, `stashDrop`.
+
+   Two additional boundaries on a read-only `Git`:
+   - `GitRemote` construction from a read-only `Git` is rejected for now.
+     Even `fetch` mutates `.git` object and ref state, so the read-only posture cannot host a remote.
+   - `tree(ref)` is allowed and grants access to historical repository contents reachable from `ref`.
+     That is consistent with the read-only mount granting authority over repository history, but it must be made explicit on the grant: callers handing out a read-only `Git` derived from a read-only mount are simultaneously granting historical-contents read access, not just present-worktree read access.
+9. **Read-only audit grants come via `Git.readOnly()`, not a separate cap shape; the method is idempotent.**
+   The operator hands the auditor `await E(git).readOnly()` and the auditor holds an attenuated `Git` whose mutation methods throw.
+   `Git.readOnly()` is idempotent: invoked on an already-read-only `Git`, it returns the same cap (or an equivalent read-only cap with the same surface); composing `readOnly()` calls does not produce nested or differently-attenuated wrappers.
+   `readOnly()` can only attenuate further, never widen; it is a one-way attenuation operator.
+   No `provideGitReadOnly()` or `provideGitTreeProvider()` host shortcut is part of the design; the readOnly() attenuation is the documented path.
+   If a future use case wants a tree-only-grant cap that hides the worktree methods entirely, the separately-grantable `GitTreeProvider` shape from § Alternatives Considered can be added without breaking existing consumers.
+10. **Bulk reads are a backend data plane.**
+    Large immutable tree operations may use native archive streams internally (see § Bulk Tree Data Plane), but that does not change the guest-visible capability surface; no `stageGitTree()` style guest API exposes the bulk path.

--- a/designs/daemon-git-remotes.md
+++ b/designs/daemon-git-remotes.md
@@ -1,0 +1,810 @@
+# Daemon Git Remotes for Agent MVP
+
+| | |
+|---|---|
+| **Created** | 2026-05-18 |
+| **Updated** | 2026-05-21 |
+| **Author** | 0xPatrick (prompted) |
+| **Status** | Proposed |
+
+> **Read in order.**
+> This is doc 3 of 3.
+> It requires [daemon-mount-capabilities](daemon-mount-capabilities.md) (doc 1) and [daemon-git-capability](daemon-git-capability.md) (doc 2) as prerequisites.
+
+## Summary
+
+Add the remote half of the git story as an explicit composition: local `Git` plus separately authorized HTTPS transport plus non-extractable bearer or basic credentials, bundled into a `GitRemote` capability that agents call directly.
+Credential injection runs through a daemon-shipped `GIT_ASKPASS` helper fed by an anonymous pipe (fd-only, never argv or env).
+CapTP carries control-plane authority (which repo, which endpoint, which credential, which directions and refs) while git packfile bytes travel on the bounded HTTPS data plane outside CapTP messages.
+Endpoint policy is formula-owned in Phase 1; controller-owned once Phase 5 lands.
+The guest receives `GitRemote` only.
+Controllers (`GitRemoteController`, `GitCredentialController`) and collection capabilities (`GitRemoteSet`) land in Phase 5 so the first phase stays minimum.
+
+## What You Should Know First
+
+This document assumes you know the following primitives from [daemon-mount-capabilities](daemon-mount-capabilities.md) (doc 1) and [daemon-git-capability](daemon-git-capability.md) (doc 2) in one-line form; the rest of the doc names them without re-introducing them.
+
+- **`EndoMount`** (doc 1) is the daemon's live-mount Exo: confined live access to one physical directory, returns `EndoMountFile` handles, and is structurally compatible with `ReadableTree`.
+- **`EndoMountEntry`** (doc 1) is the mount-scoped value-shaped descriptor for a path that may not currently exist on disk.
+- **`Git`** (doc 2) is the local-git capability derived from an already-authorized `EndoMount`; remote operations compose `Git` with separately granted transport and credential authorities to form a `GitRemote`.
+- **`Git.readOnly()`** (doc 2) is the in-place attenuation that drops mutation methods; `GitRemote` construction from a read-only `Git` is rejected (even `fetch` mutates `.git` object and ref state).
+- **`GitRef`** (doc 2) is the structured ref descriptor (`{ name, kind: 'branch' | 'tag' | 'commit' | 'detached', oid? }`); `GitRemote` accepts refs in this form or as a string.
+- **`HttpClient`** is the Endo HTTP-transport capability shape used as the bounded outbound-network authority input when constructing a remote (see [cli-http-client](cli-http-client.md) for the full controller/client split).
+
+## What is the Problem Being Solved?
+
+The local-worktree design in [daemon-git-capability](daemon-git-capability.md) deliberately keeps network and credential authority out of the base `Git` capability.
+That is the right authority boundary, but it is not enough for an agent MVP.
+
+A useful coding agent must often:
+
+- inspect remote branches;
+- fetch review updates;
+- pull or integrate upstream changes;
+- push a branch for review;
+- do so without receiving raw credentials or unconstrained network access.
+
+Today, agentic coding tools usually get all of that by inheriting the host user's ambient git configuration, SSH agent, credential helpers, and network stack.
+That posture is incompatible with Endo's capability model.
+We need remote git for the MVP, but we need it as an explicit composition of:
+
+1. local repository authority;
+2. remote endpoint authority;
+3. transport / network authority;
+4. non-extractable credential authority.
+
+This document defines that companion capability.
+
+## Goals
+
+1. Make `fetch`, `pull`, and `push` available for the agent MVP.
+2. Preserve the local `Git` capability's least-authority boundary.
+3. Represent remotes as explicit capabilities or controller-managed bindings, not as mutable strings hidden in repository config.
+4. Let an agent use credentials without ever reading or exporting them.
+5. Allow hosts to grant fetch-only, push-limited, or branch-limited remotes.
+6. Keep endpoint policy, credential policy, and local repository authority independently revocable.
+7. Make the composition visible: local `Git`, outbound transport, and credentials are separate authority inputs.
+8. Clarify how remote operations relate to repository bootstrap / clone.
+9. Keep remote git object transfer out of CapTP's data plane: CapTP should carry authority, invocation, policy, and summaries, while packfile bytes move over a bounded git transport such as HTTPS.
+
+## Non-Goals
+
+- Giving the agent raw network sockets, ambient DNS, or arbitrary `ssh` process execution.
+- Exposing plaintext tokens, SSH private keys, or credential-helper output.
+- Supporting every git transport in the first increment.
+- Replacing local branch / commit / worktree operations in the base `Git` capability.
+- Using mutable `.git/config` as the authority source of record.
+- Tunneling git packfiles through CapTP as the default remote data path.
+
+## Why This Is Separate from Local `Git`
+
+Remote operations add at least two authorities that local git does not need:
+
+| Authority | Why it is distinct |
+|---|---|
+| network transport | `fetch` and `push` communicate outside the daemon boundary |
+| credentials | authenticated remotes must use secrets the agent should not inspect |
+
+Keeping them separate means each authority can be granted, revoked, and audited independently, and a guest with one of them does not implicitly hold the others.
+The local and remote designs ship close together for product reasons but stay separate capabilities for authority-isolation reasons.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [daemon-git-capability](daemon-git-capability.md) | Required local repository capability. |
+| [daemon-mount-capabilities](daemon-mount-capabilities.md) | Required indirectly through local `Git`. |
+| [cli-http-client](cli-http-client.md) | Controller / client split for policy-bearing network capabilities. |
+| [trust-on-first-bind](trust-on-first-bind.md) | Reusable policy-binding pattern for first-seen remote endpoints. |
+| [endoclaw-network-fetch](endoclaw-network-fetch.md) | Earlier HTTP capability note; superseded in part by `cli-http-client`. |
+| [endoclaw-oauth](endoclaw-oauth.md) | Existing non-extractable credential pattern, useful by analogy. |
+| [daemon-capability-bank](daemon-capability-bank.md) | Broader resource-category framing for network, git, and credentials. |
+
+## Capability Model
+
+### Guest-Visible Facets
+
+| Capability | Role |
+|---|---|
+| `Git` | Local repository and worktree authority |
+| `GitRemote` | Authority to use one configured remote endpoint with bounded operations |
+| `GitRemoteSet` | Optional collection capability for named remotes associated with one local `Git` |
+
+### Construction Inputs
+
+| Capability | Role |
+|---|---|
+| HTTPS transport cap | Outbound network authority, initially modeled by `HttpClient`-like origin policy |
+| `BearerCredential` / `BasicCredential` | Non-extractable authentication-use authority |
+
+### Host-Private / Controller Facets
+
+| Capability | Role |
+|---|---|
+| `GitRemoteController` | Host-held policy facet for endpoint, allowed refs, direction, revocation, and inspection |
+| `GitCredentialController` | Host-held facet that installs, rotates, or revokes credential material |
+| transport-specific backing | Trusted implementation detail used by native git or another backend |
+
+The agent-facing remote capability should be able to *use* a remote, not retarget it, widen its branch policy, or read the secret backing it.
+
+`GitRemote` is the guest-visible bounded remote-use authority for one git endpoint.
+It is constructed from separate local-repository, transport, and credential capabilities.
+The guest may receive only `remote`, or both `git` and `remote`, but cannot recover or retarget the transport or credential authority that was used to construct it.
+
+```mermaid
+flowchart LR
+  mount[EndoMount] --> git[Git]
+  transport[HTTPS transport cap] --> remote[GitRemote]
+  cred[credential cap] --> remote
+  git --> remote
+```
+
+## MVP Transport Scope
+
+The first implementation should support **HTTPS remotes with bearer or basic credentials**.
+
+Reasons:
+
+- it follows the same controller/client and non-extractable-credential patterns as the existing HTTP-client and OAuth-like designs;
+- URL origins are inspectable and allowlistable;
+- credentials can be injected without exposing them to the guest;
+- it avoids granting ambient `ssh` process authority for the first cut.
+
+For the HTTPS MVP, an `HttpClient`-like capability is the right visible authority input even if the first native-git backend cannot literally call through that object.
+The important design point is that remote git is not minted from `Git` plus a URL string alone; it also requires separately granted outbound-network authority.
+
+SSH remotes are important, but they need an explicit follow-up design for host-key policy, agent forwarding, command restriction, and whether Endo should expose an `SshSession` / `GitSshTransport` capability instead of shelling through ambient `ssh`.
+
+## Proposed Vocabulary
+
+### `GitRemotePolicy`
+
+```ts
+type GitRemotePolicy = {
+  url: string;
+  allowedDirections: Array<'fetch' | 'push'>;
+  fetchRefspecs: string[];
+  pushRefspecs: string[];
+  allowedBranches?: string[];
+  allowForcePush?: boolean;
+  allowTags?: boolean;
+  allowDelete?: boolean;
+};
+```
+
+The URL is formula-owned policy in Phase 1 (baked into the `git-remote` formula at construction time and immutable thereafter) and becomes controller-mediated once Phase 5 lands; the guest cannot mutate it in either phase.
+`allowedBranches` is the user-facing shortcut; implementations may compile it into refspec policy.
+
+### `GitRemote`
+
+```ts
+interface GitRemote {
+  // Return shape mirrors GitRemoteController.inspect()'s sibling form
+  // (`Promise<GitRemotePolicy & { revoked: boolean }>`): GitRemote
+  // exposes the policy plus its own name, but never `revoked` —
+  // revocation state is the controller's domain, not the guest cap's.
+  // `allowedBranches` is normalized into `fetchRefspecs` /
+  // `pushRefspecs` at construction time and is not re-surfaced here.
+  inspect(): Promise<GitRemotePolicy & { name: string }>;
+
+  fetch(options?: {
+    prune?: boolean;
+    tags?: boolean;
+  }): Promise<GitFetchResult>;
+
+  // strategy uses an enum string rather than a tagged union because pull is
+  // a one-shot operation with mutually-exclusive integration choices, not a
+  // state machine.  rebase() uses a tagged union because its phases
+  // (start/continue/abort/skip) take genuinely different inputs.
+  pull(options?: {
+    branch?: GitRef | string;
+    strategy?: 'merge' | 'rebase' | 'ff-only';
+  }): Promise<GitPullResult>;
+
+  push(options?: {
+    source?: GitRef | string;
+    destination?: string;
+    force?: boolean;
+    setUpstream?: boolean;
+  }): Promise<GitPushResult>;
+}
+```
+
+### Result Types
+
+```ts
+type GitRefUpdate = {
+  local?: GitRef; // present on push and on fetches that update tracking refs
+  remote: GitRef | string; // GitRef when known structurally, string otherwise
+  result: 'created' | 'updated' | 'up-to-date' | 'fast-forward'
+    | 'forced' | 'pruned' | 'rejected';
+};
+
+type GitFetchResult = {
+  updatedRefs: GitRefUpdate[]; // includes pruned entries with result='pruned'
+};
+
+type GitPullResult = {
+  fetch: GitFetchResult;
+  integration: 'up-to-date' | 'fast-forward' | 'merge' | 'rebase';
+  head: GitRef;
+};
+
+type GitPushResult = {
+  updatedRefs: GitRefUpdate[];
+};
+```
+
+`updatedRefs` is shape-aligned across fetch and push so consumers that present a unified "what changed on the remote" view do not branch on the operation.
+Pruned refs are folded into the same array with `result: 'pruned'` instead of a separate `prunedRefs` field; that keeps the typed shape singular and lets a caller filter rather than join.
+
+### Sample Use
+
+```js
+// fetch updates from origin
+const fetched = await E(remote).fetch({ prune: true });
+console.error(`updated ${fetched.updatedRefs.length} refs`);
+
+// publish a local branch as agent/topic
+const pushed = await E(remote).push({
+  source: 'agent/topic',
+  destination: 'refs/heads/agent/topic',
+  setUpstream: true,
+});
+for (const update of pushed.updatedRefs) {
+  console.error(update.remote, update.result);
+}
+
+// fast-forward pull
+await E(remote).pull({ strategy: 'ff-only' });
+```
+
+The first implementation may return backend text alongside these summaries if native git output is still operationally useful.
+The structured result is the stable public shape.
+
+### `GitRemoteController`
+
+```ts
+interface GitRemoteController {
+  inspect(): Promise<GitRemotePolicy & { revoked: boolean }>;
+  setAllowedDirections(directions: Array<'fetch' | 'push'>): Promise<void>;
+  setFetchRefspecs(refspecs: string[]): Promise<void>;
+  setPushRefspecs(refspecs: string[]): Promise<void>;
+  setAllowedBranches(branches: string[]): Promise<void>;
+  setAllowForcePush(flag: boolean): Promise<void>;
+  setAllowTags(flag: boolean): Promise<void>;
+  setAllowDelete(flag: boolean): Promise<void>;
+  revoke(): Promise<void>;
+}
+```
+
+The controller can narrow or widen policy after creation.
+The guest-held `GitRemote` cannot.
+
+## Capability Construction
+
+The preferred host flow is composition.
+These calls are **one-time host setup**, run once when the operator provisions a remote for an agent; the resulting `GitRemote` (and credential cap) survive across daemon restart via formula reconstitution and do not need to be re-issued per agent session.
+
+```js
+const worktree = await E(host).provideMount('/repo', 'repo-worktree');
+const git = await E(host).provideGit(worktree, 'repo-git');
+
+const http = await E(host).provideHttpClient('github-http', {
+  allowedOrigins: ['https://github.com'],
+});
+
+const credential = await E(host).provideBearerCredential('github-token', {
+  audience: 'https://github.com',
+});
+
+const remote = await E(host).provideGitRemote({
+  git,
+  name: 'origin',
+  url: 'https://github.com/endojs/endo.git',
+  transport: http,
+  credential,
+  policy: {
+    allowedDirections: ['fetch', 'push'],
+    fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+    pushRefspecs: ['refs/heads/agent/*:refs/heads/agent/*'],
+    allowForcePush: false,
+    allowTags: false,
+    allowDelete: false,
+  },
+});
+```
+
+The exact maker names are placeholders.
+Phase 5 (see *Implementation Plan*) adds a sibling `provideGitRemoteController()` that returns the host-held controller for revocation / policy updates; until then, the operator's only post-setup lever is `revoke()` on the credential cap.
+
+The required properties are:
+
+- the remote is bound to one local `Git`;
+- the `git` argument must be a writable (non-readOnly) `Git`; `provideGitRemote` rejects a read-only `Git` with a structured error.
+  Even `fetch` mutates `.git` object and ref state, so a remote backed by a read-only `Git` could not implement its own contract; see [daemon-git-capability](daemon-git-capability.md) § Design Decision 8 for the same-authority-shape invariant this enforces;
+- the endpoint is host-specified and inspectable;
+- the transport is separately authorized and bounded before the remote is constructed;
+- the credential is separately authorized and non-extractable;
+- the agent receives only `remote`, not the credential or transport caps.
+
+### Why bundle local + transport + credential into one `GitRemote`?
+
+The deliberate ergonomic choice is to compose the three authority inputs into one guest-facing capability rather than expose them separately and ask the agent to compose them on every call.
+Reasons:
+
+- the agent's mental model is "fetch from origin / push to origin", not "compose local repo + HTTPS transport + bearer credential for one HTTPS GET";
+- the composition is fixed at construction time; an agent that holds three loose caps could try to recombine them in ways the operator did not authorize;
+- the construction-time bundling is where the host enforces "this credential is only useful with this transport against this endpoint for this repo";
+- revocation is per-bundle: revoking the credential invalidates exactly the bundles that used it, no more.
+
+The cost is that the guest holding `GitRemote` cannot observe events that touch one bundled authority without holding the controller for that authority too: a credential identity rotation (the operator swapping the bearer token behind a `BearerCredential` via `GitCredentialController.rotate()`) is invisible to the agent unless the agent is also granted the credential controller, which would defeat the non-extractable-credential guarantee.
+The agent sees only "fetch succeeded" or "fetch failed with credential-revoked"; observing *which* credential identity served a given fetch requires the host-side audit surface.
+This is the deliberate trade-off the bundling pattern makes: an agent that wants finer-grained visibility into one of the three authority axes has to either hold the controller for it (and accept the wider authority) or read the host-retained audit log.
+
+The host-side **decomposition** surface is the Phase 5 controllers (`GitRemoteController`, `GitCredentialController`).
+Splitting policy edits and credential rotation off the guest-facing cap is what lets operators change those without re-issuing the bundle to the agent.
+
+## Credentials
+
+### Required Properties
+
+The credential capability must:
+
+- let the backend authenticate requests;
+- refuse export of the underlying token / password / key;
+- be scoped to an audience or remote binding;
+- be revocable independently of the remote;
+- support rotation without replacing the guest-held `GitRemote`.
+
+### MVP Credential Shapes
+
+For HTTPS remotes, the first useful shapes are:
+
+```ts
+interface BearerCredential {
+  audience(): string;
+}
+
+interface BasicCredential {
+  audience(): string;
+}
+```
+
+These public facets may expose almost nothing beyond inspection of their scope.
+Trusted backend code obtains the sealed secret through a host-private unsealer when constructing transport requests.
+
+### Relation to OAuth
+
+This is the same pattern already described by [endoclaw-oauth](endoclaw-oauth.md): authority to use a service without authority to read the credential.
+Remote git needs the same property even when the token was minted manually rather than by an OAuth flow.
+
+## Endpoint Policy
+
+### Strict Mode
+
+The default should be strict:
+
+- remote URL fixed at construction;
+- origin must already be allowed by the supplied transport authority;
+- fetch / push direction fixed by policy;
+- refspecs fixed by policy;
+- unknown endpoint requests fail.
+
+### Trust-On-First-Bind
+
+For interactive agent setup, remote creation can optionally use the [trust-on-first-bind](trust-on-first-bind.md) pattern:
+
+- first attempted binding to `https://github.com` prompts the holder;
+- approval pins the endpoint in controller policy;
+- denial remains inspectable and revocable;
+- strict remains the default for unattended agents.
+
+This belongs in the controller layer, not in the guest-held remote cap.
+
+### Policy Validation Matrix
+
+The combinations below catch the subtle failure modes where a refspec form and a policy flag interact (`+` force prefix vs. `allowForcePush`, deletion refspecs vs. `allowDelete`, tag refspecs vs. `allowTags`, short vs. fully-qualified names, wildcard scopes, and the `allowedBranches` vs. `pushRefspecs` shortcut).
+The implementation should reject the listed "Rejected" forms with a structured error citing the offending policy field and the specific refspec / flag combination.
+
+| Policy field | Accepted forms | Rejected forms | Validation rule |
+|---|---|---|---|
+| `fetchRefspecs` | Fully-qualified refs (`refs/heads/main:refs/remotes/origin/main`); wildcards under a fixed parent (`+refs/heads/*:refs/remotes/origin/*`); leading `+` force prefix to update non-fast-forward remote-tracking refs (fetch-side force is local-only and does not require `allowForcePush`); deletion refspecs (`:refs/remotes/origin/foo`) only when `allowDelete: true` | Short names (`main:origin/main`); refspecs whose destination lies outside `refs/remotes/<remote-name>/`; tag refspecs (`refs/tags/*`) when `allowTags: false`; deletion refspecs when `allowDelete: false` | At construction, every fetch refspec must parse to `[+]<src>:<dst>` where `<dst>` is rooted at `refs/remotes/<remote-name>/`; deletion forms (empty `<src>`) require `allowDelete: true`; tag-prefix sources require `allowTags: true` |
+| `pushRefspecs` | Fully-qualified source and destination (`refs/heads/agent/main:refs/heads/agent/main`); wildcards under a fixed parent on both sides (`refs/heads/agent/*:refs/heads/agent/*`); leading `+` only when `allowForcePush: true`; deletion refspecs (`:refs/heads/foo`) only when `allowDelete: true`; tag-source refspecs only when `allowTags: true` | Short names; `+`-prefixed refspecs when `allowForcePush: false`; deletion refspecs when `allowDelete: false`; tag refspecs when `allowTags: false`; refspecs whose source resolves outside the local repo's `refs/` namespace | Mirror of `fetchRefspecs` validation, plus the force / delete / tag flag interactions; the source side must be a known local ref namespace, not an arbitrary string |
+| `allowedBranches` | A list of branch names or `refs/heads/<glob>` patterns interpreted as a shortcut: equivalent to a derived `pushRefspecs` of `refs/heads/<b>:refs/heads/<b>` for each branch, AND a destination-side filter on any explicit `pushRefspecs` | Short names with no `refs/heads/` anchoring that would also match tags or remote-tracking refs by accident | If both `allowedBranches` and `pushRefspecs` are set, the union is forbidden: the policy must choose one mode.  If only `allowedBranches` is set, the implementation derives `pushRefspecs` from it.  If `pushRefspecs` is empty AND `allowedBranches` is empty, push is rejected entirely (a push-direction remote with no allowed targets is misconfigured, not "permit nothing"; the operator must say so explicitly with `allowedDirections: ['fetch']`) |
+| `allowTags` | `true` to allow tag refspecs in fetch and push (`refs/tags/*` on either side); `false` (default) to reject any tag-prefix refspec | Tag refspecs when `false` | Validated at refspec-parse time against both `fetchRefspecs` and `pushRefspecs` |
+| `allowDelete` | `true` to allow deletion refspecs (empty `<src>`) in fetch (`:refs/remotes/origin/foo`) and push (`:refs/heads/foo`); `false` (default) to reject deletion forms | Deletion refspecs when `false` | Deletion form is detected by an empty `<src>` in `[+]<src>:<dst>`; both directions are gated by the same flag |
+| `allowForcePush` | `true` to allow leading `+` on `pushRefspecs` entries; `false` (default) to reject the `+` prefix on push.  Fetch-side `+` is unaffected (remote-tracking refs are local). | `+`-prefixed push refspecs when `false`; non-`+` push refspecs that the server reports as non-fast-forward (the local validation cannot detect this; the post-push response check fail-closes) | Local validation rejects the `+` prefix at refspec-parse time; the post-push response check rejects an upstream non-fast-forward result regardless of the `+` flag |
+
+## Operation Semantics
+
+### `fetch`
+
+`fetch()`:
+
+- requires fetch direction;
+- uses only controller-approved fetch refspecs;
+- may update local remote-tracking refs;
+- does not mutate the worktree.
+
+### `pull`
+
+`pull()`:
+
+- requires fetch direction;
+- composes `fetch()` with a local integration operation on the paired `Git` capability;
+- requires the relevant local mutation authority;
+- should default to a host-selected mode such as `ff-only` or `rebase`, not silently choose broad merge behavior.
+
+### `push`
+
+`push()`:
+
+- requires push direction;
+- validates source and destination against push policy;
+- refuses force, tag creation, and deletes unless explicitly authorized;
+- uses only the bound credential and endpoint.
+
+## Remote Data Plane
+
+`GitRemote` should be a CapTP control-plane capability, not a CapTP packfile tunnel.
+
+The guest-visible operation is a capability invocation:
+
+```js
+await E(remote).fetch();
+await E(remote).push({
+  source: 'HEAD',
+  destination: 'refs/heads/agent/topic',
+});
+```
+
+That invocation carries authority and policy through CapTP:
+
+- which local repository is paired with the remote;
+- which endpoint the host has approved;
+- which credential may be used without being exposed;
+- which directions and refs are allowed;
+- what summary, audit record, or error is returned to the guest.
+
+The bulk git object exchange should then happen outside CapTP through the approved git transport.
+For the HTTPS MVP, trusted backend code should run the git smart HTTP protocol, either through native git or a future HTTP git client, using the policy-owned URL (formula-owned in Phase 1; controller-mediated once Phase 5 lands) and sealed credential material.
+The packfiles, deltas, and large object payloads should not be serialized as CapTP messages merely because the initiating authority was a CapTP object.
+
+This distinction keeps several boundaries clear:
+
+- CapTP remains the object-capability layer for authorization and durable references.
+- HTTPS remains the first remote data plane because it is already the normal git transport, has inspectable origins, and composes with bearer/basic credential patterns.
+- The daemon can enforce endpoint and ref policy before starting the data transfer, then summarize the result after it completes.
+- Large fetches and pushes avoid per-object CapTP round trips and avoid making the remote protocol depend on CapTP framing.
+
+The backend must still be careful not to smuggle in ambient authority.
+A native-git HTTPS implementation should provide the endpoint and credential through trusted code, suppress ambient credential helpers, and reject any call-time URL supplied by the guest.
+Moving packfile bytes outside CapTP does not mean bypassing policy; it means applying policy before handing the bulk transfer to the transport best suited for that data.
+
+### Future Encrypted Transports
+
+HTTPS is the right first target.
+It is available today, has clear origin policy, and matches the credential patterns already in this design.
+SSH requires separate design work for host keys, agent forwarding, command restriction, and key-use authority.
+
+A future Noise-based transport could be useful if Endo later wants a capability-native encrypted channel for peer-to-peer git object exchange or for remotes that are not ordinary Git hosting services.
+That should remain future work until the HTTPS data-plane shape is proven.
+The durable design requirement is not "always HTTPS"; it is "remote git bulk bytes travel on a bounded transport capability, while CapTP remains the control and authority plane."
+
+## Repository Bootstrap and `clone`
+
+`GitRemote` is intentionally bound to an existing local `Git`, so `clone()` does not belong on that facet.
+Cloning creates both repository metadata and a worktree; it crosses the boundary between remote transport and mount provisioning.
+
+For the MVP there are two legitimate product flows:
+
+1. The host provides an already-existing physical worktree mount, then derives `Git` and `GitRemote`.
+2. The host performs a separate trusted bootstrap operation that creates a new physical worktree from a bounded remote source and then returns the resulting `EndoMount` plus `Git`.
+
+The second flow is product-relevant when an agent starts from only a remote repository, but it should remain host-mediated.
+It should not become guest authority to clone arbitrary remotes into arbitrary host paths.
+The exact bootstrap API is a follow-up design point because it must combine mount creation, endpoint policy, and sealed credential authority before a local `Git` exists.
+
+## Security Model
+
+### Authority Separation
+
+| Capability | Grants |
+|---|---|
+| `Git` | local repository operations |
+| transport cap | outbound network access bounded by origin / transport policy |
+| `GitRemote` | bounded use of one remote |
+| `GitRemote` endpoint policy | bounded access to one remote endpoint |
+| credential cap | non-extractable authentication use |
+
+The guest-held `GitRemote` intentionally composes bounded local-repository use, outbound transport, endpoint use, and credential use for one remote.
+The host-held controllers remain separate so endpoint policy and credential state can be revoked or changed independently.
+
+### Required Restrictions
+
+- no remote URLs or refspecs supplied by the guest at call time;
+- no remote add / rename / set-url on the guest facet;
+- no guest access to credential material; ambient credential helpers and SSH agents are not consulted in the HTTPS MVP;
+- no force-push, tag-push, or deletion unless separately enabled, and no push on a fetch-only remote;
+- no use of a remote after either the remote controller or credential has been revoked.
+
+### Audit Surface
+
+Controllers should retain an audit log of:
+
+- endpoint creation and policy changes;
+- credential attachment / rotation / revocation;
+- fetch / pull / push invocations;
+- refs updated by push;
+- rejected attempts.
+
+The guest may get summaries of its own operations; the host retains the full audit surface.
+
+## Agent MVP Profile
+
+For a practical first release, a useful default profile is:
+
+```text
+origin:
+  transport: HTTPS only
+  credential: scoped bearer token
+  fetch: allowed
+  pull: allowed, default ff-only or rebase
+  push: allowed only for refs/heads/agent/*
+  force push: denied
+  tag push: denied
+  delete: denied
+```
+
+That lets an agent:
+
+- advance work already present in the mounted worktree from upstream;
+- publish its own review branches;
+- avoid writing over protected human branches;
+- remain unable to retarget the token or push arbitrary refs.
+
+Fetch-only remotes are a natural stricter profile for review or analysis agents.
+
+## Transport and Backend Boundary
+
+The public `GitRemote` API should not commit the design to one internal transport implementation, but its construction should still make transport authority explicit.
+
+```ts
+interface GitRemoteBackend {
+  fetch(...): Promise<GitFetchResult>;
+  push(...): Promise<GitPushResult>;
+}
+```
+
+### Initial Backend
+
+The first backend may still use native git internally.
+A native `git` process cannot literally consume an Endo `HttpClient` object, so the MVP should not pretend that generic HTTP-client composition is already the runtime call path.
+The transport capability is still a real required input: trusted daemon code must verify the policy-owned URL (formula-owned in Phase 1; controller-mediated once Phase 5 lands) against the granted transport authority, then invoke native git only with the approved URL, approved refspecs, and sealed credential material.
+
+That means:
+
+- a daemon-shipped `GIT_ASKPASS` helper binary, exec'd by `git` and fed the credential through an anonymous pipe whose read-end fd is inherited by the helper (the secret is passed via fd-pointer, never via argv or process env);
+- `GIT_TERMINAL_PROMPT=0` so a missed askpass does not hang waiting for a TTY;
+- sanitized git environment that drops `GIT_*_HELPER`, `GIT_PROXY_COMMAND`, and other credential / process-shell vectors;
+- repo config and ambient-credential-helper suppression (`-c credential.helper=` empties the ambient helper list for the invocation; the daemon-shipped `GIT_ASKPASS` above remains the controlled injection path);
+- explicit remote URL supplied from controller state, written into the invocation as a positional argument never derived from a guest input;
+- no shell interpolation; argv-array spawn only.
+
+These two concerns are orthogonal and should not be conflated.
+A **secret manager** answers *where durable secret authority lives*: a daemon-owned (or external) capability that holds, rotates, and revokes credentials across restarts and across multiple repos.
+The **fd-based askpass** answers *how one native-git invocation receives the secret without disk, env, or argv exposure*: it is the in-process injection envelope, not a place to durably store anything.
+The long-term home for durable authority is [daemon-capability-bank](daemon-capability-bank.md); once it lands, the askpass helper should fetch the credential from that bank (or an external secret manager it fronts) on demand rather than reading from git's own credential store, which keeps `.git` restartable without making git credential files durable.
+Until then, Phase 1 ships the askpass envelope on its own and treats bank-backed sourcing as the planned follow-up for unattended, multi-repo, post-restart workflows.
+
+The safe target for credential injection is: **no secret in argv, in process environment, in formula state, in inspect output, in logs, or in any persisted or durable temp file.**
+The askpass-fed-by-anonymous-pipe mechanism above is the only path that meets that bar for the basic (username/password) case.
+
+For bearer-token HTTPS remotes, native git also supports `http.extraHeader`.
+Passing the header through `-c "http.extraHeader=Authorization: Bearer ..."` leaks the token to `/proc/*/cmdline` (and is the standard reason public guides warn against the flag).
+Env-variable injection paths fail the bar in the other direction (any env-borne secret lands in `/proc/*/environ`, which is world-readable on most Linux distros), and config-file injection paths fail because a persisted temp file is exactly what the bar excludes.
+None of those approaches meets the "no secret in env, argv, or persisted state" target.
+
+Bearer-token support is therefore **conditional on the credential-injection spike** confirming an askpass / anonymous-pipe path that keeps the bearer token out of argv, env, and any persisted location.
+Until the spike completes, the implementation:
+
+- defaults to basic credentials (HTTPS username/password fed through the askpass helper);
+- treats bearer support as gated by the spike's go/no-go;
+- or, where bearer is the only option, uses the askpass mechanism for bearer too (treating the bearer as a password fed through askpass), which keeps the credential on the proven path rather than inventing a parallel injection mechanism.
+
+This preserves the same authority shape as `HttpClient` even when the first implementation adapts that authority into a native-git invocation rather than issuing requests through the object directly.
+
+### Spike: confirm credential-injection portability
+
+Before Phase 2 ships the first credential-bearing remote, run a spike across the target host matrix (Linux, macOS, Windows where applicable) to measure:
+
+1. Whether the anonymous-pipe-fed `GIT_ASKPASS` helper works on every target host's stock `git` (≥ 2.30; see [daemon-git-capability](daemon-git-capability.md) for the version pin), including under `git`'s recent `setup_credential_helpers` defaults.
+2. Whether the askpass-fed-by-anonymous-pipe path can carry a bearer token (treating the bearer as a password fed through askpass) while keeping the token out of argv, `/proc/*/environ`, and any persisted temp-file artifact a panicked git invocation might leave behind.
+   If not, bearer support stays gated until a mechanism that meets the "no secret in env / argv / temp file" bar is identified.
+3. Whether the daemon-shipped helper binary can be located on macOS in a way that survives `git`'s notarization / quarantine attributes for packaged installers.
+4. Whether `pipe2(O_CLOEXEC)` (Linux) and equivalent (macOS `pipe` + `fcntl(FD_CLOEXEC)`) prevent the credential fd from leaking into sibling subprocesses git may spawn (`git config --show-origin`, smart HTTP helpers, etc.).
+
+The spike's deliverable is a one-page note in `designs/` recording which mechanism works on which host and any fallback ladder.
+The note must include an explicit **"no secret in env / argv / temp file" verification step** per credential type tested: a procedure that scrapes `/proc/<pid>/environ`, `/proc/<pid>/cmdline`, the helper-bin temp dir, and any `GIT_CONFIG_*` file location during and after a representative git operation, and confirms the secret is not visible at any of those surfaces.
+The capability contract does not change with the spike's outcome; the implementation detail does.
+
+The native invocation should also be treated as a bulk data-plane adapter.
+CapTP starts the operation and receives completion metadata; native git and HTTPS carry the packfile exchange.
+Tests should assert policy behavior and observable results, not require packfile bytes to pass through CapTP.
+
+### Future Backends
+
+Future implementations may use:
+
+- a JS git backend over an Endo transport adapter;
+- a dedicated HTTP git smart-protocol client;
+- an SSH transport capability once separately designed.
+- a future Noise-based transport capability for git object exchange, if Endo grows a peer-to-peer git use case that justifies it.
+
+The public `GitRemote` contract should survive those swaps.
+
+## Implementation Plan
+
+### Phase 1: Remote Model (MVA)
+
+- [ ] Add `GitRemote` and credential-capability types (`BearerCredential`, `BasicCredential`).
+- [ ] Add `git-remote` formula type bound to a local `Git`.
+- [ ] Add a host method to mint a `GitRemote` with policy baked in at construction (`provideGitRemote({...})`), including fetch-only, push-limited, and branch-limited validation.
+- [ ] The minimum viable agent flow (fetch + ff-only-pull + branch-limited push) is exercised end-to-end on this surface, with no controller in sight.
+  Controllers come in Phase 5.
+
+### Phase 2: HTTPS Credentialed Fetch
+
+- [ ] Support HTTPS bearer/basic credential injection through trusted backend code.
+- [ ] Implement `fetch()` with fixed endpoint and approved refspecs.
+- [ ] Keep packfile transfer on the HTTPS/native-git data plane rather than relaying git object bytes through CapTP.
+- [ ] Add revocation tests for remote and credential caps.
+
+### Phase 3: Pull and Local Integration
+
+- [ ] Implement `pull()` as `fetch + local Git integration`.
+- [ ] Make the default integration mode explicit.
+- [ ] Add divergence / conflict tests.
+
+### Phase 4: Push for MVP
+
+- [ ] Implement branch-limited `push()`.
+- [ ] Deny force, tags, and deletes by default.
+- [ ] Keep push packfile transfer on the bounded HTTPS/native-git data plane.
+- [ ] Add audit entries for outbound ref updates.
+- [ ] Add end-to-end tests for publishing `agent/*` branches.
+
+### Phase 5: Controllers and Revocation
+
+- [ ] Add `GitRemoteController` and `GitCredentialController` for post-construction policy updates and revocation.
+- [ ] Add `GitRemoteSet` if a collection capability is useful (host can also defer this).
+- [ ] Wire `revoke()` against in-flight operations (see *daemon-restart mid-operation* in the testing plan).
+- [ ] The agent-facing surface from Phase 1 does not change; controllers add a parallel host-held authority for ops-team work.
+
+### Phase 6: Interactive Provisioning
+
+- [ ] Add form / CLI flows for creating common remote profiles.
+- [ ] Optionally integrate trust-on-first-bind for interactive endpoint approval.
+- [ ] Add clear inspection surfaces so users can see which remotes and push targets are granted.
+
+### Phase 7: Extended Transports
+
+- [ ] Design SSH-specific transport and credential capability.
+- [ ] Decide whether SSH belongs under a general network/process capability or a git-specialized transport cap.
+- [ ] Revisit Noise only after HTTPS semantics, policy, and audit are stable.
+- [ ] Add mirror / tag / delete profiles only after explicit policy designs.
+
+## Testing Plan
+
+### Capability Tests
+
+- remote cannot be created without local `Git`;
+- remote cannot be created without transport authority;
+- remote cannot be created without compatible credential authority;
+- credential cannot be read by the guest;
+- revoked credential blocks remote operations;
+- remote URL cannot be changed by the guest.
+
+### Policy Tests
+
+- fetch-only remote rejects push;
+- push-limited remote rejects branches outside policy;
+- force push, tags, and deletion are denied by default;
+- audience mismatch rejects credential use;
+- strict endpoint policy rejects unknown remotes.
+
+### Workflow Tests
+
+- fetch updates remote-tracking refs;
+- pull fast-forwards;
+- pull rebase path;
+- push creates an allowed review branch;
+- large fetch / push fixtures complete without exposing packfile bytes or remote credentials through the guest-visible CapTP result;
+- restart persistence preserves remote policy without exposing secrets;
+- **revoke()** in-flight: call `GitRemoteController.revoke()` while a `push()` is mid-packfile; the in-flight transfer aborts cleanly and the remote-tracking ref is not advanced past the last-acknowledged commit;
+- **credential rotation mid-operation**: call `GitCredentialController.rotate()` between a `fetch()` and a `push()` on the same `GitRemote`; the `push()` either uses the new credential or fails with a credential-revoked error, never both;
+- **daemon restart mid-fetch**: kill the daemon while `fetch()` is streaming a large packfile, restart, and confirm the partial remote-tracking state is either consistent with the last completed ref-update batch or fully rolled back, not an intermediate per-pack state.
+- **in-flight authentication failure**: configure the test server to accept the initial smart-HTTP handshake and then return a `401 Unauthorized` on the packfile request mid-`fetch()`; confirm the operation surfaces a structured credential-revoked-style error (distinct from a pre-operation auth failure or a mid-operation credential rotation), the in-flight transfer aborts cleanly, and remote-tracking refs are not advanced past the last completed ref-update batch.
+- **in-flight transport error**: configure the test server to accept the initial smart-HTTP request and then return a `502 Bad Gateway` / `503 Service Unavailable` / TCP-reset mid-`push()`; confirm the operation surfaces a structured transport-error result (distinct from a credential failure and from a pre-operation network error), the in-flight push aborts cleanly without partial ref advancement on the remote (where the server reports), and the client-side `GitPushResult.updatedRefs` reflects only the refs the server acknowledged before the error.
+
+### Hardening Tests
+
+- global/system git config ignored;
+- no ambient git credential helpers; only daemon-controlled credential injection (e.g., the daemon-shipped askpass helper) is in scope;
+- guest-provided refspecs cannot widen policy;
+- guest-provided URLs are never accepted by call-time methods;
+- backend never falls back to ambient SSH or shell.
+- remote packfile transport is only started after endpoint, direction, ref, and credential policy checks pass.
+
+## Relationship to Existing Git Designs
+
+- [daemon-git-capability](daemon-git-capability.md) defines local worktree git and remains the prerequisite.
+- This document is the remote companion required for a practical agent MVP.
+- [daemon-agent-tools](daemon-agent-tools.md) should eventually describe two tool groups:
+  - local git tools from `Git`;
+  - remote git tools from granted `GitRemote` values.
+
+## Open Questions
+
+1. **Concrete peer-to-peer use case for a Noise-based git transport.**
+   Explicitly deferred until HTTPS data-plane shape is proven (§ Future Encrypted Transports).
+   A real use case (Endo agents exchanging git objects directly, sneakernet repo sync, etc.) is what justifies designing the transport and its endpoint-identity policy.
+
+### Resolved (recorded as Design Decisions)
+
+- `pull()` location — decision 7.
+- `GitRemote.inspect()` URL reveal scope — decision 8.
+- Credential capability generality (generic vs `GitCredential`) — decision 9.
+- Provider-specific branch protection — decision 10.
+- `HttpClient` vs `GitHttpsTransport` narrowing — decision 11.
+
+### Spike Tasks
+
+These are open questions that need measurement or a concrete use case before the answer is design-stable.
+Each gets a one-line follow-up deliverable.
+
+- **MVP transport scope: HTTPS-only sufficient?**
+  Before Phase 1 ships, survey the target endo-MVP users (likely the Fae / Lal / Genie agents' current operators) and confirm that HTTPS bearer/basic credentials cover their first-release flows.
+  If a non-trivial fraction needs SSH, the SSH design in Phase 7 moves earlier.
+  Deliverable: a one-page note in `designs/` confirming or revising the HTTPS-only Phase 1.
+- **Bootstrap / clone API.**
+  A `provideGitClone({...})` host flow that composes mount creation + endpoint policy + sealed credential authority before a local `Git` exists is a real follow-up requirement (early-draft Open Question #6).
+  Design lives in its own `designs/daemon-git-clone.md` follow-up; the spike's deliverable is the design doc, scheduled for Phase 6 after HTTPS fetch/push are exercised in real workflows.
+- **Telemetry to distinguish CapTP control-plane time from remote transport data-plane time.**
+  During Phase 2, add structured timing fields to `GitFetchResult` and `GitPushResult` (initial shape: `{ captpMs: number; transportMs: number }` augmenting the existing result types) and iterate based on what debug sessions actually need.
+  The shape may change after the spike; the principle (timing is observable) is decision 12.
+
+## Design Decisions
+
+1. **Remote git is MVP scope.**
+   Agents need fetch / pull / push to be useful in real coding workflows.
+2. **Remote git is still a separate capability.**
+   MVP relevance does not justify folding network and credentials into base local `Git`.
+3. **HTTPS first.**
+   It gives the shortest path to a secure useful release and composes with existing HTTP / OAuth patterns.
+4. **Endpoint policy ownership is phase-conditional: formula-owned in Phase 1, controller-owned once Phase 5 lands.**
+   In Phase 1, endpoint policy is baked into the `git-remote` formula at construction time and is immutable thereafter; the only post-construction lever is credential revocation.
+   Once the Phase 5 `GitRemoteController` lands, the policy becomes controller-mediated and can be narrowed or widened post-construction.
+   Guests use remotes in both phases; hosts decide what they point at.
+5. **Push is bounded by default.**
+   A practical default permits review-branch publication without granting arbitrary external write authority.
+6. **CapTP is the remote control plane.**
+   Remote git packfiles should move over bounded HTTPS or another explicit git transport, not through CapTP object messages by default.
+7. **`pull()` lives on `GitRemote`.**
+   The composition is `fetch + local integration` per § Operation Semantics; the `strategy` enum keeps the policy explicit on every call.
+   An agent that wants finer-grained composition can still call `E(remote).fetch()` and then `E(git).merge()` or `E(git).rebase()` separately, but the bundled `pull()` is the ergonomic path for the common case.
+8. **`GitRemote.inspect()` reveals the full remote URL.**
+   The URL is policy the host already chose to share (formula-owned in Phase 1; controller-mediated once Phase 5 lands); hiding it behind a host-assigned label adds an indirection without obviously protecting anything (the guest can correlate operations to the URL anyway).
+   Construction-time rejection of URLs with embedded `user:password@host` userinfo prevents the only case where the URL itself would carry a secret.
+9. **Credentials are generic across services.**
+   `BearerCredential` and `BasicCredential` are not git-specific; the same caps work for any HTTPS service that accepts the same authentication shape.
+   Specializing to `GitCredential` after the fact is cheap; generalizing a specialized one later is expensive.
+10. **Provider-specific branch protection is server-side, not daemon-side.**
+    The daemon does not introspect GitHub / GitLab / Forgejo / Gitea branch-protection APIs; relying on server-side rejection keeps the daemon free of provider-specific knowledge.
+    Local policy (`pushRefspecs`, `allowForcePush`, `allowDelete`) covers the operator-known constraints; server-side rejection covers the provider-specific ones.
+11. **HTTPS transport input remains a general `HttpClient` initially.**
+    A dedicated `GitHttpsTransport` capability may emerge later if spike-measured git-specific needs (smart-protocol pipelining, sideband channel handling) make it worth specializing.
+    Until then, the general transport cap composes cleanly with other Endo HTTP consumers.
+12. **Timing is observable on every remote operation.**
+    Phase 2 adds timing fields to `GitFetchResult` / `GitPushResult` so a debugging consumer can distinguish CapTP control-plane time from remote transport data-plane time without needing daemon-side instrumentation.

--- a/designs/daemon-mount-capabilities.md
+++ b/designs/daemon-mount-capabilities.md
@@ -1,0 +1,561 @@
+# EndoMount Capability Completion Plan
+
+| | |
+|---|---|
+| **Created** | 2026-05-18 |
+| **Updated** | 2026-05-20 |
+| **Author** | 0xPatrick (prompted) |
+| **Status** | Proposed |
+
+> **Read in order.**
+> This is doc 1 of 3.
+> The trio works as one design: (1) [daemon-mount-capabilities](daemon-mount-capabilities.md) (you are here) completes the mount surface; (2) [daemon-git-capability](daemon-git-capability.md) builds a local git capability on top of it; (3) [daemon-git-remotes](daemon-git-remotes.md) adds remote git on top of (2).
+> Read in that order.
+
+## Summary
+
+Finish the `EndoMount` capability so it can serve as the live, handle-first filesystem basis for agent tools and the revised git capability.
+Three pieces land together.
+`EndoMount.snapshot()` becomes real instead of throwing.
+An `EndoMountEntry` value type carries mount-scoped descriptors for paths that may not currently exist (its authority is the issuing mount, not the entry itself).
+A hidden `EndoMountBacking` Exo facet on the mount formula gives trusted daemon code physical-worktree access without leaking host paths to guests.
+The mount surface stays read-compatible with `ReadableTree` / `ReadableBlob`.
+
+## What You Should Know First
+
+This document assumes you know the following Endo primitives in one-line form; the rest of the doc names them without re-introducing them.
+
+- **`EndoMount`** (today) is the daemon's existing live-mount Exo: it grants confined live access to one physical directory and returns `EndoMountFile` handles.
+- **`ReadableTree` / `ReadableBlob`** are the shared read-surface interfaces in [platform-fs](platform-fs.md); `EndoMount` and `EndoMountFile` are already structurally compatible with their read side.
+- **`Exo`** is the Endo "passable object with an interface guard" primitive (`makeExo(name, interfaceGuard, methods)`); every public capability in this doc is implemented as an Exo or a record under `harden()`.
+
+## What is the Problem Being Solved?
+
+`EndoMount` is already useful: it grants live, confined access to one physical directory, exposes the `ReadableTree` read surface, and returns `EndoMountFile` handles for existing files.
+It is also already relied on by higher-level workflows such as staging trees into scratch mounts.
+
+However, the current implementation stops one step short of becoming the general live-filesystem capability that newer agent features need:
+
+- `snapshot()` is part of the interface but still throws.
+- The public surface is still primarily path-string based.
+- `lookup()` can only produce handles for nodes that already exist.
+- There is no mount-scoped descriptor for a deleted, staged, or not-yet-created entry.
+- The mount surface lacks metadata-oriented operations such as `stat()`.
+- The physical path backing a mount is encoded in the formula, but there is no explicit host-private way for trusted providers to derive adjacent capabilities from that backing without leaking the path through the public mount facet.
+
+These gaps matter on their own, and they are blocking for a principled git capability.
+Git needs to discuss files that do not currently have live handles, and it needs a stable bridge between a public mount capability and trusted host-side access to the same physical worktree.
+
+This document completes the current `EndoMount` design into the concrete live-directory capability that [daemon-git-capability](daemon-git-capability.md) will build on.
+It narrows the older speculative filesystem work in [daemon-capability-filesystem](daemon-capability-filesystem.md) to the pieces needed by the implementation already in tree.
+
+## Goals
+
+1. Finish the live-mount lifecycle already promised by the interface.
+2. Make new filesystem work handle-first while preserving compatibility with the existing `ReadableTree`-compatible methods.
+3. Introduce a mount-scoped descriptor for entries that may not currently exist as live nodes.
+4. Align `EndoMount` and `EndoMountFile` with the `Directory` / `File` vocabulary in [platform-fs](platform-fs.md).
+5. Provide the trusted host-side bridge required for capabilities such as git without exposing ambient host paths to guests.
+
+## Non-Goals
+
+- Designing the full multi-provider VFS namespace.
+- Replacing `EndoMount` with a new public type in one step.
+- Giving guests ambient path access or raw `FilePowers`.
+- Making every VFS backend usable as a writable git worktree.
+- Solving stable inode identity on Node.js; descriptors in this design are mount-relative logical identities, not OS inode handles.
+
+## Current State
+
+### Implemented Today
+
+`EndoMount` currently provides:
+
+- `has(...pathSegments)`
+- `list(...pathSegments)`
+- `lookup(path)`
+- `readText(path)`
+- `maybeReadText(path)`
+- `writeText(path, content)`
+- `remove(path)`
+- `move(from, to)`
+- `makeDirectory(path)`
+- `readOnly()`
+- `snapshot()` placeholder
+
+`EndoMountFile` currently provides:
+
+- `text()`
+- `streamBase64()`
+- `json()`
+- `writeText(content)`
+- `writeBytes(readableRef)`
+- `readOnly()`
+
+The implementation is symlink-aware and confines all resolved paths to the mount root.
+`EndoMount` is already structurally compatible with the read surface of `ReadableTree`; `EndoMountFile` is already structurally compatible with the read surface of `ReadableBlob`.
+
+### Existing Related Designs
+
+| Design | Relationship |
+|---|---|
+| [daemon-mount](daemon-mount.md) | Current implementation note for mount and scratch-mount formulas.  This plan completes the unfinished capability surface. |
+| [platform-fs](platform-fs.md) | Shared type lattice for `ReadableBlob`, `ReadableTree`, `File`, `Directory`, `SnapshotBlob`, and `SnapshotTree`. |
+| [daemon-capability-filesystem](daemon-capability-filesystem.md) | Broader VFS vision covering `Dir` / `File`, multi-provider backends, and caretaker control. |
+| [virtual-filesystem-design](../docs/virtual-filesystem-design.md) | Earlier handle-oriented sketch and logical-node-identity model. |
+
+## Design Principles
+
+### 1. Public Authority Is an Object, Not a Host Path
+
+The guest should hold `EndoMount`, `EndoMountFile`, and related capabilities.
+The guest should not receive the physical path that the daemon uses internally to implement a mount.
+
+### 2. Strings Are Selectors, Not Authorities
+
+Relative strings remain useful for user input and convenience calls, but they should be consumed to mint mount-owned capabilities.
+New APIs should prefer passing `EndoMountEntry`, `EndoMountFile`, or `EndoMount` values after that first resolution step.
+
+### 3. Separate Live Handles from Logical Entry References
+
+An existing file can be represented by `EndoMountFile`.
+A deleted file, an untracked path before creation, or a staged path that is absent from the worktree cannot.
+Those require a separate logical descriptor rooted in a mount.
+
+### 4. Keep the Read Surface Structurally Compatible
+
+Existing code that consumes `ReadableTree` or `ReadableBlob` should continue to work with mounts and mount files on the read path.
+
+### 5. Make Attenuation Structural Where Practical
+
+`readOnly()` should continue to remove mutation authority.
+Future read-only views should prefer exposing read-only interfaces rather than only exposing writable methods that throw.
+
+## Capability Model
+
+### Public Facets
+
+| Capability | Role |
+|---|---|
+| `EndoMount` | Live mutable directory rooted at a confined physical subtree |
+| `EndoMountFile` | Live mutable file inside an `EndoMount` |
+| `EndoMountEntry` | Mount-scoped logical reference to a normalized relative entry, whether or not that entry currently exists |
+
+### Host-Private Facets
+
+| Capability | Role |
+|---|---|
+| `EndoMountBacking` | Trusted physical-backing facet or sealed grant for daemon providers that need the real worktree path |
+| `EndoMountControl` | Future caretaker facet for host-only mutability / revocation control, if the broader capability-filesystem plan is realized |
+
+`EndoMountBacking` is deliberately not part of the guest-facing interface.
+It is the bridge a trusted provider such as native git needs in order to operate on the same physical worktree without making that path observable to the guest.
+Its purpose is to keep adjacent capabilities such as `Git` downstream of an already-authorized mount rather than letting them become parallel raw-path grants.
+
+## Proposed Interfaces
+
+The names below are intentionally explicit about their daemon role.
+A later package-level migration can map them onto `Directory`, `File`, and related `@endo/platform/fs` vocabulary.
+
+### `EndoMount`
+
+```ts
+interface EndoMount {
+  // Existing ReadableTree-compatible queries.  `has(entry)` is the
+  // no-observational-authority existence test for an `EndoMountEntry`
+  // value.  Path-bearing methods on this interface use the
+  // array-parameter form (`path: string[]`), not the rest-parameter
+  // form (`...path: string[]`), so siblings (`has`, `list`, `lookup`,
+  // `readText`, and the path-form mutators) stay coherent across the
+  // surface.
+  has(path: string[]): Promise<boolean>;
+  has(entry: EndoMountEntry): Promise<boolean>;
+  list(path: string[]): Promise<string[]>;
+  lookup(path: string[]): Promise<EndoMount | EndoMountFile>;
+  lookup(entry: EndoMountEntry): Promise<EndoMount | EndoMountFile>;
+
+  // Descriptor minting.  No I/O; the resulting entry can name a path
+  // that does not currently exist on disk (a deleted git file, a
+  // staged-but-absent target, a not-yet-created node).  `entry()` is
+  // the documented "string as selector" boundary: it accepts either a
+  // slash-joined string or a segment array and normalizes once.
+  // Elsewhere the interface uses `string[]` only.
+  entry(path: string | string[]): EndoMountEntry;
+
+  // Metadata.  `stat(entry)` is the no-observational-authority
+  // metadata query for an `EndoMountEntry` value.
+  stat(path: string[]): Promise<EndoMountStat | undefined>;
+  stat(entry: EndoMountEntry): Promise<EndoMountStat | undefined>;
+
+  // Existing convenience I/O.  Retain for compatibility.
+  readText(path: string[]): Promise<string>;
+  maybeReadText(path: string[]): Promise<string | undefined>;
+  writeText(path: string[], content: string): Promise<void>;
+
+  // Path-form mutators.  All take a path-segment array and return
+  // void.  The path locates where to act; it is not a held reference
+  // to a node.  Failure modes are the usual filesystem ones
+  // (EEXIST, ENOENT-parent, EACCES).  `makeFile` is the path-form
+  // sibling of `makeDirectory` for parallel construction and for
+  // binary content; the existing `writeText(path, content)` remains
+  // the truncate-and-write path for the text-only case.
+  makeDirectory(path: string[]): Promise<void>;
+  makeFile(path: string[], content?: string | Uint8Array): Promise<void>;
+  remove(path: string[]): Promise<void>;
+  move(from: string[], to: string[]): Promise<void>;
+
+  // Attenuation and capture.
+  readOnly(): EndoMount;
+  snapshot(): Promise<SnapshotTree>;
+}
+```
+
+`lookup()` is the single handle-minting method.
+It returns either an `EndoMount` or an `EndoMountFile` depending on what is at the path, and throws `EndoMountMissingError` for an absent path (see § *`lookup()` semantics on missing nodes* below).
+There is no separate `openFile` / `openDirectory` pair: `lookup` already covers both kinds, and the existing `mount.has(entry) → mount.lookup(entry)` idiom (or a runtime `kind` check on the returned handle) handles the cases where the caller wants to discriminate.
+
+### `EndoMountFile`
+
+```ts
+interface EndoMountFile {
+  // Existing ReadableBlob-compatible surface.
+  text(): Promise<string>;
+  streamBase64(): AsyncIterator<string>;
+  json(): Promise<unknown>;
+
+  // Mutable File surface.
+  writeText(content: string): Promise<void>;
+  writeBytes(readableRef: AsyncIterator<Uint8Array>): Promise<void>;
+  append(content: string): Promise<void>;
+  stat(): Promise<EndoMountStat>;
+
+  // Attenuation and capture.
+  readOnly(): EndoMountFile;
+  snapshot(): Promise<SnapshotBlob>;
+}
+```
+
+`streamBase64()` already provides binary read access.
+The next increment should favor file handles over adding more directory-level path convenience methods for byte I/O.
+
+### `EndoMountEntry`
+
+```ts
+interface EndoMountEntry {
+  // Copyable presentation data, always mount-relative.
+  segments(): string[];
+  displayPath(): string;
+
+  // Narrow to a child entry without granting access outside the mount.
+  child(name: string): EndoMountEntry;
+}
+```
+
+An `EndoMountEntry` is a **value**, not a handle.
+It carries:
+
+- mount-lineage provenance (so another mount rejects it on identity);
+- normalized relative segments;
+- enough presentation data for status reports.
+
+It carries **no live-filesystem authority at all** — no observational queries like `exists()` or `stat()`, and no handle-minting methods.
+Existence and metadata queries live on `EndoMount` and accept an entry: `mount.has(entry)` for the existence test and `mount.stat(entry)` for the metadata query.
+Handle-minting also lives on `EndoMount` and accepts an entry as the path-bearing argument: `mount.lookup(entry)`.
+This keeps the entry shape value-shaped — a deeply read-only value an agent can pass around freely — and concentrates *both* observational authority and handle-minting authority on the mount where they can be revoked or attenuated as a unit.
+
+An entry:
+
+- can represent a missing path;
+- cannot be fabricated by the caller for a different mount;
+- does not claim inode stability;
+- can carry enough relative presentation data for user interfaces and status reports without leaking host absolute paths.
+
+The implementation can model an entry as `{ mountGrant, normalizedSegments }` inside an Exo (or as a passable record under SES `harden`), with `mountGrant` checked by identity when another capability accepts the entry.
+
+#### Alternative Considered: Entries as Mini-Capabilities
+
+An earlier shape put **both** observational authority (`exists()`, `stat()`) and handle-minting (`lookup()`, `openFile()`, `openDirectory()`) on the entry itself:
+
+```ts
+// Considered and rejected:
+interface EndoMountEntry {
+  // ...value-shaped members...
+  exists(): Promise<boolean>;
+  stat(): Promise<EndoMountStat | undefined>;
+  lookup(): Promise<EndoMount | EndoMountFile>;
+  openDirectory(): Promise<EndoMount>;
+  openFile(): Promise<EndoMountFile>;
+}
+```
+
+That shape made entries mini-capabilities that both observed the live filesystem (every `entry.exists()` / `entry.stat()` call reaches the backing storage) and minted handles on themselves, ergonomic per call site (`await E(entry).openFile()` rather than `await E(mount).lookup(entry)`).
+
+Rejected for these reasons:
+
+- **Diffuses authority across many handles.**
+  Every entry holding both a reference to its mount's observational authority *and* its handle-minting authority means the mount's effective surface is everywhere a passed-around entry lives.
+  The mount becomes the sum of its issued entries plus itself; revoking or attenuating the mount has to chase down the entries too.
+  An entry that looks like a value but invokes the backing filesystem on every call is not really a value — it is a mini-capability with the syntax of a value, which is harder to reason about than either pole.
+- **Harder to reason about authority lineage.**
+  When a handle is minted via `entry.openFile()`, the lineage is `mount → entry → handle`; the entry might be from a `readOnly()` view, or it might predate a mount attenuation, and the resulting handle's authority is the *minimum* of all three layers.
+  When the same mint goes through the mount (`mount.lookup(entry)`), the mount's current state is the single-point authority.
+  The same argument applies to observational authority: `entry.exists()` against a stale mount-attenuation state is harder to reason about than `mount.has(entry)` against the current mount.
+- **Concentrates authority where the panel-flagged ocap-discipline says it should be.**
+  The same reasoning the maintainer applied to MF1 (`provideGit` should accept a cap, not a pet name that triggers a name-table lookup) applies here: both observational queries and handle-minting are the mount's authority, exercised by the mount.
+  Entries are values you pass to the mount; they don't carry authority of their own.
+- **Matches the existing `EndoMount.readOnly()` attenuation idiom.**
+  A `readOnly()` mount minting handles via `mount.lookup(entry)` and answering `mount.has(entry)` / `mount.stat(entry)` is trivially attenuated.
+  A `readOnly()` mount returning entries that carry their own observational or handle-minting methods would have to attenuate every issued entry too, or fail to attenuate at all.
+
+The chosen shape — entries hold neither observational authority nor handle-minting authority — is the strict ocap version.
+The trade-off is a small ergonomic loss (`mount.lookup(entry)` and `mount.has(entry)` are one extra noun per call vs. `entry.openFile()` and `entry.exists()`) for a substantial authority-reasoning gain.
+If a real use case surfaces where the value shape is awkward enough to warrant revisiting, the implementation can re-add either axis to the entry as a sugar layer over the mount's authority; that addition would not break the mount-is-authority discipline as long as the entries continue to delegate to the mount rather than holding authority directly.
+
+### `EndoMount.lookup()` semantics on missing nodes
+
+`EndoMount.lookup(entry)` returns a live handle for an existing node and **throws** `EndoMountMissingError` for a missing one.
+Callers that want to test before opening use `mount.has(entry)` first; the `mount.has(entry) → mount.lookup(entry)` pattern is the recommended idiom.
+No `maybeLookup` sibling is part of the initial design; if usage warrants one later, it can be added without contract breakage.
+The throw-on-missing default is consistent with the existing `lookup(path)` behavior that exists today.
+
+### `EndoMountStat`
+
+```ts
+type EndoMountStat = {
+  kind: 'file' | 'directory' | 'symlink';
+  sizeBytes?: number;
+  modifiedMs?: number;
+};
+```
+
+This is intentionally narrower than Node's `Stats` object.
+It exposes the portable facts callers commonly need without coupling public APIs to Node.
+
+## Path and Descriptor Semantics
+
+### Path Input
+
+Path strings remain accepted only as relative selectors within an already granted mount.
+They are normalized once when turned into an `EndoMountEntry`.
+
+Recommended rules:
+
+- Reject empty segments.
+- Reject embedded `/`, `\`, or NUL bytes in segment-oriented APIs.
+- For descriptor minting, reject `..` rather than silently clamping it.
+- Preserve compatibility behavior for older convenience methods until callers migrate.
+
+Rejecting traversal when minting descriptors is preferable to preserving a representation that only becomes safe after later clamping.
+
+### Descriptor Provenance
+
+Any operation accepting `EndoMountEntry` must verify that:
+
+1. The entry was minted by the same mount lineage.
+2. The caller is not using an entry from an attenuated view to regain write authority removed by `readOnly()`.
+3. The normalized path remains confined at operation time after symlink resolution.
+
+The third condition preserves the current TOCTOU-resistant confinement check already used by `EndoMount`.
+
+## Snapshot Semantics
+
+`snapshot()` should become the canonical bridge from live mutable storage to immutable snapshot storage:
+
+```mermaid
+flowchart TD
+  call["EndoMount.snapshot()"]
+  walk["recursively check in the mount read surface"]
+  persist["persist readable-blob / readable-tree formulas"]
+  result["return SnapshotTree"]
+  call --> walk --> persist --> result
+```
+
+Implementation should reuse the existing platform checkin machinery rather than reimplementing traversal:
+
+- `EndoMount` already satisfies the `ReadableTree` read surface.
+- `EndoMountFile` already satisfies the `ReadableBlob` read surface.
+- The daemon already delegates tree ingestion to `@endo/platform/fs/lite` `checkinTree()`.
+
+`snapshot()` must state its consistency guarantee.
+The minimum viable contract is **per-file consistency, no per-tree guarantee**.
+Each captured blob is the exact bytes that were present in that file at some moment during the snapshot operation.
+Each captured tree-entry name is the exact name that existed at some moment during the snapshot operation.
+The captures of different files may correspond to different moments.
+A concurrent writer that touches file A and then file B during the operation may produce a snapshot in which A reflects the post-write state while B reflects the pre-write state.
+The snapshot is hash-consistent per file, not per tree.
+
+**Missing-file and missing-directory races.**  A file removed mid-snapshot (the directory walk listed it, the per-file open found it absent) and a directory renamed or removed mid-snapshot (its listing succeeded, its child traversal found the path gone) **omit that entry from the snapshot tree** rather than fail the whole operation with a structured error.  The captured tree represents what was reachable from the mount root during the operation; an entry that vanished before its bytes could be captured was reachable for less than the whole walk and is excluded.  Reasoning: the per-file consistency contract above already permits the snapshot to represent different files at different moments, so omitting a moment-zero-existed-then-vanished entry is the natural extension of that mode, and the existing `@endo/platform/fs/lite` `checkinTree()` ingestion already accommodates a tree whose listing reflects what was reachable at walk time.  The structured-error alternative ("a missing-file race fails the whole snapshot") would push the burden onto every caller to retry against a sufficiently quiescent worktree, which the per-file mode already promises not to require.  If a downstream consumer surfaces a need to distinguish "absent because never present" from "absent because raced", the structured-error variant can be added as a stricter consistency mode alongside the future transactional mode.
+
+Stronger transactional capture (single filesystem instant across the whole tree) can be future work.
+
+## Host-Private Physical Backing
+
+Some trusted providers need more than the public read/write surface.
+A git provider, for example, needs to operate on repository metadata and the physical worktree together.
+
+Add a host-private backing abstraction:
+
+```ts
+interface EndoMountBacking {
+  kind(): 'physical';
+  // Returned only to trusted daemon code, never to guests.
+  getPhysicalRoot(): string;
+  grantFor(entry?: EndoMountEntry): SealedMountGrant;
+}
+```
+
+### Implementation: Hidden Facet on the Mount Formula
+
+The mount formula gains an additional Exo facet — `EndoMountBacking` — that lives alongside the guest-visible `EndoMount` and `EndoMountFile` facets but is never returned by any public method.
+Trusted daemon code holds a reference to the backing facet through a private host-side name table keyed on the mount's formula identifier; guest-visible introspection (`__getMethodNames__`, `inspect`, etc.) sees only the public facets.
+
+Trade-off rationale (WeakMap vs sealer/unsealer were the other live options):
+
+- a hidden Exo facet **survives daemon restart trivially** because it is reconstituted from the same formula as its sibling public facet, which matches `provideGit()`'s expectation that "the mount-derived `Git` capability re-derives correctly after restart" without any extra persistence machinery;
+- a `WeakMap` keyed on the public Exo would not survive restart; every `provideGit()` after restart would have to re-derive the backing out-of-band, doubling the surface that has to know about mount internals;
+- a sealer/unsealer pair would need a persisted seal key with its own threat model (where does the key live, how is it rotated, who else has unseal authority) and adds a separate first-class secret to the daemon.
+
+The hidden-facet implementation:
+
+- guests can pass mounts and entries around without ever observing the backing facet;
+- trusted providers prove two values belong to the same physical mount by identity-checking against the backing facet keyed on the public mount's formula id;
+- no public method reveals ambient filesystem paths; `getPhysicalRoot()` is on the backing facet only.
+
+## Relationship to `@endo/platform/fs`
+
+The intended convergence is:
+
+| Current daemon term | Shared filesystem role |
+|---|---|
+| `EndoMountFile` | `File` |
+| `EndoMount` | `Directory` |
+| `EndoMountFile.readOnly()` | `ReadableBlob` view |
+| `EndoMount.readOnly()` | `ReadableTree` view |
+| `EndoMountFile.snapshot()` | `SnapshotBlob` |
+| `EndoMount.snapshot()` | `SnapshotTree` |
+
+This plan does not require renaming the current daemon interfaces first.
+Instead, it requires every new method to move toward the shared shape so a later adapter or migration is mostly mechanical.
+
+## Security Considerations
+
+- **No public physical path leak.**
+  `displayPath()` is mount-relative only.
+- **Descriptor provenance is enforced.**
+  Callers cannot fabricate entries for another mount by passing arbitrary host strings.
+- **Symlink confinement remains operation-time.**
+  A descriptor does not bypass realpath checks.
+- **Read-only attenuation remains irreversible.**
+  A read-only mount should mint read-only entries and read-only handles.
+- **Descriptors are not ambient authority.**
+  They are useful only with the mount lineage that minted them.
+- **Missing paths are representable without write authority.**
+  Merely naming a possible entry does not create it or grant mutation.
+
+## Implementation Plan
+
+### Phase 1: Finish the Existing Contract
+
+- [ ] Implement `EndoMount.snapshot()`.
+- [ ] Add integration tests for snapshot round-tripping:
+  - [ ] live mount -> snapshot tree
+  - [ ] nested directories
+  - [ ] binary file streaming
+  - [ ] symlink confinement behavior
+- [ ] Update `daemon-mount.md` status once shipped.
+
+### Phase 2: Add Entry Descriptors
+
+- [ ] Add `EndoMountEntryInterface`.
+- [ ] Add `entry(path)` to `EndoMount`.
+- [ ] Store normalized relative segments plus mount lineage provenance.
+- [ ] Add `segments()`, `displayPath()`, and `child()` on entries (value-shaped, no observational authority and no handle-minting per Design Decision 3).
+- [ ] Observational queries (`has(entry)`, `stat(entry)`) and handle-minting (`lookup(entry)`) all live on `EndoMount` and accept an entry as the path-bearing argument; see next phase.
+- [ ] Add descriptor provenance tests:
+  - [ ] entries from one mount rejected by another mount
+  - [ ] read-only entries (via `readOnly()` mount) cannot regain write authority through handle-minting on a sibling mutable mount
+  - [ ] missing entries can round-trip without creating files
+
+### Phase 3: Add Entry Overloads, Metadata, and the `makeFile` Sibling
+
+- [ ] Add the `lookup(entry)`, `has(entry)`, and `stat(entry)` overloads on `EndoMount`.
+  Each accepts an entry as the path-bearing argument (the no-observational-authority queries an earlier draft had on the entry itself).
+- [ ] Add `stat(path)` for the path-form metadata query.
+- [ ] Add `makeFile(path, content?)` as the path-form sibling of `makeDirectory` (parallel construction; binary content via `Uint8Array`).
+  Existing path-form mutators (`writeText`, `remove`, `move`, `makeDirectory`) keep their current signatures unchanged.
+- [ ] Add `stat`, `append`, and `snapshot` on `EndoMountFile`.
+- [ ] Keep existing path convenience methods for compatibility.
+- [ ] Update help text and TypeScript declarations together with interface guards.
+
+### Phase 4: Add Trusted Backing Provenance
+
+- [ ] Introduce the host-private physical-backing facet or sealed-grant mechanism.
+- [ ] Ensure public mounts do not expose backing paths.
+- [ ] Add tests proving trusted code can correlate a mount with its backing while guest-visible introspection cannot recover that path.
+
+**Prerequisite.** The rationale claim that the hidden-facet implementation "survives daemon restart trivially because it is reconstituted from the same formula" assumes the daemon's formula machinery can reconstitute a sibling facet alongside the public `EndoMount` facet on the same formula.  Today's `mount` formula in `packages/daemon/src/mount.js` returns a single `makeExo('EndoMount', ...)` and `packages/daemon/src/daemon.js`'s formula switch (`case 'mount':`) returns one Exo per formula id.  The phase therefore depends on one of:
+- adding multi-facet support to the formula reconstitution path (a sibling Exo on the same formula id, addressable through a host-private name table keyed by formula id), or
+- expressing the backing facet as a derived formula that reconstitutes from the same mount formula id but lives in a separate host-private name table.
+
+The current implementation supports neither out of the box; the phase's first task is to choose between those two paths (or a third that the maintainer prefers) and to add the supporting formula-machinery change before any backing-facet code lands.
+
+### Phase 5: Converge with Shared Filesystem Types
+
+- [ ] Add adapters or aliases to make `EndoMount` / `EndoMountFile` satisfy the `Directory` / `File` contracts where practical.
+- [ ] Decide whether `EndoMount` remains a daemon-specific wrapper around `Directory` or becomes a daemon-local specialization.
+- [ ] Keep `ReadableTree` / `ReadableBlob` compatibility tests in place during migration.
+
+## Migration Notes
+
+- Existing users of `list`, `lookup`, `readText`, `writeText`, `remove`, `move`, and `makeDirectory` continue to work with their current signatures.
+  `makeDirectory` keeps its name and shape; it is the established convention across `daemon-mount`, `platform-fs`, `daemon-weblet-application`, `filesystem-watchers`, the implemented `packages/platform/src/fs` surface, and its consumers in `packages/chat`, `packages/fae`, and `packages/lal`.
+- `makeFile(path, content?)` is the new path-form sibling of `makeDirectory`.
+  It is additive: no existing method is renamed, removed, or re-typed.
+  `writeText(path, content)` remains the truncate-and-write path for the text-only case; `makeFile` is the constructive sibling for parallel use with `makeDirectory` and for binary content.
+- Entry overloads (`has(entry)`, `stat(entry)`, `lookup(entry)`) are additive overloads on existing query / handle-minting methods; the path-form callers remain unchanged.
+- New code that performs more than one operation on the same node should prefer entries and handles.
+- Git should depend on `EndoMountEntry`, not on free-form relative path strings.
+- Future Fae / Lal filesystem tools should expose user-friendly path arguments at the tool boundary, then immediately convert them into mount entries internally.
+
+## Open Questions
+
+1. **Descriptors mount-local or namespace-local?**
+   When the full VFS namespace arrives, descriptors need to compose across providers (physical mount, git tree, memory backend, CAS).
+   This is a real open question whose answer depends on VFS-namespace design that lives in [daemon-capability-filesystem](daemon-capability-filesystem.md) and is out of scope for this trio.
+
+### Resolved (recorded as Design Decisions)
+
+The following questions were carried in early drafts; their resolutions live in *Design Decisions* below.
+
+- `readOnly()` interface narrowing — decision 6.
+- `entry(path)` accepting both arrays and slash strings — already in the `EndoMount` interface (`string | string[]`).
+- `displayPath()` public — decision 7.
+
+### Spike Tasks
+
+These are open questions that need measurement or a concrete use case before the answer is design-stable.
+Each lives as a checklist item under its associated phase.
+
+- **Snapshot consistency for build-reproducibility.**
+  The current contract is per-file-consistent, per-tree best-effort ([§ Snapshot Semantics](#snapshot-semantics)).
+  If a downstream caller (caplet build, deterministic test fixture) actually needs single-instant capture, run a spike during the snapshot-consumer's design pass to measure whether the per-file guarantee is sufficient or whether a stronger mode is required, then either accept the current contract or add a `snapshot({ consistency: 'transactional' })` option in a follow-up doc.
+  Until a real consumer surfaces the need, the per-file guarantee stays.
+
+## Design Decisions
+
+1. **Mount authority is an object.**
+   The guest holds `EndoMount`, `EndoMountFile`, and `EndoMountEntry`; the guest never holds the physical host path.
+2. **Strings are selectors, not authorities.**
+   Relative paths remain accepted as convenience inputs but are normalized into entries at the boundary.
+3. **`EndoMountEntry` is a value, not a handle.**
+   The entry carries no live-filesystem authority at all: no observational queries (`exists`, `stat`) and no handle-minting (`lookup`).
+   Both axes live on `EndoMount` and accept an entry as the path-bearing argument (`mount.has(entry)`, `mount.stat(entry)`, `mount.lookup(entry)`).
+   The entry is a passable, deeply read-only value the agent can hand around without conferring access.
+4. **`EndoMountBacking` is a hidden Exo facet on the mount formula.**
+   Restart-trivial, no extra persistence machinery, no separate seal key.
+5. **Snapshot consistency is per-file, best-effort per-tree.**
+   Stronger modes are a future addition gated on a real consumer.
+6. **`readOnly()` keeps the same-named-throwing-Exo convention initially.**
+   The structural-narrowing form (returning a `ReadableTree` / `ReadableBlob` that has no mutation methods at all) lands in Phase 5 alongside the shared `Directory` / `File` adoption; the initial form preserves source compatibility for the existing daemon callers.
+7. **`displayPath()` is public.**
+   The data is mount-relative-only (no host-path leak) and the convenience is worth more than the alternative "callers carry their own presentation string"; treating presentation as a property of the capability keeps the rendering consistent across consumers.


### PR DESCRIPTION
## Description

Three interdependent design documents that complete the EndoMount surface and add capability-derived git on top:

1. `designs/daemon-mount-capabilities.md` — completes EndoMount. `snapshot()` becomes real (per-file consistency, no per-tree guarantee). `EndoMountEntry` is a passable value carrying mount lineage and normalized segments only; observational (`has`, `stat`) and handle-minting (`lookup`) authority lives on `EndoMount` and accepts entries as path-bearing arguments via additive overloads. `makeFile(path, content?)` is added as the path-form sibling of the existing `makeDirectory` (parallel construction; binary content via `Uint8Array`); no existing method is renamed. `EndoMountBacking` is a hidden Exo facet on the mount formula for trusted host-private physical access without leaking host paths.

2. `designs/daemon-git-capability.md` — revised git design over EndoMount. `provideGit(mountCap, petName)` is cap-passing only; name-table lookup is a separate authority that agent harnesses may use as a convenience at their layer. Worktree mutation, `tree(ref)` for historical reads, and `readOnly()` for in-place attenuation all live on the `Git` cap. Both construction paths produce the same authority shape internally: `provideGit(writableMount).readOnly()` and `provideGit(readOnlyMount)` yield equivalent read-only `Git` caps; `readOnly()` is idempotent; the `Git` formula carries read-only state as a field, not a wrapper convention. `GitRemote` construction is rejected from a read-only `Git`. Repository identity is pinned at construction via a common-dir + first-commit-OID + config-hash tuple with named handling for empty repos, unborn branches, linked worktrees, detached HEAD, and submodules. `GitBackend` is the essential contract, native-first; `NativeGitBackend` carries the hardening envelope separately so a future JS backend can implement the essential parts. Pinned git >= 2.30 with `--porcelain=v2` parsing surfaces. Structured result shapes (`GitDiff`, `GitConflict`, `GitMergeResult`, etc.) named for Phase 7 alongside `*Text` porcelain siblings.

3. `designs/daemon-git-remotes.md` — remote git companion. `fetch` / `pull` / `push` composed from local `Git` plus separately authorized HTTPS transport plus non-extractable bearer or basic credentials, bundled into a `GitRemote` capability. Credential injection runs through a daemon-shipped `GIT_ASKPASS` helper fed by an anonymous pipe (fd-only, never argv, env, or persisted state). No ambient git credential helpers; only daemon-controlled injection. Bearer support is gated on the credential-injection portability spike. CapTP carries control-plane authority while git packfile bytes travel on the bounded HTTPS data plane outside CapTP messages. Endpoint policy is formula-owned in Phase 1, controller-owned once Phase 5 lands. A Policy Validation Matrix table spells out the refspec / branch / tag / delete / force / wildcard / deletion combinations.

### Security Considerations

This PR is a security-relevant design. The trio describes object-capability discipline for filesystem and git access:

- `EndoMount` authority is an object, not a path string; the host's physical-backing facet is hidden and not part of the guest surface.
- `EndoMountEntry` is a value with no observational or handle-minting authority of its own; entries are passed *to* the mount, never used to mint authority directly.
- `Git` derives only from a cap-passed `EndoMount`; no string→`Git` path exists.
- `Git.readOnly()` returns an attenuated cap whose mutation methods throw; `provideGit(readOnlyMount)` yields the same authority shape directly. Both forms are idempotent.
- Repository identity is pinned at construction to defend against `.git` being swapped under the mount.
- Remote credentials are non-extractable: injected via daemon-controlled `GIT_ASKPASS` over an anonymous pipe; never in argv, env, persisted temp files, or guest-visible state.
- No ambient git credential helpers, SSH agents, or hooks; daemon-controlled injection is the only path.

### Scaling Considerations

Bulk tree reads (`storeTree`, `stageTree`, checkout-like flows, caplet source import) avoid per-file shell-outs by streaming `git archive --format=tar` through trusted daemon code; the guest still sees only `ReadableTree` / `ReadableBlob`. The bulk path is a backend-private data plane, not a public API.

### Documentation Considerations

This PR *is* the documentation. Each doc is self-contained: metadata, Summary, Read-in-order preamble, Design Decisions, Open Questions, Spike Tasks. `designs/README.md` row updated for each of the three docs.

### Testing Considerations

Test catalogs in each design doc (§ Testing Plan). Coverage includes:

- Daemon-restart-mid-operation: rebase across restart, push interrupted by `revoke()`, credential rotation mid-operation, `.git` replaced under the mount mid-operation.
- Capability tests: rejection of read-only-mount writes, `Git.readOnly()` idempotence, `GitRemote` rejection from read-only `Git`, identity-pinning verification across `.git` swap.
- Hardening tests: no ambient credential helpers, no shell interpolation, no secrets visible via `/proc/*/environ`.
- Bulk-tree tests: large subtree materialization via archive path produces the same CAS result as the lazy tree walk; rejects malformed/malicious archive entries.

### Compatibility Considerations

Design-only PR; no source changes in this PR. All `EndoMount` changes are additive: new overloads on `has` / `stat` / `lookup` that accept an `EndoMountEntry`, new `entry(path)` and `stat(path)` methods, and a new `makeFile(path, content?)` sibling of the existing `makeDirectory`. No existing method is renamed or re-typed.

### Upgrade Considerations

N/A.
