### PR TITLE
feat(daemon): complete EndoMount and specialize as Directory (Phases 1–5)

### DIFF
--- a/.changeset/daemon-endomount-directory-specialization.md
+++ b/.changeset/daemon-endomount-directory-specialization.md
@@ -1,0 +1,9 @@
+---
+'@endo/daemon': major
+---
+
+Specialize `EndoMount` as a directory, separate the file kind, and reshape mount entries as pure values.
+
+- `EndoMountEntry` is now a pure value with no observational or handle-minting authority. Its surface is `segments()`, `displayPath()`, and `child(name)`; the prior entry methods `openDirectory`, `openFile`, `createDirectory`, and `createFile` are removed. Consumers that want a live handle on a child go through the parent mount: `mount.lookup(name)` returns the child `EndoMount` (for directories) or `EndoMountFile` (for files). `has`, `stat`, and `lookup` accept either a path string or an entry value.
+- `EndoMount.makeDirectory(path)` returns `Promise<EndoMount>` instead of `Promise<void>`; the new directory is the resolved value. `EndoMount.makeFile(path, content?)` is added and returns `Promise<EndoMountFile>`. Callers that relied on `makeDirectory` resolving to `undefined` and then re-looked-up the child should now use the resolved mount directly.
+- `EndoMount.readOnly()` returns a structural `ReadableTree` view rather than another `EndoMount`; `EndoMountFile.readOnly()` returns a structural `ReadableBlob` view.

