### PR TITLE
fix(ci): address zizmor findings on ci/ci-docs/familiar-release

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -23,9 +23,9 @@ on:
       - '**/*.md'
       - 'docs/**'
 
+# Docs-only CI only needs checkout access.
 permissions:
   contents: read
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,12 +40,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22.x
           cache: yarn
@@ -67,12 +69,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22.x
           cache: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22.x
           cache: yarn
@@ -203,12 +205,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22.x
           cache: yarn
@@ -424,7 +428,7 @@ jobs:
 
       - name: Detect workflow changes
         id: paths
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             workflows:
@@ -661,6 +665,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Cache Cargo + target
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/familiar-release.yml
+++ b/.github/workflows/familiar-release.yml
@@ -11,8 +11,13 @@ on:
     tags:
       - 'familiar-v*'
 
+# Build jobs only need checkout access; release write access is scoped below.
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.version || 'tag' }}
+  cancel-in-progress: true
 
 # Defense in depth against npm lifecycle scripts running implicitly at install.
 # See designs/ci-no-npm-lifecycle.md.
@@ -28,14 +33,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - run: corepack enable
 
+      # `package-manager-cache: false` defends against the cache-poisoning class
+      # zizmor flags on release-triggered workflows. setup-node@v6 auto-enables
+      # yarn caching when package.json carries a `packageManager` field, so the
+      # explicit opt-out is load-bearing — removing this line re-enables the cache.
       - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22.x
-          cache: yarn
+          package-manager-cache: false
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -62,6 +73,9 @@ jobs:
     name: Make (${{ matrix.target-os }}-${{ matrix.target-arch }})
     needs: build-artifacts
     runs-on: ${{ matrix.runner }}
+    env:
+      TARGET_ARCH: ${{ matrix.target-arch }}
+      TARGET_OS: ${{ matrix.target-os }}
 
     strategy:
       matrix:
@@ -79,14 +93,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - run: corepack enable
 
+      # `package-manager-cache: false` defends against the cache-poisoning class
+      # zizmor flags on release-triggered workflows. setup-node@v6 auto-enables
+      # yarn caching when package.json carries a `packageManager` field, so the
+      # explicit opt-out is load-bearing — removing this line re-enables the cache.
       - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22.x
-          cache: yarn
+          package-manager-cache: false
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -106,12 +126,12 @@ jobs:
       - name: Download Node.js binary
         run: |
           cd packages/familiar
-          ./scripts/download-node.sh v20.18.1 ${{ matrix.target-os }} ${{ matrix.target-arch }}
+          ./scripts/download-node.sh v20.18.1 "$TARGET_OS" "$TARGET_ARCH"
 
       - name: Prepare package
         run: |
           cd packages/familiar
-          ./scripts/prepare-package.sh ${{ matrix.target-os }} ${{ matrix.target-arch }}
+          ./scripts/prepare-package.sh "$TARGET_OS" "$TARGET_ARCH"
 
       - name: Make distributables
         run: yarn workspace @endo/familiar step:make
@@ -127,6 +147,8 @@ jobs:
     needs: make
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/familiar-v') || github.event.inputs.version != ''
+    permissions:
+      contents: write # Create the draft release and upload assets.
 
     steps:
       - name: Download all artifacts
@@ -137,15 +159,29 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version || '' }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "tag=familiar-v${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_VERSION" ]; then
+            if [[ ! "$INPUT_VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid release version: $INPUT_VERSION" >&2
+              exit 1
+            fi
+            tag="familiar-v$INPUT_VERSION"
           else
-            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            tag="$REF_NAME"
           fi
 
+          if [[ ! "$tag" =~ ^familiar-v[0-9A-Za-z._+-]+$ ]]; then
+            echo "Invalid release tag: $tag" >&2
+            exit 1
+          fi
+
+          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Familiar ${{ steps.version.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         # This action will create/update Changesets' Release PR *or* create a
         # GitHub Release and tags if its Release PR was just merged
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: yarn changeset tag
           createGithubReleases: true


### PR DESCRIPTION
Closes: #338

## Description

Address the zizmor errors and warnings that have been red on every recent PR.

`.github/workflows/ci-docs.yml`
- Drop workflow-level `actions: write`; keep `contents: read`.
- `persist-credentials: false` on both `actions/checkout`.

`.github/workflows/ci.yml`
- `persist-credentials: false` on the three `actions/checkout` steps zizmor flagged.

`.github/workflows/familiar-release.yml`
- Narrow workflow-level `contents: write` to `contents: read`; scope write to the `release` job only.
- Lift `matrix.target-os` / `matrix.target-arch` into job `env` and quote them in shell (closes template-injection on L141/142/144).
- Validate `inputs.version` and the resolved tag against strict regexes before writing to `GITHUB_OUTPUT`.
- Replace `cache: yarn` with `package-manager-cache: false` on the two `setup-node` steps (closes cache-poisoning on L35/86). Inline comments above each step explain why the explicit opt-out is load-bearing under setup-node@v6.
- Workflow-level concurrency block.
- `persist-credentials: false` on all `actions/checkout`.

Across `ci.yml`, `ci-docs.yml`, `familiar-release.yml`, `release.yml`
- Align action hash-pin trailing comments to specific patch versions (matches the repo's existing `# vN.M.K` style on non-flagged pins). Pin hashes are unchanged; comments only.
  - `actions/setup-node` → `# v6.2.0` (6 spots)
  - `dorny/paths-filter` → `# v4.0.1` (1 spot) — **the hash actually corresponds to v4.0.1, not the `# v3` the comment claimed**; silent major-version drift, surfaced by this fix.
  - `softprops/action-gh-release` → `# v2.2.2` (1 spot)
  - `changesets/action` → `# v1.7.0` (1 spot)

Most-critical files to review: `familiar-release.yml` (the only file with shell-construction and `GITHUB_OUTPUT` changes), and the `dorny/paths-filter` pin in `ci.yml` if you want to sanity-check the v3→v4 surface.

### Security Considerations

This PR is itself the security change: narrows two workflow-level token scopes, removes shell template-expansion of matrix inputs, and validates a tag before it lands in `GITHUB_OUTPUT`. No new authorities introduced.

`.github/workflows/**` edits need `workflow` OAuth scope on the merging identity.

### Scaling Considerations

None. Adds one concurrency group on `familiar-release.yml` (cancels superseded runs on the same ref + version input).

### Documentation Considerations

None.

### Testing Considerations

Verification is the zizmor run on this branch — green on the latest commit (`186320ce8`).

### Compatibility Considerations

`familiar-release.yml` no longer caches yarn at the `setup-node` layer; per-package install times will rise on cold runs but the release workflow is rare. No interface or behavior changes for consumers.

The `dorny/paths-filter` comment now reads `# v4.0.1` to match the pinned hash. The pin itself was on v4.0.1 already (this PR did not bump it); only the misleading `# v3` comment changed.

### Upgrade Considerations

None.