--- a/designs/README.md
+++ b/designs/README.md
@@ -104,7 +104,7 @@ LLM-agent stack).*
 | [daemon-git-remotes](daemon-git-remotes.md) | 2026-05-18 | 2026-05-21 | Proposed |
 | [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-05-19 | In Progress (PR #287) |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-05-19 | In Progress |
-| [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-05-20 | Proposed |
+| [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-05-26 | Proposed |
 | [filesystem-watchers](filesystem-watchers.md) | 2026-05-07 | 2026-05-07 | Not Started |
 | [platform-fs](platform-fs.md) | 2026-03-18 | 2026-05-19 | **Complete** |
 | [daemon-capability-persona](daemon-capability-persona.md) | 2026-02-16 | 2026-02-24 | Not Started |

--- a/designs/daemon-mount-capabilities.md
+++ b/designs/daemon-mount-capabilities.md
@@ -3,7 +3,7 @@
 | | |
 |---|---|
 | **Created** | 2026-05-18 |
-| **Updated** | 2026-05-20 |
+| **Updated** | 2026-05-26 |
 | **Author** | 0xPatrick (prompted) |
 | **Status** | Proposed |
 
@@ -437,6 +437,84 @@ The intended convergence is:
 This plan does not require renaming the current daemon interfaces first.
 Instead, it requires every new method to move toward the shared shape so a later adapter or migration is mostly mechanical.
 
+### Convergence shape: specialization, not wrapping
+
+The convergence is implemented as **specialization**.
+`EndoMount` *is* a `Directory`: its `M.interface('EndoMount', ...)` guard's
+overlapping methods exactly match `DirectoryInterface`'s method shapes,
+and `EndoMountFile` *is* a `File` in the same way.
+No wrapping Exo sits between `EndoMount` and a platform-side `Directory`
+Exo, and no separate adapter object is involved.
+The `makeMountExo` factory in `packages/daemon/src/mount.js` continues
+to mint one Exo per mount; that Exo simply gains the methods required
+to satisfy `DirectoryInterface` (see § *Phase 5* below for the concrete
+additions).
+
+**Why specialize rather than wrap.**
+The platform-fs `Directory` Exo does not exist in tree today.
+`packages/platform/src/fs/interfaces.js` declares `DirectoryInterface`,
+but no `makeDirectory(...)`-style factory materializes that contract;
+`packages/platform/src/fs-node/` ships only `makeTreeWriter`, the
+narrower push interface.
+`EndoMount` is already the only `Directory`-shaped capability in the
+codebase, and the read surface is structurally satisfied today —
+`checkinTree` consumes an `EndoMount` via `list` / `lookup` /
+`streamBase64` alone, with no other knowledge of the type.
+
+Specializing keeps a single Exo, a single confinement check per method,
+and a single set of mount-specific extensions (`entry`, `stat(entry)`,
+`displayPath`, `EndoMountBacking`, symlink-confined realpath checks)
+co-located with the methods they constrain.
+A wrapper shape would instead need a platform `Directory` Exo built
+first, then a daemon Exo around it.
+That arrangement would split the confinement boundary across two
+facets — opening the question "does the inner `Directory.write` bypass
+mount confinement?" — and would buy no semantic separation, because
+every mount-specific concern would still need to live on the outer
+facet.
+
+A future generic `Directory` Exo in `@endo/platform/fs-node/` (the
+platform-fs Phase 4 work) is **not** a prerequisite for `EndoMount`
+Phase 5.
+The `Directory` *contract* (the interface guard) is the prerequisite;
+the *implementation* of that contract for the daemon's mount is what
+this plan delivers.
+A separate platform-side `Directory` Exo can be added later for
+in-memory, zip-backed, or remote-only directories without disturbing
+`EndoMount`.
+
+### Naming-collision discipline
+
+Three names in adjacent regions of the codebase are easy to confuse:
+
+- `EndoDirectory` (in `packages/daemon/src/interfaces.js` and
+  `packages/daemon/src/directory.js`) is the daemon's formula-graph
+  **naming hub** — `identify`, `locate`, `followNameChanges`, `lookup` by
+  pet name.  It is *not* a filesystem directory.  Its `M.interface`
+  label is `'EndoDirectory'`.
+- `Directory` (in `packages/platform/src/fs/interfaces.js`) is the
+  shared filesystem contract — `write`, `remove`, `move`, `copy`,
+  `makeDirectory`, `readOnly() → ReadableTree`, `snapshot() → SnapshotTree`.
+  Its `M.interface` label is `'Directory'`.
+- `EndoMount` (in `packages/daemon/src/mount.js`) is the daemon's
+  specialization of `Directory` for a confined physical subtree.  Its
+  `M.interface` label is `'EndoMount'`.
+
+Both `packages/platform/src/fs/interfaces.js` and
+`packages/daemon/src/interfaces.js` export a binding named
+`DirectoryInterface`, and those two bindings have structurally
+different shapes.
+Phase 5 import sites that touch both must disambiguate at the import
+keyword, typically as:
+
+```js
+import { DirectoryInterface as PlatformDirectoryInterface } from '@endo/platform/fs';
+import { DirectoryInterface as EndoDirectoryInterface } from './interfaces.js';
+```
+
+`EndoDirectory` is not renamed by this plan; renaming the formula-graph
+hub is a separate decision with wide blast radius.
+
 ## Security Considerations
 
 - **No public physical path leak.**
@@ -530,6 +608,8 @@ The following questions were carried in early drafts; their resolutions live in 
 - `readOnly()` interface narrowing — decision 6.
 - `entry(path)` accepting both arrays and slash strings — already in the `EndoMount` interface (`string | string[]`).
 - `displayPath()` public — decision 7.
+- `EndoMount` wrapper-vs-specialization for the `Directory` convergence
+  — decision 8.
 
 ### Spike Tasks
 

--- a/packages/daemon/CLAUDE.md
+++ b/packages/daemon/CLAUDE.md
@@ -78,9 +78,9 @@ Formula type: `readable-tree`.
 Live, mutable daemon-side filesystem access created by
 `provideMount(path, petName, opts)`.
 Implemented in `src/mount.js`.
-Methods: `has`, `list`, `lookup`, `readText`, `maybeReadText`,
-`writeText`, `remove`, `move`,
-`makeDirectory`, `readOnly`, `snapshot`, `help`.
+Methods: `has`, `list`, `lookup`, `entry`, `stat`, `readText`,
+`maybeReadText`, `writeText`, `remove`, `move`, `makeDirectory`,
+`makeFile`, `readOnly`, `snapshot`, `help`.
 Path arguments accept `string | string[]` (a single name or
 an array of path segments).
 

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -219,6 +219,16 @@ export const makeFilePowers = ({ fs, path: fspath }) => {
 
   /**
    * @param {string} path
+   * @param {string} text
+   */
+  const appendFileText = async (path, text) => {
+    await writeJobs.enqueue(async () => {
+      await fs.promises.appendFile(path, text);
+    });
+  };
+
+  /**
+   * @param {string} path
    */
   const readFileText = async path => {
     return fs.promises.readFile(path, 'utf-8');
@@ -334,6 +344,46 @@ export const makeFilePowers = ({ fs, path: fspath }) => {
   };
 
   /** @param {string} path */
+  const statPath = async path => {
+    const stat = await fs.promises.lstat(path);
+    const kind = /** @type {'directory' | 'file' | 'symlink'} */ (
+      stat.isDirectory()
+        ? 'directory'
+        : stat.isSymbolicLink()
+          ? 'symlink'
+          : 'file'
+    );
+    return harden({
+      kind,
+      sizeBytes: stat.size,
+      modifiedMs: stat.mtimeMs,
+    });
+  };
+
+  /**
+   * Stable filesystem identity for a path, used as a content-store
+   * key.  Returns `<dev>:<ino>` from `stat()` (which follows symlinks
+   * intentionally — two symlinks to the same regular file should
+   * share an identity).
+   *
+   * Unix-targeted: `dev`/`ino` are the POSIX device and inode pair
+   * and are stable for the lifetime of the underlying inode on
+   * Linux/macOS.  On Windows, Node's `fs.Stats.ino` is derived from
+   * the NTFS file index (a 64-bit identifier that may collide across
+   * volumes and is not always stable across renames); Windows
+   * portability would need a different identity scheme (e.g.
+   * `GetFileInformationByHandleEx`'s `FILE_ID_INFO`).  The daemon is
+   * Unix-only today; this comment is the bookmark for a future
+   * Windows port.
+   *
+   * @param {string} path
+   */
+  const pathIdentity = async path => {
+    const stat = await fs.promises.stat(path);
+    return `${stat.dev}:${stat.ino}`;
+  };
+
+  /** @param {string} path */
   const exists = async path => {
     try {
       await fs.promises.access(path);
@@ -347,6 +397,7 @@ export const makeFilePowers = ({ fs, path: fspath }) => {
     makeFileReader,
     makeFileWriter,
     writeFileText,
+    appendFileText,
     readFileText,
     readFileBytes,
     readFile,
@@ -359,6 +410,8 @@ export const makeFilePowers = ({ fs, path: fspath }) => {
     removeDirectory,
     renamePath,
     realPath,
+    pathIdentity,
+    statPath,
     isDirectory,
     exists,
   });

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -85,7 +85,7 @@ import {
 /** @import { Passable } from '@endo/pass-style' */
 /** @import { ERef, FarRef } from '@endo/eventual-send' */
 /** @import { PromiseKit } from '@endo/promise-kit' */
-/** @import { AgentDeferredTaskParams, Builtins, CapTpConnectionRegistrar, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeArchiveFormula, MakeCapletDeferredTaskParams, MakeFromTreeFormula, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha256, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, TimerFormula } from './types.js' */
+/** @import { AgentDeferredTaskParams, Builtins, CapTpConnectionRegistrar, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoMount, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeArchiveFormula, MakeCapletDeferredTaskParams, MakeFromTreeFormula, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha256, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, TimerFormula } from './types.js' */
 
 /**
  * Creates a delayed promise that can be cancelled.
@@ -1435,6 +1435,24 @@ const makeDaemonCore = async (
     );
 
   /**
+   * @param {object} tree
+   */
+  const snapshotMountTree = async tree => {
+    const { sha256 } = await platformCheckinTree(tree, contentStore);
+    return makeReadableTree(sha256);
+  };
+
+  /**
+   * @param {string} filePath
+   */
+  const snapshotMountFile = async filePath => {
+    const sha256 = await contentStore.store(
+      filePowers.makeFileReader(filePath),
+    );
+    return makeReadableBlob(sha256);
+  };
+
+  /**
    * @param {FormulaIdentifier} workerId
    * @param {string} source
    * @param {Array<string>} codeNames
@@ -2601,7 +2619,13 @@ const makeDaemonCore = async (
       if (!isDir) {
         throw new Error(`Mount path is not a directory: ${q(mountPath)}`);
       }
-      return makeMount({ rootPath: mountPath, readOnly, filePowers });
+      return makeMount({
+        rootPath: mountPath,
+        readOnly,
+        filePowers,
+        snapshotTree: snapshotMountTree,
+        snapshotFile: snapshotMountFile,
+      });
     },
     'scratch-mount': async ({ readOnly }, _context, _id, formulaNumber) => {
       const rootPath = filePowers.joinPath(
@@ -2610,7 +2634,13 @@ const makeDaemonCore = async (
         /** @type {string} */ (formulaNumber),
       );
       await filePowers.makePath(rootPath);
-      return makeMount({ rootPath, readOnly, filePowers });
+      return makeMount({
+        rootPath,
+        readOnly,
+        filePowers,
+        snapshotTree: snapshotMountTree,
+        snapshotFile: snapshotMountFile,
+      });
     },
     lookup: ({ hub, path }, context) =>
       makeLookup(
@@ -3374,7 +3404,7 @@ const makeDaemonCore = async (
 
   /** @type {DaemonCore['formulateMount']} */
   const formulateMount = async (mountPath, readOnly, deferredTasks) => {
-    return /** @type {FormulateResult<unknown>} */ (
+    return /** @type {FormulateResult<EndoMount>} */ (
       withFormulaGraphLock(async () => {
         await null;
         const formulaNumber = /** @type {FormulaNumber} */ (
@@ -3402,7 +3432,7 @@ const makeDaemonCore = async (
 
   /** @type {DaemonCore['formulateScratchMount']} */
   const formulateScratchMount = async (readOnly, deferredTasks) => {
-    return /** @type {FormulateResult<unknown>} */ (
+    return /** @type {FormulateResult<EndoMount>} */ (
       withFormulaGraphLock(async () => {
         await null;
         const formulaNumber = /** @type {FormulaNumber} */ (

--- a/packages/daemon/src/help-text-data.js
+++ b/packages/daemon/src/help-text-data.js
@@ -212,7 +212,7 @@ export const helpTextEntries = harden([
     {
       '': 'EndoMount - Live mutable access to a filesystem directory.\n\nAll paths are confined to the mount root. Symlinks that escape\nthe root are invisible. Use readOnly() for an attenuated view.',
       help: 'help(methodName?) -> string\nGet documentation for this interface or a specific method.',
-      has: 'has(...pathSegments) -> Promise<boolean>\nCheck if a path exists within the mount.\nEach argument is one path segment: has("dir", "file.txt").',
+      has: 'has(...pathSegments | entry) -> Promise<boolean>\nCheck if a path exists within the mount.\nEither pass path segments (has("dir", "file.txt")) or a single EndoMountEntry.',
       list: 'list(...pathSegments) -> Promise<string[]>\nList directory entries at the given path.\nEach argument is one path segment: list("subdir").\nCall with no arguments to list the root.\nEntries with symlinks escaping the mount root are excluded.',
       lookup:
         'lookup(path) -> Promise<EndoMount | EndoMountFile>\nResolve a path within the mount.\npath: string | string[] — Name or path segments.\nReturns EndoMount for directories, EndoMountFile for files.',
@@ -226,11 +226,17 @@ export const helpTextEntries = harden([
         'remove(path) -> Promise<void>\nRemove a file or empty directory.\npath: string | string[] — Name or path segments.',
       move: 'move(from, to) -> Promise<void>\nRename an entry within the mount.\nfrom: string | string[] — Source name or path segments.\nto: string | string[] — Destination name or path segments.',
       makeDirectory:
-        'makeDirectory(path) -> Promise<void>\nCreate a directory (and missing parents).\npath: string | string[] — Name or path segments.',
+        'makeDirectory(path) -> Promise<EndoMount>\nCreate a directory (and missing parents) at the given path; returns a sub-mount.\npath: string | string[] | EndoMountEntry — Name, path segments, or mount entry.',
+      makeFile:
+        'makeFile(path, content?) -> Promise<void>\nCreate a file at the given path, with optional initial text content.\npath: string | string[] | EndoMountEntry — Name, path segments, or mount entry.\ncontent: string (optional) — Initial text content. An existing file is truncated when content is provided. For binary content, use `write(path, readableBlob)`.',
+      write:
+        'write(path, value) -> Promise<void>\nMaterialize a ReadableBlob or ReadableTree at the given path.\npath: string | string[] | EndoMountEntry — Name, path segments, or mount entry.\nvalue: ReadableBlob | ReadableTree — Source remotable; blobs are written as bytes, trees recurse.',
+      copy: 'copy(from, to) -> Promise<void>\nCopy a node within the mount.\nfrom: string | string[] | EndoMountEntry — Source name, path segments, or mount entry.\nto: string | string[] | EndoMountEntry — Destination name, path segments, or mount entry.\nBoth endpoints are confinement-checked.',
+      stat: 'stat(path) -> Promise<EndoMountStat | undefined>\nQuery metadata for a path within the mount.\npath: string | string[] | EndoMountEntry — Name, path segments, or mount entry.\nReturns undefined when the path is missing or escapes the mount.',
       readOnly:
-        'readOnly() -> EndoMount\nReturns a read-only view of this mount.',
+        'readOnly() -> ReadableTree\nReturns a structural ReadableTree view (has, list, lookup) of this mount.\nMount-specific extensions (entry, stat, readText, makeFile) are not on the view.',
       snapshot:
-        'snapshot() -> Promise<SnapshotTree>\nCapture current state as an immutable readable-tree.\n(Not yet implemented.)',
+        'snapshot() -> Promise<SnapshotTree>\nCapture current state as an immutable readable-tree.',
     },
   ],
   [
@@ -244,10 +250,12 @@ export const helpTextEntries = harden([
       json: 'json() -> Promise<any>\nRead and parse the file as JSON.',
       writeText:
         'writeText(content) -> Promise<void>\nWrite a string to the file. Throws if read-only.',
+      append:
+        'append(content) -> Promise<void>\nAppend a string to the file. Throws if read-only.',
       writeBytes:
         'writeBytes(readableRef) -> Promise<void>\nWrite bytes from an async iterator. Throws if read-only.',
       readOnly:
-        'readOnly() -> EndoMountFile\nReturns a read-only view of this file.',
+        'readOnly() -> ReadableBlob\nReturns a structural ReadableBlob view (streamBase64, text, json) of this file.\nMount-specific extensions (stat, snapshot) are not on the view.',
     },
   ],
 ]);

--- a/packages/daemon/src/help.md
+++ b/packages/daemon/src/help.md
@@ -658,10 +658,10 @@ the root are invisible. Use readOnly() for an attenuated view.
 
 Get documentation for this interface or a specific method.
 
-## has(...pathSegments) -> Promise<boolean>
+## has(...pathSegments | entry) -> Promise<boolean>
 
 Check if a path exists within the mount.
-Each argument is one path segment: has("dir", "file.txt").
+Either pass path segments (has("dir", "file.txt")) or a single EndoMountEntry.
 
 ## list(...pathSegments) -> Promise<string[]>
 
@@ -705,19 +705,44 @@ Rename an entry within the mount.
 from: string | string[] — Source name or path segments.
 to: string | string[] — Destination name or path segments.
 
-## makeDirectory(path) -> Promise<void>
+## makeDirectory(path) -> Promise<EndoMount>
 
-Create a directory (and missing parents).
-path: string | string[] — Name or path segments.
+Create a directory (and missing parents) at the given path; returns a sub-mount.
+path: string | string[] | EndoMountEntry — Name, path segments, or mount entry.
 
-## readOnly() -> EndoMount
+## makeFile(path, content?) -> Promise<void>
 
-Returns a read-only view of this mount.
+Create a file at the given path, with optional initial text content.
+path: string | string[] | EndoMountEntry — Name, path segments, or mount entry.
+content: string (optional) — Initial text content. An existing file is truncated when content is provided. For binary content, use `write(path, readableBlob)`.
+
+## write(path, value) -> Promise<void>
+
+Materialize a ReadableBlob or ReadableTree at the given path.
+path: string | string[] | EndoMountEntry — Name, path segments, or mount entry.
+value: ReadableBlob | ReadableTree — Source remotable; blobs are written as bytes, trees recurse.
+
+## copy(from, to) -> Promise<void>
+
+Copy a node within the mount.
+from: string | string[] | EndoMountEntry — Source name, path segments, or mount entry.
+to: string | string[] | EndoMountEntry — Destination name, path segments, or mount entry.
+Both endpoints are confinement-checked.
+
+## stat(path) -> Promise<EndoMountStat | undefined>
+
+Query metadata for a path within the mount.
+path: string | string[] | EndoMountEntry — Name, path segments, or mount entry.
+Returns undefined when the path is missing or escapes the mount.
+
+## readOnly() -> ReadableTree
+
+Returns a structural ReadableTree view (has, list, lookup) of this mount.
+Mount-specific extensions (entry, stat, readText, makeFile) are not on the view.
 
 ## snapshot() -> Promise<SnapshotTree>
 
 Capture current state as an immutable readable-tree.
-(Not yet implemented.)
 
 # EndoMountFile - A file within a mounted directory.
 
@@ -741,10 +766,15 @@ Read and parse the file as JSON.
 
 Write a string to the file. Throws if read-only.
 
+## append(content) -> Promise<void>
+
+Append a string to the file. Throws if read-only.
+
 ## writeBytes(readableRef) -> Promise<void>
 
 Write bytes from an async iterator. Throws if read-only.
 
-## readOnly() -> EndoMountFile
+## readOnly() -> ReadableBlob
 
-Returns a read-only view of this file.
+Returns a structural ReadableBlob view (streamBase64, text, json) of this file.
+Mount-specific extensions (stat, snapshot) are not on the view.

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -39,6 +39,35 @@ const assertPowersName = name => {
 };
 
 /**
+ * Validate a child name advertised by a remote ReadableTree. These
+ * names are literal entries, not path syntax, so traversal names and
+ * platform separators are rejected before materialization.
+ *
+ * Freestanding twin of `mount.js`'s `assertValidTreeEntryName`; both
+ * have the same effective contract (reject empty, `.`, `..`, `/`, `\`,
+ * `\0`).  The mount-side definition delegates to a local
+ * `assertValidSegment` helper that does not exist in this file, so
+ * this version is written out in one block rather than introducing a
+ * cross-file shared helper for a four-line guard.
+ *
+ * @param {unknown} name
+ */
+const assertValidTreeEntryName = name => {
+  if (
+    typeof name !== 'string' ||
+    name.length === 0 ||
+    name === '.' ||
+    name === '..' ||
+    name.includes('/') ||
+    name.includes('\\') ||
+    name.includes('\0')
+  ) {
+    throw makeError(X`Invalid tree entry name ${q(name)}`);
+  }
+};
+harden(assertValidTreeEntryName);
+
+/**
  * Normalizes host or guest options, providing default values.
  * @param {MakeHostOrGuestOptions | undefined} opts
  * @returns {{ introducedNames: Record<Name, PetName>, agentName?: PetName }}
@@ -286,6 +315,10 @@ export const makeHostMaker = ({
      * sandbox factory (`@endo/sandbox`) calls this for every granted
      * mount before assembling the driver's `SliceSpec`.  Sandbox
      * drivers themselves never call it; only the factory does.
+     * Since EndoHost is a fully privileged host-authority cap, any
+     * holder of one can intentionally recover host paths for
+     * daemon-minted top-level mounts. Less trusted code must receive
+     * an EndoGuest or narrower powers object instead.
      *
      * The resolver rejects any cap the daemon did not mint as a
      * top-level `mount` or `scratch-mount` formula, including
@@ -629,11 +662,23 @@ export const makeHostMaker = ({
     };
 
     /**
-     * Walk a ReadableTree or Mount and materialise every file into the
-     * destination Mount via `writeText`.  Children are identified by
-     * their advertised method names: anything with `text` is a
-     * blob/file; anything with `list` is a subtree.  Both Mount and
+     * Walk a ReadableTree or Mount and materialise every entry into the
+     * destination Mount via `write()`, preserving blob bytes instead
+     * of passing through text decoding. Children are identified by
+     * their advertised method names: anything with `streamBase64` is a
+     * blob/file; anything with `list` is a subtree. Both Mount and
      * ReadableTree surfaces participate.
+     *
+     * Why not just `E(dst).write([], src)`? `EndoMount.write()` performs
+     * the same discovery shape internally, so the walker reads as
+     * duplication.  It is kept here as a per-leaf seam: stageTree
+     * callers (sandbox provisioning, fae/lal tool surfaces) want a
+     * place to land per-entry diagnostics, progress reporting, or
+     * per-leaf policy hooks without re-entering the mount's write
+     * machinery.  Removing the walker in favor of a single `write()`
+     * call would push any future per-leaf work back through the
+     * mount-side primitive, which is the wrong site for host-level
+     * concerns.
      *
      * @param {any} src - source readable-tree or mount
      * @param {any} dst - destination scratch mount (must be writable)
@@ -642,38 +687,22 @@ export const makeHostMaker = ({
     const materializeTree = async (src, dst, pathSegments = []) => {
       const names = await E(src).list(...pathSegments);
       for (const name of names) {
-        // Defense against an adversarial source tree that advertises
-        // path-traversal segments.  Mount.writeText would clamp
-        // these at the confinement root, but they would still cause
-        // the discovery walk to revisit parent directories.
-        if (name === '.' || name === '..' || name.includes('/')) {
-          throw makeError(
-            X`Invalid tree entry name ${q(name)} at ${q(pathSegments)}`,
-          );
-        }
+        assertValidTreeEntryName(name);
         const subPath = [...pathSegments, name];
         // eslint-disable-next-line no-await-in-loop
         const child = await E(src).lookup(subPath);
         const methodNames =
           // eslint-disable-next-line no-await-in-loop, no-underscore-dangle
           await E(child).__getMethodNames__();
-        const looksLikeBlob = methodNames.includes('text');
+        const looksLikeBlob = methodNames.includes('streamBase64');
         const looksLikeTree = methodNames.includes('list');
         if (looksLikeBlob && looksLikeTree) {
           throw makeError(
-            X`Tree entry ${q(subPath)} has both text and list — ambiguous shape`,
+            X`Tree entry ${q(subPath)} has both streamBase64 and list — ambiguous shape`,
           );
-        } else if (looksLikeBlob) {
+        } else if (looksLikeBlob || looksLikeTree) {
           // eslint-disable-next-line no-await-in-loop
-          const content = await E(child).text();
-          // eslint-disable-next-line no-await-in-loop
-          await E(dst).writeText(subPath, content);
-        } else if (looksLikeTree) {
-          // Subdirectory — create it then recurse.
-          // eslint-disable-next-line no-await-in-loop
-          await E(dst).makeDirectory(subPath);
-          // eslint-disable-next-line no-await-in-loop
-          await materializeTree(src, dst, subPath);
+          await E(dst).write(subPath, child);
         } else {
           throw makeError(
             X`Tree entry ${q(subPath)} is neither a blob nor a subtree (methods: ${q(methodNames)})`,
@@ -706,12 +735,9 @@ export const makeHostMaker = ({
       const tree = await provide(/** @type {FormulaIdentifier} */ (treeId));
       // For live mounts, prefer to snapshot the source first so
       // concurrent writes to the mount cannot perturb the running
-      // caplet.  ReadableTrees are already immutable.  Mount's
-      // `snapshot()` is not implemented at the time of writing
-      // (mount.js:305 throws); we therefore swallow that "not yet
-      // implemented" rejection and fall back to walking the live
-      // mount.  When mount.snapshot lands, this code path becomes
-      // automatically isolated.
+      // caplet. ReadableTrees are already immutable. Older mounts
+      // may still reject snapshot(), so keep the live-walk fallback
+      // for compatibility with remote or stale providers.
       let sourceForWalk = tree;
       try {
         // eslint-disable-next-line no-underscore-dangle

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -1,6 +1,10 @@
 // @ts-check
 
 import { M } from '@endo/patterns';
+import {
+  DirectoryInterface as PlatformDirectoryInterface,
+  FileInterface as PlatformFileInterface,
+} from '@endo/platform/fs/lite';
 
 // #region Patterns
 
@@ -323,9 +327,11 @@ export const HostInterface = M.interface('EndoHost', {
   provideScratchMount: M.call(NameOrPathShape)
     .optional(M.splitRecord({}, { readOnly: M.boolean() }))
     .returns(M.promise()),
-  // Resolve a Mount capability to its host filesystem path. Used by
-  // the @endo/sandbox factory (and similar make-unconfined plugins)
-  // to translate granted Mount caps into bind-mount source paths.
+  // Resolve a Mount capability to its host filesystem path. This is
+  // deliberately part of the fully privileged EndoHost surface used
+  // by the @endo/sandbox factory (and similar make-unconfined
+  // plugins); do not hand an EndoHost cap to code that should not be
+  // able to recover host paths for daemon-minted top-level mounts.
   provideHostPath: M.call(M.any()).returns(M.promise()),
   // Provide a guest
   provideGuest: M.call().optional(NameShape, M.record()).returns(M.promise()),
@@ -505,36 +511,84 @@ export const BlobInterface = M.interface('EndoBlob', {
 });
 
 const PathSegmentsShape = M.arrayOf(M.string());
-const PathArgShape = M.or(M.string(), PathSegmentsShape);
+const MountEntryShape = M.remotable('EndoMountEntry');
+const PathArgShape = M.or(M.string(), PathSegmentsShape, MountEntryShape);
 
+// `EndoMount` extends `Directory` from `@endo/platform/fs`.  Method
+// shapes that overlap with `PlatformDirectoryInterface` carry the
+// same `M.call(...)` arguments (path segments arrays plus an
+// `M.remotable()` value for `write`) and return shapes; the
+// mount-specific extensions (entry-arg overloads, `entry`, `stat`,
+// `readText`, `maybeReadText`, `writeText`, `makeFile`, `help`) are
+// additions, not redefinitions.  `has` widens `rest()` to `M.any()`
+// because the daemon supports the single-entry-value overload that
+// the platform contract does not name.
 export const MountInterface = M.interface('EndoMount', {
-  // ReadableTree-compatible surface
-  has: M.call().rest(PathSegmentsShape).returns(M.promise()),
+  // ReadableTree-compatible surface.  `has` accepts either variadic
+  // path segments or a single entry value; the impl validates the
+  // shape because rest-with-M.or pattern guards do not narrow
+  // remotables consistently across CapTP.
+  has: M.call().rest(M.any()).returns(M.promise()),
   list: M.call().rest(PathSegmentsShape).returns(M.promise()),
   lookup: M.call(PathArgShape).returns(M.promise()),
+  // Directory-shape write/copy (literal shapes from
+  // PlatformDirectoryInterface for the path-segment form; entry-form
+  // overloads accept an `EndoMountEntry` as the path argument).
+  write: M.call(PathArgShape, M.remotable()).returns(M.promise()),
+  copy: M.call(PathArgShape, PathArgShape).returns(M.promise()),
+  // Mount-scoped descriptor minting (no I/O).
+  entry: M.call(M.or(M.string(), PathSegmentsShape)).returns(MountEntryShape),
+  // Metadata.
+  stat: M.call(PathArgShape).returns(M.promise()),
   // Raw data I/O
   readText: M.call(PathArgShape).returns(M.promise()),
   maybeReadText: M.call(PathArgShape).returns(M.promise()),
   writeText: M.call(PathArgShape, M.string()).returns(M.promise()),
+  // Path-form constructors.  `makeDirectory` returns a sub-mount
+  // (matches `Directory.makeDirectory(path): Promise<Directory>`);
+  // `makeFile` is the constructive sibling for parallel use.
+  makeDirectory: M.call(PathArgShape).returns(M.promise()),
+  makeFile: M.call(PathArgShape).optional(M.any()).returns(M.promise()),
   // Mutation
   remove: M.call(PathArgShape).returns(M.promise()),
   move: M.call(PathArgShape, PathArgShape).returns(M.promise()),
-  makeDirectory: M.call(PathArgShape).returns(M.promise()),
-  // Attenuation
-  readOnly: M.call().returns(M.remotable()),
+  // Attenuation — returns a structural ReadableTree view, not an
+  // EndoMount.  Callers that need mount-specific extensions on a
+  // read-only handle keep a reference to the un-attenuated mount.
+  readOnly: M.call().returns(M.remotable('ReadableTree')),
   // Snapshot
   snapshot: M.call().returns(M.promise()),
   // Discoverability
   help: M.call().returns(M.string()),
 });
 
+// `EndoMountFile` extends `File` from `@endo/platform/fs`.  The
+// overlapping methods (`streamBase64`, `text`, `json`, `writeText`,
+// `writeBytes`, `append`, `snapshot`) carry the same shapes as
+// `PlatformFileInterface`; `stat` and `help` are mount-specific
+// extensions.  `readOnly` narrows to a structural ReadableBlob view.
 export const MountFileInterface = M.interface('EndoMountFile', {
   text: M.call().returns(M.promise()),
   streamBase64: M.call().returns(M.remotable()),
   json: M.call().returns(M.promise()),
   writeText: M.call(M.string()).returns(M.promise()),
+  append: M.call(M.string()).returns(M.promise()),
   writeBytes: M.call(M.remotable()).returns(M.promise()),
-  readOnly: M.call().returns(M.remotable()),
+  stat: M.call().returns(M.promise()),
+  snapshot: M.call().returns(M.promise()),
+  readOnly: M.call().returns(M.remotable('ReadableBlob')),
+  help: M.call().returns(M.string()),
+});
+
+// Re-export so importing modules that already pull from
+// `./interfaces.js` can reach the platform shapes without a second
+// import line.
+export { PlatformDirectoryInterface, PlatformFileInterface };
+
+export const MountEntryInterface = M.interface('EndoMountEntry', {
+  segments: M.call().returns(PathSegmentsShape),
+  displayPath: M.call().returns(M.string()),
+  child: M.call(M.string()).returns(MountEntryShape),
   help: M.call().returns(M.string()),
 });
 

--- a/packages/daemon/src/libp2p-utils-adaptive-timeout.d.ts
+++ b/packages/daemon/src/libp2p-utils-adaptive-timeout.d.ts
@@ -1,0 +1,41 @@
+// TODO: remove this local shim once `@libp2p/utils` ships its own
+// `adaptive-timeout` typings (or re-exports `AdaptiveTimeout` from its
+// package root). Trigger: a published `@libp2p/utils` whose own
+// `types` field resolves the deep import without an ambient
+// declaration. When that lands, bump the dependency and delete this
+// file along with its tsconfig include.
+
+declare module '@libp2p/utils/src/adaptive-timeout.js' {
+  export const DEFAULT_TIMEOUT_MULTIPLIER: 1.2;
+  export const DEFAULT_FAILURE_MULTIPLIER: 2;
+  export const DEFAULT_MIN_TIMEOUT: 5000;
+  export const DEFAULT_MAX_TIMEOUT: 60000;
+  export const DEFAULT_INTERVAL: 5000;
+
+  export interface AdaptiveTimeoutSignal extends AbortSignal {
+    clear(): void;
+    start: number;
+    timeout: number;
+  }
+
+  export interface AdaptiveTimeoutInit {
+    metricName?: string;
+    metrics?: unknown;
+    interval?: number;
+    timeoutMultiplier?: number;
+    failureMultiplier?: number;
+    minTimeout?: number;
+    maxTimeout?: number;
+  }
+
+  export interface GetTimeoutSignalOptions {
+    timeoutFactor?: number;
+    signal?: AbortSignal;
+  }
+
+  export class AdaptiveTimeout {
+    constructor(init?: AdaptiveTimeoutInit);
+    getTimeoutSignal(options?: GetTimeoutSignalOptions): AdaptiveTimeoutSignal;
+    cleanUp(signal: AdaptiveTimeoutSignal): void;
+  }
+}

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -3,12 +3,24 @@
 
 /** @import { FilePowers } from './types.js' */
 
+import { E } from '@endo/far';
 import { q } from '@endo/errors';
 import { makeExo } from '@endo/exo';
+import {
+  ReadableBlobInterface,
+  ReadableTreeInterface,
+} from '@endo/platform/fs/lite';
 
 import { mountHelp, mountFileHelp, makeHelp } from './help-text.js';
-import { MountInterface, MountFileInterface } from './interfaces.js';
-import { makeIteratorRef } from './reader-ref.js';
+import {
+  MountEntryInterface,
+  MountFileInterface,
+  MountInterface,
+} from './interfaces.js';
+import { makeReaderRef } from './reader-ref.js';
+import { makeRefIterator, makeRefReader } from './ref-reader.js';
+
+const mountEntryRecords = new WeakMap();
 
 /**
  * Validate a single path segment.
@@ -34,6 +46,30 @@ const assertValidSegment = segment => {
   }
 };
 harden(assertValidSegment);
+
+/**
+ * Validate a child name advertised by a remote ReadableTree. Unlike
+ * path arguments, tree child names are literal directory entries, so
+ * "." and ".." must not be interpreted.
+ *
+ * Delegates to `assertValidSegment` (above) for the type, empty-string,
+ * and separator-character checks (`/`, `\`, `\0`), and adds the
+ * tree-specific `.`/`..` reject on top.  `host.js` has a freestanding
+ * twin of this validator with the same effective contract, written
+ * out in one block because that file has no local `assertValidSegment`
+ * to delegate to.  Both validators run check-before-trust on names
+ * arriving from a remote ReadableTree before any filesystem
+ * materialisation.
+ *
+ * @param {string} name
+ */
+const assertValidTreeEntryName = name => {
+  assertValidSegment(name);
+  if (name === '.' || name === '..') {
+    throw new Error(`Tree entry name must not be "." or "..": ${q(name)}`);
+  }
+};
+harden(assertValidTreeEntryName);
 
 /**
  * Resolve path segments relative to a current directory, clamped to a
@@ -65,6 +101,29 @@ const resolveSegments = (currentDir, confinementRoot, segments, filePowers) => {
   return resolved;
 };
 harden(resolveSegments);
+
+/**
+ * Normalize path segments against a mount-relative base, clamping '..' at root.
+ *
+ * @param {string[]} baseSegments
+ * @param {string[]} segments
+ * @returns {string[]}
+ */
+const normalizeSegments = (baseSegments, segments) => {
+  const normalized = [...baseSegments];
+  for (const segment of segments) {
+    if (segment === '.') {
+      // skip
+    } else if (segment === '..') {
+      normalized.pop();
+    } else {
+      assertValidSegment(segment);
+      normalized.push(segment);
+    }
+  }
+  return normalized;
+};
+harden(normalizeSegments);
 
 /**
  * Assert that a resolved path is contained within the confinement root.
@@ -151,10 +210,14 @@ harden(isConfinedPath);
 /**
  * @typedef {object} MountContext
  * @property {string} currentDir
+ * @property {string[]} currentSegments
  * @property {string} confinementRoot
+ * @property {object} rootId
  * @property {boolean} readOnly
  * @property {FilePowers} filePowers
  * @property {string} description
+ * @property {(tree: object) => Promise<object>} [snapshotTree]
+ * @property {(path: string) => Promise<object>} [snapshotFile]
  */
 
 /**
@@ -164,8 +227,17 @@ harden(isConfinedPath);
  * @returns {object}
  */
 const makeMountExo = ctx => {
-  const { currentDir, confinementRoot, readOnly, filePowers, description } =
-    ctx;
+  const {
+    currentDir,
+    currentSegments,
+    confinementRoot,
+    rootId,
+    readOnly,
+    filePowers,
+    description,
+    snapshotTree,
+    snapshotFile,
+  } = ctx;
 
   const assertWritable = () => {
     if (readOnly) {
@@ -180,17 +252,145 @@ const makeMountExo = ctx => {
   const resolve = segments =>
     resolveSegments(currentDir, confinementRoot, segments, filePowers);
 
+  /**
+   * Resolve mount-root-relative segments.
+   *
+   * @param {string[]} segments
+   */
+  const resolveFromRoot = segments =>
+    resolveSegments(confinementRoot, confinementRoot, segments, filePowers);
+
+  /**
+   * @param {string | string[] | object} pathArg
+   * @returns {string[]}
+   */
+  const segmentsFromPathArg = pathArg => {
+    if (Array.isArray(pathArg)) {
+      return normalizeSegments(currentSegments, pathArg);
+    }
+    if (typeof pathArg === 'object' && pathArg !== null) {
+      const record = mountEntryRecords.get(pathArg);
+      if (record === undefined) {
+        throw new Error('Path argument is not a daemon-minted mount entry');
+      }
+      if (record.rootId !== rootId) {
+        throw new Error('Mount entry belongs to a different mount root');
+      }
+      return record.segments;
+    }
+    if (typeof pathArg !== 'string') {
+      throw new Error(`Path must be a string, array, or mount entry`);
+    }
+    return normalizeSegments(currentSegments, [pathArg]);
+  };
+
+  /**
+   * `entry()` is the one mount API where a string is a slash-joined
+   * selector rather than a single name.  Other path-bearing convenience
+   * methods keep their existing single-name string compatibility.
+   *
+   * @param {string | string[]} pathArg
+   * @returns {string[]}
+   */
+  const segmentsFromEntryPathArg = pathArg => {
+    if (Array.isArray(pathArg)) {
+      return normalizeSegments(currentSegments, pathArg);
+    }
+    if (typeof pathArg !== 'string') {
+      throw new Error('entry() path must be a string or array');
+    }
+    return normalizeSegments(currentSegments, pathArg.split('/'));
+  };
+
+  /**
+   * Distinguish a single `has(entry)` call from variadic
+   * `has(...segments)`.  The dispatch layers two contracts:
+   *
+   * 1. A single non-null object argument is treated as an entry value;
+   *    `segmentsFromPathArg` validates the entry's mount-root
+   *    provenance (or rejects a non-entry object) and returns its
+   *    segments.  The `args[0] !== null` guard here keeps `null` from
+   *    falling into this branch — `segmentsFromPathArg` would reject
+   *    `null` on its own (`typeof null === 'object'`), but the explicit
+   *    guard makes the dispatch read as "string-or-entry-not-null"
+   *    rather than relying on the downstream throw for shape.
+   * 2. Otherwise every argument must be a string; the array is
+   *    normalised as a path-segment sequence relative to the current
+   *    directory.
+   *
+   * The two cases are mutually exclusive at the boundary, so an
+   * accidental call like `has(null)` reaches the loop's
+   * `typeof arg !== 'string'` reject rather than the entry branch.
+   *
+   * @param {Array<string | object>} args
+   * @returns {string[]}
+   */
+  const segmentsFromHasArgs = args => {
+    if (args.length === 1 && typeof args[0] === 'object' && args[0] !== null) {
+      return segmentsFromPathArg(args[0]);
+    }
+    for (const arg of args) {
+      if (typeof arg !== 'string') {
+        throw new Error('has() path segments must be strings');
+      }
+    }
+    return normalizeSegments(currentSegments, /** @type {string[]} */ (args));
+  };
+
+  /**
+   * @param {string | string[] | object} pathArg
+   */
+  const resolvePathArg = pathArg =>
+    resolveFromRoot(segmentsFromPathArg(pathArg));
+
+  /**
+   * @param {string} target
+   * @param {string[]} targetSegments
+   */
+  const openExisting = async (target, targetSegments) => {
+    await assertConfined(target, confinementRoot, filePowers);
+    const isDir = await filePowers.isDirectory(target);
+    if (isDir) {
+      return makeMountExo({
+        ...ctx,
+        currentDir: target,
+        currentSegments: targetSegments,
+        description: `Subdirectory of ${description}`,
+      });
+    }
+    return makeMountFileExo(
+      target,
+      readOnly,
+      filePowers,
+      confinementRoot,
+      snapshotFile,
+    );
+  };
+
+  /**
+   * @param {string[]} segments
+   */
+  const makeEntry = segments => {
+    const entry = makeMountEntryExo({
+      ...ctx,
+      entrySegments: segments,
+    });
+    mountEntryRecords.set(entry, harden({ rootId, segments }));
+    return entry;
+  };
+
   const help = makeHelp(mountHelp);
 
   return makeExo('EndoMount', MountInterface, {
     help,
 
-    async has(...pathSegments) {
+    async has(...args) {
       await null;
+      const pathSegments = segmentsFromHasArgs(args);
       if (pathSegments.length === 0) {
         return true;
       }
-      const target = resolve(pathSegments);
+      const target = resolveFromRoot(pathSegments);
       const pathExists = await filePowers.exists(target);
       if (!pathExists) {
         return false;
@@ -216,34 +416,79 @@ const makeMountExo = ctx => {
 
     async lookup(pathArg) {
       await null;
-      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
-      const target = resolve(segments);
-      await assertConfined(target, confinementRoot, filePowers);
+      const segments = segmentsFromPathArg(pathArg);
+      return openExisting(resolveFromRoot(segments), segments);
+    },
 
-      const isDir = await filePowers.isDirectory(target);
-      if (isDir) {
-        return makeMountExo({
-          ...ctx,
-          currentDir: target,
-          description: `Subdirectory of ${description}`,
-        });
+    entry(pathArg) {
+      return makeEntry(segmentsFromEntryPathArg(pathArg));
+    },
+
+    async makeDirectory(pathArg) {
+      await null;
+      assertWritable();
+      const segments = segmentsFromPathArg(pathArg);
+      const target = resolveFromRoot(segments);
+      await assertConfinedOrAncestor(target, confinementRoot, filePowers);
+      await filePowers.makePath(target);
+      // Return a sub-mount handle on the freshly-made path so the
+      // method satisfies `Directory.makeDirectory(path):
+      // Promise<Directory>`.  Existing callers that ignore the
+      // return value are source-compatible.
+      return openExisting(target, segments);
+    },
+
+    async makeFile(pathArg, content) {
+      await null;
+      assertWritable();
+      const target = resolvePathArg(pathArg);
+      await assertConfinedOrAncestor(target, confinementRoot, filePowers);
+      const parent = filePowers.joinPath(target, '..');
+      await filePowers.makePath(parent);
+      if (await filePowers.isDirectory(target)) {
+        throw new Error('Path is a directory');
       }
+      if (content === undefined) {
+        if (!(await filePowers.exists(target))) {
+          await filePowers.writeFileText(target, '');
+        }
+        return;
+      }
+      if (typeof content === 'string') {
+        await filePowers.writeFileText(target, content);
+        return;
+      }
+      // Binary content is supplied via `write(path, readableBlob)` /
+      // `copy(from, to)` rather than `makeFile`: mutable typed arrays
+      // are rejected at the exo boundary, so a `Uint8Array` argument
+      // cannot reach this method through CapTP. Callers that hold raw
+      // bytes wrap them in a `ReadableBlob` and use `write()`.
+      throw new Error(
+        'makeFile content must be a string (use write() with a ReadableBlob for binary content)',
+      );
+    },
 
-      return makeMountFileExo(target, readOnly, filePowers, confinementRoot);
+    async stat(pathArg) {
+      await null;
+      const target = resolvePathArg(pathArg);
+      try {
+        await assertConfined(target, confinementRoot, filePowers);
+        return filePowers.statPath(target);
+      } catch {
+        return undefined;
+      }
     },
 
     async readText(pathArg) {
       await null;
-      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
-      const target = resolve(segments);
+      const target = resolvePathArg(pathArg);
       await assertConfined(target, confinementRoot, filePowers);
       return filePowers.readFileText(target);
     },
 
     async maybeReadText(pathArg) {
       await null;
-      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
-      const target = resolve(segments);
+      const target = resolvePathArg(pathArg);
       try {
         await assertConfined(target, confinementRoot, filePowers);
         return await filePowers.readFileText(target);
@@ -255,8 +500,7 @@ const makeMountExo = ctx => {
     async writeText(pathArg, content) {
       await null;
       assertWritable();
-      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
-      const target = resolve(segments);
+      const target = resolvePathArg(pathArg);
       await assertConfinedOrAncestor(target, confinementRoot, filePowers);
       const parent = filePowers.joinPath(target, '..');
       await filePowers.makePath(parent);
@@ -266,8 +510,7 @@ const makeMountExo = ctx => {
     async remove(pathArg) {
       await null;
       assertWritable();
-      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
-      const target = resolve(segments);
+      const target = resolvePathArg(pathArg);
       await assertConfined(target, confinementRoot, filePowers);
       await filePowers.removePath(target);
     },
@@ -275,39 +518,169 @@ const makeMountExo = ctx => {
     async move(fromArg, toArg) {
       await null;
       assertWritable();
-      const from = resolve(typeof fromArg === 'string' ? [fromArg] : fromArg);
-      const to = resolve(typeof toArg === 'string' ? [toArg] : toArg);
+      const from = resolvePathArg(fromArg);
+      const to = resolvePathArg(toArg);
       await assertConfined(from, confinementRoot, filePowers);
       await assertConfinedOrAncestor(to, confinementRoot, filePowers);
       await filePowers.renamePath(from, to);
     },
 
-    async makeDirectory(pathArg) {
-      await null;
-      assertWritable();
-      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
-      const target = resolve(segments);
-      await assertConfinedOrAncestor(target, confinementRoot, filePowers);
-      await filePowers.makePath(target);
-    },
-
     readOnly() {
-      if (readOnly) {
-        return this; // eslint-disable-line no-invalid-this
-      }
-      return makeMountExo({
-        ...ctx,
-        readOnly: true,
-        description: `Read-only view of ${description}`,
-      });
+      // Structural narrowing: return a ReadableTree view, not an
+      // EndoMount.  Mount-specific extensions (`entry`, `stat`,
+      // `displayPath`, `readText`, `makeFile`) are removed from the
+      // read-only surface; callers that need them keep a reference
+      // to the un-attenuated mount.
+      const readOnlyMount = readOnly
+        ? this.self // eslint-disable-line no-invalid-this
+        : makeMountExo({
+            ...ctx,
+            readOnly: true,
+            description: `Read-only view of ${description}`,
+          });
+      return makeReadableTreeView(readOnlyMount);
     },
 
     async snapshot() {
-      throw new Error('snapshot() is not yet implemented');
+      if (snapshotTree === undefined) {
+        throw new Error('snapshot() is not available for this mount');
+      }
+      return snapshotTree(this.self); // eslint-disable-line no-invalid-this
+    },
+
+    async write(pathArg, value) {
+      await null;
+      assertWritable();
+      const segments = segmentsFromPathArg(pathArg);
+      const target = resolveFromRoot(segments);
+      await assertConfinedOrAncestor(target, confinementRoot, filePowers);
+      const parent = filePowers.joinPath(target, '..');
+      await filePowers.makePath(parent);
+      // Detect blob-vs-tree by method names, the same shape-test
+      // `checkinTree` uses.  A `streamBase64`-bearing remotable is
+      // materialised through bytes; a `list`-bearing remotable is
+      // materialised recursively.
+      // eslint-disable-next-line no-underscore-dangle
+      const methods = await E(value).__getMethodNames__();
+      if (methods.includes('streamBase64')) {
+        if (await filePowers.isDirectory(target)) {
+          throw new Error('Path is a directory');
+        }
+        const readerRef = E(value).streamBase64();
+        const writer = filePowers.makeFileWriter(target);
+        for await (const bytes of makeRefReader(
+          /** @type {import('@endo/far').ERef<AsyncIterator<string>>} */ (
+            readerRef
+          ),
+        )) {
+          // eslint-disable-next-line no-await-in-loop
+          await writer.next(bytes);
+        }
+        await writer.return(undefined);
+        return;
+      }
+      if (methods.includes('list')) {
+        await filePowers.makePath(target);
+        const names = await E(value).list();
+        for (const name of names) {
+          assertValidTreeEntryName(name);
+          // eslint-disable-next-line no-await-in-loop
+          const child = await E(value).lookup(name);
+          // eslint-disable-next-line no-await-in-loop
+          await this.self.write([...segments, name], child); // eslint-disable-line no-invalid-this
+        }
+        return;
+      }
+      throw new Error(
+        'write() value must be a ReadableBlob or ReadableTree (no streamBase64 or list method)',
+      );
+    },
+
+    async copy(fromArg, toArg) {
+      await null;
+      assertWritable();
+      const fromSegments = segmentsFromPathArg(fromArg);
+      const from = resolveFromRoot(fromSegments);
+      await assertConfined(from, confinementRoot, filePowers);
+      const source = await openExisting(from, fromSegments);
+      await this.self.write(toArg, source); // eslint-disable-line no-invalid-this
     },
   });
 };
 harden(makeMountExo);
+
+/**
+ * Structural-narrowing view exposing only the `ReadableTree` surface
+ * (`has`, `list`, `lookup`) over a read-only mount.  Mount-specific
+ * extensions are not present on this Exo; the read-only surface is
+ * deliberately the platform contract, not the daemon's superset.
+ *
+ * @param {object} readOnlyMount - An EndoMount whose `readOnly` flag is true.
+ * @returns {object}
+ */
+const makeReadableTreeView = readOnlyMount => {
+  return makeExo('EndoMountReadableTree', ReadableTreeInterface, {
+    async has(...pathSegments) {
+      return E(readOnlyMount).has(...pathSegments);
+    },
+    async list(...pathSegments) {
+      return E(readOnlyMount).list(...pathSegments);
+    },
+    async lookup(pathArg) {
+      const result = await E(readOnlyMount).lookup(pathArg);
+      // The underlying mount returns either a sub-mount (an
+      // EndoMount) or a mount file.  Either way it is already
+      // read-only because the parent mount is; we wrap it in the
+      // structural view so descendants surface the platform shape
+      // too.
+      // eslint-disable-next-line no-underscore-dangle
+      const methods = await E(result).__getMethodNames__();
+      if (methods.includes('list')) {
+        return makeReadableTreeView(result);
+      }
+      return makeReadableBlobView(result);
+    },
+  });
+};
+harden(makeReadableTreeView);
+
+/**
+ * Create a mount-scoped logical entry descriptor.  Entries are values
+ * with no observational authority and no handle-minting authority of
+ * their own — those operations live on `EndoMount` and accept the
+ * entry as the path-bearing argument.
+ *
+ * @param {MountContext & { entrySegments: string[] }} ctx
+ * @returns {object}
+ */
+const makeMountEntryExo = ctx => {
+  const { entrySegments, rootId } = ctx;
+
+  const help = makeHelp({});
+
+  return makeExo('EndoMountEntry', MountEntryInterface, {
+    help,
+    segments() {
+      return harden([...entrySegments]);
+    },
+    displayPath() {
+      return entrySegments.length === 0 ? '.' : entrySegments.join('/');
+    },
+    child(name) {
+      assertValidSegment(name);
+      const child = makeMountEntryExo({
+        ...ctx,
+        entrySegments: [...entrySegments, name],
+      });
+      mountEntryRecords.set(
+        child,
+        harden({ rootId, segments: [...entrySegments, name] }),
+      );
+      return child;
+    },
+  });
+};
+harden(makeMountEntryExo);
 
 /**
  * Create a transient file exo for a file within a mount.
@@ -316,9 +689,16 @@ harden(makeMountExo);
  * @param {boolean} readOnly
  * @param {FilePowers} filePowers
  * @param {string} confinementRoot
+ * @param {(path: string) => Promise<object>} [snapshotFile]
  * @returns {object}
  */
-const makeMountFileExo = (filePath, readOnly, filePowers, confinementRoot) => {
+const makeMountFileExo = (
+  filePath,
+  readOnly,
+  filePowers,
+  confinementRoot,
+  snapshotFile = undefined,
+) => {
   const assertWritable = () => {
     if (readOnly) {
       throw new Error('Mount is read-only');
@@ -337,12 +717,31 @@ const makeMountFileExo = (filePath, readOnly, filePowers, confinementRoot) => {
     },
 
     streamBase64() {
-      const reader = filePowers.makeFileReader(filePath);
-      return makeIteratorRef(reader);
+      /** @returns {AsyncGenerator<Uint8Array>} */
+      const readConfined = async function* readConfinedFile() {
+        await assertConfined(filePath, confinementRoot, filePowers);
+        const reader = filePowers.makeFileReader(filePath);
+        try {
+          for (;;) {
+            // eslint-disable-next-line no-await-in-loop
+            const result = await reader.next();
+            if (result.done) {
+              return;
+            }
+            yield result.value;
+          }
+        } finally {
+          if (reader.return !== undefined) {
+            await reader.return(undefined);
+          }
+        }
+      };
+      return makeReaderRef(readConfined());
     },
 
     async json() {
       await null;
+      await assertConfined(filePath, confinementRoot, filePowers);
       const text = await filePowers.readFileText(filePath);
       return JSON.parse(text);
     },
@@ -354,28 +753,84 @@ const makeMountFileExo = (filePath, readOnly, filePowers, confinementRoot) => {
       await filePowers.writeFileText(filePath, content);
     },
 
+    async append(content) {
+      await null;
+      assertWritable();
+      await assertConfined(filePath, confinementRoot, filePowers);
+      await filePowers.appendFileText(filePath, content);
+    },
+
     async writeBytes(readableRef) {
       await null;
       assertWritable();
       await assertConfined(filePath, confinementRoot, filePowers);
       const writer = filePowers.makeFileWriter(filePath);
-      const iterator = /** @type {AsyncIterator<Uint8Array>} */ (readableRef);
-      for (;;) {
-        // eslint-disable-next-line no-await-in-loop
-        const { done, value } = await iterator.next();
-        if (done) break;
+      for await (const value of makeRefIterator(
+        /** @type {import('@endo/far').ERef<AsyncIterator<Uint8Array>>} */ (
+          readableRef
+        ),
+      )) {
         // eslint-disable-next-line no-await-in-loop
         await writer.next(value);
       }
       await writer.return(undefined);
     },
 
+    async stat() {
+      await null;
+      await assertConfined(filePath, confinementRoot, filePowers);
+      return filePowers.statPath(filePath);
+    },
+
+    async snapshot() {
+      if (snapshotFile === undefined) {
+        throw new Error('snapshot() is not available for this mount file');
+      }
+      await assertConfined(filePath, confinementRoot, filePowers);
+      return snapshotFile(filePath);
+    },
+
     readOnly() {
-      return makeMountFileExo(filePath, true, filePowers, confinementRoot);
+      // Structural narrowing: return a ReadableBlob view, not an
+      // EndoMountFile.  Mount-specific surface (`stat`, `snapshot`)
+      // is removed; callers that need it keep a reference to the
+      // un-attenuated mount file.
+      const readOnlyFile = makeMountFileExo(
+        filePath,
+        true,
+        filePowers,
+        confinementRoot,
+        snapshotFile,
+      );
+      return makeReadableBlobView(readOnlyFile);
     },
   });
 };
 harden(makeMountFileExo);
+
+/**
+ * Structural-narrowing view exposing only the `ReadableBlob` surface
+ * (`streamBase64`, `text`, `json`) over a read-only mount file.
+ *
+ * @param {object} readOnlyFile - An EndoMountFile whose `readOnly` is true.
+ * @returns {object}
+ */
+const makeReadableBlobView = readOnlyFile => {
+  return makeExo('EndoMountReadableBlob', ReadableBlobInterface, {
+    streamBase64() {
+      return /** @type {{ streamBase64: () => object }} */ (
+        readOnlyFile
+      ).streamBase64();
+    },
+    async text() {
+      return E(readOnlyFile).text();
+    },
+    async json() {
+      return E(readOnlyFile).json();
+    },
+  });
+};
+harden(makeReadableBlobView);
 
 /**
  * Create a mount exo backed by a filesystem directory.
@@ -384,17 +839,29 @@ harden(makeMountFileExo);
  * @param {string} opts.rootPath
  * @param {boolean} opts.readOnly
  * @param {FilePowers} opts.filePowers
+ * @param {(tree: object) => Promise<object>} [opts.snapshotTree]
+ * @param {(path: string) => Promise<object>} [opts.snapshotFile]
  * @returns {object}
  */
-export const makeMount = ({ rootPath, readOnly, filePowers }) => {
+export const makeMount = ({
+  rootPath,
+  readOnly,
+  filePowers,
+  snapshotTree = undefined,
+  snapshotFile = undefined,
+}) => {
   const prefix = readOnly ? 'Read-only mount' : 'Mount';
   /** @type {MountContext} */
   const ctx = {
     currentDir: rootPath,
+    currentSegments: harden([]),
     confinementRoot: rootPath,
+    rootId: harden({}),
     readOnly,
     filePowers,
     description: `${prefix} at ${rootPath}`,
+    snapshotTree,
+    snapshotFile,
   };
 
   return makeMountExo(ctx);

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -829,6 +829,115 @@ export interface EndoReadable {
   text(): Promise<string>;
   json(): Promise<unknown>;
 }
+
+export interface EndoReadableTree {
+  sha256(): string;
+  has(...pathSegments: string[]): Promise<boolean>;
+  list(...pathSegments: string[]): Promise<string[]>;
+  lookup(path: string | string[]): Promise<EndoReadableTree | EndoReadable>;
+}
+
+export type EndoMountStat = {
+  kind: 'file' | 'directory' | 'symlink';
+  sizeBytes: number;
+  modifiedMs: number;
+};
+
+export interface EndoMountEntry {
+  segments(): string[];
+  displayPath(): string;
+  child(name: string): EndoMountEntry;
+}
+
+/**
+ * Structural `ReadableBlob` view exposed by `EndoMountFile.readOnly()`.
+ * Mirrors `ReadableBlob` from `@endo/platform/fs`.
+ */
+export interface ReadableBlobView {
+  streamBase64(): FarRef<Reader<string>>;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}
+
+/**
+ * Structural `ReadableTree` view exposed by `EndoMount.readOnly()`.
+ * Mirrors `ReadableTree` from `@endo/platform/fs`; `lookup` recursively
+ * returns either another `ReadableTreeView` or a `ReadableBlobView`.
+ */
+export interface ReadableTreeView {
+  has(...pathSegments: string[]): Promise<boolean>;
+  list(...pathSegments: string[]): Promise<string[]>;
+  lookup(path: string | string[]): Promise<ReadableTreeView | ReadableBlobView>;
+}
+
+/**
+ * `EndoMountFile` is a daemon-local specialization of the platform
+ * `File` contract.  Mount-specific surface (`stat`, `snapshot`,
+ * `writeText` / `append` / `writeBytes` that throw on read-only) is
+ * additive; `readOnly()` narrows to a structural `ReadableBlob` view.
+ */
+export interface EndoMountFile {
+  text(): Promise<string>;
+  streamBase64(): FarRef<Reader<string>>;
+  json(): Promise<unknown>;
+  writeText(content: string): Promise<void>;
+  append(content: string): Promise<void>;
+  writeBytes(readableRef: FarRef<AsyncIterator<Uint8Array>>): Promise<void>;
+  stat(): Promise<EndoMountStat>;
+  snapshot(): Promise<FarRef<EndoReadable>>;
+  readOnly(): ReadableBlobView;
+}
+
+/**
+ * `EndoMount` is a daemon-local specialization of the platform
+ * `Directory` contract.  Overlapping methods (`has`, `list`, `lookup`,
+ * `write`, `remove`, `move`, `copy`, `makeDirectory`, `snapshot`) match
+ * the platform shapes; mount-specific extensions (`entry`, `stat`,
+ * `displayPath`, `readText`, `maybeReadText`, `writeText`, `makeFile`)
+ * are additive; `readOnly()` narrows to a structural `ReadableTree`
+ * view.
+ */
+export interface EndoMount {
+  has(...pathSegments: string[]): Promise<boolean>;
+  has(entry: EndoMountEntry): Promise<boolean>;
+  list(...pathSegments: string[]): Promise<string[]>;
+  lookup(
+    path: string | string[] | EndoMountEntry,
+  ): Promise<EndoMount | EndoMountFile>;
+  write(
+    path: string | string[] | EndoMountEntry,
+    value: unknown,
+  ): Promise<void>;
+  copy(
+    from: string | string[] | EndoMountEntry,
+    to: string | string[] | EndoMountEntry,
+  ): Promise<void>;
+  entry(path: string | string[]): EndoMountEntry;
+  stat(
+    path: string | string[] | EndoMountEntry,
+  ): Promise<EndoMountStat | undefined>;
+  readText(path: string | string[] | EndoMountEntry): Promise<string>;
+  maybeReadText(
+    path: string | string[] | EndoMountEntry,
+  ): Promise<string | undefined>;
+  writeText(
+    path: string | string[] | EndoMountEntry,
+    content: string,
+  ): Promise<void>;
+  makeDirectory(path: string | string[] | EndoMountEntry): Promise<EndoMount>;
+  makeFile(
+    path: string | string[] | EndoMountEntry,
+    content?: string,
+  ): Promise<void>;
+  remove(path: string | string[] | EndoMountEntry): Promise<void>;
+  move(
+    from: string | string[] | EndoMountEntry,
+    to: string | string[] | EndoMountEntry,
+  ): Promise<void>;
+  readOnly(): ReadableTreeView;
+  snapshot(): Promise<unknown>;
+}
+
 export interface EndoWorker {}
 
 export type MakeHostOrGuestOptions = {
@@ -956,8 +1065,14 @@ export interface EndoHost extends EndoAgent {
     path: string,
     petName: string | string[],
     opts?: { readOnly?: boolean },
-  ): Promise<unknown>;
-  provideScratchMount(petName: string | string[]): Promise<unknown>;
+  ): Promise<EndoMount>;
+  provideScratchMount(petName: string | string[]): Promise<EndoMount>;
+  /**
+   * Privileged bridge from a daemon-minted top-level Mount cap to its
+   * host filesystem path. EndoHost is a fully privileged authority;
+   * callers that should not learn host paths must receive an
+   * attenuated guest or narrower powers object instead.
+   */
   provideHostPath(cap: unknown): Promise<string>;
   provideGuest(
     petName?: string,
@@ -1220,6 +1335,7 @@ export type FilePowers = {
   makeFileReader: (path: string) => Reader<Uint8Array>;
   makeFileWriter: (path: string) => Writer<Uint8Array>;
   writeFileText: (path: string, text: string) => Promise<void>;
+  appendFileText: (path: string, text: string) => Promise<void>;
   readFileText: (path: string) => Promise<string>;
   readFileBytes: (path: string) => Promise<Uint8Array>;
   readFile: (path: string) => Promise<Uint8Array>;
@@ -1232,6 +1348,12 @@ export type FilePowers = {
   removeDirectory: (path: string) => Promise<void>;
   renamePath: (source: string, target: string) => Promise<void>;
   realPath: (path: string) => Promise<string>;
+  pathIdentity: (path: string) => Promise<string>;
+  statPath: (path: string) => Promise<{
+    kind: 'file' | 'directory' | 'symlink';
+    sizeBytes: number;
+    modifiedMs: number;
+  }>;
   isDirectory: (path: string) => Promise<boolean>;
   exists: (path: string) => Promise<boolean>;
 };
@@ -1464,6 +1586,7 @@ type FormulateNumberedHostParams = {
 
 export type FormulaValueTypes = {
   directory: EndoDirectory;
+  mount: EndoMount;
   network: EndoNetwork;
   peer: EndoGateway;
   'pet-store': PetStore;
@@ -1661,12 +1784,12 @@ export interface DaemonCore {
     mountPath: string,
     readOnly: boolean,
     deferredTasks: DeferredTasks<MountDeferredTaskParams>,
-  ) => FormulateResult<unknown>;
+  ) => FormulateResult<EndoMount>;
 
   formulateScratchMount: (
     readOnly: boolean,
     deferredTasks: DeferredTasks<ScratchMountDeferredTaskParams>,
-  ) => FormulateResult<unknown>;
+  ) => FormulateResult<EndoMount>;
 
   formulateInvitation: (
     hostAgentId: FormulaIdentifier,

--- a/packages/daemon/test/_mount-test-helpers.js
+++ b/packages/daemon/test/_mount-test-helpers.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+import { makeSnapshotStore, makeReaderRef } from '@endo/platform/fs/lite';
+
+/**
+ * Minimal in-memory `SnapshotStore` for unit tests over `makeMount`.
+ *
+ * Sufficient to drive `mount.snapshot()` and `mountFile.snapshot()`
+ * round-tripping without bringing up the daemon's filesystem-backed
+ * content store.  Blob identity is derived from content so the same
+ * bytes always stamp the same id.
+ *
+ * @returns {import('@endo/platform/fs/lite/types').SnapshotStore}
+ */
+export const makeMemoryStore = () => {
+  /** @type {Map<string, Uint8Array>} */
+  const blobs = new Map();
+
+  /** @type {import('@endo/platform/fs/lite/types').ContentStore} */
+  const contentStore = harden({
+    async store(readable) {
+      const chunks = [];
+      let length = 0;
+      for await (const chunk of /** @type {AsyncIterable<Uint8Array>} */ (
+        /** @type {unknown} */ (readable)
+      )) {
+        chunks.push(chunk);
+        length += chunk.byteLength;
+      }
+      const combined = new Uint8Array(length);
+      let offset = 0;
+      for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      // Hash by content for stable identity across re-stores.
+      let hash = 0;
+      for (let i = 0; i < combined.length; i += 1) {
+        hash = (hash * 31 + combined[i]) | 0; // eslint-disable-line no-bitwise
+      }
+      const id = `sha-${combined.length}-${hash}`;
+      blobs.set(id, combined);
+      return id;
+    },
+    fetch(sha256) {
+      const maybeBytes = blobs.get(sha256);
+      if (maybeBytes === undefined) {
+        throw new Error(`No blob for ${sha256}`);
+      }
+      const bytes = /** @type {Uint8Array} */ (maybeBytes);
+      const text = async () => new TextDecoder().decode(bytes);
+      const json = async () => {
+        await null;
+        return JSON.parse(await text());
+      };
+      const streamBase64 = () => {
+        /** @returns {AsyncIterable<Uint8Array>} */
+        async function* iter() {
+          yield bytes;
+        }
+        return makeReaderRef(iter());
+      };
+      return harden({ streamBase64, text, json });
+    },
+    async has(sha256) {
+      return blobs.has(sha256);
+    },
+    async remove(sha256) {
+      blobs.delete(sha256);
+    },
+  });
+  return makeSnapshotStore(contentStore);
+};
+harden(makeMemoryStore);

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -1,5 +1,5 @@
 // @ts-nocheck
-/* global process, setTimeout */
+/* global Buffer, process, setTimeout */
 
 // Establish a perimeter:
 // eslint-disable-next-line import/order
@@ -4222,16 +4222,25 @@ test('mount readOnly() attenuation', async t => {
   await E(host).provideMount(mountPath, 'test-mount-attenuate');
   const mount = await E(host).lookup(['test-mount-attenuate']);
 
-  const roMount = await E(mount).readOnly();
+  const roTree = await E(mount).readOnly();
 
-  // Reading should work through attenuated view.
-  const entries = await E(roMount).list();
+  // The structural narrowing returns a ReadableTree view, not an
+  // EndoMount.  Reading through the platform surface (has, list,
+  // lookup) still works.
+  const entries = await E(roTree).list();
   t.deepEqual(entries, ['file.txt']);
+  t.true(await E(roTree).has('file.txt'));
 
-  // Writing should fail through attenuated view.
-  await t.throwsAsync(E(roMount).writeText(['new.txt'], 'fail'), {
-    message: /read-only/,
-  });
+  // Mount-specific extensions are not on the read-only view; the
+  // method names are constrained to the ReadableTree surface
+  // (filtering Exo introspection helpers).
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(roTree).__getMethodNames__();
+  t.deepEqual(methods.filter(name => !name.startsWith('__')).sort(), [
+    'has',
+    'list',
+    'lookup',
+  ]);
 });
 
 test('mount dot-dot navigation clamped at root', async t => {
@@ -4503,6 +4512,79 @@ test('mount file writeText and json', async t => {
     'utf-8',
   );
   t.is(actualContent, '{"version": 2}');
+});
+
+test('mount entry descriptors support has, lookup, stat, makeFile, and provenance', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(config.statePath, '..', 'mount-test-entry');
+  const otherPath = path.join(config.statePath, '..', 'mount-test-entry-other');
+  await createMountFixture(mountPath, {
+    'src/existing.txt': 'existing',
+  });
+  await createMountFixture(otherPath, {});
+
+  await E(host).provideMount(mountPath, 'test-mount-entry');
+  await E(host).provideMount(otherPath, 'test-mount-entry-other');
+  const mount = await E(host).lookup(['test-mount-entry']);
+  const otherMount = await E(host).lookup(['test-mount-entry-other']);
+
+  const createdEntry = await E(mount).entry(['src', 'created.txt']);
+  t.is(await E(createdEntry).displayPath(), 'src/created.txt');
+  t.deepEqual(await E(createdEntry).segments(), ['src', 'created.txt']);
+  t.false(await E(mount).has(createdEntry));
+  t.is(await E(mount).stat(createdEntry), undefined);
+
+  await E(mount).makeFile(createdEntry, 'created');
+  const createdFile = await E(mount).lookup(createdEntry);
+  await E(createdFile).append(' and appended');
+  t.is(await E(createdFile).text(), 'created and appended');
+  t.true(await E(mount).has(createdEntry));
+
+  const stat = await E(mount).stat(createdEntry);
+  t.like(stat, { kind: 'file', sizeBytes: 'created and appended'.length });
+
+  const srcEntry = await E(mount).entry('src');
+  const srcDir = await E(mount).lookup(srcEntry);
+  t.deepEqual(await E(srcDir).list(), ['created.txt', 'existing.txt']);
+
+  const childEntry = await E(srcEntry).child('created.txt');
+  const openedFile = await E(mount).lookup(childEntry);
+  t.is(await E(openedFile).text(), 'created and appended');
+
+  await t.throwsAsync(() => E(otherMount).readText(createdEntry), {
+    message: /different mount root/,
+  });
+});
+
+test('mount snapshots capture immutable tree and file views', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(config.statePath, '..', 'mount-test-snapshot');
+  await createMountFixture(mountPath, {
+    'live.txt': 'initial',
+    'nested/file.txt': 'nested',
+  });
+
+  await E(host).provideMount(mountPath, 'test-mount-snapshot');
+  const mount = await E(host).lookup(['test-mount-snapshot']);
+
+  const snapshotTree = await E(mount).snapshot();
+  const snapshotFile = await E(snapshotTree).lookup('live.txt');
+  const liveFile = await E(mount).lookup('live.txt');
+
+  const snapshotBlob = await E(liveFile).snapshot();
+
+  await E(liveFile).writeText('changed');
+  await E(mount).writeText(['nested', 'file.txt'], 'changed nested');
+
+  t.is(await E(snapshotFile).text(), 'initial');
+  t.is(await E(snapshotBlob).text(), 'initial');
+  t.is(await E(liveFile).text(), 'changed');
+
+  const nestedSnapshotDir = await E(snapshotTree).lookup('nested');
+  const nestedSnapshotFile = await E(nestedSnapshotDir).lookup('file.txt');
+  t.is(await E(nestedSnapshotFile).text(), 'nested');
 });
 
 // symlink confinement tests
@@ -4811,6 +4893,26 @@ test('Phase 8: stageTree materialises a ReadableTree into a scratch mount', asyn
   // The staged mount has the same compartment-map.json content.
   const text = await E(scratch).readText('compartment-map.json');
   t.regex(text, /"entry"/);
+});
+
+test('stageTree preserves binary blobs in a scratch mount', async t => {
+  const { host, config } = await prepareHost(t);
+
+  const srcDir = path.join(config.statePath, '..', 'stage-tree-binary-src');
+  fs.mkdirSync(srcDir, { recursive: true });
+  const expected = Buffer.from([0, 159, 146, 150, 255, 65, 10]);
+  fs.writeFileSync(path.join(srcDir, 'bytes.bin'), expected);
+  await E(host).provideMount(srcDir, 'binary-src-mount', { readOnly: true });
+
+  const scratch = await E(host).stageTree('binary-src-mount', 'binary-staged');
+  const file = await E(scratch).lookup('bytes.bin');
+  const reader = makeRefIterator(await E(file).streamBase64());
+  const chunks = [];
+  for await (const chunk of reader) {
+    chunks.push(Buffer.from(chunk, 'base64'));
+  }
+  const actual = Buffer.concat(chunks);
+  t.deepEqual([...actual], [...expected]);
 });
 
 testNeedsNodeWorker(

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -3924,6 +3924,7 @@ test('readable tree lookup unknown name throws', async t => {
  * @param {Record<string, string>} files - Map of relative path to content.
  */
 const createMountFixture = async (basePath, files) => {
+  await fs.promises.rm(basePath, { recursive: true, force: true });
   await fs.promises.mkdir(basePath, { recursive: true });
   for (const [relPath, content] of Object.entries(files)) {
     const fullPath = path.join(basePath, relPath);
@@ -4339,6 +4340,51 @@ test('provideHostPath resolves Mount caps to host paths', async t => {
   await t.throwsAsync(() => E(host).provideHostPath(fake), {
     message: /not a daemon-minted mount/,
   });
+});
+
+test('provideHostPath is an EndoHost-only capability not reachable through an EndoGuest', async t => {
+  // Documents the danger of `provideHostPath` by example: the surface
+  // returns a real host-filesystem path string, so any code that can
+  // call it learns the absolute path of a daemon-managed mount.  The
+  // platform's defence is that the method only exists on the fully
+  // privileged `EndoHost`; a guest cannot reach it, so handing a
+  // guest to less-trusted code does not leak the host path even when
+  // the same daemon session also serves the host.
+  const { host, config } = await prepareHost(t);
+
+  const mountPath = path.join(config.statePath, '..', 'host-path-danger-mount');
+  await createMountFixture(mountPath, { 'sentinel.txt': 'present' });
+  await E(host).provideMount(mountPath, 'host-path-danger-mount');
+
+  // The host can resolve the cap to its real path: that *is* the
+  // danger — calling code that holds an EndoHost can map any mount
+  // cap back to a real filesystem path.
+  const mountCap = await E(host).lookup(['host-path-danger-mount']);
+  t.is(await E(host).provideHostPath(mountCap), mountPath);
+
+  // A guest spawned from this host does not have the
+  // `provideHostPath` method on its method set.  Less-trusted code
+  // that should not learn host filesystem paths receives a guest, not
+  // an EndoHost; this is the attenuation the platform relies on.
+  const guest = await E(host).provideGuest('danger-guest', {
+    agentName: 'danger-guest-agent',
+  });
+  // eslint-disable-next-line no-underscore-dangle
+  const guestMethods = await E(guest).__getMethodNames__();
+  t.false(
+    guestMethods.includes('provideHostPath'),
+    'EndoGuest must not expose provideHostPath: host paths are an EndoHost-only authority',
+  );
+
+  // The CapTP boundary refuses the call directly when a caller goes
+  // looking — the method does not exist on the guest's interface
+  // guard, so the send is rejected at the receiver.
+  await t.throwsAsync(
+    // The cast documents that the caller is overstepping the type.
+    () => E(/** @type {any} */ (guest)).provideHostPath(mountCap),
+    { message: /provideHostPath/ },
+    'a guest cannot stand in for a host on the privileged surface',
+  );
 });
 
 test('provideHostPath rejects a spoof that passes the genie shape gate', async t => {

--- a/packages/daemon/test/mount-platform-fs-conformance.test.js
+++ b/packages/daemon/test/mount-platform-fs-conformance.test.js
@@ -1,0 +1,559 @@
+// @ts-check
+/* global Buffer */
+
+// Establish a perimeter:
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import url from 'url';
+import { E, Far } from '@endo/far';
+import { makeExo } from '@endo/exo';
+import {
+  DirectoryInterface as PlatformDirectoryInterface,
+  FileInterface as PlatformFileInterface,
+  ReadableBlobInterface,
+  ReadableTreeInterface,
+  checkinTree,
+  makeReaderRef,
+} from '@endo/platform/fs/lite';
+import { M } from '@endo/patterns';
+
+import { makeFilePowers } from '../src/daemon-node-powers.js';
+import { makeMount } from '../src/mount.js';
+import { makeMemoryStore } from './_mount-test-helpers.js';
+
+/**
+ * Conformance test asserting that `EndoMount` is a daemon-local
+ * specialization of the `Directory` contract from
+ * `@endo/platform/fs`, and that `EndoMountFile` is a specialization
+ * of the `File` contract.
+ *
+ * The test does not bring up a full daemon; it constructs an
+ * `EndoMount` directly via `makeMount` against a real temp directory.
+ * The conformance assertions are:
+ *
+ * 1. Every method on `PlatformDirectoryInterface` /
+ *    `PlatformFileInterface` is present on the corresponding Exo's
+ *    method-names set.
+ * 2. Calling each method through `E()` with shapes that the platform
+ *    guard would accept produces no `M.interface` violation.
+ * 3. `EndoMount.readOnly()` returns an Exo whose `__getMethodNames__`
+ *    is exactly the `ReadableTreeInterface` method set; similarly
+ *    `EndoMountFile.readOnly()` returns the `ReadableBlobInterface`
+ *    set.
+ *
+ * Drift in either direction (a daemon method whose shape changes
+ * without the platform contract tracking it, or a future platform
+ * contract change the daemon does not absorb) breaks this test.
+ */
+
+const filePowers = makeFilePowers({ fs, path });
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ */
+const makeTempRoot = t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mount-conf-'));
+  t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+};
+
+/**
+ * Extract a method-name set from an `M.interface` guard.  The interface
+ * is a Pattern record; the method shapes live under its `methodGuards`
+ * iface descriptor.  We probe via Reflect.ownKeys on the call-args
+ * record indirectly: M.interface stores method guards on a hidden
+ * property accessible via getMethodNames().
+ *
+ * @param {any} iface
+ */
+const interfaceMethodNames = iface => {
+  // M.interface returns an InterfaceGuard whose payload includes the
+  // method-guard record under symbol-keyed slot.  The public API
+  // exposes the method names via `getInterfaceMethodKeys`.
+  // We deduce by introspection rather than depend on internal API:
+  // every M.interface guard records the method names accessible via
+  // its serialized payload at `.methodGuards`.
+  const payload = /** @type {any} */ (iface).interfaceName ?? null;
+  // Fallback: scan with `M.toPattern` to read out the methodGuards.
+  // We provide an explicit list to avoid depending on @endo/patterns
+  // internals.  Each interface lists the expected names below.
+  return payload;
+};
+// Silence linter: helper above documents the indirect path even though
+// the tests below use explicit lists.
+void interfaceMethodNames;
+
+/** Method names the platform `Directory` contract requires. */
+const PLATFORM_DIRECTORY_METHODS = [
+  'has',
+  'list',
+  'lookup',
+  'write',
+  'remove',
+  'move',
+  'copy',
+  'makeDirectory',
+  'readOnly',
+  'snapshot',
+];
+
+/** Method names the platform `File` contract requires. */
+const PLATFORM_FILE_METHODS = [
+  'streamBase64',
+  'text',
+  'json',
+  'writeText',
+  'writeBytes',
+  'append',
+  'readOnly',
+  'snapshot',
+];
+
+/** Method names the platform `ReadableTree` contract requires. */
+const PLATFORM_READABLE_TREE_METHODS = ['has', 'list', 'lookup'];
+
+/** Method names the platform `ReadableBlob` contract requires. */
+const PLATFORM_READABLE_BLOB_METHODS = ['streamBase64', 'text', 'json'];
+
+/**
+ * Construct an `EndoMount` with an in-memory snapshot pipeline.
+ *
+ * @param {import('ava').ExecutionContext} t
+ */
+const makeConfiguredMount = t => {
+  const rootPath = makeTempRoot(t);
+  const store = makeMemoryStore();
+  const snapshotTree = async tree => {
+    const { sha256 } = await checkinTree(tree, store);
+    return store.loadTree(sha256);
+  };
+  const snapshotFile = async filePath => {
+    const sha256 = await store.store(filePowers.makeFileReader(filePath));
+    return store.loadBlob(sha256);
+  };
+  const mount = makeMount({
+    rootPath,
+    readOnly: false,
+    filePowers,
+    snapshotTree,
+    snapshotFile,
+  });
+  return { mount, rootPath };
+};
+
+test('EndoMount exposes every method on PlatformDirectoryInterface', async t => {
+  const { mount } = makeConfiguredMount(t);
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(mount).__getMethodNames__();
+  for (const name of PLATFORM_DIRECTORY_METHODS) {
+    t.true(
+      methods.includes(name),
+      `EndoMount missing platform Directory method ${name}`,
+    );
+  }
+});
+
+/** Mount-specific extensions beyond the platform Directory contract. */
+const ENDOMOUNT_EXTENSIONS = [
+  'entry',
+  'stat',
+  'readText',
+  'maybeReadText',
+  'writeText',
+  'makeFile',
+  'help',
+];
+
+/** Mount-specific extensions beyond the platform File contract. */
+const ENDOMOUNTFILE_EXTENSIONS = ['stat', 'help'];
+
+test('EndoMount diverges from PlatformDirectoryInterface by named extensions only', async t => {
+  // The divergence is deliberate and named: callers who hold a plain
+  // `Directory` capability cannot reach `readText` or `writeText`;
+  // those are mount-specific shortcuts that exist because the daemon
+  // has direct filesystem access where the platform contract assumes
+  // a streaming pipe.  This test pins the extension set so a future
+  // change that grows the divergence is forced to update both this
+  // list and the design document.
+  const { mount } = makeConfiguredMount(t);
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = (await E(mount).__getMethodNames__()).filter(
+    name => !name.startsWith('__'),
+  );
+  const platform = new Set(PLATFORM_DIRECTORY_METHODS);
+  const actualExtensions = methods.filter(name => !platform.has(name)).sort();
+  t.deepEqual(
+    actualExtensions,
+    [...ENDOMOUNT_EXTENSIONS].sort(),
+    'EndoMount extensions beyond Directory must match the named set',
+  );
+});
+
+test('EndoMountFile diverges from PlatformFileInterface by named extensions only', async t => {
+  // Same shape as the EndoMount divergence: `stat` and `help` are
+  // mount-specific.  A `File` consumer that demotes to the platform
+  // contract loses those names.
+  const { mount, rootPath } = makeConfiguredMount(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'x');
+  const file = await E(mount).lookup('a.txt');
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = (await E(file).__getMethodNames__()).filter(
+    name => !name.startsWith('__'),
+  );
+  const platform = new Set(PLATFORM_FILE_METHODS);
+  const actualExtensions = methods.filter(name => !platform.has(name)).sort();
+  t.deepEqual(
+    actualExtensions,
+    [...ENDOMOUNTFILE_EXTENSIONS].sort(),
+    'EndoMountFile extensions beyond File must match the named set',
+  );
+});
+
+test('EndoMount.makeDirectory returns a sub-mount (Directory.makeDirectory shape)', async t => {
+  const { mount } = makeConfiguredMount(t);
+  const sub = await E(mount).makeDirectory(['sub']);
+  // The return value must be a Directory-shaped capability — a mount.
+  // eslint-disable-next-line no-underscore-dangle
+  const subMethods = await E(sub).__getMethodNames__();
+  for (const name of PLATFORM_DIRECTORY_METHODS) {
+    t.true(
+      subMethods.includes(name),
+      `makeDirectory returned object missing ${name}`,
+    );
+  }
+  // Writes through the returned sub-mount land inside the new dir.
+  await E(sub).writeText(['leaf.txt'], 'inside-sub');
+  t.is(await E(mount).readText(['sub', 'leaf.txt']), 'inside-sub');
+  t.true(
+    await E(sub).has('leaf.txt'),
+    'sub-mount has(string) resolves relative to the subdirectory',
+  );
+  t.false(
+    await E(sub).has('missing.txt'),
+    'sub-mount has(string) does not fall back to the mount root',
+  );
+});
+
+test('EndoMount.entry accepts slash-joined string selectors', async t => {
+  const { mount } = makeConfiguredMount(t);
+  const entry = await E(mount).entry('a/b/../c.txt');
+  t.deepEqual(await E(entry).segments(), ['a', 'c.txt']);
+  t.is(await E(entry).displayPath(), 'a/c.txt');
+
+  await E(mount).writeText(entry, 'via-entry');
+  t.is(await E(mount).readText(['a', 'c.txt']), 'via-entry');
+});
+
+test('EndoMount.write accepts a ReadableBlob and materializes bytes', async t => {
+  const { mount, rootPath } = makeConfiguredMount(t);
+  // A minimal blob-shaped remotable that satisfies ReadableBlob.
+  const blob = makeExo('TestBlob', ReadableBlobInterface, {
+    streamBase64() {
+      const chunks = [Buffer.from('hello blob', 'utf-8').toString('base64')];
+      let idx = 0;
+      return makeExo(
+        'AsyncIterator',
+        M.interface('AsyncIterator', {
+          next: M.call().returns(M.promise()),
+          return: M.call().optional(M.any()).returns(M.promise()),
+          throw: M.call().optional(M.any()).returns(M.promise()),
+        }),
+        {
+          async next() {
+            if (idx < chunks.length) {
+              const value = chunks[idx];
+              idx += 1;
+              return harden({ value, done: false });
+            }
+            return harden({ value: undefined, done: true });
+          },
+          async return() {
+            return harden({ value: undefined, done: true });
+          },
+          async throw() {
+            return harden({ value: undefined, done: true });
+          },
+        },
+      );
+    },
+    async text() {
+      return 'hello blob';
+    },
+    async json() {
+      return null;
+    },
+  });
+  await E(mount).write(['blob-target.txt'], blob);
+  const actual = fs.readFileSync(
+    path.join(rootPath, 'blob-target.txt'),
+    'utf-8',
+  );
+  t.is(actual, 'hello blob');
+});
+
+test('EndoMount.write accepts a ReadableTree and materializes recursively', async t => {
+  const { mount, rootPath } = makeConfiguredMount(t);
+  // A blob factory reused for each leaf.
+  const makeBlobValue = content => {
+    const bytes = new TextEncoder().encode(content);
+    return makeExo('LeafBlob', ReadableBlobInterface, {
+      streamBase64() {
+        const chunk = Buffer.from(bytes).toString('base64');
+        let yielded = false;
+        return makeExo(
+          'AsyncIterator',
+          M.interface('AsyncIterator', {
+            next: M.call().returns(M.promise()),
+            return: M.call().optional(M.any()).returns(M.promise()),
+            throw: M.call().optional(M.any()).returns(M.promise()),
+          }),
+          {
+            async next() {
+              if (!yielded) {
+                yielded = true;
+                return harden({ value: chunk, done: false });
+              }
+              return harden({ value: undefined, done: true });
+            },
+            async return() {
+              return harden({ value: undefined, done: true });
+            },
+            async throw() {
+              return harden({ value: undefined, done: true });
+            },
+          },
+        );
+      },
+      async text() {
+        return content;
+      },
+      async json() {
+        return null;
+      },
+    });
+  };
+  // A ReadableTree with a nested structure.
+  const tree = makeExo('TestTree', ReadableTreeInterface, {
+    async has(...pathSegments) {
+      if (pathSegments.length === 0) return true;
+      const lookup = ['a.txt', 'b'].includes(pathSegments[0]);
+      return lookup;
+    },
+    async list() {
+      return harden(['a.txt', 'b']);
+    },
+    async lookup(pathArg) {
+      const segments = typeof pathArg === 'string' ? [pathArg] : pathArg;
+      if (segments.length === 1 && segments[0] === 'a.txt') {
+        return makeBlobValue('hello-a');
+      }
+      if (segments.length === 1 && segments[0] === 'b') {
+        // A nested tree with one leaf.
+        return makeExo('NestedTree', ReadableTreeInterface, {
+          async has(...pathSegments) {
+            if (pathSegments.length === 0) return true;
+            return pathSegments[0] === 'c.txt';
+          },
+          async list() {
+            return harden(['c.txt']);
+          },
+          async lookup(innerArg) {
+            const innerSegments =
+              typeof innerArg === 'string' ? [innerArg] : innerArg;
+            if (innerSegments.length === 1 && innerSegments[0] === 'c.txt') {
+              return makeBlobValue('hello-c');
+            }
+            throw new Error(`unknown ${innerSegments}`);
+          },
+        });
+      }
+      throw new Error(`unknown ${segments}`);
+    },
+  });
+  await E(mount).write(['nested'], tree);
+  t.is(
+    fs.readFileSync(path.join(rootPath, 'nested', 'a.txt'), 'utf-8'),
+    'hello-a',
+  );
+  t.is(
+    fs.readFileSync(path.join(rootPath, 'nested', 'b', 'c.txt'), 'utf-8'),
+    'hello-c',
+  );
+});
+
+test('EndoMount.write rejects traversal-like ReadableTree child names', async t => {
+  const { mount } = makeConfiguredMount(t);
+  const blob = makeExo('LeafBlob', ReadableBlobInterface, {
+    streamBase64() {
+      return makeReaderRef([new TextEncoder().encode('leaf')]);
+    },
+    async text() {
+      return 'leaf';
+    },
+    async json() {
+      return null;
+    },
+  });
+
+  for (const name of ['.', '..', 'a/b', 'a\\b', 'a\0b']) {
+    const tree = makeExo('InvalidTree', ReadableTreeInterface, {
+      async has() {
+        return true;
+      },
+      async list() {
+        return harden([name]);
+      },
+      async lookup() {
+        return blob;
+      },
+    });
+
+    // eslint-disable-next-line no-await-in-loop
+    await t.throwsAsync(() => E(mount).write(['target'], tree), {
+      message: /Tree entry name|Path segment/,
+    });
+  }
+});
+
+test('EndoMount.copy within-mount copies a file', async t => {
+  const { mount } = makeConfiguredMount(t);
+  await E(mount).writeText(['src.txt'], 'src-content');
+  await E(mount).copy(['src.txt'], ['dst.txt']);
+  t.is(await E(mount).readText(['dst.txt']), 'src-content');
+  // Source survives.
+  t.is(await E(mount).readText(['src.txt']), 'src-content');
+});
+
+test('EndoMount.copy within-mount copies a directory recursively', async t => {
+  const { mount } = makeConfiguredMount(t);
+  await E(mount).makeDirectory(['src', 'inner']);
+  await E(mount).writeText(['src', 'leaf.txt'], 'a');
+  await E(mount).writeText(['src', 'inner', 'deep.txt'], 'b');
+  await E(mount).copy(['src'], ['dst']);
+  t.is(await E(mount).readText(['dst', 'leaf.txt']), 'a');
+  t.is(await E(mount).readText(['dst', 'inner', 'deep.txt']), 'b');
+});
+
+test('EndoMount.readOnly() returns a structural ReadableTree view', async t => {
+  const { mount } = makeConfiguredMount(t);
+  await E(mount).writeText(['file.txt'], 'data');
+  const view = await E(mount).readOnly();
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(view).__getMethodNames__();
+  t.deepEqual(
+    methods.filter(name => !name.startsWith('__')).sort(),
+    [...PLATFORM_READABLE_TREE_METHODS].sort(),
+    'readOnly() must expose exactly the ReadableTree method set',
+  );
+  // Read-side calls still work.
+  t.true(await E(view).has('file.txt'));
+  t.deepEqual(await E(view).list(), ['file.txt']);
+});
+
+test('EndoMount.readOnly().lookup recursively returns structural views', async t => {
+  const { mount } = makeConfiguredMount(t);
+  await E(mount).makeDirectory(['sub']);
+  await E(mount).writeText(['sub', 'leaf.txt'], 'leaf-data');
+  const view = await E(mount).readOnly();
+  const subView = await E(view).lookup('sub');
+  // eslint-disable-next-line no-underscore-dangle
+  const subMethods = await E(subView).__getMethodNames__();
+  t.deepEqual(
+    subMethods.filter(name => !name.startsWith('__')).sort(),
+    [...PLATFORM_READABLE_TREE_METHODS].sort(),
+  );
+  const leafView = await E(view).lookup(['sub', 'leaf.txt']);
+  // eslint-disable-next-line no-underscore-dangle
+  const leafMethods = await E(leafView).__getMethodNames__();
+  t.deepEqual(
+    leafMethods.filter(name => !name.startsWith('__')).sort(),
+    [...PLATFORM_READABLE_BLOB_METHODS].sort(),
+  );
+  t.is(await E(leafView).text(), 'leaf-data');
+});
+
+test('EndoMountFile exposes every method on PlatformFileInterface', async t => {
+  const { mount } = makeConfiguredMount(t);
+  await E(mount).writeText(['file.txt'], 'data');
+  const file = await E(mount).lookup('file.txt');
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(file).__getMethodNames__();
+  for (const name of PLATFORM_FILE_METHODS) {
+    t.true(
+      methods.includes(name),
+      `EndoMountFile missing platform File method ${name}`,
+    );
+  }
+});
+
+test('EndoMountFile.readOnly() returns a structural ReadableBlob view', async t => {
+  const { mount } = makeConfiguredMount(t);
+  await E(mount).writeText(['file.txt'], 'rb-data');
+  const file = await E(mount).lookup('file.txt');
+  const view = await E(file).readOnly();
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(view).__getMethodNames__();
+  t.deepEqual(
+    methods.filter(name => !name.startsWith('__')).sort(),
+    [...PLATFORM_READABLE_BLOB_METHODS].sort(),
+    'readOnly() must expose exactly the ReadableBlob method set',
+  );
+  t.is(await E(view).text(), 'rb-data');
+
+  const iter = await E(view).streamBase64();
+  const first = await E(iter).next();
+  t.false(first.done);
+  t.is(
+    Buffer.from(first.value, 'base64').toString('utf-8'),
+    'rb-data',
+    'read-only blob view streams through the platform surface',
+  );
+});
+
+test('EndoMountFile json and streamBase64 re-check confinement on use', async t => {
+  const { mount, rootPath } = makeConfiguredMount(t);
+  const outsideRoot = makeTempRoot(t);
+  const outsideFile = path.join(outsideRoot, 'outside.json');
+  fs.writeFileSync(outsideFile, '{"secret":true}');
+
+  const fileName = 'confined.json';
+  const mountFile = path.join(rootPath, fileName);
+  await E(mount).writeText([fileName], '{"ok":true}');
+  const file = await E(mount).lookup(fileName);
+
+  fs.rmSync(mountFile);
+  fs.symlinkSync(outsideFile, mountFile);
+
+  await t.throwsAsync(() => E(file).json(), {
+    message: /escapes mount root/,
+  });
+
+  const reader = await E(file).streamBase64();
+  await t.throwsAsync(() => E(reader).next(), {
+    message: /escapes mount root/,
+  });
+});
+
+test('EndoMount.snapshot returns a SnapshotTree-shaped capability', async t => {
+  const { mount } = makeConfiguredMount(t);
+  await E(mount).writeText(['s.txt'], 'snap');
+  const snapshot = await E(mount).snapshot();
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(snapshot).__getMethodNames__();
+  t.true(methods.includes('has'));
+  t.true(methods.includes('list'));
+  t.true(methods.includes('lookup'));
+  t.true(methods.includes('sha256'));
+});
+
+// Suppress unused-import warnings for the platform interfaces; their
+// presence in this file documents the conformance target.
+void PlatformDirectoryInterface;
+void PlatformFileInterface;
+void url;
+void Far;

--- a/packages/daemon/test/mount-snapshot-and-entry.test.js
+++ b/packages/daemon/test/mount-snapshot-and-entry.test.js
@@ -1,0 +1,264 @@
+// @ts-check
+
+// Establish a perimeter:
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { E } from '@endo/far';
+import { decodeBase64 } from '@endo/base64';
+import { checkinTree } from '@endo/platform/fs/lite';
+
+import { makeFilePowers } from '../src/daemon-node-powers.js';
+import { makeMount } from '../src/mount.js';
+import { makeMemoryStore } from './_mount-test-helpers.js';
+
+/**
+ * Behavior-level snapshot and entry tests for `makeMount`:
+ *
+ *  - Snapshot round-trips a binary (non-UTF8) file via `streamBase64`.
+ *  - Snapshot of a mount with an internal symlink follows the link
+ *    into confinement; an escaping symlink is hidden rather than
+ *    leaking the outside target's bytes.
+ *  - An entry minted by a read-only mount cannot regain write
+ *    authority on a sibling writable mount (descriptor provenance).
+ *
+ * All three exercise `makeMount` directly so they do not pay the
+ * daemon-fork cost.
+ */
+
+const filePowers = makeFilePowers({ fs, path });
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ */
+const makeTempRoot = t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mount-snap-'));
+  t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+};
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ */
+const makeConfiguredMount = t => {
+  const rootPath = makeTempRoot(t);
+  const store = makeMemoryStore();
+  const snapshotTree = async tree => {
+    const { sha256 } = await checkinTree(tree, store);
+    return store.loadTree(sha256);
+  };
+  const snapshotFile = async filePath => {
+    const sha256 = await store.store(filePowers.makeFileReader(filePath));
+    return store.loadBlob(sha256);
+  };
+  const mount = makeMount({
+    rootPath,
+    readOnly: false,
+    filePowers,
+    snapshotTree,
+    snapshotFile,
+  });
+  return { mount, rootPath };
+};
+
+// --- Snapshot round-tripping: binary file streaming ---
+
+test('snapshot round-trips a binary (non-UTF8) file via streamBase64', async t => {
+  const { mount, rootPath } = makeConfiguredMount(t);
+
+  // A payload that is not valid UTF-8: PNG signature bytes plus high
+  // bytes that any naive readText() pipeline would mangle.
+  const payload = new Uint8Array([
+    0x89,
+    0x50,
+    0x4e,
+    0x47,
+    0x0d,
+    0x0a,
+    0x1a,
+    0x0a, // PNG magic
+    0x00,
+    0xff,
+    0xfe,
+    0xfd,
+    0xfc,
+    0xfb,
+    0xfa,
+    0xf9,
+    0x80,
+    0x81,
+    0x82,
+    0x83,
+    0x84,
+    0x85,
+    0x86,
+    0x87,
+  ]);
+  fs.writeFileSync(path.join(rootPath, 'binary.dat'), payload);
+
+  const snapshot = await E(mount).snapshot();
+  const snapshotBlob = await E(snapshot).lookup('binary.dat');
+
+  // Drive the base64 stream and reassemble the bytes.
+  const iter = await E(snapshotBlob).streamBase64();
+  const chunks = [];
+  for (;;) {
+    // eslint-disable-next-line no-await-in-loop
+    const { done, value } = await E(iter).next();
+    if (done) break;
+    chunks.push(decodeBase64(value));
+  }
+  const totalLength = chunks.reduce((acc, c) => acc + c.byteLength, 0);
+  const reassembled = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const c of chunks) {
+    reassembled.set(c, offset);
+    offset += c.byteLength;
+  }
+  t.deepEqual(
+    Array.from(reassembled),
+    Array.from(payload),
+    'binary bytes must round-trip through snapshot streamBase64()',
+  );
+});
+
+// --- Snapshot round-tripping: symlink confinement behavior ---
+
+test('snapshot of a mount with an internal symlink follows the link into confinement', async t => {
+  const { mount, rootPath } = makeConfiguredMount(t);
+
+  // Lay out:
+  //   rootPath/
+  //     real/
+  //       leaf.txt          (content "real")
+  //     via-link            -> real           (internal relative symlink)
+  fs.mkdirSync(path.join(rootPath, 'real'));
+  fs.writeFileSync(path.join(rootPath, 'real', 'leaf.txt'), 'real');
+  fs.symlinkSync('real', path.join(rootPath, 'via-link'));
+
+  const snapshot = await E(mount).snapshot();
+  const names = await E(snapshot).list();
+  t.true(names.includes('via-link'), 'internal symlink visible in snapshot');
+  t.true(names.includes('real'), 'real directory visible in snapshot');
+
+  // Through the symlink-named entry in the snapshot, the leaf is
+  // reachable with the linked-through content (no host-path leak).
+  const linked = await E(snapshot).lookup('via-link');
+  const leaf = await E(linked).lookup('leaf.txt');
+  t.is(await E(leaf).text(), 'real');
+});
+
+test('snapshot of a mount with an escaping symlink hides the link rather than leaking the target', async t => {
+  const { mount, rootPath } = makeConfiguredMount(t);
+
+  // An escaping symlink target outside the mount root.  Snapshotting
+  // the mount must not leak the host path or the outside file's
+  // bytes through the symlink-named entry.
+  const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mount-outside-'));
+  t.teardown(() => fs.rmSync(outsideRoot, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(outsideRoot, 'secret.txt'), 'should-not-leak');
+
+  fs.writeFileSync(path.join(rootPath, 'visible.txt'), 'fine');
+  fs.symlinkSync(outsideRoot, path.join(rootPath, 'escape-abs'));
+
+  const snapshot = await E(mount).snapshot();
+  const names = await E(snapshot).list();
+
+  // The visible content is captured.
+  t.true(names.includes('visible.txt'));
+  // The escaping link is filtered out of the snapshot's surface; the
+  // mount's `list` already excludes it, and checkin follows the
+  // mount's list.  Either way, no entry in the snapshot reads as
+  // "secret.txt" or yields the outside content.
+  t.false(
+    names.includes('escape-abs'),
+    'escaping symlink must not appear in the snapshot listing',
+  );
+  // Defensive double-check: no snapshot entry exposes the outside
+  // string anywhere we can reach by walking the snapshot.
+  for (const name of names) {
+    // eslint-disable-next-line no-await-in-loop
+    const child = await E(snapshot).lookup(name);
+    const childMethods =
+      // eslint-disable-next-line no-await-in-loop, no-underscore-dangle
+      await E(child).__getMethodNames__();
+    if (childMethods.includes('text')) {
+      // eslint-disable-next-line no-await-in-loop
+      const text = await E(child).text();
+      t.notRegex(
+        text,
+        /should-not-leak/,
+        `no captured blob leaks the outside file: ${name}`,
+      );
+    }
+  }
+});
+
+// --- Descriptor provenance: read-only entry cannot regain write authority ---
+
+test('an entry minted by a read-only mount cannot regain write authority on a sibling writable mount', async t => {
+  // Two mounts share the same backing directory.  One is read-only.
+  // An entry minted by the read-only mount must not be usable to
+  // write through the writable sibling.
+  const rootPath = makeTempRoot(t);
+
+  const writableMount = makeMount({
+    rootPath,
+    readOnly: false,
+    filePowers,
+  });
+  const readOnlySiblingMount = makeMount({
+    rootPath,
+    readOnly: true,
+    filePowers,
+  });
+
+  // The read-only mount mints an entry.  Entries are values rooted
+  // in their mount's lineage; passing one to a different mount must
+  // be rejected on identity, even if the path target is identical.
+  const readOnlyEntry = await E(readOnlySiblingMount).entry(['leaked.txt']);
+
+  // Attempting to write through the writable sibling using the
+  // foreign entry must throw on provenance — not silently write.
+  await t.throwsAsync(
+    () => E(writableMount).writeText(readOnlyEntry, 'should not land'),
+    {
+      message: /different mount root/,
+    },
+    'writable sibling must reject a foreign read-only entry by provenance',
+  );
+
+  // The file was never created on disk.
+  t.false(fs.existsSync(path.join(rootPath, 'leaked.txt')));
+});
+
+test('an entry minted on a readOnly() attenuated mount cannot regain write authority via the parent mount', async t => {
+  // The structural-narrowing form of readOnly() does not expose
+  // entry() (entry is removed from the read-only view).  This test
+  // documents the property: the only way to mint an entry against an
+  // already-attenuated mount is to go through a separately-issued
+  // read-only mount (covered above) or to lose the writable
+  // capability entirely.  Here we verify the read-only view's method
+  // surface — there is no `entry` to call.
+  const { mount } = makeConfiguredMount(t);
+  await E(mount).writeText(['file.txt'], 'data');
+  const view = await E(mount).readOnly();
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(view).__getMethodNames__();
+  t.false(
+    methods.includes('entry'),
+    'read-only ReadableTree view must not expose entry()',
+  );
+  t.false(
+    methods.includes('writeText'),
+    'read-only ReadableTree view must not expose writeText()',
+  );
+  t.false(
+    methods.includes('makeFile'),
+    'read-only ReadableTree view must not expose makeFile()',
+  );
+});

--- a/packages/daemon/test/mount.test.js
+++ b/packages/daemon/test/mount.test.js
@@ -1,0 +1,611 @@
+// @ts-check
+
+// Establish a perimeter:
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { E } from '@endo/far';
+import { makeExo } from '@endo/exo';
+import { M } from '@endo/patterns';
+import {
+  ReadableBlobInterface,
+  checkinTree,
+  makeReaderRef,
+} from '@endo/platform/fs/lite';
+
+import { makeFilePowers } from '../src/daemon-node-powers.js';
+import { makeMount } from '../src/mount.js';
+import { makeMemoryStore } from './_mount-test-helpers.js';
+
+/**
+ * Coverage-driven integration tests for `src/mount.js`.
+ *
+ * These tests exercise reachable branches on the public `EndoMount`,
+ * `EndoMountEntry`, and `EndoMountFile` surfaces that the existing
+ * mount-platform-fs-conformance and mount-snapshot-and-entry tests
+ * do not reach: input validation, confinement error paths, write
+ * variants, read-only rejection paths, and the optional `snapshot`
+ * surface's not-configured error path. Each test exercises one
+ * specific reachable branch and asserts on observable behavior.
+ */
+
+const filePowers = makeFilePowers({ fs, path });
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ */
+const makeTempRoot = t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mount-cov-'));
+  t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+};
+
+// --- Path-segment validation ---
+
+test('writeText rejects a path-like object passed as a segment (realistic adversarial input)', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  // A git-file-shaped record `{ path: '../' }` is the kind of value
+  // a caller might forward through the mount thinking the API
+  // unwraps `.path`.  It does not; the Exo guard rejects on shape,
+  // and a downstream reader can see that the `path` field is not a
+  // tunnel back to the relative segment, even when the value
+  // *looks* like a path-bearing record.
+  const gitLikeFile = harden({ path: '../', mode: '100644' });
+  await t.throwsAsync(
+    () => E(mount).writeText(/** @type {any} */ ([gitLikeFile]), 'content'),
+    { message: /Must match/ },
+    'guard rejects a record-shaped segment even when it carries a path field',
+  );
+});
+
+test('writeText rejects empty path segment', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).writeText(['a', '', 'b'], 'c'), {
+    message: /must not be empty/,
+  });
+});
+
+test('writeText rejects path segment containing forward slash', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).writeText(['a/b'], 'c'), {
+    message: /must not contain/,
+  });
+});
+
+test('writeText rejects path segment containing backslash', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).writeText(['a\\b'], 'c'), {
+    message: /must not contain/,
+  });
+});
+
+test('writeText rejects path segment containing NUL byte', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).writeText(['a\0b'], 'c'), {
+    message: /must not contain/,
+  });
+});
+
+// --- Path normalization (dot / dotdot) ---
+
+test('writeText resolves "." path segments to current directory', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['.', 'hello.txt'], 'data');
+  t.is(fs.readFileSync(path.join(rootPath, 'hello.txt'), 'utf8'), 'data');
+});
+
+test('writeText resolves ".." segments and clamps at confinement root', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  // ['..', '..', 'a.txt'] from the root pops to the root twice (clamped)
+  // and then writes a.txt at the root.
+  await E(mount).writeText(['..', '..', 'a.txt'], 'data');
+  t.is(fs.readFileSync(path.join(rootPath, 'a.txt'), 'utf8'), 'data');
+});
+
+test('writeText with a slash-joined ".." string segment is treated as a single literal name', async t => {
+  // writeText uses normalizeSegments on [stringArg], so a string like
+  // 'sub/..' is NOT split by /; the slash inside the single segment
+  // triggers the validator.
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).writeText('sub/..', 'data'), {
+    message: /must not contain/,
+  });
+});
+
+// --- assertConfined error paths ---
+
+test('readText reports a missing-path error rather than leaking host filesystem state', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).readText(['does-not-exist.txt']), {
+    message: /does not exist|cannot be verified|ENOENT/,
+  });
+});
+
+test('maybeReadText returns undefined for a missing path', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  const result = await E(mount).maybeReadText(['does-not-exist.txt']);
+  t.is(result, undefined);
+});
+
+test('maybeReadText returns the content for an existing file', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['present.txt'], 'hello');
+  t.is(await E(mount).maybeReadText(['present.txt']), 'hello');
+});
+
+test('stat returns undefined for a missing path', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  const result = await E(mount).stat(['does-not-exist.txt']);
+  t.is(result, undefined);
+});
+
+test('stat returns a populated record for an existing file', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['present.txt'], 'hello');
+  const result = await E(mount).stat(['present.txt']);
+  t.truthy(result);
+});
+
+// --- has() variants ---
+
+test('has() with zero arguments returns true for the mount root', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await null;
+  t.true(await E(mount).has());
+});
+
+test('has() returns false for an absent path', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await null;
+  t.false(await E(mount).has('missing.txt'));
+});
+
+test('has() returns true for a present file via variadic segments', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['dir', 'file.txt'], 'x');
+  t.true(await E(mount).has('dir', 'file.txt'));
+});
+
+test('has() rejects a non-string positional argument when the first arg is a string', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).has('a', /** @type {any} */ (42)), {
+    message: /segments must be strings/,
+  });
+});
+
+// --- entry() and child() ---
+
+test('entry() default of root has displayPath "."', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  const rootEntry = await E(mount).entry([]);
+  t.is(await E(rootEntry).displayPath(), '.');
+  t.deepEqual(await E(rootEntry).segments(), []);
+});
+
+test('entry() with array path mints a nested entry with matching segments', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  const entry = await E(mount).entry(['a', 'b']);
+  t.deepEqual(await E(entry).segments(), ['a', 'b']);
+  t.is(await E(entry).displayPath(), 'a/b');
+});
+
+test('entry().child() extends the entry by one segment', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  const e = await E(mount).entry(['a']);
+  const c = await E(e).child('b');
+  t.deepEqual(await E(c).segments(), ['a', 'b']);
+});
+
+test('entry().child() rejects an invalid name segment', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  const e = await E(mount).entry(['a']);
+  await t.throwsAsync(() => E(e).child(''), { message: /must not be empty/ });
+  await t.throwsAsync(() => E(e).child('x/y'), { message: /must not contain/ });
+});
+
+test('entry() rejects a non-string, non-array argument', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).entry(/** @type {any} */ (42)), {
+    message: /Must match|must be a string or array/,
+  });
+});
+
+// --- Entry provenance across mounts ---
+
+test('writeText through an entry from a different mount root is rejected on provenance', async t => {
+  const aRoot = makeTempRoot(t);
+  const bRoot = makeTempRoot(t);
+  const a = makeMount({ rootPath: aRoot, readOnly: false, filePowers });
+  const b = makeMount({ rootPath: bRoot, readOnly: false, filePowers });
+  const foreign = await E(a).entry(['leaked.txt']);
+  await t.throwsAsync(() => E(b).writeText(foreign, 'x'), {
+    message: /different mount root/,
+  });
+});
+
+test('writeText rejects a foreign (non-entry) object as path argument (documented gap)', async t => {
+  // The "unrecognized object" branch in segmentsFromPathArg is gated
+  // by the writeText M.interface guard (which accepts string,
+  // arrayOf string, or an EndoMountEntry remotable). A bare hardened
+  // record cannot pass the guard, so the inner WeakMap-miss branch
+  // is unreachable from the public API. The provenance branch
+  // (different-rootId) is the reachable failure mode and is covered
+  // by the previous test.
+  t.pass();
+});
+
+// --- makeFile content variants ---
+
+test('makeFile with no content creates an empty file when absent', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).makeFile('empty.txt');
+  t.is(fs.readFileSync(path.join(rootPath, 'empty.txt'), 'utf8'), '');
+});
+
+test('makeFile with no content is a no-op when the file already exists', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  fs.writeFileSync(path.join(rootPath, 'keep.txt'), 'preserved');
+  await E(mount).makeFile('keep.txt');
+  t.is(fs.readFileSync(path.join(rootPath, 'keep.txt'), 'utf8'), 'preserved');
+});
+
+test('makeFile with a string overwrites with that string', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).makeFile('s.txt', 'first');
+  await E(mount).makeFile('s.txt', 'second');
+  t.is(fs.readFileSync(path.join(rootPath, 's.txt'), 'utf8'), 'second');
+});
+
+test('makeFile rejects mutable Uint8Array at the exo guard', async t => {
+  // The makeFile interface guard `M.call(PathArgShape).optional(M.any())`
+  // accepts only passable values; a raw Uint8Array is mutable and is
+  // therefore rejected at the exo boundary. Binary content reaches the
+  // mount through `write(path, readableBlob)` instead; `makeFile`
+  // accepts only `string` content (or `undefined` for a touch-style
+  // empty file).
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  const bytes = new Uint8Array([0x00, 0xff]);
+  await t.throwsAsync(
+    () => E(mount).makeFile('b.bin', /** @type {any} */ (bytes)),
+    { message: /Cannot pass mutable typed arrays|Must match/ },
+    'mutable Uint8Array rejected at the exo guard',
+  );
+});
+
+test('makeFile rejects non-string content', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(
+    () => E(mount).makeFile('bad.txt', /** @type {any} */ (42)),
+    { message: /must be a string/ },
+  );
+});
+
+test('makeFile rejects writing to an existing directory path', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  fs.mkdirSync(path.join(rootPath, 'adir'));
+  await t.throwsAsync(() => E(mount).makeFile('adir', 'x'), {
+    message: /is a directory/,
+  });
+});
+
+// --- remove / move ---
+
+test('remove deletes an existing file', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['gone.txt'], 'x');
+  await E(mount).remove(['gone.txt']);
+  t.false(fs.existsSync(path.join(rootPath, 'gone.txt')));
+});
+
+test('move renames a file within the mount', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['src.txt'], 'data');
+  await E(mount).move(['src.txt'], ['dst.txt']);
+  t.false(fs.existsSync(path.join(rootPath, 'src.txt')));
+  t.is(fs.readFileSync(path.join(rootPath, 'dst.txt'), 'utf8'), 'data');
+});
+
+// --- Read-only rejection paths ---
+
+test('read-only mount rejects writeText', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'exists.txt'), 'x');
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  await t.throwsAsync(() => E(mount).writeText(['hello.txt'], 'data'), {
+    message: /read-only/,
+  });
+});
+
+test('read-only mount rejects makeFile', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  await t.throwsAsync(() => E(mount).makeFile('nope.txt'), {
+    message: /read-only/,
+  });
+});
+
+test('read-only mount rejects makeDirectory', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  await t.throwsAsync(() => E(mount).makeDirectory('nope'), {
+    message: /read-only/,
+  });
+});
+
+test('read-only mount rejects remove', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'present.txt'), 'x');
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  await t.throwsAsync(() => E(mount).remove(['present.txt']), {
+    message: /read-only/,
+  });
+});
+
+test('read-only mount rejects move', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'x');
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  await t.throwsAsync(() => E(mount).move(['a.txt'], ['b.txt']), {
+    message: /read-only/,
+  });
+});
+
+test('read-only mount rejects copy', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'x');
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  await t.throwsAsync(() => E(mount).copy(['a.txt'], ['b.txt']), {
+    message: /read-only/,
+  });
+});
+
+test('readOnly() called on an already-read-only mount returns a working view', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'persist');
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  const view = await E(mount).readOnly();
+  t.true(await E(view).has('a.txt'));
+});
+
+// --- snapshot() not configured ---
+
+test('snapshot() throws when no snapshotTree was wired in', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await t.throwsAsync(() => E(mount).snapshot(), {
+    message: /snapshot.* not available/,
+  });
+});
+
+// --- EndoMountFile surface ---
+
+test('lookup of a present file returns an EndoMountFile with text/json', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  fs.writeFileSync(path.join(rootPath, 'value.json'), '{"a":1}');
+  const file = await E(mount).lookup('value.json');
+  t.is(await E(file).text(), '{"a":1}');
+  t.deepEqual(await E(file).json(), { a: 1 });
+});
+
+test('EndoMountFile.append extends the file content', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['log.txt'], 'one\n');
+  const file = await E(mount).lookup('log.txt');
+  await E(file).append('two\n');
+  t.is(fs.readFileSync(path.join(rootPath, 'log.txt'), 'utf8'), 'one\ntwo\n');
+});
+
+test('EndoMountFile.writeText replaces the file content', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['v.txt'], 'old');
+  const file = await E(mount).lookup('v.txt');
+  await E(file).writeText('new');
+  t.is(fs.readFileSync(path.join(rootPath, 'v.txt'), 'utf8'), 'new');
+});
+
+test('EndoMountFile.stat returns a record for a present file', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['s.txt'], 'x');
+  const file = await E(mount).lookup('s.txt');
+  const st = await E(file).stat();
+  t.truthy(st);
+});
+
+test('EndoMountFile.snapshot throws when no snapshotFile was wired in', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['s.txt'], 'x');
+  const file = await E(mount).lookup('s.txt');
+  await t.throwsAsync(() => E(file).snapshot(), {
+    message: /snapshot.* not available/,
+  });
+});
+
+test('EndoMountFile from a read-only mount rejects writeText / append', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'r.txt'), 'x');
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  const file = await E(mount).lookup('r.txt');
+  await t.throwsAsync(() => E(file).writeText('new'), { message: /read-only/ });
+  await t.throwsAsync(() => E(file).append('more'), { message: /read-only/ });
+});
+
+// --- write() error branches ---
+
+test('write rejects a value that is neither a ReadableBlob nor a ReadableTree', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+
+  // A remotable that has neither `streamBase64` nor `list` — the
+  // duck-typing branch falls through to the explicit reject.
+  const RandoInterface = M.interface('Rando', {
+    nothing: M.call().returns(M.string()),
+  });
+  const rando = makeExo('Rando', RandoInterface, {
+    nothing() {
+      return 'nope';
+    },
+  });
+  await t.throwsAsync(() => E(mount).write(['x'], rando), {
+    message: /ReadableBlob or ReadableTree/,
+  });
+});
+
+test('write rejects writing a ReadableBlob to an existing directory target', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  fs.mkdirSync(path.join(rootPath, 'occupied'));
+
+  const blob = makeExo('Blob', ReadableBlobInterface, {
+    streamBase64() {
+      // The streamBase64() result is never iterated in this test —
+      // the is-a-directory check fires first.
+      return makeReaderRef([new Uint8Array(0)]);
+    },
+    async text() {
+      return '';
+    },
+    async json() {
+      return null;
+    },
+  });
+  await t.throwsAsync(() => E(mount).write(['occupied'], blob), {
+    message: /is a directory/,
+  });
+});
+
+// --- Snapshot wiring (covers the snapshotTree wrapper) ---
+
+test('snapshot() returns a usable snapshot when snapshotTree is wired', async t => {
+  const rootPath = makeTempRoot(t);
+  const store = makeMemoryStore();
+  const snapshotTree = async tree => {
+    const { sha256 } = await checkinTree(tree, store);
+    return store.loadTree(sha256);
+  };
+  const mount = makeMount({
+    rootPath,
+    readOnly: false,
+    filePowers,
+    snapshotTree,
+  });
+  await E(mount).writeText(['x.txt'], 'snap');
+  const snap = await E(mount).snapshot();
+  const names = await E(snap).list();
+  t.true(names.includes('x.txt'));
+});
+
+// --- ReadableTree view recursion ---
+
+// --- Additional resolveSegments / EndoMountFile paths ---
+
+test('lookup with ".." segments clamps at the confinement root', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'top.txt'), 'top-content');
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  // From the root, '..' should clamp to the root (not escape to the
+  // host filesystem); then 'top.txt' resolves to the existing file.
+  const file = await E(mount).lookup(['..', '..', 'top.txt']);
+  t.is(await E(file).text(), 'top-content');
+});
+
+test('list with "." returns the root listing unchanged', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'x');
+  fs.writeFileSync(path.join(rootPath, 'b.txt'), 'y');
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  const names = await E(mount).list('.');
+  t.deepEqual([...names].sort(), ['a.txt', 'b.txt']);
+});
+
+test('EndoMountFile.snapshot returns a usable file snapshot when wired', async t => {
+  const rootPath = makeTempRoot(t);
+  const store = makeMemoryStore();
+  const snapshotFile = async filePath => {
+    const sha256 = await store.store(filePowers.makeFileReader(filePath));
+    return store.loadBlob(sha256);
+  };
+  const mount = makeMount({
+    rootPath,
+    readOnly: false,
+    filePowers,
+    snapshotFile,
+  });
+  await E(mount).writeText(['s.txt'], 'snapshot-me');
+  const file = await E(mount).lookup('s.txt');
+  const blob = await E(file).snapshot();
+  t.is(await E(blob).text(), 'snapshot-me');
+});
+
+test('EndoMountFile.writeBytes is reachable through the read-only-rejection branch', async t => {
+  // The writeBytes body (mount.js ~736) is reachable through the
+  // read-only-rejection assertWritable() call before any byte ever
+  // moves; that's the entry point most callers hit incorrectly. A
+  // full happy-path exercise requires a remote producer that yields
+  // raw Uint8Array values without the marshaler's base64 encoding, a
+  // shape only available across a CapTP boundary with a real daemon.
+  // The in-process AVA harness cannot satisfy it, so this test pins
+  // the read-only-rejection observation instead.
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'r.bin'), '');
+  const mount = makeMount({ rootPath, readOnly: true, filePowers });
+  const file = await E(mount).lookup('r.bin');
+  async function* iter() {
+    yield new Uint8Array([1]);
+  }
+  await t.throwsAsync(() => E(file).writeBytes(makeReaderRef(iter())), {
+    message: /read-only/,
+  });
+});
+
+test('readOnly() narrows to a ReadableTree view that recursively narrows file lookups', async t => {
+  const rootPath = makeTempRoot(t);
+  const mount = makeMount({ rootPath, readOnly: false, filePowers });
+  await E(mount).writeText(['a.txt'], 'hi');
+  const view = await E(mount).readOnly();
+  const file = await E(view).lookup('a.txt');
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(file).__getMethodNames__();
+  // The view-of-a-file is a ReadableBlob, not an EndoMountFile.
+  t.true(methods.includes('streamBase64'));
+  t.true(methods.includes('text'));
+  t.false(methods.includes('writeText'), 'attenuated, not full file');
+});

--- a/packages/daemon/tsconfig.json
+++ b/packages/daemon/tsconfig.json
@@ -7,6 +7,7 @@
   "include": [
     "*.js",
     "src/**/*.js",
+    "src/libp2p-utils-adaptive-timeout.d.ts",
     "src/types.d.ts",
     "test",
     "types.d.ts",

--- a/packages/platform/src/fs/types.js
+++ b/packages/platform/src/fs/types.js
@@ -74,5 +74,42 @@
  * @property {(pathSegments: string[]) => Promise<void>} makeDirectory
  */
 
+/**
+ * A File presents a mutable byte-content interface that also satisfies
+ * the ReadableBlob read surface.  Concrete implementations supply
+ * confinement and provenance (e.g. EndoMountFile constrains writes to
+ * a mount root).
+ *
+ * @typedef {object} File
+ * @property {() => unknown} streamBase64
+ * @property {() => Promise<string>} text
+ * @property {() => Promise<any>} json
+ * @property {(content: string) => Promise<void>} writeText
+ * @property {(readable: unknown) => Promise<void>} writeBytes
+ * @property {(content: string) => Promise<void>} append
+ * @property {() => ReadableBlob} readOnly
+ * @property {() => Promise<SnapshotBlob>} snapshot
+ */
+
+/**
+ * A Directory presents a mutable handle-first filesystem interface
+ * that also satisfies the ReadableTree read surface on the query side.
+ * `write` accepts a `ReadableBlob` (materialised as bytes at `path`) or
+ * a `ReadableTree` (materialised recursively).  Concrete
+ * implementations supply confinement and provenance.
+ *
+ * @typedef {object} Directory
+ * @property {(...path: string[]) => Promise<boolean>} has
+ * @property {(...path: string[]) => Promise<string[]>} list
+ * @property {(path: string | string[]) => Promise<unknown>} lookup
+ * @property {(path: string[], value: unknown) => Promise<void>} write
+ * @property {(path: string[]) => Promise<void>} remove
+ * @property {(from: string[], to: string[]) => Promise<void>} move
+ * @property {(from: string[], to: string[]) => Promise<void>} copy
+ * @property {(path: string[]) => Promise<Directory>} makeDirectory
+ * @property {() => ReadableTree} readOnly
+ * @property {() => Promise<SnapshotTree>} snapshot
+ */
+
 // This module has no runtime exports.
 export {};

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -179,6 +179,10 @@ The daemon's `EndoHost` exposes both `provideScratchMount` and
 `endo run --UNCONFINED packages/sandbox/src/agent.js` with
 `--powers @host` (the default for `make-unconfined`) gets the full
 `SandboxPowers` surface for free — no per-caller stub is required.
+This relies on `EndoHost` being a fully privileged host-authority
+capability: any holder of one can recover host paths for
+daemon-minted top-level mounts. Do not pass `EndoHost` to code that
+should only receive an attenuated guest or narrower sandbox powers.
 The resolver lives at `packages/daemon/src/host.js` `provideHostPath`;
 it rejects any cap the daemon did not mint as a top-level `mount`
 or `scratch-mount` formula, so an arbitrary remote object that quacks


### PR DESCRIPTION
Refs: `designs/daemon-mount-capabilities.md` (resolved Phase 5)

## Description

Lands Phases 1–5 of `designs/daemon-mount-capabilities.md` on top of the mount/git design trio merged in #327. `EndoMount` becomes a daemon-local specialization of the shared `@endo/platform/fs` `Directory` contract: a single Exo per mount satisfies both the platform-fs read surface and the daemon's mount-specific extensions (entry-valued lookups, snapshot, `EndoMountBacking`, host-private `materializeTree`). The read-only narrowing surface is the structural `@endo/platform/fs` view; the mount-private extensions are not reachable through it.

Mount entries are values: an `EndoMountEntry` is `{ segments, displayPath, child }` with no authority of its own, and handle-minting moves to `lookup(path | entry)`. Snapshots round-trip binary content through a `streamBase64` host fast path with a daemon-side fallback, and symlinks that escape the mount root are filtered from snapshot listings — bytes behind an escaping link are unreachable through any other captured entry. Cross-mount entry forgeries are rejected on `rootId`.

The branch is nine commits beyond `llm`: the design-doc resolution lands first, followed by the specialization spine, host `materializeTree` streamBase64 path, node-powers extensions for `EndoMountFile`, help-text and CLAUDE.md updates, TypeScript scaffolding for snapshot-view types, two test commits (an `EndoHost`-only `provideHostPath` invariant, and an `@endo/platform/fs` conformance + snapshot + entry-descriptor matrix), and the changeset.

### Security Considerations

- `EndoMountEntry` is a pure value with no observational or handle-minting authority; the entry alone cannot read, write, or stat its target.
- Descriptors carry mount provenance: an entry minted by one mount is rejected by a sibling mount on `rootId`, so a guest cannot smuggle a sibling's authority across mounts.
- `readOnly()` returns the structural `@endo/platform/fs` `ReadableTree` / `ReadableBlob` view; `entry`, `writeText`, and `makeFile` are not reachable from an attenuated mount, so a holder of the read-only view cannot mint authority-bearing handles.
- `FilePowers.pathIdentity` correlates trusted-backing provenance for the host-private facet without leaking host paths into the guest surface.
- Symlink confinement: snapshot follows internal symlinks; an escaping symlink is filtered from the snapshot listing and its bytes are unreachable through any other captured entry.
- `provideHostPath` is an `EndoHost`-only capability and is not reachable through an `EndoGuest`, asserted as a structural invariant by a dedicated test.

### Scaling Considerations

`materializeTree`'s host fast path streams binary content through `streamBase64` rather than buffering whole files in the daemon; the daemon-side fallback handles cases where the host path is unavailable. Snapshots remain bounded by the structural walk of the mount root and do not traverse escaping symlinks.

### Documentation Considerations

`designs/daemon-mount-capabilities.md` is updated to its Phase-5-resolved form: it records the specialization-vs-wrapping decision, the divergence sets between the daemon's `EndoMount` and the platform-fs `Directory`, the naming-collision discipline for `EndoDirectory` vs `Directory` imports across daemon and platform packages, and the checklist of items the resolution closes from Phases 1–4. The daemon's help text and CLAUDE.md are updated for the specialized `EndoMount` surface.

### Testing Considerations

- A new `@endo/platform/fs` conformance test verifies that every method of the shared `Directory` / `File` contract is present on the daemon Exo over a real temp directory, and that `readOnly()` exposes exactly the structural method set in either direction. This is the drift detector for the specialization.
- A new snapshot-and-entry-descriptor test exercises binary snapshot round-trip, internal-vs-escaping symlink confinement, and cross-mount entry-provenance rejection.
- A new `provideHostPath` test pins the `EndoHost`-only invariant against an `EndoGuest` reach attempt.
- The existing `mount readOnly() attenuation` test adopts the structural-method-set assertion shape introduced by the conformance suite.

### Compatibility Considerations

Three breaking changes, all in `packages/daemon`:

- `EndoMountEntry` is now a pure value. `openDirectory` / `openFile` / `createDirectory` / `createFile` are removed in favour of `lookup(path | entry)` for handle-minting; `has` / `stat` / `lookup` accept either a path or an entry.
- `EndoMount.makeDirectory(path)` returns `Promise<EndoMount>` (was `Promise<void>`) to match the shared `Directory.makeDirectory` shape. `EndoMount.makeFile(path, content?)` is added as the path-form sibling.
- `EndoMount.readOnly()` returns a structural `ReadableTree` view (was `EndoMount`); `EndoMountFile.readOnly()` returns a structural `ReadableBlob` view (was `EndoMountFile`). In-tree call sites are source-compatible.

`EndoMountStat` is `{ kind, sizeBytes, modifiedMs }` across the `FilePowers` layer (lstat-based) and the public type.

A `major`-bump changeset is included.

### Upgrade Considerations

Callers that previously held an `EndoMountEntry` as an authority-bearing handle must round-trip through `lookup(entry)` to recover a handle; the entry itself is a value. Callers of `makeDirectory` that ignored the previous `void` return are unaffected by the change to `Promise<EndoMount>`. No on-disk format change.
