### PR TITLE
feat(daemon): GitRemote capability composing Git + transport + credentials

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -72,6 +72,7 @@ import {
   makeBearerCredential,
   makeUnavailableGitCredential,
 } from './git-credential.js';
+import { makeGitRemote } from './git-remote.js';
 
 // Sorted:
 import {
@@ -621,6 +622,14 @@ const makeDaemonCore = async (
         return [['mount', formula.mountId]];
       case 'git-credential':
         return [];
+      case 'git-remote': {
+        /** @type {Array<[string, FormulaIdentifier]>} */
+        const deps = [['git', formula.gitId]];
+        if (formula.credentialId !== undefined) {
+          deps.push(['credential', formula.credentialId]);
+        }
+        return deps;
+      }
       case 'pet-inspector':
         return [['petStore', formula.petStore]];
       case 'directory':
@@ -2758,6 +2767,52 @@ const makeDaemonCore = async (
         onRevoke,
       });
     },
+    'git-remote': async (formula, context, id) => {
+      const { gitId, credentialId, name, policy, revoked = false } = formula;
+      let currentFormula = formula;
+      const persistGitRemoteState = async ({
+        policy: nextPolicy,
+        revoked: nextRevoked,
+      }) => {
+        await withFormulaGraphLock(async () => {
+          const { number: formulaNumber, node: formulaNode } = parseId(id);
+          const latestFormula = formulaForId.get(id) ?? currentFormula;
+          if (latestFormula.type !== 'git-remote') {
+            throw makeError(
+              X`GitRemote controller cannot update non-remote formula ${q(id)}`,
+            );
+          }
+          const nextFormula = harden({
+            ...latestFormula,
+            policy: nextPolicy,
+            revoked: nextRevoked,
+          });
+          await persistencePowers.writeFormula(
+            formulaNumber,
+            formulaNode,
+            nextFormula,
+          );
+          formulaForId.set(id, nextFormula);
+          currentFormula = nextFormula;
+        });
+      };
+      context.thisDiesIfThatDies(gitId);
+      if (credentialId !== undefined) {
+        context.thisDiesIfThatDies(credentialId);
+      }
+      const git = await provide(gitId);
+      const credential =
+        credentialId === undefined ? undefined : await provide(credentialId);
+      const { remote } = makeGitRemote({
+        git,
+        credential,
+        name,
+        policy,
+        revoked,
+        onStateChange: persistGitRemoteState,
+      });
+      return remote;
+    },
     lookup: ({ hub, path }, context) =>
       makeLookup(
         hub,
@@ -3645,6 +3700,42 @@ const makeDaemonCore = async (
           type: 'git-credential',
           kind,
           audience,
+        });
+
+        return formulate(formulaNumber, formula);
+      })
+    );
+  };
+
+  /** @type {DaemonCore['formulateGitRemote']} */
+  const formulateGitRemote = async (
+    gitId,
+    credentialId,
+    name,
+    policy,
+    deferredTasks,
+  ) => {
+    return /** @type {FormulateResult<unknown>} */ (
+      withFormulaGraphLock(async () => {
+        await null;
+        const formulaNumber = /** @type {FormulaNumber} */ (
+          await randomHex256()
+        );
+
+        await deferredTasks.execute({
+          gitRemoteId: formatId({
+            number: formulaNumber,
+            node: localNodeNumber,
+          }),
+        });
+
+        /** @type {import('./types.js').GitRemoteFormula} */
+        const formula = harden({
+          type: 'git-remote',
+          gitId,
+          ...(credentialId === undefined ? {} : { credentialId }),
+          name,
+          policy,
         });
 
         return formulate(formulaNumber, formula);
@@ -5538,6 +5629,7 @@ const makeDaemonCore = async (
     formulateScratchMount,
     formulateGit,
     formulateGitCredential,
+    formulateGitRemote,
     formulateInvitation,
     formulateDirectoryForStore,
     getPeerIdForNodeIdentifier,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -67,6 +67,11 @@ import {
 import { getMountBacking, makeMount } from './mount.js';
 import { makeGit } from './git.js';
 import { makeNativeGitBackend } from './native-git-backend.js';
+import {
+  makeBasicCredential,
+  makeBearerCredential,
+  makeUnavailableGitCredential,
+} from './git-credential.js';
 
 // Sorted:
 import {
@@ -88,6 +93,10 @@ import {
 /** @import { ERef, FarRef } from '@endo/eventual-send' */
 /** @import { PromiseKit } from '@endo/promise-kit' */
 /** @import { AgentDeferredTaskParams, Builtins, CapTpConnectionRegistrar, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGit, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoMount, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeArchiveFormula, MakeCapletDeferredTaskParams, MakeFromTreeFormula, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha256, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, TimerFormula } from './types.js' */
+
+/**
+ * @typedef {{ kind: 'bearer', token: string } | { kind: 'basic', username: string, password: string }} GitCredentialMaterial
+ */
 
 /**
  * Creates a delayed promise that can be cancelled.
@@ -610,6 +619,8 @@ const makeDaemonCore = async (
         return [];
       case 'git':
         return [['mount', formula.mountId]];
+      case 'git-credential':
+        return [];
       case 'pet-inspector':
         return [['petStore', formula.petStore]];
       case 'directory':
@@ -675,6 +686,9 @@ const makeDaemonCore = async (
       const formula = collectedFormulas.get(id);
       if (formula !== undefined) {
         const { number: collectedNumber, node: collectedNode } = parseId(id);
+        if (formula.type === 'git-credential') {
+          gitCredentialMaterialForId.delete(id);
+        }
         formulaForId.delete(id);
         formulaChangeTopic.publisher.next(
           harden({ remove: collectedNumber, node: collectedNode }),
@@ -952,6 +966,40 @@ const makeDaemonCore = async (
 
   /** @type {WeakMap<object, FormulaIdentifier>} */
   const agentIdForHandle = new WeakMap();
+  /** @type {Map<FormulaIdentifier, GitCredentialMaterial>} */
+  const gitCredentialMaterialForId = new Map();
+
+  /**
+   * @param {FormulaIdentifier} id
+   * @param {'bearer' | 'basic'} kind
+   * @param {Record<string, unknown>} material
+   */
+  const rememberGitCredentialMaterial = (id, kind, material) => {
+    if (kind === 'bearer' && typeof material.token === 'string') {
+      gitCredentialMaterialForId.set(
+        id,
+        harden({ kind, token: material.token }),
+      );
+      return;
+    }
+    if (
+      kind === 'basic' &&
+      typeof material.username === 'string' &&
+      typeof material.password === 'string'
+    ) {
+      gitCredentialMaterialForId.set(
+        id,
+        harden({
+          kind,
+          username: material.username,
+          password: material.password,
+        }),
+      );
+      return;
+    }
+    gitCredentialMaterialForId.delete(id);
+  };
+  harden(rememberGitCredentialMaterial);
 
   // The following are functions that manage that state.
 
@@ -2677,6 +2725,39 @@ const makeDaemonCore = async (
       await backend.assertRepositoryRoot();
       return makeGit({ mount, backend, readOnly: backing.readOnly });
     },
+    'git-credential': ({ kind, audience }, _context, id) => {
+      const material = gitCredentialMaterialForId.get(id);
+      const onRotate = rotated =>
+        rememberGitCredentialMaterial(
+          id,
+          kind,
+          /** @type {Record<string, unknown>} */ (rotated),
+        );
+      const onRevoke = () => gitCredentialMaterialForId.delete(id);
+      if (kind === 'bearer' && material?.kind === 'bearer') {
+        return makeBearerCredential({
+          audience,
+          token: material.token,
+          onRotate,
+          onRevoke,
+        });
+      }
+      if (kind === 'basic' && material?.kind === 'basic') {
+        return makeBasicCredential({
+          audience,
+          username: material.username,
+          password: material.password,
+          onRotate,
+          onRevoke,
+        });
+      }
+      return makeUnavailableGitCredential({
+        kind,
+        audience,
+        onRotate,
+        onRevoke,
+      });
+    },
     lookup: ({ hub, path }, context) =>
       makeLookup(
         hub,
@@ -3512,6 +3593,58 @@ const makeDaemonCore = async (
         const formula = harden({
           type: 'git',
           mountId,
+        });
+
+        return formulate(formulaNumber, formula);
+      })
+    );
+  };
+
+  /** @type {DaemonCore['formulateGitCredential']} */
+  const formulateGitCredential = async (
+    kind,
+    audience,
+    material,
+    deferredTasks,
+  ) => {
+    /** @type {GitCredentialMaterial} */
+    let storedMaterial;
+    if (kind === 'bearer' && typeof material.token === 'string') {
+      storedMaterial = harden({ kind, token: material.token });
+    } else if (
+      kind === 'basic' &&
+      typeof material.username === 'string' &&
+      typeof material.password === 'string'
+    ) {
+      storedMaterial = harden({
+        kind,
+        username: material.username,
+        password: material.password,
+      });
+    } else {
+      throw makeError(
+        X`Git credential material does not match kind ${q(kind)}`,
+      );
+    }
+    return /** @type {FormulateResult<unknown>} */ (
+      withFormulaGraphLock(async () => {
+        await null;
+        const formulaNumber = /** @type {FormulaNumber} */ (
+          await randomHex256()
+        );
+        const gitCredentialId = formatId({
+          number: formulaNumber,
+          node: localNodeNumber,
+        });
+
+        await deferredTasks.execute({ gitCredentialId });
+        gitCredentialMaterialForId.set(gitCredentialId, storedMaterial);
+
+        /** @type {import('./types.js').GitCredentialFormula} */
+        const formula = harden({
+          type: 'git-credential',
+          kind,
+          audience,
         });
 
         return formulate(formulaNumber, formula);
@@ -5404,6 +5537,7 @@ const makeDaemonCore = async (
     formulateMount,
     formulateScratchMount,
     formulateGit,
+    formulateGitCredential,
     formulateInvitation,
     formulateDirectoryForStore,
     getPeerIdForNodeIdentifier,

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -10,6 +10,7 @@ const formulaTypes = new Set([
   'eval',
   'git',
   'git-credential',
+  'git-remote',
   'guest',
   'handle',
   'host',

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -9,6 +9,7 @@ const formulaTypes = new Set([
   'endo',
   'eval',
   'git',
+  'git-credential',
   'guest',
   'handle',
   'host',

--- a/packages/daemon/src/git-credential.js
+++ b/packages/daemon/src/git-credential.js
@@ -1,0 +1,379 @@
+// @ts-check
+/// <reference types="ses"/>
+
+import { q } from '@endo/errors';
+import { makeExo } from '@endo/exo';
+
+import {
+  BasicCredentialInterface,
+  BearerCredentialInterface,
+  GitCredentialControllerInterface,
+} from './interfaces.js';
+
+/**
+ * @typedef {'bearer' | 'basic'} GitCredentialKind
+ */
+
+/**
+ * @typedef {{ token: string } | { username: string, password: string } | { unavailable: true }} GitCredentialMaterial
+ */
+
+/**
+ * @typedef {object} GitCredentialRecord
+ * @property {GitCredentialKind} kind
+ * @property {string} audience
+ * @property {() => GitCredentialMaterial} getMaterial
+ * @property {() => number} getVersion
+ * @property {() => boolean} isRevoked
+ * @property {(listener: () => void) => (() => void)} watchChange
+ * @property {(material: GitCredentialMaterial) => void} rotate
+ * @property {() => void} revoke
+ */
+
+/**
+ * @type {WeakMap<object, GitCredentialRecord>}
+ */
+const credentialRecords = new WeakMap();
+
+/**
+ * @type {WeakMap<object, object>}
+ */
+const credentialControllers = new WeakMap();
+
+/**
+ * @param {unknown} value
+ * @param {string} fieldName
+ * @returns {string}
+ */
+const requireCredentialString = (value, fieldName) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${fieldName} must be a non-empty string`);
+  }
+  if (value.includes('\0')) {
+    throw new Error(`${fieldName} must not contain NUL bytes`);
+  }
+  return value;
+};
+harden(requireCredentialString);
+
+/**
+ * @param {GitCredentialKind} kind
+ * @param {Record<string, unknown>} material
+ * @param {string} label
+ * @returns {GitCredentialMaterial}
+ */
+const normalizeMaterial = (kind, material, label) => {
+  if (kind === 'bearer') {
+    return harden({
+      token: requireCredentialString(material.token, `${label} token`),
+    });
+  }
+  if (kind === 'basic') {
+    return harden({
+      username: requireCredentialString(material.username, `${label} username`),
+      password: requireCredentialString(material.password, `${label} password`),
+    });
+  }
+  throw new Error(`GitCredential kind must be bearer or basic: ${q(kind)}`);
+};
+harden(normalizeMaterial);
+
+/**
+ * @param {GitCredentialRecord} record
+ */
+const makeGitCredentialController = record =>
+  makeExo('GitCredentialController', GitCredentialControllerInterface, {
+    async inspect() {
+      return harden({
+        kind: record.kind,
+        audience: record.audience,
+        available: !Object.hasOwn(record.getMaterial(), 'unavailable'),
+        revoked: record.isRevoked(),
+      });
+    },
+
+    async rotate(material) {
+      record.rotate(
+        normalizeMaterial(
+          record.kind,
+          /** @type {Record<string, unknown>} */ (material),
+          'GitCredentialController.rotate',
+        ),
+      );
+    },
+
+    async revoke() {
+      record.revoke();
+    },
+  });
+harden(makeGitCredentialController);
+
+/**
+ * @param {object} credential
+ * @param {GitCredentialRecord} record
+ */
+const registerCredential = (credential, record) => {
+  const durableRecord = harden(record);
+  credentialRecords.set(credential, durableRecord);
+  credentialControllers.set(
+    credential,
+    makeGitCredentialController(durableRecord),
+  );
+  return credential;
+};
+harden(registerCredential);
+
+const makeChangeNotifier = () => {
+  /** @type {Set<() => void>} */
+  const listeners = new Set();
+  return harden({
+    watchChange: listener => {
+      listeners.add(listener);
+      return harden(() => {
+        listeners.delete(listener);
+      });
+    },
+    notifyChange: () => {
+      for (const listener of [...listeners]) {
+        listener();
+      }
+    },
+  });
+};
+harden(makeChangeNotifier);
+
+/**
+ * @param {object} credential
+ * @param {string} expectedAudience
+ * @param {object} [options]
+ * @param {boolean} [options.allowRevoked]
+ * @returns {GitCredentialRecord}
+ */
+export const assertGitCredentialForUrl = (
+  credential,
+  expectedAudience,
+  options = {},
+) => {
+  const record = credentialRecords.get(credential);
+  if (record === undefined) {
+    throw new Error('GitRemote requires a daemon-minted Git credential cap');
+  }
+  if (record.audience !== expectedAudience) {
+    throw new Error(
+      `Git credential audience ${q(record.audience)} does not match remote origin ${q(expectedAudience)}`,
+    );
+  }
+  if (!options.allowRevoked && record.isRevoked()) {
+    throw new Error(
+      `Git credential for ${q(record.audience)} has been revoked`,
+    );
+  }
+  return record;
+};
+harden(assertGitCredentialForUrl);
+
+/**
+ * Host-private revocation helper for tests and low-level call sites. The
+ * public host surface normally uses GitCredentialController.revoke().
+ *
+ * @param {object} credential
+ */
+export const revokeGitCredential = credential => {
+  const record = credentialRecords.get(credential);
+  if (record === undefined) {
+    throw new Error('Cannot revoke a non-daemon Git credential cap');
+  }
+  record.revoke();
+};
+harden(revokeGitCredential);
+
+/**
+ * @param {unknown} credential
+ */
+export const getGitCredentialController = credential =>
+  credentialControllers.get(/** @type {object} */ (credential));
+harden(getGitCredentialController);
+
+/**
+ * @param {object} args
+ * @param {string} args.audience  URL origin this bearer token may be used for.
+ * @param {string} args.token  Non-extractable bearer token secret.
+ * @param {(material: GitCredentialMaterial) => void} [args.onRotate]
+ * @param {() => void} [args.onRevoke]
+ */
+export const makeBearerCredential = ({
+  audience,
+  token,
+  onRotate,
+  onRevoke,
+}) => {
+  const normalizedAudience = requireCredentialString(
+    audience,
+    'BearerCredential audience',
+  );
+  const tokenText = requireCredentialString(token, 'BearerCredential token');
+  /** @type {GitCredentialMaterial} */
+  let currentMaterial = harden({ token: tokenText });
+  let version = 0;
+  let revoked = false;
+  const changeNotifier = makeChangeNotifier();
+  const credential = makeExo('BearerCredential', BearerCredentialInterface, {
+    audience() {
+      return normalizedAudience;
+    },
+  });
+  return registerCredential(credential, {
+    kind: 'bearer',
+    audience: normalizedAudience,
+    getMaterial: () => currentMaterial,
+    getVersion: () => version,
+    isRevoked: () => revoked,
+    watchChange: changeNotifier.watchChange,
+    rotate: material => {
+      currentMaterial = material;
+      version += 1;
+      revoked = false;
+      onRotate?.(material);
+      changeNotifier.notifyChange();
+    },
+    revoke: () => {
+      revoked = true;
+      currentMaterial = harden({ unavailable: true });
+      version += 1;
+      onRevoke?.();
+      changeNotifier.notifyChange();
+    },
+  });
+};
+harden(makeBearerCredential);
+
+/**
+ * @param {object} args
+ * @param {string} args.audience  URL origin this basic credential may be used for.
+ * @param {string} args.username  Non-extractable username.
+ * @param {string} args.password  Non-extractable password.
+ * @param {(material: GitCredentialMaterial) => void} [args.onRotate]
+ * @param {() => void} [args.onRevoke]
+ */
+export const makeBasicCredential = ({
+  audience,
+  username,
+  password,
+  onRotate,
+  onRevoke,
+}) => {
+  const normalizedAudience = requireCredentialString(
+    audience,
+    'BasicCredential audience',
+  );
+  const usernameText = requireCredentialString(
+    username,
+    'BasicCredential username',
+  );
+  const passwordText = requireCredentialString(
+    password,
+    'BasicCredential password',
+  );
+  /** @type {GitCredentialMaterial} */
+  let currentMaterial = harden({
+    username: usernameText,
+    password: passwordText,
+  });
+  let version = 0;
+  let revoked = false;
+  const changeNotifier = makeChangeNotifier();
+  const credential = makeExo('BasicCredential', BasicCredentialInterface, {
+    audience() {
+      return normalizedAudience;
+    },
+  });
+  return registerCredential(credential, {
+    kind: 'basic',
+    audience: normalizedAudience,
+    getMaterial: () => currentMaterial,
+    getVersion: () => version,
+    isRevoked: () => revoked,
+    watchChange: changeNotifier.watchChange,
+    rotate: material => {
+      currentMaterial = material;
+      version += 1;
+      revoked = false;
+      onRotate?.(material);
+      changeNotifier.notifyChange();
+    },
+    revoke: () => {
+      revoked = true;
+      currentMaterial = harden({ unavailable: true });
+      version += 1;
+      onRevoke?.();
+      changeNotifier.notifyChange();
+    },
+  });
+};
+harden(makeBasicCredential);
+
+/**
+ * Reconstitute a credential formula when the daemon no longer has the
+ * process-local secret material.  The cap remains identifiable and
+ * inspectable by audience, but any transport use fails closed until the
+ * operator reprovisions the secret.
+ *
+ * @param {object} args
+ * @param {GitCredentialKind} args.kind
+ * @param {string} args.audience
+ * @param {(material: GitCredentialMaterial) => void} [args.onRotate]
+ * @param {() => void} [args.onRevoke]
+ */
+export const makeUnavailableGitCredential = ({
+  kind,
+  audience,
+  onRotate,
+  onRevoke,
+}) => {
+  const normalizedAudience = requireCredentialString(
+    audience,
+    'GitCredential audience',
+  );
+  if (kind !== 'bearer' && kind !== 'basic') {
+    throw new Error(`GitCredential kind must be bearer or basic: ${q(kind)}`);
+  }
+  const Interface =
+    kind === 'bearer' ? BearerCredentialInterface : BasicCredentialInterface;
+  const credential = makeExo(
+    kind === 'bearer' ? 'BearerCredential' : 'BasicCredential',
+    Interface,
+    {
+      audience() {
+        return normalizedAudience;
+      },
+    },
+  );
+  /** @type {GitCredentialMaterial} */
+  let currentMaterial = harden({ unavailable: true });
+  let version = 0;
+  let revoked = true;
+  const changeNotifier = makeChangeNotifier();
+  return registerCredential(credential, {
+    kind,
+    audience: normalizedAudience,
+    getMaterial: () => currentMaterial,
+    getVersion: () => version,
+    isRevoked: () => revoked,
+    watchChange: changeNotifier.watchChange,
+    rotate: material => {
+      currentMaterial = material;
+      version += 1;
+      revoked = false;
+      onRotate?.(material);
+      changeNotifier.notifyChange();
+    },
+    revoke: () => {
+      revoked = true;
+      currentMaterial = harden({ unavailable: true });
+      version += 1;
+      onRevoke?.();
+      changeNotifier.notifyChange();
+    },
+  });
+};
+harden(makeUnavailableGitCredential);

--- a/packages/daemon/src/git-remote.js
+++ b/packages/daemon/src/git-remote.js
@@ -834,6 +834,15 @@ export const makeGitRemote = ({
     if (parsed.force && !currentPolicy.allowForcePush) {
       throw new Error('GitRemote push force requires allowForcePush');
     }
+    // Revalidate the concrete (post-override) refspec against the full
+    // construction-time policy gate.  A wildcard policy refspec can
+    // syntactically match a concrete override whose src or dst is a tag
+    // (`refs/heads/tags/v1:refs/tags/v1` under `refs/heads/*:refs/*`) or
+    // a deletion; the wildcard match below does not re-derive those
+    // properties, so without this the tag / delete policy is bypassed.
+    // Reuse the same `validatePushRefspec` that gates policy refspecs at
+    // construction rather than inlining a parallel tag / delete check.
+    validatePushRefspec(candidate, currentPolicy, 'GitRemote push refspec');
     const allowed = currentPolicy.pushRefspecs.some(refspec => {
       const policyRefspec = parseRefspec(
         refspec,

--- a/packages/daemon/src/git-remote.js
+++ b/packages/daemon/src/git-remote.js
@@ -1,0 +1,1059 @@
+// @ts-check
+/// <reference types="ses"/>
+
+import { URL } from 'node:url';
+
+import { q } from '@endo/errors';
+import { makeExo } from '@endo/exo';
+import { E } from '@endo/eventual-send';
+
+import {
+  GitRemoteInterface,
+  GitRemoteControllerInterface,
+} from './interfaces.js';
+import { getGitBackend, isGitReadOnly } from './git.js';
+import { assertGitCredentialForUrl } from './git-credential.js';
+
+/**
+ * @typedef {'fetch' | 'push'} GitDirection
+ */
+
+/**
+ * @typedef {object} GitRemotePolicy
+ * @property {string} url
+ *   Host-controlled remote endpoint URL.  Guests cannot mutate this
+ *   field at call time; only `GitRemoteController.revoke()` or future
+ *   controller methods adjust the binding.
+ * @property {GitDirection[]} allowedDirections
+ * @property {string[]} fetchRefspecs
+ * @property {string[]} pushRefspecs
+ * @property {string[]} [allowedBranches]
+ * @property {boolean} [allowForcePush]
+ * @property {boolean} [allowTags]
+ * @property {boolean} [allowDelete]
+ * @property {boolean} [allowLocalFileTransport]
+ */
+
+/**
+ * @typedef {object} GitRemoteAuditEvent
+ * @property {number} sequence
+ * @property {string} type
+ */
+
+const DEFAULT_POLICY = harden(
+  /** @type {Required<Omit<GitRemotePolicy, 'allowedBranches' | 'url'>>} */ ({
+    allowedDirections: harden(['fetch']),
+    fetchRefspecs: harden([]),
+    pushRefspecs: harden([]),
+    allowForcePush: false,
+    allowTags: false,
+    allowDelete: false,
+    allowLocalFileTransport: false,
+  }),
+);
+
+/**
+ * @param {unknown} value
+ * @param {string} fieldName
+ * @returns {string}
+ */
+const requirePolicyString = (value, fieldName) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${fieldName} must be a non-empty string`);
+  }
+  if (value.includes('\0')) {
+    throw new Error(`${fieldName} must not contain NUL bytes`);
+  }
+  return value;
+};
+harden(requirePolicyString);
+
+/**
+ * @param {unknown} value
+ * @param {string} fieldName
+ * @returns {string[]}
+ */
+const requirePolicyStringArray = (value, fieldName) => {
+  if (!Array.isArray(value)) {
+    throw new Error(`${fieldName} must be an array of strings`);
+  }
+  return value.map((item, index) =>
+    requirePolicyString(item, `${fieldName}[${index}]`),
+  );
+};
+harden(requirePolicyStringArray);
+
+/**
+ * @param {unknown} value
+ * @param {boolean} [allowLocalFileTransport]
+ * @returns {string}
+ */
+const normalizeRemoteUrl = (value, allowLocalFileTransport = false) => {
+  const urlText = requirePolicyString(value, 'GitRemote policy.url');
+  let parsed;
+  try {
+    parsed = new URL(urlText);
+  } catch {
+    throw new Error(`GitRemote policy.url is not a valid URL: ${q(urlText)}`);
+  }
+  if (
+    parsed.protocol !== 'https:' &&
+    !(allowLocalFileTransport && parsed.protocol === 'file:')
+  ) {
+    throw new Error(
+      `GitRemote policy.url must use https: for the MVP transport: ${q(urlText)}`,
+    );
+  }
+  if (parsed.username !== '' || parsed.password !== '') {
+    throw new Error(
+      `GitRemote policy.url must not include embedded credentials: ${q(urlText)}`,
+    );
+  }
+  return urlText;
+};
+harden(normalizeRemoteUrl);
+
+/**
+ * @param {unknown} value
+ * @returns {GitDirection[]}
+ */
+const normalizeDirections = value => {
+  const directions = requirePolicyStringArray(
+    value || DEFAULT_POLICY.allowedDirections,
+    'GitRemote policy.allowedDirections',
+  );
+  if (directions.length === 0) {
+    throw new Error('GitRemote policy.allowedDirections must not be empty');
+  }
+  for (const direction of directions) {
+    if (direction !== 'fetch' && direction !== 'push') {
+      throw new Error(
+        `GitRemote policy.allowedDirections contains invalid direction ${q(direction)}`,
+      );
+    }
+  }
+  return harden(/** @type {GitDirection[]} */ ([...new Set(directions)]));
+};
+harden(normalizeDirections);
+
+/**
+ * @param {string} ref
+ * @param {string} fieldName
+ */
+const assertQualifiedRef = (ref, fieldName) => {
+  if (!ref.startsWith('refs/')) {
+    throw new Error(
+      `${fieldName} must be fully qualified under refs/: ${q(ref)}`,
+    );
+  }
+  if (
+    ref.includes('..') ||
+    ref.includes('\\') ||
+    ref.includes('//') ||
+    ref.endsWith('/') ||
+    ref.includes('@{')
+  ) {
+    throw new Error(`${fieldName} contains an invalid git ref: ${q(ref)}`);
+  }
+};
+harden(assertQualifiedRef);
+
+/**
+ * @param {string} ref
+ */
+const isTagRef = ref => ref.startsWith('refs/tags/');
+harden(isTagRef);
+
+/**
+ * @param {string} ref
+ */
+const wildcardCount = ref => [...ref].filter(ch => ch === '*').length;
+harden(wildcardCount);
+
+/**
+ * @param {string} src
+ * @param {string} dst
+ * @param {string} fieldName
+ */
+const assertWildcardShape = (src, dst, fieldName) => {
+  const srcWildcards = wildcardCount(src);
+  const dstWildcards = wildcardCount(dst);
+  if (srcWildcards > 1 || dstWildcards > 1) {
+    throw new Error(`${fieldName} may contain at most one wildcard per side`);
+  }
+  if (srcWildcards !== dstWildcards) {
+    throw new Error(
+      `${fieldName} wildcard source and destination must match: ${q(`${src}:${dst}`)}`,
+    );
+  }
+  if (
+    (srcWildcards === 1 && !src.endsWith('/*')) ||
+    (dstWildcards === 1 && !dst.endsWith('/*'))
+  ) {
+    throw new Error(
+      `${fieldName} wildcards must be rooted under a fixed parent: ${q(`${src}:${dst}`)}`,
+    );
+  }
+};
+harden(assertWildcardShape);
+
+/**
+ * @param {string} refspec
+ * @param {string} fieldName
+ * @returns {{ force: boolean, src: string, dst: string }}
+ */
+const parseRefspec = (refspec, fieldName) => {
+  const raw = requirePolicyString(refspec, fieldName);
+  const force = raw.startsWith('+');
+  const body = force ? raw.slice(1) : raw;
+  const colon = body.indexOf(':');
+  if (colon < 0 || body.indexOf(':', colon + 1) >= 0) {
+    throw new Error(
+      `${fieldName} must be a single [ + ]<src>:<dst> refspec: ${q(raw)}`,
+    );
+  }
+  const src = body.slice(0, colon);
+  const dst = body.slice(colon + 1);
+  if (dst === '') {
+    throw new Error(`${fieldName} destination must not be empty: ${q(raw)}`);
+  }
+  return harden({ force, src, dst });
+};
+harden(parseRefspec);
+
+/**
+ * @param {string} refspec
+ * @param {GitRemotePolicy} policy
+ * @param {string} remoteName
+ * @param {string} fieldName
+ */
+const validateFetchRefspec = (refspec, policy, remoteName, fieldName) => {
+  const { src, dst } = parseRefspec(refspec, fieldName);
+  assertQualifiedRef(dst, `${fieldName} destination`);
+  if (!dst.startsWith(`refs/remotes/${remoteName}/`)) {
+    throw new Error(
+      `${fieldName} destination must stay under refs/remotes/${remoteName}/: ${q(dst)}`,
+    );
+  }
+  if (src === '') {
+    if (!policy.allowDelete) {
+      throw new Error(`${fieldName} deletion requires allowDelete: true`);
+    }
+    if (dst.includes('*')) {
+      throw new Error(`${fieldName} deletion refspecs must not use wildcards`);
+    }
+    return;
+  }
+  assertQualifiedRef(src, `${fieldName} source`);
+  if ((isTagRef(src) || isTagRef(dst)) && !policy.allowTags) {
+    throw new Error(`${fieldName} tag refs require allowTags: true`);
+  }
+  assertWildcardShape(src, dst, fieldName);
+};
+harden(validateFetchRefspec);
+
+/**
+ * @param {string} refspec
+ * @param {GitRemotePolicy} policy
+ * @param {string} fieldName
+ */
+const validatePushRefspec = (refspec, policy, fieldName) => {
+  const { force, src, dst } = parseRefspec(refspec, fieldName);
+  if (force && !policy.allowForcePush) {
+    throw new Error(`${fieldName} force-push refspec requires allowForcePush`);
+  }
+  assertQualifiedRef(dst, `${fieldName} destination`);
+  if (src === '') {
+    if (!policy.allowDelete) {
+      throw new Error(`${fieldName} deletion requires allowDelete: true`);
+    }
+    if (dst.includes('*')) {
+      throw new Error(`${fieldName} deletion refspecs must not use wildcards`);
+    }
+    return;
+  }
+  assertQualifiedRef(src, `${fieldName} source`);
+  if (!src.startsWith('refs/heads/') && !src.startsWith('refs/tags/')) {
+    throw new Error(
+      `${fieldName} source must be a local branch or tag ref: ${q(src)}`,
+    );
+  }
+  if ((isTagRef(src) || isTagRef(dst)) && !policy.allowTags) {
+    throw new Error(`${fieldName} tag refs require allowTags: true`);
+  }
+  assertWildcardShape(src, dst, fieldName);
+};
+harden(validatePushRefspec);
+
+/**
+ * @param {string} branch
+ * @param {string} fieldName
+ * @returns {string}
+ */
+const branchRefFromAllowedBranch = (branch, fieldName) => {
+  const value = requirePolicyString(branch, fieldName);
+  if (
+    value.startsWith('+') ||
+    value.includes(':') ||
+    value.includes('\\') ||
+    value.includes('..') ||
+    value.includes('//') ||
+    value.includes('@{') ||
+    value.startsWith('/') ||
+    value.endsWith('/')
+  ) {
+    throw new Error(`${fieldName} is not a valid branch selector: ${q(value)}`);
+  }
+  if (value.startsWith('refs/') && !value.startsWith('refs/heads/')) {
+    throw new Error(`${fieldName} must be rooted under refs/heads/`);
+  }
+  if (value.includes('*') && !value.startsWith('refs/heads/')) {
+    throw new Error(
+      `${fieldName} wildcard branches must be rooted under refs/heads/`,
+    );
+  }
+  const ref = value.startsWith('refs/heads/') ? value : `refs/heads/${value}`;
+  assertQualifiedRef(ref, fieldName);
+  if (wildcardCount(ref) > 1 || (ref.includes('*') && !ref.endsWith('/*'))) {
+    throw new Error(
+      `${fieldName} wildcard must be rooted under a fixed parent: ${q(value)}`,
+    );
+  }
+  return ref;
+};
+harden(branchRefFromAllowedBranch);
+
+/**
+ * @param {string[]} branches
+ * @returns {string[]}
+ */
+const derivePushRefspecsFromBranches = branches =>
+  branches.map((branch, index) => {
+    const ref = branchRefFromAllowedBranch(
+      branch,
+      `GitRemote policy.allowedBranches[${index}]`,
+    );
+    return `${ref}:${ref}`;
+  });
+harden(derivePushRefspecsFromBranches);
+
+/**
+ * @param {object} args
+ * @param {string} args.name
+ * @param {GitRemotePolicy} args.policy
+ * @returns {GitRemotePolicy}
+ */
+const normalizePolicy = ({ name, policy }) => {
+  const allowLocalFileTransport =
+    policy.allowLocalFileTransport ?? DEFAULT_POLICY.allowLocalFileTransport;
+  const url = normalizeRemoteUrl(policy && policy.url, allowLocalFileTransport);
+  const allowedDirections = normalizeDirections(policy.allowedDirections);
+  const fetchRefspecs = requirePolicyStringArray(
+    policy.fetchRefspecs || DEFAULT_POLICY.fetchRefspecs,
+    'GitRemote policy.fetchRefspecs',
+  );
+  const explicitPushRefspecs = requirePolicyStringArray(
+    policy.pushRefspecs || DEFAULT_POLICY.pushRefspecs,
+    'GitRemote policy.pushRefspecs',
+  );
+  const allowedBranches =
+    policy.allowedBranches === undefined
+      ? []
+      : requirePolicyStringArray(
+          policy.allowedBranches,
+          'GitRemote policy.allowedBranches',
+        );
+  if (allowedBranches.length > 0 && explicitPushRefspecs.length > 0) {
+    throw new Error(
+      'GitRemote policy must choose allowedBranches or pushRefspecs, not both',
+    );
+  }
+  const pushRefspecs =
+    allowedBranches.length > 0
+      ? derivePushRefspecsFromBranches(allowedBranches)
+      : explicitPushRefspecs;
+  const normalized = harden({
+    url,
+    allowedDirections,
+    fetchRefspecs: harden(fetchRefspecs),
+    pushRefspecs: harden(pushRefspecs),
+    allowForcePush: policy.allowForcePush ?? DEFAULT_POLICY.allowForcePush,
+    allowTags: policy.allowTags ?? DEFAULT_POLICY.allowTags,
+    allowDelete: policy.allowDelete ?? DEFAULT_POLICY.allowDelete,
+    allowLocalFileTransport,
+  });
+  for (const [index, refspec] of normalized.fetchRefspecs.entries()) {
+    validateFetchRefspec(
+      refspec,
+      normalized,
+      name,
+      `GitRemote policy.fetchRefspecs[${index}]`,
+    );
+  }
+  for (const [index, refspec] of normalized.pushRefspecs.entries()) {
+    validatePushRefspec(
+      refspec,
+      normalized,
+      `GitRemote policy.pushRefspecs[${index}]`,
+    );
+  }
+  if (
+    normalized.allowedDirections.includes('push') &&
+    normalized.pushRefspecs.length === 0
+  ) {
+    throw new Error(
+      'GitRemote policy allows push but has no pushRefspecs or allowedBranches',
+    );
+  }
+  return normalized;
+};
+harden(normalizePolicy);
+
+/**
+ * Host-private map from a remote exo to its controller exo.  The
+ * controller is a companion accessed through a daemon-side host method
+ * (`getGitRemoteController`); its durable state lives on the remote
+ * formula rather than a separate top-level formula.
+ *
+ * @type {WeakMap<object, object>}
+ */
+const remoteControllers = new WeakMap();
+const AUDIT_LIMIT = 128;
+
+/**
+ * Host-private accessor: returns the controller exo paired with a
+ * daemon-minted remote exo, or undefined for spoofs / fakes.
+ *
+ * @param {unknown} remote
+ * @returns {object | undefined}
+ */
+export const getGitRemoteController = remote =>
+  remoteControllers.get(/** @type {object} */ (remote));
+harden(getGitRemoteController);
+
+/**
+ * Mint a paired (guest-held, host-held) facet for one remote endpoint.
+ *
+ * This facet is the policy gate for remote use.  It validates endpoint,
+ * direction, and refspec policy before delegating to the local Git
+ * backend's bounded native data plane.
+ *
+ * @param {object} args
+ * @param {object} args.git  The local `Git` capability this remote is
+ *   bound to.  Guest operations on the remote always compose with this
+ *   Git; revoking the local Git collects the remote too.
+ * @param {string} args.name  Remote name (typically 'origin').
+ * @param {GitRemotePolicy} args.policy
+ * @param {boolean} [args.revoked]
+ * @param {object} [args.credential]
+ * @param {(state: { policy: GitRemotePolicy, revoked: boolean }) => Promise<void> | void} [args.onStateChange]
+ * @returns {{ remote: object, controller: object }}
+ */
+export const makeGitRemote = ({
+  git,
+  name,
+  policy,
+  revoked: initialRevoked = false,
+  credential,
+  onStateChange,
+}) => {
+  if (isGitReadOnly(git)) {
+    throw new Error('GitRemote cannot be constructed from a read-only Git');
+  }
+  const backend = getGitBackend(git);
+  if (backend === undefined) {
+    throw new Error('GitRemote requires a daemon-minted Git cap');
+  }
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error('GitRemote name must be a non-empty string');
+  }
+  if (
+    !policy ||
+    typeof policy !== 'object' ||
+    typeof policy.url !== 'string' ||
+    policy.url.length === 0
+  ) {
+    throw new Error('GitRemote policy must include a non-empty url');
+  }
+
+  // The policy record is mutable through the controller; we keep a
+  // mutable struct here and freeze each read view we hand out.
+  /** @type {GitRemotePolicy} */
+  let currentPolicy = normalizePolicy({ name, policy });
+  const url = new URL(currentPolicy.url);
+  const requiresCredential = url.protocol === 'https:';
+  const credentialRecord =
+    credential === undefined
+      ? undefined
+      : assertGitCredentialForUrl(credential, url.origin, {
+          allowRevoked: true,
+        });
+  if (requiresCredential && credentialRecord === undefined) {
+    throw new Error('GitRemote HTTPS remotes require a Git credential cap');
+  }
+
+  let revoked = initialRevoked;
+  let operationEpoch = 0;
+  /** @type {'policy' | 'revoke' | undefined} */
+  let operationInvalidation;
+  /** @type {Set<AbortController>} */
+  const activeOperationControllers = new Set();
+
+  const abortActiveOperations = () => {
+    for (const abortController of [...activeOperationControllers]) {
+      abortController.abort();
+    }
+  };
+
+  const invalidateOperations = reason => {
+    operationEpoch += 1;
+    operationInvalidation = reason;
+    abortActiveOperations();
+  };
+
+  const beginOperation = () => {
+    const abortController = new AbortController();
+    activeOperationControllers.add(abortController);
+    return {
+      signal: abortController.signal,
+      finish: () => {
+        activeOperationControllers.delete(abortController);
+      },
+    };
+  };
+
+  if (credentialRecord !== undefined) {
+    credentialRecord.watchChange(abortActiveOperations);
+  }
+
+  const persistState = async (nextPolicy, nextRevoked) => {
+    await null;
+    if (onStateChange !== undefined) {
+      await onStateChange(harden({ policy: nextPolicy, revoked: nextRevoked }));
+    }
+  };
+
+  const ensureLive = () => {
+    if (revoked) {
+      throw new Error(`GitRemote ${q(name)} has been revoked`);
+    }
+  };
+
+  const ensureDirection = direction => {
+    ensureLive();
+    if (!currentPolicy.allowedDirections.includes(direction)) {
+      throw new Error(
+        `GitRemote ${q(name)} does not permit ${q(direction)} (allowed: ${currentPolicy.allowedDirections.join(', ')})`,
+      );
+    }
+  };
+
+  const ensureCredentialUsable = () => {
+    if (requiresCredential) {
+      const record = assertGitCredentialForUrl(
+        /** @type {object} */ (credential),
+        url.origin,
+      );
+      return harden({ kind: record.kind, material: record.getMaterial() });
+    }
+    return undefined;
+  };
+
+  const captureOperationFence = () =>
+    harden({
+      epoch: operationEpoch,
+      credentialVersion:
+        requiresCredential && credentialRecord !== undefined
+          ? credentialRecord.getVersion()
+          : undefined,
+    });
+
+  const assertOperationFence = (operation, fence) => {
+    if (operationEpoch !== fence.epoch) {
+      if (revoked || operationInvalidation === 'revoke') {
+        throw new Error(`GitRemote ${q(name)} was revoked during ${operation}`);
+      }
+      throw new Error(
+        `GitRemote ${q(name)} policy changed during ${operation}`,
+      );
+    }
+    if (requiresCredential && credentialRecord !== undefined) {
+      const currentCredentialRecord = assertGitCredentialForUrl(
+        /** @type {object} */ (credential),
+        url.origin,
+        { allowRevoked: true },
+      );
+      if (currentCredentialRecord.getVersion() !== fence.credentialVersion) {
+        if (currentCredentialRecord.isRevoked()) {
+          throw new Error(
+            `Git credential for ${q(currentCredentialRecord.audience)} was revoked during ${operation}`,
+          );
+        }
+        throw new Error(
+          `Git credential for ${q(currentCredentialRecord.audience)} changed during ${operation}`,
+        );
+      }
+    }
+  };
+
+  const operationError = (operation, fence, err) => {
+    try {
+      assertOperationFence(operation, fence);
+    } catch (fenceErr) {
+      return fenceErr;
+    }
+    return err;
+  };
+
+  const snapshotPolicy = () =>
+    harden({
+      name,
+      url: currentPolicy.url,
+      allowedDirections: harden([...currentPolicy.allowedDirections]),
+      fetchRefspecs: harden([...currentPolicy.fetchRefspecs]),
+      pushRefspecs: harden([...currentPolicy.pushRefspecs]),
+      allowForcePush: currentPolicy.allowForcePush,
+      allowTags: currentPolicy.allowTags,
+      allowDelete: currentPolicy.allowDelete,
+      allowLocalFileTransport: currentPolicy.allowLocalFileTransport,
+    });
+
+  /** @type {GitRemoteAuditEvent[]} */
+  const auditLog = [];
+  let auditSequence = 0;
+  const recordAudit = event => {
+    auditSequence += 1;
+    auditLog.push(
+      harden({
+        sequence: auditSequence,
+        ...event,
+      }),
+    );
+    if (auditLog.length > AUDIT_LIMIT) {
+      auditLog.shift();
+    }
+  };
+
+  recordAudit({ type: 'create', policy: snapshotPolicy(), revoked });
+
+  /**
+   * @param {string} type
+   * @param {unknown} result
+   */
+  const recordOperationSuccess = (type, result) => {
+    const record =
+      /** @type {{ updatedRefs?: unknown, fetch?: { updatedRefs?: unknown }, integration?: unknown, head?: unknown }} */ (
+        result
+      );
+    const updatedRefs =
+      type === 'pull' ? record.fetch?.updatedRefs : record.updatedRefs;
+    recordAudit({
+      type,
+      outcome: 'ok',
+      ...(updatedRefs === undefined ? {} : { updatedRefs }),
+      ...(record.integration === undefined
+        ? {}
+        : { integration: record.integration }),
+      ...(record.head === undefined ? {} : { head: record.head }),
+    });
+  };
+
+  /**
+   * @param {string} type
+   * @param {unknown} err
+   */
+  const recordOperationFailure = (type, err) => {
+    recordAudit({
+      type,
+      outcome: 'error',
+      message:
+        /** @type {{ message?: string }} */ (err)?.message || String(err),
+    });
+  };
+
+  /**
+   * @param {unknown} value
+   * @param {string} fieldName
+   */
+  const normalizeRefArg = (value, fieldName) => {
+    const raw =
+      typeof value === 'string'
+        ? value
+        : /** @type {{ name?: unknown }} */ (value || {}).name;
+    const ref = requirePolicyString(raw, fieldName);
+    if (ref.startsWith('-')) {
+      throw new Error(`${fieldName} must not start with "-"`);
+    }
+    return ref.startsWith('refs/') ? ref : `refs/heads/${ref}`;
+  };
+
+  /**
+   * @param {string} ref
+   * @param {string} pattern
+   * @returns {string | undefined}
+   */
+  const refPatternCapture = (ref, pattern) => {
+    if (!pattern.includes('*')) {
+      return ref === pattern ? '' : undefined;
+    }
+    const [prefix, suffix] = pattern.split('*');
+    if (!ref.startsWith(prefix) || !ref.endsWith(suffix)) {
+      return undefined;
+    }
+    return ref.slice(
+      prefix.length,
+      suffix.length === 0 ? undefined : -suffix.length,
+    );
+  };
+
+  /**
+   * @param {{ src: string, dst: string }} parsed
+   * @param {{ src: string, dst: string }} policyRefspec
+   */
+  const refspecMatchesPattern = (parsed, policyRefspec) => {
+    const srcCapture = refPatternCapture(parsed.src, policyRefspec.src);
+    if (srcCapture === undefined) {
+      return false;
+    }
+    const dstCapture = refPatternCapture(parsed.dst, policyRefspec.dst);
+    if (dstCapture === undefined) {
+      return false;
+    }
+    const policyHasWildcard =
+      policyRefspec.src.includes('*') || policyRefspec.dst.includes('*');
+    return !policyHasWildcard || srcCapture === dstCapture;
+  };
+
+  /**
+   * @param {string} candidate
+   */
+  const assertPushRefspecAllowed = candidate => {
+    const parsed = parseRefspec(candidate, 'GitRemote push refspec');
+    if (parsed.force && !currentPolicy.allowForcePush) {
+      throw new Error('GitRemote push force requires allowForcePush');
+    }
+    const allowed = currentPolicy.pushRefspecs.some(refspec => {
+      const policyRefspec = parseRefspec(
+        refspec,
+        'GitRemote policy.pushRefspecs[]',
+      );
+      return refspecMatchesPattern(parsed, policyRefspec);
+    });
+    if (!allowed) {
+      throw new Error(
+        `GitRemote ${q(name)} push refspec is outside policy: ${q(candidate)}`,
+      );
+    }
+  };
+
+  /**
+   * @param {unknown} options
+   */
+  const pushRefspecsFromOptions = options => {
+    const opts =
+      /** @type {{ source?: unknown, destination?: unknown, force?: boolean, setUpstream?: boolean }} */ (
+        options || {}
+      );
+    if (opts.source === undefined && opts.destination === undefined) {
+      if (opts.setUpstream) {
+        throw new Error(
+          'GitRemote.push setUpstream requires an explicit source and destination',
+        );
+      }
+      return harden({
+        refspecs: harden([...currentPolicy.pushRefspecs]),
+        setUpstream: false,
+      });
+    }
+    const source = normalizeRefArg(opts.source, 'GitRemote.push source');
+    const destination = normalizeRefArg(
+      opts.destination ?? source,
+      'GitRemote.push destination',
+    );
+    const refspec = `${opts.force ? '+' : ''}${source}:${destination}`;
+    assertPushRefspecAllowed(refspec);
+    return harden({
+      refspecs: harden([refspec]),
+      setUpstream: !!opts.setUpstream,
+    });
+  };
+
+  /**
+   * @param {unknown} branch
+   */
+  const normalizePullBranch = branch => {
+    if (branch !== undefined) {
+      return normalizeRefArg(branch, 'GitRemote.pull branch');
+    }
+    const concreteFetch = currentPolicy.fetchRefspecs.find(
+      refspec => !refspec.includes('*') && parseRefspec(refspec, 'fetch').src,
+    );
+    if (concreteFetch === undefined) {
+      throw new Error(
+        'GitRemote.pull requires a branch when fetchRefspecs are empty or wildcarded',
+      );
+    }
+    return parseRefspec(concreteFetch, 'GitRemote.pull fetchRefspec').dst;
+  };
+
+  /**
+   * @param {unknown} options
+   */
+  const fetchOptionsFromOptions = options => {
+    const opts = /** @type {{ prune?: boolean, tags?: boolean }} */ (
+      options || {}
+    );
+    if (opts.tags && !currentPolicy.allowTags) {
+      throw new Error('GitRemote fetch tags require allowTags: true');
+    }
+    if (opts.prune && !currentPolicy.allowDelete) {
+      throw new Error('GitRemote fetch prune requires allowDelete: true');
+    }
+    return harden({ prune: !!opts.prune, tags: !!opts.tags });
+  };
+
+  const remote = makeExo('GitRemote', GitRemoteInterface, {
+    async inspect() {
+      ensureLive();
+      return snapshotPolicy();
+    },
+
+    async fetch(options = {}) {
+      await null;
+      let fence;
+      try {
+        ensureDirection('fetch');
+        const fetchOptions = fetchOptionsFromOptions(options);
+        fence = captureOperationFence();
+        const transportCredential = ensureCredentialUsable();
+        const activeOperation = beginOperation();
+        let result;
+        try {
+          result = await backend.remoteFetch({
+            url: currentPolicy.url,
+            refspecs: currentPolicy.fetchRefspecs,
+            prune: fetchOptions.prune,
+            tags: fetchOptions.tags,
+            credential: transportCredential,
+            signal: activeOperation.signal,
+          });
+        } finally {
+          activeOperation.finish();
+        }
+        assertOperationFence('fetch', fence);
+        recordOperationSuccess('fetch', result);
+        return result;
+      } catch (err) {
+        const finalErr =
+          fence === undefined ? err : operationError('fetch', fence, err);
+        recordOperationFailure('fetch', finalErr);
+        throw finalErr;
+      }
+    },
+
+    async pull(options = {}) {
+      await null;
+      let fence;
+      try {
+        ensureDirection('fetch');
+        const fetchOptions = fetchOptionsFromOptions(options);
+        fence = captureOperationFence();
+        const transportCredential = ensureCredentialUsable();
+        const opts =
+          /** @type {{ branch?: unknown, strategy?: 'merge' | 'rebase' | 'ff-only' }} */ (
+            options
+          );
+        const activeOperation = beginOperation();
+        let fetch;
+        try {
+          fetch = await backend.remoteFetch({
+            url: currentPolicy.url,
+            refspecs: currentPolicy.fetchRefspecs,
+            prune: fetchOptions.prune,
+            tags: fetchOptions.tags,
+            credential: transportCredential,
+            signal: activeOperation.signal,
+          });
+        } finally {
+          activeOperation.finish();
+        }
+        assertOperationFence('pull', fence);
+        const branch = normalizePullBranch(opts.branch);
+        const strategy = opts.strategy || 'ff-only';
+        if (strategy === 'ff-only') {
+          await E(git).merge(branch, { fastForwardOnly: true });
+        } else if (strategy === 'merge') {
+          await E(git).merge(branch);
+        } else if (strategy === 'rebase') {
+          await E(git).rebase({ mode: 'start', upstream: branch });
+        } else {
+          throw new Error(
+            'GitRemote.pull strategy must be merge, rebase, or ff-only',
+          );
+        }
+        const head = await E(git).revParse('HEAD');
+        const result = harden({ fetch, integration: strategy, head });
+        assertOperationFence('pull', fence);
+        recordOperationSuccess('pull', result);
+        return result;
+      } catch (err) {
+        const finalErr =
+          fence === undefined ? err : operationError('pull', fence, err);
+        recordOperationFailure('pull', finalErr);
+        throw finalErr;
+      }
+    },
+
+    async push(options = {}) {
+      await null;
+      let fence;
+      try {
+        ensureDirection('push');
+        fence = captureOperationFence();
+        const transportCredential = ensureCredentialUsable();
+        const { refspecs, setUpstream } = pushRefspecsFromOptions(options);
+        const activeOperation = beginOperation();
+        let result;
+        try {
+          result = await backend.remotePush({
+            url: currentPolicy.url,
+            refspecs,
+            setUpstream,
+            credential: transportCredential,
+            signal: activeOperation.signal,
+          });
+        } finally {
+          activeOperation.finish();
+        }
+        assertOperationFence('push', fence);
+        recordOperationSuccess('push', result);
+        return result;
+      } catch (err) {
+        const finalErr =
+          fence === undefined ? err : operationError('push', fence, err);
+        recordOperationFailure('push', finalErr);
+        throw finalErr;
+      }
+    },
+  });
+
+  const recordPolicyChange = method => {
+    recordAudit({
+      type: 'policy',
+      method,
+      policy: snapshotPolicy(),
+      revoked,
+    });
+  };
+
+  const controller = makeExo(
+    'GitRemoteController',
+    GitRemoteControllerInterface,
+    {
+      async inspect() {
+        return harden({ ...snapshotPolicy(), revoked });
+      },
+
+      async audit() {
+        return harden([...auditLog]);
+      },
+
+      async setAllowedDirections(directions) {
+        const nextPolicy = normalizePolicy({
+          name,
+          policy: {
+            ...currentPolicy,
+            allowedDirections: /** @type {GitDirection[]} */ (directions),
+          },
+        });
+        await persistState(nextPolicy, revoked);
+        currentPolicy = nextPolicy;
+        invalidateOperations('policy');
+        recordPolicyChange('setAllowedDirections');
+      },
+
+      async setFetchRefspecs(refspecs) {
+        const nextPolicy = normalizePolicy({
+          name,
+          policy: { ...currentPolicy, fetchRefspecs: refspecs },
+        });
+        await persistState(nextPolicy, revoked);
+        currentPolicy = nextPolicy;
+        invalidateOperations('policy');
+        recordPolicyChange('setFetchRefspecs');
+      },
+
+      async setPushRefspecs(refspecs) {
+        const nextPolicy = normalizePolicy({
+          name,
+          policy: { ...currentPolicy, pushRefspecs: refspecs },
+        });
+        await persistState(nextPolicy, revoked);
+        currentPolicy = nextPolicy;
+        invalidateOperations('policy');
+        recordPolicyChange('setPushRefspecs');
+      },
+
+      async setAllowedBranches(branches) {
+        const nextPolicy = normalizePolicy({
+          name,
+          policy: {
+            ...currentPolicy,
+            pushRefspecs: [],
+            allowedBranches: branches,
+          },
+        });
+        await persistState(nextPolicy, revoked);
+        currentPolicy = nextPolicy;
+        invalidateOperations('policy');
+        recordPolicyChange('setAllowedBranches');
+      },
+
+      async setAllowForcePush(flag) {
+        const nextPolicy = normalizePolicy({
+          name,
+          policy: { ...currentPolicy, allowForcePush: !!flag },
+        });
+        await persistState(nextPolicy, revoked);
+        currentPolicy = nextPolicy;
+        invalidateOperations('policy');
+        recordPolicyChange('setAllowForcePush');
+      },
+
+      async setAllowTags(flag) {
+        const nextPolicy = normalizePolicy({
+          name,
+          policy: { ...currentPolicy, allowTags: !!flag },
+        });
+        await persistState(nextPolicy, revoked);
+        currentPolicy = nextPolicy;
+        invalidateOperations('policy');
+        recordPolicyChange('setAllowTags');
+      },
+
+      async setAllowDelete(flag) {
+        const nextPolicy = normalizePolicy({
+          name,
+          policy: { ...currentPolicy, allowDelete: !!flag },
+        });
+        await persistState(nextPolicy, revoked);
+        currentPolicy = nextPolicy;
+        invalidateOperations('policy');
+        recordPolicyChange('setAllowDelete');
+      },
+
+      async revoke() {
+        revoked = true;
+        invalidateOperations('revoke');
+        recordAudit({ type: 'revoke', policy: snapshotPolicy(), revoked });
+        await persistState(currentPolicy, true);
+      },
+    },
+  );
+
+  // Register the controller in the host-private companion map.
+  remoteControllers.set(remote, controller);
+
+  return harden({ remote, controller });
+};
+harden(makeGitRemote);

--- a/packages/daemon/src/git-remote.js
+++ b/packages/daemon/src/git-remote.js
@@ -35,9 +35,53 @@ import { assertGitCredentialForUrl } from './git-credential.js';
  */
 
 /**
- * @typedef {object} GitRemoteAuditEvent
+ * Audit-log entry shape.  Every entry carries `sequence` and `type`;
+ * the additional fields are type-discriminated.  The union form below
+ * narrows on `type` so consumers of `audit()` can branch without
+ * casting.
+ *
+ * @typedef {object} GitRemoteAuditEventBase
  * @property {number} sequence
- * @property {string} type
+ */
+
+/**
+ * @typedef {GitRemoteAuditEventBase & {
+ *   type: 'create' | 'revoke' | 'policy',
+ *   policy: ReturnType<() => GitRemotePolicy & { name: string }>,
+ *   revoked: boolean,
+ *   method?: string,
+ * }} GitRemotePolicyAuditEvent
+ */
+
+/**
+ * @typedef {GitRemoteAuditEventBase & {
+ *   type: 'fetch' | 'pull' | 'push',
+ *   outcome: 'ok',
+ *   updatedRefs?: unknown,
+ *   integration?: 'up-to-date' | 'fast-forward' | 'merge' | 'rebase',
+ *   head?: unknown,
+ * }} GitRemoteOperationSuccessAuditEvent
+ */
+
+/**
+ * `appliedLocally` records that the pull's local integration step
+ * mutated HEAD before a later policy / credential / revoke event
+ * forced the operation to throw.  Callers learn the operation failed;
+ * the audit log names which side effect already landed on the
+ * worktree.
+ *
+ * @typedef {GitRemoteAuditEventBase & {
+ *   type: 'fetch' | 'pull' | 'push',
+ *   outcome: 'error',
+ *   message: string,
+ *   appliedLocally?: boolean,
+ * }} GitRemoteOperationFailureAuditEvent
+ */
+
+/**
+ * @typedef {GitRemotePolicyAuditEvent
+ *   | GitRemoteOperationSuccessAuditEvent
+ *   | GitRemoteOperationFailureAuditEvent} GitRemoteAuditEvent
  */
 
 const DEFAULT_POLICY = harden(
@@ -672,13 +716,15 @@ export const makeGitRemote = ({
   /**
    * @param {string} type
    * @param {unknown} err
+   * @param {{ appliedLocally?: boolean }} [extra]
    */
-  const recordOperationFailure = (type, err) => {
+  const recordOperationFailure = (type, err, extra = {}) => {
     recordAudit({
       type,
       outcome: 'error',
       message:
         /** @type {{ message?: string }} */ (err)?.message || String(err),
+      ...(extra.appliedLocally ? { appliedLocally: true } : {}),
     });
   };
 
@@ -865,6 +911,7 @@ export const makeGitRemote = ({
     async pull(options = {}) {
       await null;
       let fence;
+      let appliedLocally = false;
       try {
         ensureDirection('fetch');
         const fetchOptions = fetchOptionsFromOptions(options);
@@ -890,18 +937,23 @@ export const makeGitRemote = ({
         }
         assertOperationFence('pull', fence);
         const branch = normalizePullBranch(opts.branch);
+        /** @type {'merge' | 'rebase' | 'ff-only'} */
         const strategy = opts.strategy || 'ff-only';
         const headBefore = await E(git).revParse('HEAD');
-        if (strategy === 'ff-only') {
-          await E(git).merge(branch, { fastForwardOnly: true });
-        } else if (strategy === 'merge') {
-          await E(git).merge(branch);
-        } else if (strategy === 'rebase') {
-          await E(git).rebase({ mode: 'start', upstream: branch });
-        } else {
-          throw new Error(
-            'GitRemote.pull strategy must be merge, rebase, or ff-only',
-          );
+        switch (strategy) {
+          case 'ff-only':
+            await E(git).merge(branch, { fastForwardOnly: true });
+            break;
+          case 'merge':
+            await E(git).merge(branch);
+            break;
+          case 'rebase':
+            await E(git).rebase({ mode: 'start', upstream: branch });
+            break;
+          default:
+            throw new Error(
+              'GitRemote.pull strategy must be merge, rebase, or ff-only',
+            );
         }
         const head = await E(git).revParse('HEAD');
         const headOidBefore =
@@ -911,10 +963,23 @@ export const makeGitRemote = ({
         let integration;
         if (headOidBefore === headOid) {
           integration = 'up-to-date';
-        } else if (strategy === 'ff-only') {
-          integration = 'fast-forward';
         } else {
-          integration = strategy;
+          appliedLocally = true;
+          switch (strategy) {
+            case 'ff-only':
+              integration = 'fast-forward';
+              break;
+            case 'merge':
+              integration = 'merge';
+              break;
+            case 'rebase':
+              integration = 'rebase';
+              break;
+            default:
+              throw new Error(
+                'GitRemote.pull strategy must be merge, rebase, or ff-only',
+              );
+          }
         }
         const result = harden({ fetch, integration, head });
         assertOperationFence('pull', fence);
@@ -923,7 +988,7 @@ export const makeGitRemote = ({
       } catch (err) {
         const finalErr =
           fence === undefined ? err : operationError('pull', fence, err);
-        recordOperationFailure('pull', finalErr);
+        recordOperationFailure('pull', finalErr, { appliedLocally });
         throw finalErr;
       }
     },

--- a/packages/daemon/src/git-remote.js
+++ b/packages/daemon/src/git-remote.js
@@ -113,6 +113,29 @@ const requirePolicyString = (value, fieldName) => {
 harden(requirePolicyString);
 
 /**
+ * Coerce-free read of a policy `allow*` flag.  An omitted flag falls
+ * back to its hardened default; a present flag must be a real boolean.
+ * Any non-boolean (`'false'`, `0`, `1`, `{}`) is rejected rather than
+ * truthiness-coerced, so a policy can never silently enable an
+ * authority it spelled with the wrong type.  Fail closed.
+ *
+ * @param {unknown} value
+ * @param {boolean} fallback
+ * @param {string} fieldName
+ * @returns {boolean}
+ */
+const requirePolicyBoolean = (value, fallback, fieldName) => {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== 'boolean') {
+    throw new Error(`${fieldName} must be a boolean: ${q(value)}`);
+  }
+  return value;
+};
+harden(requirePolicyBoolean);
+
+/**
  * @param {unknown} value
  * @param {string} fieldName
  * @returns {string[]}
@@ -388,8 +411,11 @@ harden(derivePushRefspecsFromBranches);
  * @returns {GitRemotePolicy}
  */
 const normalizePolicy = ({ name, policy }) => {
-  const allowLocalFileTransport =
-    policy.allowLocalFileTransport ?? DEFAULT_POLICY.allowLocalFileTransport;
+  const allowLocalFileTransport = requirePolicyBoolean(
+    policy.allowLocalFileTransport,
+    DEFAULT_POLICY.allowLocalFileTransport,
+    'GitRemote policy.allowLocalFileTransport',
+  );
   const url = normalizeRemoteUrl(policy && policy.url, allowLocalFileTransport);
   const allowedDirections = normalizeDirections(policy.allowedDirections);
   const fetchRefspecs = requirePolicyStringArray(
@@ -421,9 +447,21 @@ const normalizePolicy = ({ name, policy }) => {
     allowedDirections,
     fetchRefspecs: harden(fetchRefspecs),
     pushRefspecs: harden(pushRefspecs),
-    allowForcePush: policy.allowForcePush ?? DEFAULT_POLICY.allowForcePush,
-    allowTags: policy.allowTags ?? DEFAULT_POLICY.allowTags,
-    allowDelete: policy.allowDelete ?? DEFAULT_POLICY.allowDelete,
+    allowForcePush: requirePolicyBoolean(
+      policy.allowForcePush,
+      DEFAULT_POLICY.allowForcePush,
+      'GitRemote policy.allowForcePush',
+    ),
+    allowTags: requirePolicyBoolean(
+      policy.allowTags,
+      DEFAULT_POLICY.allowTags,
+      'GitRemote policy.allowTags',
+    ),
+    allowDelete: requirePolicyBoolean(
+      policy.allowDelete,
+      DEFAULT_POLICY.allowDelete,
+      'GitRemote policy.allowDelete',
+    ),
     allowLocalFileTransport,
   });
   for (const [index, refspec] of normalized.fetchRefspecs.entries()) {

--- a/packages/daemon/src/git-remote.js
+++ b/packages/daemon/src/git-remote.js
@@ -880,6 +880,7 @@ export const makeGitRemote = ({
         assertOperationFence('pull', fence);
         const branch = normalizePullBranch(opts.branch);
         const strategy = opts.strategy || 'ff-only';
+        const headBefore = await E(git).revParse('HEAD');
         if (strategy === 'ff-only') {
           await E(git).merge(branch, { fastForwardOnly: true });
         } else if (strategy === 'merge') {
@@ -892,7 +893,19 @@ export const makeGitRemote = ({
           );
         }
         const head = await E(git).revParse('HEAD');
-        const result = harden({ fetch, integration: strategy, head });
+        const headOidBefore =
+          /** @type {{ oid?: string }} */ (headBefore).oid || '';
+        const headOid = /** @type {{ oid?: string }} */ (head).oid || '';
+        /** @type {'up-to-date' | 'fast-forward' | 'merge' | 'rebase'} */
+        let integration;
+        if (headOidBefore === headOid) {
+          integration = 'up-to-date';
+        } else if (strategy === 'ff-only') {
+          integration = 'fast-forward';
+        } else {
+          integration = strategy;
+        }
+        const result = harden({ fetch, integration, head });
         assertOperationFence('pull', fence);
         recordOperationSuccess('pull', result);
         return result;

--- a/packages/daemon/src/git-remote.js
+++ b/packages/daemon/src/git-remote.js
@@ -885,7 +885,25 @@ export const makeGitRemote = ({
    */
   const normalizePullBranch = branch => {
     if (branch !== undefined) {
-      return normalizeRefArg(branch, 'GitRemote.pull branch');
+      const ref = normalizeRefArg(branch, 'GitRemote.pull branch');
+      // The local merge / rebase integration step may only target a ref
+      // the fetch policy is allowed to populate — i.e. the destination
+      // of one of `currentPolicy.fetchRefspecs`.  Without this, a holder
+      // whose policy only fetches `refs/remotes/origin/main` could ask
+      // to integrate an unrelated existing local ref (`refs/heads/private`),
+      // gaining local-integration authority outside the remote policy.
+      // Reuse the same `refPatternCapture` matcher the fetch path uses
+      // (via `refspecMatchesPattern`) rather than a parallel matcher.
+      const withinFetchPolicy = currentPolicy.fetchRefspecs.some(refspec => {
+        const { dst } = parseRefspec(refspec, 'GitRemote.pull fetchRefspec');
+        return refPatternCapture(ref, dst) !== undefined;
+      });
+      if (!withinFetchPolicy) {
+        throw new Error(
+          `GitRemote ${q(name)} pull branch is outside fetch policy: ${q(ref)}`,
+        );
+      }
+      return ref;
     }
     const concreteFetch = currentPolicy.fetchRefspecs.find(
       refspec => !refspec.includes('*') && parseRefspec(refspec, 'fetch').src,

--- a/packages/daemon/src/git-remote.js
+++ b/packages/daemon/src/git-remote.js
@@ -629,8 +629,19 @@ export const makeGitRemote = ({
         ...event,
       }),
     );
+    // Preserve the `'create'` entry across rolling shifts past
+    // `AUDIT_LIMIT` so the audit log always names the policy the
+    // remote was constructed against.  The shift removes the second
+    // entry (the oldest non-`'create'` event) when the head is the
+    // sentinel.
     if (auditLog.length > AUDIT_LIMIT) {
-      auditLog.shift();
+      const headIsCreate =
+        /** @type {{ type?: string }} */ (auditLog[0])?.type === 'create';
+      if (headIsCreate && auditLog.length > 1) {
+        auditLog.splice(1, 1);
+      } else {
+        auditLog.shift();
+      }
     }
   };
 

--- a/packages/daemon/src/git-remote.js
+++ b/packages/daemon/src/git-remote.js
@@ -782,6 +782,13 @@ export const makeGitRemote = ({
   };
 
   /**
+   * Runtime gate for caller-supplied push overrides (`source` /
+   * `destination` on `push()` options).  Policy refspecs are
+   * shape-validated at construction by `normalizePolicy`; this runtime
+   * check covers the override path only.  The default push (no
+   * override) ships `currentPolicy.pushRefspecs` directly without
+   * passing through this gate.
+   *
    * @param {string} candidate
    */
   const assertPushRefspecAllowed = candidate => {

--- a/packages/daemon/src/git.js
+++ b/packages/daemon/src/git.js
@@ -149,6 +149,14 @@ harden(getGitBackend);
  * @property {(ref: string) => Promise<unknown>} tree  Returns a
  *   `ReadableTree` exo for the given tree-ish; blobs implement
  *   `ReadableBlob`.
+ * @property {(input: { url?: unknown, refspecs?: unknown, prune?: boolean, tags?: boolean, credential?: unknown, signal?: AbortSignal }) => Promise<object>} remoteFetch
+ *   Fetch from a policy-bound remote URL.  The caller has already
+ *   validated the URL and the refspecs against `GitRemote`'s policy;
+ *   this method runs the underlying `git fetch` invocation through the
+ *   sanitized environment.
+ * @property {(input: { url?: unknown, refspecs?: unknown, setUpstream?: boolean, credential?: unknown, signal?: AbortSignal }) => Promise<object>} remotePush
+ *   Push to a policy-bound remote URL with the same policy
+ *   pre-validation contract as `remoteFetch`.
  */
 
 /**
@@ -492,6 +500,8 @@ export const makeNotYetImplementedBackend = () => {
     stashPop: async () => fail('stashPop'),
     stashDrop: async () => fail('stashDrop'),
     tree: async () => fail('tree'),
+    remoteFetch: async () => fail('remoteFetch'),
+    remotePush: async () => fail('remotePush'),
   });
 };
 harden(makeNotYetImplementedBackend);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 /** @import { ERef } from '@endo/eventual-send' */
-/** @import { AgentDeferredTaskParams, ChannelDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EnvRecord, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, GitCredentialDeferredTaskParams, GitDeferredTaskParams, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeCapletOptions, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, MountDeferredTaskParams, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, ReadableTreeDeferredTaskParams, MarshalDeferredTaskParams, ScratchMountDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
+/** @import { AgentDeferredTaskParams, ChannelDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EnvRecord, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, GitCredentialDeferredTaskParams, GitDeferredTaskParams, GitRemoteDeferredTaskParams, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeCapletOptions, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, MountDeferredTaskParams, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, ReadableTreeDeferredTaskParams, MarshalDeferredTaskParams, ScratchMountDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
 
 import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
@@ -30,7 +30,9 @@ import { makeDeferredTasks } from './deferred-tasks.js';
 import { HostInterface } from './interfaces.js';
 import { hostHelp, makeHelp } from './help-text.js';
 import { assertValidTreeEntryName } from './mount.js';
+import { isGitReadOnly } from './git.js';
 import { getGitCredentialController as getGitCredentialControllerForCap } from './git-credential.js';
+import { getGitRemoteController as getGitRemoteControllerForCap } from './git-remote.js';
 
 /**
  * @param {string} name
@@ -77,6 +79,7 @@ const normalizeHostOrGuestOptions = opts => {
  * @param {DaemonCore['formulateScratchMount']} args.formulateScratchMount
  * @param {DaemonCore['formulateGit']} args.formulateGit
  * @param {DaemonCore['formulateGitCredential']} args.formulateGitCredential
+ * @param {DaemonCore['formulateGitRemote']} args.formulateGitRemote
  * @param {DaemonCore['formulateInvitation']} args.formulateInvitation
  * @param {DaemonCore['formulateDirectoryForStore']} args.formulateDirectoryForStore
  * @param {DaemonCore['getPeerIdForNodeIdentifier']} args.getPeerIdForNodeIdentifier
@@ -114,6 +117,7 @@ export const makeHostMaker = ({
   formulateScratchMount,
   formulateGit,
   formulateGitCredential,
+  formulateGitRemote,
   formulateInvitation,
   formulateDirectoryForStore,
   getPeerIdForNodeIdentifier,
@@ -460,6 +464,88 @@ export const makeHostMaker = ({
         );
       }
       return controller;
+    };
+
+    /** @type {EndoHost['getGitRemoteController']} */
+    const getGitRemoteController = async remoteCap => {
+      await null;
+      const controller = getGitRemoteControllerForCap(remoteCap);
+      if (controller === undefined) {
+        throw makeError(
+          X`getGitRemoteController: argument must be a daemon-minted GitRemote cap`,
+        );
+      }
+      return controller;
+    };
+
+    /** @type {EndoHost['provideGitRemote']} */
+    const provideGitRemote = async (gitCap, petName, opts) => {
+      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const gitId = getIdForRef(gitCap);
+      if (gitId === undefined) {
+        throw makeError(
+          X`provideGitRemote: first argument must be a daemon-minted Git cap`,
+        );
+      }
+      if (isGitReadOnly(gitCap)) {
+        throw makeError(
+          X`provideGitRemote: cannot construct a remote from a read-only Git cap`,
+        );
+      }
+      if (
+        !opts ||
+        typeof opts !== 'object' ||
+        typeof opts.name !== 'string' ||
+        typeof opts.url !== 'string'
+      ) {
+        throw makeError(
+          X`provideGitRemote: options must include a string name and url`,
+        );
+      }
+      /** @type {FormulaIdentifier | undefined} */
+      let credentialId;
+      if (opts.credential !== undefined) {
+        credentialId = getIdForRef(opts.credential);
+        if (credentialId === undefined) {
+          throw makeError(
+            X`provideGitRemote: credential must be a daemon-minted Git credential cap`,
+          );
+        }
+      }
+      const policy = harden({
+        url: opts.url,
+        allowedDirections: harden([...(opts.allowedDirections || ['fetch'])]),
+        fetchRefspecs: harden([...(opts.fetchRefspecs || [])]),
+        pushRefspecs: harden([...(opts.pushRefspecs || [])]),
+        ...(opts.allowedBranches !== undefined
+          ? { allowedBranches: harden([...opts.allowedBranches]) }
+          : {}),
+        ...(opts.allowForcePush !== undefined
+          ? { allowForcePush: opts.allowForcePush }
+          : {}),
+        ...(opts.allowTags !== undefined ? { allowTags: opts.allowTags } : {}),
+        ...(opts.allowDelete !== undefined
+          ? { allowDelete: opts.allowDelete }
+          : {}),
+        ...(opts.allowLocalFileTransport !== undefined
+          ? { allowLocalFileTransport: opts.allowLocalFileTransport }
+          : {}),
+      });
+
+      /** @type {DeferredTasks<GitRemoteDeferredTaskParams>} */
+      const tasks = makeDeferredTasks();
+      tasks.push(identifiers =>
+        E(directory).storeIdentifier(namePath, identifiers.gitRemoteId),
+      );
+
+      const { value } = await formulateGitRemote(
+        gitId,
+        credentialId,
+        opts.name,
+        policy,
+        tasks,
+      );
+      return value;
     };
 
     /** @type {EndoHost['storeValue']} */
@@ -1562,9 +1648,11 @@ export const makeHostMaker = ({
       provideMount,
       provideScratchMount,
       provideGit,
+      provideGitRemote,
       provideBearerCredential,
       provideBasicCredential,
       getGitCredentialController,
+      getGitRemoteController,
       provideHostPath,
       provideGuest,
       provideHost,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 /** @import { ERef } from '@endo/eventual-send' */
-/** @import { AgentDeferredTaskParams, ChannelDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EnvRecord, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, GitDeferredTaskParams, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeCapletOptions, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, MountDeferredTaskParams, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, ReadableTreeDeferredTaskParams, MarshalDeferredTaskParams, ScratchMountDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
+/** @import { AgentDeferredTaskParams, ChannelDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EnvRecord, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, GitCredentialDeferredTaskParams, GitDeferredTaskParams, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeCapletOptions, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, MountDeferredTaskParams, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, ReadableTreeDeferredTaskParams, MarshalDeferredTaskParams, ScratchMountDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
 
 import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
@@ -30,6 +30,7 @@ import { makeDeferredTasks } from './deferred-tasks.js';
 import { HostInterface } from './interfaces.js';
 import { hostHelp, makeHelp } from './help-text.js';
 import { assertValidTreeEntryName } from './mount.js';
+import { getGitCredentialController as getGitCredentialControllerForCap } from './git-credential.js';
 
 /**
  * @param {string} name
@@ -75,6 +76,7 @@ const normalizeHostOrGuestOptions = opts => {
  * @param {DaemonCore['formulateMount']} args.formulateMount
  * @param {DaemonCore['formulateScratchMount']} args.formulateScratchMount
  * @param {DaemonCore['formulateGit']} args.formulateGit
+ * @param {DaemonCore['formulateGitCredential']} args.formulateGitCredential
  * @param {DaemonCore['formulateInvitation']} args.formulateInvitation
  * @param {DaemonCore['formulateDirectoryForStore']} args.formulateDirectoryForStore
  * @param {DaemonCore['getPeerIdForNodeIdentifier']} args.getPeerIdForNodeIdentifier
@@ -111,6 +113,7 @@ export const makeHostMaker = ({
   formulateMount,
   formulateScratchMount,
   formulateGit,
+  formulateGitCredential,
   formulateInvitation,
   formulateDirectoryForStore,
   getPeerIdForNodeIdentifier,
@@ -344,6 +347,21 @@ export const makeHostMaker = ({
       return value;
     };
 
+    /**
+     * @param {unknown} value
+     * @param {string} fieldName
+     * @returns {string}
+     */
+    const requireGitCredentialString = (value, fieldName) => {
+      if (typeof value !== 'string' || value.length === 0) {
+        throw makeError(X`${fieldName} must be a non-empty string`);
+      }
+      if (value.includes('\0')) {
+        throw makeError(X`${fieldName} must not contain NUL bytes`);
+      }
+      return value;
+    };
+
     /** @type {EndoHost['provideGit']} */
     const provideGit = async (mountCap, petName) => {
       const { namePath } = assertPetNamePath(namePathFrom(petName));
@@ -362,6 +380,86 @@ export const makeHostMaker = ({
 
       const { value } = await formulateGit(mountId, tasks);
       return value;
+    };
+
+    /** @type {EndoHost['provideBearerCredential']} */
+    const provideBearerCredential = async (petName, options) => {
+      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      if (!options || typeof options !== 'object') {
+        throw makeError(
+          X`provideBearerCredential: options must include audience and token`,
+        );
+      }
+      const audience = requireGitCredentialString(
+        options.audience,
+        'provideBearerCredential: audience',
+      );
+      const token = requireGitCredentialString(
+        options.token,
+        'provideBearerCredential: token',
+      );
+
+      /** @type {DeferredTasks<GitCredentialDeferredTaskParams>} */
+      const tasks = makeDeferredTasks();
+      tasks.push(identifiers =>
+        E(directory).storeIdentifier(namePath, identifiers.gitCredentialId),
+      );
+
+      const { value } = await formulateGitCredential(
+        'bearer',
+        audience,
+        harden({ token }),
+        tasks,
+      );
+      return value;
+    };
+
+    /** @type {EndoHost['provideBasicCredential']} */
+    const provideBasicCredential = async (petName, options) => {
+      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      if (!options || typeof options !== 'object') {
+        throw makeError(
+          X`provideBasicCredential: options must include audience, username, and password`,
+        );
+      }
+      const audience = requireGitCredentialString(
+        options.audience,
+        'provideBasicCredential: audience',
+      );
+      const username = requireGitCredentialString(
+        options.username,
+        'provideBasicCredential: username',
+      );
+      const password = requireGitCredentialString(
+        options.password,
+        'provideBasicCredential: password',
+      );
+
+      /** @type {DeferredTasks<GitCredentialDeferredTaskParams>} */
+      const tasks = makeDeferredTasks();
+      tasks.push(identifiers =>
+        E(directory).storeIdentifier(namePath, identifiers.gitCredentialId),
+      );
+
+      const { value } = await formulateGitCredential(
+        'basic',
+        audience,
+        harden({ username, password }),
+        tasks,
+      );
+      return value;
+    };
+
+    /** @type {EndoHost['getGitCredentialController']} */
+    const getGitCredentialController = async credentialCap => {
+      await null;
+      const controller = getGitCredentialControllerForCap(credentialCap);
+      if (controller === undefined) {
+        throw makeError(
+          X`getGitCredentialController: argument must be a daemon-minted Git credential cap`,
+        );
+      }
+      return controller;
     };
 
     /** @type {EndoHost['storeValue']} */
@@ -1464,6 +1562,9 @@ export const makeHostMaker = ({
       provideMount,
       provideScratchMount,
       provideGit,
+      provideBearerCredential,
+      provideBasicCredential,
+      getGitCredentialController,
       provideHostPath,
       provideGuest,
       provideHost,

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -331,6 +331,13 @@ export const HostInterface = M.interface('EndoHost', {
   provideGit: M.callWhen(M.remotable(), NameOrPathShape).returns(
     M.remotable('Git'),
   ),
+  // Mint a GitRemote capability that wraps a writable Git cap with a
+  // policy-bound endpoint and (optional) credential.
+  provideGitRemote: M.callWhen(
+    M.remotable(),
+    NameOrPathShape,
+    M.recordOf(M.string(), M.any()),
+  ).returns(M.remotable('GitRemote')),
   // Mint daemon-private Git credential capabilities.
   provideBearerCredential: M.callWhen(
     NameOrPathShape,
@@ -340,9 +347,12 @@ export const HostInterface = M.interface('EndoHost', {
     NameOrPathShape,
     M.recordOf(M.string(), M.any()),
   ).returns(M.remotable('BasicCredential')),
-  // Host-side controller for a daemon-minted credential cap.
+  // Host-side controllers for daemon-minted credential / remote caps.
   getGitCredentialController: M.callWhen(M.remotable()).returns(
     M.remotable('GitCredentialController'),
+  ),
+  getGitRemoteController: M.callWhen(M.remotable()).returns(
+    M.remotable('GitRemoteController'),
   ),
   // Resolve a Mount capability to its host filesystem path. This is
   // deliberately part of the fully privileged EndoHost surface used
@@ -610,6 +620,7 @@ export const MountEntryInterface = M.interface('EndoMountEntry', {
 });
 
 const RefArgShape = M.or(M.string(), M.recordOf(M.string(), M.any()));
+const GitDirectionShape = M.or(M.eq('fetch'), M.eq('push'));
 
 const GitIndexStatusShape = M.or(
   'clean',
@@ -708,6 +719,30 @@ export const GitInterface = M.interface('Git', {
   stashDrop: M.callWhen().optional(M.number()).returns(M.undefined()),
   tree: M.callWhen(RefArgShape).returns(M.remotable('EndoReadableTree')),
   readOnly: M.call().returns(M.remotable('Git')),
+});
+
+export const GitRemoteInterface = M.interface('GitRemote', {
+  inspect: M.call().returns(M.promise()),
+  fetch: M.call()
+    .optional(M.recordOf(M.string(), M.any()))
+    .returns(M.promise()),
+  pull: M.call().optional(M.recordOf(M.string(), M.any())).returns(M.promise()),
+  push: M.call().optional(M.recordOf(M.string(), M.any())).returns(M.promise()),
+});
+
+export const GitRemoteControllerInterface = M.interface('GitRemoteController', {
+  inspect: M.call().returns(M.promise()),
+  audit: M.call().returns(M.promise()),
+  setAllowedDirections: M.call(M.arrayOf(GitDirectionShape)).returns(
+    M.promise(),
+  ),
+  setFetchRefspecs: M.call(M.arrayOf(M.string())).returns(M.promise()),
+  setPushRefspecs: M.call(M.arrayOf(M.string())).returns(M.promise()),
+  setAllowedBranches: M.call(M.arrayOf(M.string())).returns(M.promise()),
+  setAllowForcePush: M.call(M.boolean()).returns(M.promise()),
+  setAllowTags: M.call(M.boolean()).returns(M.promise()),
+  setAllowDelete: M.call(M.boolean()).returns(M.promise()),
+  revoke: M.call().returns(M.promise()),
 });
 
 export const GitCredentialControllerInterface = M.interface(

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -331,6 +331,19 @@ export const HostInterface = M.interface('EndoHost', {
   provideGit: M.callWhen(M.remotable(), NameOrPathShape).returns(
     M.remotable('Git'),
   ),
+  // Mint daemon-private Git credential capabilities.
+  provideBearerCredential: M.callWhen(
+    NameOrPathShape,
+    M.recordOf(M.string(), M.any()),
+  ).returns(M.remotable('BearerCredential')),
+  provideBasicCredential: M.callWhen(
+    NameOrPathShape,
+    M.recordOf(M.string(), M.any()),
+  ).returns(M.remotable('BasicCredential')),
+  // Host-side controller for a daemon-minted credential cap.
+  getGitCredentialController: M.callWhen(M.remotable()).returns(
+    M.remotable('GitCredentialController'),
+  ),
   // Resolve a Mount capability to its host filesystem path. This is
   // deliberately part of the fully privileged EndoHost surface used
   // by the @endo/sandbox factory (and similar make-unconfined
@@ -695,6 +708,23 @@ export const GitInterface = M.interface('Git', {
   stashDrop: M.callWhen().optional(M.number()).returns(M.undefined()),
   tree: M.callWhen(RefArgShape).returns(M.remotable('EndoReadableTree')),
   readOnly: M.call().returns(M.remotable('Git')),
+});
+
+export const GitCredentialControllerInterface = M.interface(
+  'GitCredentialController',
+  {
+    inspect: M.call().returns(M.promise()),
+    rotate: M.call(M.recordOf(M.string(), M.any())).returns(M.promise()),
+    revoke: M.call().returns(M.promise()),
+  },
+);
+
+export const BearerCredentialInterface = M.interface('BearerCredential', {
+  audience: M.call().returns(M.string()),
+});
+
+export const BasicCredentialInterface = M.interface('BasicCredential', {
+  audience: M.call().returns(M.string()),
 });
 
 export const ReadableTreeInterface = M.interface('EndoReadableTree', {

--- a/packages/daemon/src/native-git-backend.js
+++ b/packages/daemon/src/native-git-backend.js
@@ -8,6 +8,9 @@ import process from 'node:process';
 import { setTimeout, clearTimeout } from 'node:timers';
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
+import net from 'node:net';
+import { URL } from 'node:url';
 
 import { q } from '@endo/errors';
 import { makeExo } from '@endo/exo';
@@ -41,6 +44,10 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: false });
  * } from './types.js'
  */
 
+/**
+ * @typedef {{ kind: 'bearer', material: { token: string } } | { kind: 'basic', material: { username: string, password: string } }} NativeGitCredential
+ */
+
 const execFileAsync = promisify(execFile);
 
 const gitNullDevice = process.platform === 'win32' ? 'NUL' : '/dev/null';
@@ -69,8 +76,7 @@ const GIT_BASE_ARGS = harden([
   '-c',
   'tag.gpgSign=false',
   // Suppress ambient credential helpers.  A blank helper resets the
-  // helper list so the local-worktree surface cannot prompt for or
-  // forward host credentials.
+  // helper list; credentialed remote calls use the daemon askpass helper.
   '-c',
   'credential.helper=',
 ]);
@@ -293,6 +299,17 @@ harden(normalizeTreePath);
  * @property {string} name
  */
 
+/**
+ * @typedef {'created' | 'updated' | 'up-to-date' | 'fast-forward' | 'forced' | 'pruned' | 'rejected'} GitRefUpdateResult
+ */
+
+/**
+ * @typedef {object} RemoteRefspec
+ * @property {boolean} force
+ * @property {string} src
+ * @property {string} dst
+ */
+
 // Repository-local configurations that can execute code on read/write
 // paths and must be refused before any mutating operation runs.  The
 // public Git exo dispatches read-only methods (status, diff, log,
@@ -303,6 +320,137 @@ harden(normalizeTreePath);
 // stashDrop) gate on `assertNoExecutableRepoConfig` first.
 const EXECUTABLE_REPO_CONFIG =
   /^(filter\..*\.(clean|smudge|process)|merge\..*\.driver)$/u;
+
+// Repository-local configurations that can redirect or alter an
+// explicitly-policy-bound remote URL. Remote operations pass a URL
+// selected by GitRemote policy; local `.git/config` must not rewrite
+// that endpoint, inject headers/credentials, loosen protocol controls,
+// or route it through a configured proxy.
+const REMOTE_TRANSPORT_REPO_CONFIG =
+  /^(url\..*\.(insteadof|pushinsteadof)|protocol\..*|https?\..*|credential(\.|$)|core\.(sshcommand|gitproxy)|ssh\..*|include(\.|if\.))/u;
+
+/**
+ * @param {string} name
+ * @param {string | undefined} oid
+ * @returns {GitRef}
+ */
+const makeRefUpdateGitRef = (name, oid) =>
+  harden({
+    name,
+    kind: /** @type {'branch' | 'tag' | 'commit' | 'detached'} */ (
+      name.startsWith('refs/tags/') ? 'tag' : 'branch'
+    ),
+    ...(oid === undefined ? {} : { oid }),
+  });
+harden(makeRefUpdateGitRef);
+
+/**
+ * @param {string} refspec
+ * @param {string} fieldName
+ * @returns {RemoteRefspec}
+ */
+const parseRemoteRefspec = (refspec, fieldName) => {
+  const raw = requireNonEmptyString(refspec, fieldName);
+  const force = raw.startsWith('+');
+  const body = force ? raw.slice(1) : raw;
+  const colon = body.indexOf(':');
+  return harden({
+    force,
+    src: colon < 0 ? body : body.slice(0, colon),
+    dst: colon < 0 ? '' : body.slice(colon + 1),
+  });
+};
+harden(parseRemoteRefspec);
+
+/**
+ * @param {string} ref
+ * @param {string} pattern
+ */
+const refMatchesPattern = (ref, pattern) => {
+  if (!pattern.includes('*')) {
+    return ref === pattern;
+  }
+  const [prefix, suffix] = pattern.split('*');
+  return ref.startsWith(prefix) && ref.endsWith(suffix);
+};
+harden(refMatchesPattern);
+
+/**
+ * @param {string} srcPattern
+ * @param {string} dstPattern
+ * @param {string} dst
+ */
+const sourceForDestination = (srcPattern, dstPattern, dst) => {
+  if (!srcPattern.includes('*') || !dstPattern.includes('*')) {
+    return srcPattern;
+  }
+  const [dstPrefix, dstSuffix] = dstPattern.split('*');
+  const [srcPrefix, srcSuffix] = srcPattern.split('*');
+  const suffixLength = dstSuffix.length;
+  const middle = dst.slice(
+    dstPrefix.length,
+    suffixLength === 0 ? undefined : -suffixLength,
+  );
+  return `${srcPrefix}${middle}${srcSuffix}`;
+};
+harden(sourceForDestination);
+
+/**
+ * @param {string} pattern
+ */
+const selectorForDestinationPattern = pattern => {
+  if (!pattern.includes('*')) {
+    return pattern;
+  }
+  return pattern.slice(0, pattern.indexOf('*'));
+};
+harden(selectorForDestinationPattern);
+
+/**
+ * @param {string | undefined} beforeOid
+ * @param {string | undefined} afterOid
+ * @returns {GitRefUpdateResult | undefined}
+ */
+const fetchUpdateResult = (beforeOid, afterOid) => {
+  if (beforeOid === undefined && afterOid === undefined) {
+    return undefined;
+  }
+  if (beforeOid === undefined) {
+    return 'created';
+  }
+  if (afterOid === undefined) {
+    return 'pruned';
+  }
+  if (beforeOid === afterOid) {
+    return 'up-to-date';
+  }
+  return 'updated';
+};
+harden(fetchUpdateResult);
+
+/**
+ * @param {string} flag
+ * @returns {GitRefUpdateResult}
+ */
+const pushPorcelainFlagToResult = flag => {
+  switch (flag) {
+    case '*':
+      return 'created';
+    case '=':
+      return 'up-to-date';
+    case ' ':
+      return 'fast-forward';
+    case '+':
+      return 'forced';
+    case '-':
+      return 'pruned';
+    case '!':
+      return 'rejected';
+    default:
+      return 'updated';
+  }
+};
+harden(pushPorcelainFlagToResult);
 
 /**
  * @typedef {object} RepositoryIdentity
@@ -459,6 +607,119 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
   let versionVerification;
   /** @type {RepositoryIdentity | undefined} */
   let repositoryIdentity;
+  /** @type {Promise<string> | undefined} */
+  let askpassPath;
+
+  const ensureAskpassPath = async () => {
+    if (askpassPath === undefined) {
+      askpassPath = (async () => {
+        const askpassDir = await fs.promises.mkdtemp(
+          path.join(os.tmpdir(), 'endo-git-askpass-'),
+        );
+        const scriptPath = path.join(askpassDir, 'askpass.sh');
+        await fs.promises.writeFile(
+          scriptPath,
+          [
+            `#!${process.execPath}`,
+            "const net = require('node:net');",
+            'const socketPath = process.env.ENDO_GIT_ASKPASS_SOCKET;',
+            'if (!socketPath) { process.exit(1); }',
+            'const client = net.createConnection(socketPath);',
+            "let response = '';",
+            "client.setEncoding('utf8');",
+            "client.on('connect', () => {",
+            '  client.end(JSON.stringify({ prompt: process.argv.slice(2).join(" ") }));',
+            '});',
+            "client.on('data', chunk => { response += chunk; });",
+            "client.on('end', () => { process.stdout.write(response); });",
+            "client.on('error', () => { process.exit(1); });",
+            '',
+          ].join('\n'),
+          { mode: 0o700 },
+        );
+        await fs.promises.chmod(scriptPath, 0o700);
+        return scriptPath;
+      })();
+    }
+    return askpassPath;
+  };
+
+  /**
+   * @param {unknown} credential
+   * @returns {Promise<{ env: Record<string, string>, close: () => Promise<void> }>}
+   */
+  const makeCredentialTransport = async credential => {
+    if (credential === undefined) {
+      return harden({
+        env: harden({}),
+        close: async () => {},
+      });
+    }
+    const nativeCredential = /** @type {NativeGitCredential} */ (credential);
+    /** @type {string} */
+    let username;
+    /** @type {string} */
+    let password;
+    if (nativeCredential.kind === 'bearer') {
+      username = 'x-access-token';
+      password = requireNonEmptyString(
+        nativeCredential.material?.token,
+        'remote credential token',
+      );
+    } else if (nativeCredential.kind === 'basic') {
+      username = requireNonEmptyString(
+        nativeCredential.material?.username,
+        'remote credential username',
+      );
+      password = requireNonEmptyString(
+        nativeCredential.material?.password,
+        'remote credential password',
+      );
+    } else {
+      throw new Error('Unsupported remote credential kind');
+    }
+
+    const askpassDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'endo-git-askpass-socket-'),
+    );
+    const socketPath = path.join(askpassDir, 'askpass.sock');
+    const server = net.createServer(socket => {
+      socket.setEncoding('utf8');
+      let request = '';
+      socket.on('data', chunk => {
+        request += String(chunk);
+      });
+      socket.on('end', () => {
+        let prompt = '';
+        try {
+          prompt =
+            /** @type {{ prompt?: string }} */ (JSON.parse(request || '{}'))
+              .prompt || '';
+        } catch {
+          prompt = '';
+        }
+        const response = /sername/iu.test(prompt) ? username : password;
+        socket.end(`${response}\n`);
+      });
+    });
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, () => resolve(undefined));
+    });
+
+    return harden({
+      env: harden({
+        GIT_ASKPASS: await ensureAskpassPath(),
+        ENDO_GIT_ASKPASS_SOCKET: socketPath,
+      }),
+      close: async () => {
+        await new Promise(resolve => {
+          server.close(() => resolve(undefined));
+        });
+        await fs.promises.rm(askpassDir, { recursive: true, force: true });
+      },
+    });
+  };
 
   const verifyGitVersion = async () => {
     if (!versionVerification) {
@@ -816,6 +1077,214 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
         `Refusing git operation because repository config can execute commands: ${offending.join(', ')}`,
       );
     }
+  };
+
+  /**
+   * Refuse repository-local configuration that can redirect or modify
+   * an explicit remote URL. Unlike ordinary local branch metadata, these
+   * keys apply even when the daemon invokes `git fetch <url>` or
+   * `git push <url>` with a policy-controlled URL.
+   */
+  const assertNoRemoteTransportRepoConfig = async () => {
+    await verifyRepositoryIdentity();
+    const { stdout } = await execFileAsync(
+      'git',
+      [...GIT_BASE_ARGS, 'config', '--local', '--name-only', '--list'],
+      {
+        cwd: repoRoot,
+        env: makeGitEnv(repoRoot),
+        timeout: GIT_TIMEOUT_MS,
+        maxBuffer: GIT_MAX_BUFFER,
+      },
+    );
+    const offending = stdout
+      .split('\n')
+      .map(name => name.trim())
+      .filter(name => REMOTE_TRANSPORT_REPO_CONFIG.test(name.toLowerCase()));
+    if (offending.length > 0) {
+      throw new Error(
+        `Refusing remote git operation because repository config can alter remote transport: ${offending.join(', ')}`,
+      );
+    }
+  };
+
+  /**
+   * Add command-line protocol policy for explicit URL remote operations.
+   * The URL itself still comes from GitRemote policy; these flags ensure
+   * the protocol selected for that URL is the only protocol git may use
+   * after its normal URL handling.
+   *
+   * @param {string} urlText
+   * @returns {string[]}
+   */
+  const remoteProtocolArgs = urlText => {
+    let protocol;
+    try {
+      protocol = new URL(urlText).protocol;
+    } catch {
+      throw new Error(`remote URL is not a valid URL: ${q(urlText)}`);
+    }
+    if (protocol === 'https:') {
+      return harden([
+        '-c',
+        'protocol.allow=never',
+        '-c',
+        'protocol.https.allow=always',
+      ]);
+    }
+    if (protocol === 'http:') {
+      return harden([
+        '-c',
+        'protocol.allow=never',
+        '-c',
+        'protocol.http.allow=always',
+      ]);
+    }
+    if (protocol === 'file:') {
+      return harden([
+        '-c',
+        'protocol.allow=never',
+        '-c',
+        'protocol.file.allow=always',
+      ]);
+    }
+    throw new Error(`remote URL protocol is not supported: ${q(protocol)}`);
+  };
+  harden(remoteProtocolArgs);
+
+  /**
+   * @param {string[]} selectors
+   * @returns {Promise<Map<string, string>>}
+   */
+  const readRefMap = async selectors => {
+    if (selectors.length === 0) {
+      return new Map();
+    }
+    const raw = await runGitRaw([
+      'for-each-ref',
+      '--format=%(refname)%09%(objectname)',
+      ...selectors,
+    ]);
+    const refs = new Map();
+    for (const line of raw.split('\n').filter(entry => entry !== '')) {
+      const tab = line.indexOf('\t');
+      if (tab < 0) {
+        throw new Error(`Could not parse git for-each-ref line: ${q(line)}`);
+      }
+      refs.set(line.slice(0, tab), line.slice(tab + 1));
+    }
+    return refs;
+  };
+
+  /**
+   * @param {string[]} refspecs
+   */
+  const selectorsForFetchRefspecs = refspecs =>
+    harden(
+      [
+        ...new Set(
+          refspecs
+            .map((refspec, index) =>
+              parseRemoteRefspec(refspec, `remoteFetch.refspecs[${index}]`),
+            )
+            .map(({ dst }) => dst)
+            .filter(dst => dst !== '')
+            .map(selectorForDestinationPattern),
+        ),
+      ].filter(selector => selector !== ''),
+    );
+
+  /**
+   * @param {string[]} refspecs
+   * @param {Map<string, string>} before
+   * @param {Map<string, string>} after
+   */
+  const summarizeFetchRefUpdates = (refspecs, before, after) => {
+    /** @type {Array<{ local: GitRef, remote: string, result: GitRefUpdateResult }>} */
+    const updates = [];
+    const seen = new Set();
+    for (const [index, refspec] of refspecs.entries()) {
+      const parsed = parseRemoteRefspec(
+        refspec,
+        `remoteFetch.refspecs[${index}]`,
+      );
+      if (parsed.dst !== '') {
+        const candidates = [
+          ...new Set([...before.keys(), ...after.keys()].sort()),
+        ].filter(ref => refMatchesPattern(ref, parsed.dst) && !seen.has(ref));
+        for (const dst of candidates) {
+          seen.add(dst);
+          const beforeOid = before.get(dst);
+          const afterOid = after.get(dst);
+          const result = fetchUpdateResult(beforeOid, afterOid);
+          if (result !== undefined) {
+            updates.push(
+              harden({
+                local: makeRefUpdateGitRef(dst, afterOid || beforeOid),
+                remote: sourceForDestination(parsed.src, parsed.dst, dst),
+                result,
+              }),
+            );
+          }
+        }
+      }
+    }
+    return harden(updates);
+  };
+
+  /**
+   * @param {string} ref
+   * @returns {Promise<GitRef | undefined>}
+   */
+  const resolveOptionalRef = async ref => {
+    if (ref === '') {
+      return undefined;
+    }
+    try {
+      const oid = (await runGitRaw(['rev-parse', '--verify', ref])).trim();
+      return makeRefUpdateGitRef(ref, oid);
+    } catch {
+      return makeRefUpdateGitRef(ref, undefined);
+    }
+  };
+
+  /**
+   * @param {string} raw
+   * @returns {Promise<Array<{ local?: GitRef, remote: string, result: GitRefUpdateResult }>>}
+   */
+  const parsePushPorcelainUpdates = async raw => {
+    const records = raw.split('\n').flatMap(line => {
+      const flag = line[0];
+      const rest = line.slice(1);
+      const fields = rest.startsWith('\t') ? rest.slice(1).split('\t') : [];
+      if (
+        line === '' ||
+        line === 'Done' ||
+        line.startsWith('To ') ||
+        fields.length < 2
+      ) {
+        return [];
+      }
+      const colon = fields[0].indexOf(':');
+      return harden([
+        harden({
+          src: colon < 0 ? fields[0] : fields[0].slice(0, colon),
+          dst: colon < 0 ? fields[0] : fields[0].slice(colon + 1),
+          flag,
+        }),
+      ]);
+    });
+    const updates = await Promise.all(
+      records.map(async ({ src, dst, flag }) => {
+        const local = await resolveOptionalRef(src);
+        return harden({
+          ...(local === undefined ? {} : { local }),
+          remote: dst,
+          result: pushPorcelainFlagToResult(flag),
+        });
+      }),
+    );
+    return harden(updates);
   };
 
   /**
@@ -1547,6 +2016,74 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
         `${revision}^{tree}`,
       ]);
       return makeGitTree(rawTree.trim());
+    },
+
+    remoteFetch: async input => {
+      const opts =
+        /** @type {{ url?: unknown, refspecs?: unknown, prune?: boolean, tags?: boolean, credential?: unknown, signal?: AbortSignal }} */ (
+          input
+        );
+      const url = requireRevision(opts.url, 'remoteFetch.url');
+      const refspecs = Array.isArray(opts.refspecs)
+        ? opts.refspecs.map((refspec, index) =>
+            requireNonEmptyString(refspec, `remoteFetch.refspecs[${index}]`),
+          )
+        : [];
+      await assertNoExecutableRepoConfig();
+      await assertNoRemoteTransportRepoConfig();
+      const selectors = selectorsForFetchRefspecs(refspecs);
+      const before = await readRefMap([...selectors]);
+      const args = [...remoteProtocolArgs(url), 'fetch'];
+      if (opts.prune) {
+        args.push('--prune');
+      }
+      args.push(opts.tags ? '--tags' : '--no-tags');
+      args.push(url, ...refspecs);
+      const credentialTransport = await makeCredentialTransport(
+        opts.credential,
+      );
+      try {
+        const text = await runGit(args, credentialTransport.env, opts.signal);
+        const after = await readRefMap([...selectors]);
+        const updatedRefs = summarizeFetchRefUpdates(refspecs, before, after);
+        return harden({ updatedRefs, text });
+      } finally {
+        await credentialTransport.close();
+      }
+    },
+
+    remotePush: async input => {
+      const opts =
+        /** @type {{ url?: unknown, refspecs?: unknown, setUpstream?: boolean, credential?: unknown, signal?: AbortSignal }} */ (
+          input
+        );
+      const url = requireRevision(opts.url, 'remotePush.url');
+      const refspecs = Array.isArray(opts.refspecs)
+        ? opts.refspecs.map((refspec, index) =>
+            requireNonEmptyString(refspec, `remotePush.refspecs[${index}]`),
+          )
+        : [];
+      if (refspecs.length === 0) {
+        throw new Error('remotePush.refspecs must not be empty');
+      }
+      await assertNoExecutableRepoConfig();
+      await assertNoRemoteTransportRepoConfig();
+      const args = [...remoteProtocolArgs(url), 'push', '--porcelain'];
+      if (opts.setUpstream) {
+        args.push('--set-upstream');
+      }
+      args.push(url, ...refspecs);
+      const credentialTransport = await makeCredentialTransport(
+        opts.credential,
+      );
+      try {
+        const raw = await runGitRaw(args, credentialTransport.env, opts.signal);
+        const updatedRefs = await parsePushPorcelainUpdates(raw);
+        const text = truncateOutput(raw.trim() || '(no output)');
+        return harden({ updatedRefs, text });
+      } finally {
+        await credentialTransport.close();
+      }
     },
   });
 };

--- a/packages/daemon/src/native-git-backend.js
+++ b/packages/daemon/src/native-git-backend.js
@@ -8,7 +8,7 @@ import process from 'node:process';
 import { setTimeout, clearTimeout } from 'node:timers';
 import fs from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
+import { tmpdir } from 'node:os';
 import net from 'node:net';
 import { URL } from 'node:url';
 
@@ -614,7 +614,7 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
     if (askpassPath === undefined) {
       askpassPath = (async () => {
         const askpassDir = await fs.promises.mkdtemp(
-          path.join(os.tmpdir(), 'endo-git-askpass-'),
+          path.join(tmpdir(), 'endo-git-askpass-'),
         );
         const scriptPath = path.join(askpassDir, 'askpass.sh');
         await fs.promises.writeFile(
@@ -680,7 +680,7 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
     }
 
     const askpassDir = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), 'endo-git-askpass-socket-'),
+      path.join(tmpdir(), 'endo-git-askpass-socket-'),
     );
     const socketPath = path.join(askpassDir, 'askpass.sock');
     const server = net.createServer(socket => {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -229,6 +229,12 @@ export type GitFormula = {
   mountId: FormulaIdentifier;
 };
 
+export type GitCredentialFormula = {
+  type: 'git-credential';
+  kind: 'bearer' | 'basic';
+  audience: string;
+};
+
 // Public Git capability surface.  These types describe the inputs and
 // outputs of the `Git` exo's methods (see `src/interfaces.js` for the
 // runtime guard and `src/git.js` for the implementation); they are part
@@ -420,6 +426,10 @@ export type GitDeferredTaskParams = {
   gitId: FormulaIdentifier;
 };
 
+export type GitCredentialDeferredTaskParams = {
+  gitCredentialId: FormulaIdentifier;
+};
+
 type LookupFormula = {
   type: 'lookup';
 
@@ -600,6 +610,7 @@ export type Formula =
   | MountFormula
   | ScratchMountFormula
   | GitFormula
+  | GitCredentialFormula
   | LookupFormula
   | MakeUnconfinedFormula
   | MakeArchiveFormula
@@ -1257,6 +1268,15 @@ export interface EndoHost extends EndoAgent {
   ): Promise<EndoMount>;
   provideScratchMount(petName: string | string[]): Promise<EndoMount>;
   provideGit(mountCap: EndoMount, petName: string | string[]): Promise<EndoGit>;
+  provideBearerCredential(
+    petName: string | string[],
+    options: { audience: string; token: string },
+  ): Promise<unknown>;
+  provideBasicCredential(
+    petName: string | string[],
+    options: { audience: string; username: string; password: string },
+  ): Promise<unknown>;
+  getGitCredentialController(credential: unknown): Promise<unknown>;
   /**
    * Privileged bridge from a daemon-minted top-level Mount cap to its
    * host filesystem path. EndoHost is a fully privileged authority;
@@ -1985,6 +2005,13 @@ export interface DaemonCore {
     mountId: FormulaIdentifier,
     deferredTasks: DeferredTasks<GitDeferredTaskParams>,
   ) => FormulateResult<EndoGit>;
+
+  formulateGitCredential: (
+    kind: GitCredentialFormula['kind'],
+    audience: string,
+    material: Record<string, string>,
+    deferredTasks: DeferredTasks<GitCredentialDeferredTaskParams>,
+  ) => FormulateResult<unknown>;
 
   formulateInvitation: (
     hostAgentId: FormulaIdentifier,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -235,6 +235,25 @@ export type GitCredentialFormula = {
   audience: string;
 };
 
+export type GitRemoteFormula = {
+  type: 'git-remote';
+  gitId: FormulaIdentifier;
+  credentialId?: FormulaIdentifier;
+  name: string;
+  policy: {
+    url: string;
+    allowedDirections: Array<'fetch' | 'push'>;
+    fetchRefspecs: string[];
+    pushRefspecs: string[];
+    allowedBranches?: string[];
+    allowForcePush?: boolean;
+    allowTags?: boolean;
+    allowDelete?: boolean;
+    allowLocalFileTransport?: boolean;
+  };
+  revoked?: boolean;
+};
+
 // Public Git capability surface.  These types describe the inputs and
 // outputs of the `Git` exo's methods (see `src/interfaces.js` for the
 // runtime guard and `src/git.js` for the implementation); they are part
@@ -430,6 +449,10 @@ export type GitCredentialDeferredTaskParams = {
   gitCredentialId: FormulaIdentifier;
 };
 
+export type GitRemoteDeferredTaskParams = {
+  gitRemoteId: FormulaIdentifier;
+};
+
 type LookupFormula = {
   type: 'lookup';
 
@@ -611,6 +634,7 @@ export type Formula =
   | ScratchMountFormula
   | GitFormula
   | GitCredentialFormula
+  | GitRemoteFormula
   | LookupFormula
   | MakeUnconfinedFormula
   | MakeArchiveFormula
@@ -1268,6 +1292,23 @@ export interface EndoHost extends EndoAgent {
   ): Promise<EndoMount>;
   provideScratchMount(petName: string | string[]): Promise<EndoMount>;
   provideGit(mountCap: EndoMount, petName: string | string[]): Promise<EndoGit>;
+  provideGitRemote(
+    gitCap: unknown,
+    petName: string | string[],
+    opts: {
+      name: string;
+      url: string;
+      allowedDirections?: Array<'fetch' | 'push'>;
+      fetchRefspecs?: string[];
+      pushRefspecs?: string[];
+      allowedBranches?: string[];
+      allowForcePush?: boolean;
+      allowTags?: boolean;
+      allowDelete?: boolean;
+      allowLocalFileTransport?: boolean;
+      credential?: unknown;
+    },
+  ): Promise<unknown>;
   provideBearerCredential(
     petName: string | string[],
     options: { audience: string; token: string },
@@ -1277,6 +1318,7 @@ export interface EndoHost extends EndoAgent {
     options: { audience: string; username: string; password: string },
   ): Promise<unknown>;
   getGitCredentialController(credential: unknown): Promise<unknown>;
+  getGitRemoteController(remote: unknown): Promise<unknown>;
   /**
    * Privileged bridge from a daemon-minted top-level Mount cap to its
    * host filesystem path. EndoHost is a fully privileged authority;
@@ -2011,6 +2053,14 @@ export interface DaemonCore {
     audience: string,
     material: Record<string, string>,
     deferredTasks: DeferredTasks<GitCredentialDeferredTaskParams>,
+  ) => FormulateResult<unknown>;
+
+  formulateGitRemote: (
+    gitId: FormulaIdentifier,
+    credentialId: FormulaIdentifier | undefined,
+    name: string,
+    policy: GitRemoteFormula['policy'],
+    deferredTasks: DeferredTasks<GitRemoteDeferredTaskParams>,
   ) => FormulateResult<unknown>;
 
   formulateInvitation: (

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1292,6 +1292,16 @@ export interface EndoHost extends EndoAgent {
   ): Promise<EndoMount>;
   provideScratchMount(petName: string | string[]): Promise<EndoMount>;
   provideGit(mountCap: EndoMount, petName: string | string[]): Promise<EndoGit>;
+  /**
+   * Mint a `GitRemote` capability bound to `gitCap`, persist its
+   * formula, and bind it to `petName`.  The remote enforces the
+   * supplied policy (allowed directions, refspecs, force-push, etc.)
+   * against every operation.  Host-only; not exposed to guests.  The
+   * guest holds the returned exo (which exposes `fetch`/`pull`/`push`
+   * and `inspect()`); the controller surface
+   * (`getGitRemoteController`) lives on the host side and stays
+   * within `EndoHost`.
+   */
   provideGitRemote(
     gitCap: unknown,
     petName: string | string[],
@@ -1309,15 +1319,46 @@ export interface EndoHost extends EndoAgent {
       credential?: unknown;
     },
   ): Promise<unknown>;
+  /**
+   * Mint a bearer-token `GitCredential` capability scoped to
+   * `audience` (a URL origin) and bind it to `petName`.  Material
+   * lives in a daemon-process-local map; daemon restart routes the
+   * cap through `makeUnavailableGitCredential` (durable identity,
+   * ephemeral material).  Host-only; not exposed to guests.  Guests
+   * receive only the `audience()` view of the resulting capability.
+   */
   provideBearerCredential(
     petName: string | string[],
     options: { audience: string; token: string },
   ): Promise<unknown>;
+  /**
+   * Mint a basic-auth `GitCredential` capability scoped to `audience`
+   * and bind it to `petName`.  Same material-residency contract as
+   * `provideBearerCredential`: host-only, daemon-process-local
+   * material, audience-gated transport use.
+   */
   provideBasicCredential(
     petName: string | string[],
     options: { audience: string; username: string; password: string },
   ): Promise<unknown>;
+  /**
+   * Privileged accessor: return the host-side controller paired with
+   * a daemon-minted `GitCredential` exo.  The controller exposes
+   * `inspect`, `rotate`, `revoke`, and `audit`; the guest-held
+   * credential exposes only `audience()`.  Host-only; not exposed to
+   * guests.  Returns `undefined` for spoof / fake credentials that
+   * did not pass through `provideBearerCredential` or
+   * `provideBasicCredential`.
+   */
   getGitCredentialController(credential: unknown): Promise<unknown>;
+  /**
+   * Privileged accessor: return the host-side controller paired with
+   * a daemon-minted `GitRemote` exo.  The controller exposes policy
+   * setters (`setAllowedDirections`, `setFetchRefspecs`,
+   * `setPushRefspecs`, ...), `revoke`, and `audit`.  Host-only; not
+   * exposed to guests.  Returns `undefined` for spoof / fake remotes
+   * that did not pass through `provideGitRemote`.
+   */
   getGitRemoteController(remote: unknown): Promise<unknown>;
   /**
    * Privileged bridge from a daemon-minted top-level Mount cap to its

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -340,6 +340,8 @@ test('GitRemote passes HTTPS credential material to backend transport only', asy
   });
   const git = makeGit({ mount: Far('FakeMount', {}), backend });
   const credential = exampleCredential();
+  const credentialController = getGitCredentialController(credential);
+  t.truthy(credentialController);
   const { remote } = makeGitRemote({
     git,
     name: 'origin',
@@ -351,6 +353,8 @@ test('GitRemote passes HTTPS credential material to backend transport only', asy
       pushRefspecs: [],
     },
   });
+  const remoteController = getGitRemoteController(remote);
+  t.truthy(remoteController);
 
   t.false(JSON.stringify(await E(remote).inspect()).includes('test-token'));
   await E(remote).fetch();
@@ -359,6 +363,26 @@ test('GitRemote passes HTTPS credential material to backend transport only', asy
     /** @type {{ credential?: unknown }} */ (fetchCalls[0]).credential,
     harden({ kind: 'bearer', material: harden({ token: 'test-token' }) }),
   );
+
+  // The audit-log surface must not embed any credential material —
+  // not the initial token, not a rotated token, and not a revoked
+  // token.  Widening the negative-string check across the rotate-plus-
+  // revoke path keeps the secrecy invariant load-bearing on the same
+  // axis the transport check above covers.
+  await E(credentialController).rotate({ token: 'rotated-token' });
+  await E(remote).fetch();
+  await E(credentialController).revoke();
+  await t.throwsAsync(E(remote).fetch(), {
+    message: /credential .* revoked/,
+  });
+  const remoteAudit = JSON.stringify(await E(remoteController).audit());
+  t.false(remoteAudit.includes('test-token'));
+  t.false(remoteAudit.includes('rotated-token'));
+  const credentialView = JSON.stringify(
+    await E(credentialController).inspect(),
+  );
+  t.false(credentialView.includes('test-token'));
+  t.false(credentialView.includes('rotated-token'));
 });
 
 test('GitCredentialController rotates material used by existing remotes', async t => {

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -873,6 +873,35 @@ test('makeGitRemote rejects a read-only Git cap', async t => {
   );
 });
 
+test('makeGitRemote rejects a spoofed Git cap not minted by the daemon', async t => {
+  // A spoof exo shaped like Git is not in the daemon's
+  // `gitReadOnly` / `gitBackends` WeakMaps, so `getGitBackend`
+  // returns undefined and the constructor refuses.  This pins the
+  // host-side check-before-trust gate that keeps `makeGitRemote`
+  // from composing against a guest-fabricated Git.
+  const spoofGit = Far('SpoofGit', {
+    /** @returns {Promise<unknown>} */
+    async readOnly() {
+      return spoofGit;
+    },
+  });
+  t.throws(
+    () =>
+      makeGitRemote({
+        git: spoofGit,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          url: 'https://github.com/example/repo.git',
+          allowedDirections: ['fetch'],
+          fetchRefspecs: [],
+          pushRefspecs: [],
+        },
+      }),
+    { message: /GitRemote requires a daemon-minted Git cap/ },
+  );
+});
+
 test('GitRemoteController mutates policy, snapshot reflects the change', async t => {
   const { git } = await provisionGitContext(t);
   const { remote, controller } = makeGitRemote({

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -630,7 +630,7 @@ test('GitRemote fetch / pull / push use the bounded native data plane', async t 
     branch: 'refs/remotes/origin/main',
     strategy: 'ff-only',
   });
-  t.is(pullResult.integration, 'ff-only');
+  t.is(pullResult.integration, 'fast-forward');
   t.deepEqual(
     [...pullResult.fetch.updatedRefs],
     [
@@ -646,6 +646,12 @@ test('GitRemote fetch / pull / push use the bounded native data plane', async t 
     ],
   );
   t.is(await E(mount).readText(['upstream.txt']), 'upstream\n');
+
+  const upToDatePullResult = await E(remote).pull({
+    branch: 'refs/remotes/origin/main',
+    strategy: 'ff-only',
+  });
+  t.is(upToDatePullResult.integration, 'up-to-date');
 
   await E(git).createBranch('agent/topic', { switchAfterCreate: true });
   const note = await E(mount).entry(['agent.txt']);
@@ -694,12 +700,21 @@ test('GitRemote fetch / pull / push use the bounded native data plane', async t 
   const audit = await E(controller).audit();
   t.deepEqual(
     audit.map(event => event.type),
-    ['create', 'fetch', 'pull', 'push'],
+    ['create', 'fetch', 'pull', 'pull', 'push'],
   );
   t.like(audit[1], { type: 'fetch', outcome: 'ok' });
-  t.like(audit[2], { type: 'pull', outcome: 'ok', integration: 'ff-only' });
-  t.like(audit[3], { type: 'push', outcome: 'ok' });
-  t.deepEqual([...audit[3].updatedRefs], [...pushResult.updatedRefs]);
+  t.like(audit[2], {
+    type: 'pull',
+    outcome: 'ok',
+    integration: 'fast-forward',
+  });
+  t.like(audit[3], {
+    type: 'pull',
+    outcome: 'ok',
+    integration: 'up-to-date',
+  });
+  t.like(audit[4], { type: 'push', outcome: 'ok' });
+  t.deepEqual([...audit[4].updatedRefs], [...pushResult.updatedRefs]);
 });
 
 test('GitRemote enforces allowedDirections at the call boundary', async t => {

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -14,8 +14,11 @@ import { E, Far } from '@endo/far';
 
 import { makeFilePowers } from '../src/daemon-node-powers.js';
 import {
-  makeBearerCredential,
+  assertGitCredentialForUrl,
   getGitCredentialController,
+  makeBasicCredential,
+  makeBearerCredential,
+  makeUnavailableGitCredential,
   revokeGitCredential,
 } from '../src/git-credential.js';
 import { makeMount } from '../src/mount.js';
@@ -959,4 +962,310 @@ test('getGitRemoteController rejects fabricated remote exos', async t => {
     push: () => Promise.reject(new Error('spoof')),
   });
   t.is(getGitRemoteController(fake), undefined);
+});
+
+test('GitRemoteController policy setters update the snapshot for refspecs and flags', async t => {
+  // Covers the controller setters that the existing coverage tests
+  // did not reach: setFetchRefspecs, setPushRefspecs, setAllowForcePush.
+  // setAllowedBranches / setAllowedDirections are exercised in the
+  // "mutates policy" test above; setAllowTags / setAllowDelete in the
+  // tag-and-prune test.
+  const { git } = await provisionGitContext(t);
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch', 'push'],
+      fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+      pushRefspecs: ['refs/heads/agent/x:refs/heads/agent/x'],
+    },
+  });
+
+  await E(controller).setFetchRefspecs([
+    '+refs/heads/main:refs/remotes/origin/main',
+  ]);
+  let snapshot = await E(remote).inspect();
+  t.deepEqual(
+    [...snapshot.fetchRefspecs],
+    ['+refs/heads/main:refs/remotes/origin/main'],
+  );
+
+  // Push refspecs without a leading '+' do not require allowForcePush.
+  await E(controller).setPushRefspecs([
+    'refs/heads/agent/y:refs/heads/agent/y',
+  ]);
+  snapshot = await E(remote).inspect();
+  t.deepEqual(
+    [...snapshot.pushRefspecs],
+    ['refs/heads/agent/y:refs/heads/agent/y'],
+  );
+  t.false(snapshot.allowForcePush);
+
+  // Widening allowForcePush makes a subsequent force-push refspec
+  // accept.
+  await E(controller).setAllowForcePush(true);
+  snapshot = await E(remote).inspect();
+  t.true(snapshot.allowForcePush);
+  await E(controller).setPushRefspecs([
+    '+refs/heads/agent/z:refs/heads/agent/z',
+  ]);
+  snapshot = await E(remote).inspect();
+  t.deepEqual(
+    [...snapshot.pushRefspecs],
+    ['+refs/heads/agent/z:refs/heads/agent/z'],
+  );
+
+  // Narrowing allowForcePush while force-push refspecs are still
+  // present is rejected by the policy normalizer.  Replace the
+  // refspecs first, then narrow.
+  await t.throwsAsync(E(controller).setAllowForcePush(false), {
+    message: /force-push refspec requires allowForcePush/,
+  });
+  await E(controller).setPushRefspecs([
+    'refs/heads/agent/w:refs/heads/agent/w',
+  ]);
+  await E(controller).setAllowForcePush(false);
+  snapshot = await E(remote).inspect();
+  t.false(snapshot.allowForcePush);
+
+  const audit = await E(controller).audit();
+  t.deepEqual(audit.map(event => event.method).slice(1), [
+    'setFetchRefspecs',
+    'setPushRefspecs',
+    'setAllowForcePush',
+    'setPushRefspecs',
+    'setPushRefspecs',
+    'setAllowForcePush',
+  ]);
+});
+
+test('makeBasicCredential normalizes audience/username/password and supports rotate + revoke', async t => {
+  // The bearer factory has the full lifecycle covered above; the
+  // basic factory shares the structure but its surface is currently
+  // unexercised in tests.  makeBasicCredential mints a daemon-minted
+  // cap whose `audience()` method, controller-side inspect, rotate,
+  // and revoke parallel the bearer's.
+  /** @type {Array<{ kind?: string, material?: unknown }>} */
+  const rotateEvents = [];
+  let revokeCount = 0;
+  const credential = makeBasicCredential({
+    audience: 'https://gitlab.example.com',
+    username: 'agent',
+    password: 'initial-password',
+    onRotate: material => rotateEvents.push({ kind: 'basic', material }),
+    onRevoke: () => {
+      revokeCount += 1;
+    },
+  });
+  t.is(credential.audience(), 'https://gitlab.example.com');
+
+  const controller = getGitCredentialController(credential);
+  t.truthy(controller);
+  let view = await E(controller).inspect();
+  t.like(view, {
+    kind: 'basic',
+    audience: 'https://gitlab.example.com',
+    available: true,
+    revoked: false,
+  });
+
+  // The host-side audience-matching helper accepts the daemon-minted
+  // cap and rejects non-matching origins; the audience-helper's
+  // surface is otherwise reachable only via the GitRemote
+  // construction path.
+  t.notThrows(() =>
+    assertGitCredentialForUrl(credential, 'https://gitlab.example.com'),
+  );
+  t.throws(() => assertGitCredentialForUrl(credential, 'https://github.com'), {
+    message: /audience .* does not match remote origin/,
+  });
+
+  await E(controller).rotate({
+    username: 'agent',
+    password: 'rotated-password',
+  });
+  t.is(rotateEvents.length, 1);
+  t.like(rotateEvents[0], {
+    kind: 'basic',
+    material: { username: 'agent', password: 'rotated-password' },
+  });
+
+  await E(controller).revoke();
+  t.is(revokeCount, 1);
+  view = await E(controller).inspect();
+  t.like(view, {
+    available: false,
+    revoked: true,
+  });
+  t.throws(
+    () => assertGitCredentialForUrl(credential, 'https://gitlab.example.com'),
+    { message: /has been revoked/ },
+  );
+  // The allowRevoked option lets host-side audit paths inspect a
+  // revoked credential by audience without re-throwing.
+  t.notThrows(() =>
+    assertGitCredentialForUrl(credential, 'https://gitlab.example.com', {
+      allowRevoked: true,
+    }),
+  );
+});
+
+test('makeBasicCredential rejects empty or NUL-bearing fields', async t => {
+  // requireCredentialString is shared with the bearer factory; the
+  // basic factory's parallel path is otherwise unexercised.
+  t.throws(
+    () =>
+      makeBasicCredential({
+        audience: '',
+        username: 'u',
+        password: 'p',
+      }),
+    { message: /BasicCredential audience must be a non-empty string/ },
+  );
+  t.throws(
+    () =>
+      makeBasicCredential({
+        audience: 'https://x',
+        username: '',
+        password: 'p',
+      }),
+    { message: /BasicCredential username must be a non-empty string/ },
+  );
+  t.throws(
+    () =>
+      makeBasicCredential({
+        audience: 'https://x',
+        username: 'u',
+        password: '',
+      }),
+    { message: /BasicCredential password must be a non-empty string/ },
+  );
+  t.throws(
+    () =>
+      makeBasicCredential({
+        audience: 'https://x',
+        username: 'u',
+        password: 'p\0secret',
+      }),
+    { message: /BasicCredential password must not contain NUL bytes/ },
+  );
+});
+
+test('makeUnavailableGitCredential mints a revoked cap that the operator can rotate back', async t => {
+  // The reconstitution path on daemon restart: a basic or bearer
+  // credential formula whose process-local secret has been forgotten
+  // mints an Unavailable cap so the formula stays identifiable; the
+  // operator rotates new material in to bring the cap back to life.
+  /** @type {Array<{ kind: string, material: unknown }>} */
+  const rotateEvents = [];
+  const credential = makeUnavailableGitCredential({
+    kind: 'basic',
+    audience: 'https://gitlab.example.com',
+    onRotate: material => rotateEvents.push({ kind: 'basic', material }),
+  });
+  t.is(credential.audience(), 'https://gitlab.example.com');
+
+  const controller = getGitCredentialController(credential);
+  t.truthy(controller);
+  let view = await E(controller).inspect();
+  t.like(view, {
+    kind: 'basic',
+    audience: 'https://gitlab.example.com',
+    available: false,
+    revoked: true,
+  });
+
+  // The cap is reachable via the audience helper for non-transport
+  // bookkeeping when allowRevoked is set.
+  t.notThrows(() =>
+    assertGitCredentialForUrl(credential, 'https://gitlab.example.com', {
+      allowRevoked: true,
+    }),
+  );
+
+  await E(controller).rotate({
+    username: 'agent',
+    password: 'restored-password',
+  });
+  view = await E(controller).inspect();
+  t.like(view, {
+    available: true,
+    revoked: false,
+  });
+  t.is(rotateEvents.length, 1);
+  t.like(rotateEvents[0], {
+    kind: 'basic',
+    material: { username: 'agent', password: 'restored-password' },
+  });
+
+  // A bearer-kind unavailable cap takes a token on rotate, mirroring
+  // the bearer factory.  The bearer cap also exposes audience()
+  // directly on its exo surface (sync-call), the same shape as the
+  // basic cap above.
+  let revokeFired = 0;
+  const bearerUnavailable = makeUnavailableGitCredential({
+    kind: 'bearer',
+    audience: 'https://github.com',
+    onRevoke: () => {
+      revokeFired += 1;
+    },
+  });
+  t.is(bearerUnavailable.audience(), 'https://github.com');
+  const bearerController = getGitCredentialController(bearerUnavailable);
+  await E(bearerController).rotate({ token: 'restored-token' });
+  let bearerView = await E(bearerController).inspect();
+  t.like(bearerView, {
+    kind: 'bearer',
+    audience: 'https://github.com',
+    available: true,
+    revoked: false,
+  });
+
+  // Revoking a previously-restored Unavailable cap turns it back to
+  // unavailable and fires the onRevoke hook.
+  await E(bearerController).revoke();
+  bearerView = await E(bearerController).inspect();
+  t.like(bearerView, { available: false, revoked: true });
+  t.is(revokeFired, 1);
+});
+
+test('makeUnavailableGitCredential rejects kinds other than bearer or basic', async t => {
+  t.throws(
+    () =>
+      makeUnavailableGitCredential({
+        // @ts-expect-error — exercising the runtime guard
+        kind: 'oauth',
+        audience: 'https://github.com',
+      }),
+    { message: /GitCredential kind must be bearer or basic/ },
+  );
+});
+
+test('assertGitCredentialForUrl and revokeGitCredential reject non-daemon-minted caps', async t => {
+  // The two host-private helpers gate on WeakMap membership; a
+  // remote-shaped value that never went through the daemon's mint
+  // path has no record and is refused at the boundary.
+  const fakeCredential = Far('FakeGitCredential', {
+    audience: () => 'https://github.com',
+  });
+  t.throws(
+    () => assertGitCredentialForUrl(fakeCredential, 'https://github.com'),
+    { message: /requires a daemon-minted Git credential cap/ },
+  );
+  t.throws(() => revokeGitCredential(fakeCredential), {
+    message: /Cannot revoke a non-daemon Git credential cap/,
+  });
+});
+
+test('BearerCredential.audience returns the normalized origin', t => {
+  // The bearer cap's audience() method on the exo surface is the
+  // public read accessor a guest uses to inspect its credential's
+  // audience.  The basic cap's audience() is covered above.
+  const credential = makeBearerCredential({
+    audience: 'https://github.com',
+    token: 'a-token',
+  });
+  t.is(credential.audience(), 'https://github.com');
 });

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -853,6 +853,58 @@ test('GitRemote wildcard push policy binds source and destination names', async 
   });
 });
 
+test('GitRemote.push revalidates concrete tag overrides against allowTags', async t => {
+  // P2-3: a broad tag-disabled policy refspec (refs/heads/*:refs/*)
+  // wildcard-matches a concrete override pushing a branch to a tag
+  // (refs/heads/tags/v1 -> refs/tags/v1).  The force + wildcard check
+  // passes, but the concrete refspec must still be revalidated against
+  // the tag policy, or allowTags: false is bypassed.  Fail closed.
+  const { mount } = await provisionGitContext(t);
+  /** @type {unknown[]} */
+  const pushCalls = [];
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remotePush: async input => {
+      pushCalls.push(input);
+      return harden({ updatedRefs: [] });
+    },
+  });
+  const git = makeGit({ mount, backend });
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['push'],
+      fetchRefspecs: [],
+      // Broad, tag-disabled: dst wildcard reaches refs/tags/* but
+      // allowTags is false.
+      pushRefspecs: ['refs/heads/*:refs/*'],
+    },
+  });
+
+  await t.throwsAsync(
+    E(remote).push({
+      source: 'refs/heads/tags/v1',
+      destination: 'refs/tags/v1',
+    }),
+    { message: /tag refs require allowTags/ },
+  );
+  // The override never reached the backend transport.
+  t.deepEqual(pushCalls, []);
+
+  // Enabling allowTags lets the same concrete tag push through the gate.
+  await E(controller).setAllowTags(true);
+  await E(remote).push({
+    source: 'refs/heads/tags/v1',
+    destination: 'refs/tags/v1',
+  });
+  t.like(/** @type {{ refspecs?: string[] }} */ (pushCalls[0]), {
+    refspecs: ['refs/heads/tags/v1:refs/tags/v1'],
+  });
+});
+
 test('GitRemote.pull rejects an integration branch outside fetch policy', async t => {
   // P2-1: a fetch-only policy that may populate refs/remotes/origin/main
   // must not let the holder integrate an unrelated existing local ref

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -1,0 +1,947 @@
+// @ts-check
+/// <reference types="ses"/>
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify as nodePromisify } from 'node:util';
+
+import { E, Far } from '@endo/far';
+
+import { makeFilePowers } from '../src/daemon-node-powers.js';
+import {
+  makeBearerCredential,
+  getGitCredentialController,
+  revokeGitCredential,
+} from '../src/git-credential.js';
+import { makeMount } from '../src/mount.js';
+import { makeGit, makeNotYetImplementedBackend } from '../src/git.js';
+import { makeNativeGitBackend } from '../src/native-git-backend.js';
+import { makeGitRemote, getGitRemoteController } from '../src/git-remote.js';
+
+const execFileAsync = nodePromisify(execFile);
+const exampleCredential = () =>
+  makeBearerCredential({
+    audience: 'https://github.com',
+    token: 'test-token',
+  });
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ */
+const provisionGitContext = async t => {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'git-remote-'));
+  t.teardown(() => fs.promises.rm(root, { recursive: true, force: true }));
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '--allow-empty',
+      '-m',
+      'init',
+    ],
+    { cwd: root },
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: root, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot: root });
+  await backend.assertRepositoryRoot();
+  const git = makeGit({ mount, backend });
+  return { git, mount, root };
+};
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} sourceRepo
+ */
+const provisionBareRemote = async (t, sourceRepo) => {
+  const remoteParent = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'git-remote-bare-'),
+  );
+  t.teardown(() =>
+    fs.promises.rm(remoteParent, { recursive: true, force: true }),
+  );
+  const remoteRoot = path.join(remoteParent, 'remote.git');
+  await execFileAsync('git', ['clone', '--bare', sourceRepo, remoteRoot]);
+  return remoteRoot;
+};
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} remoteRoot
+ */
+const advanceRemoteMain = async (t, remoteRoot) => {
+  const cloneRoot = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'git-remote-upstream-'),
+  );
+  t.teardown(() => fs.promises.rm(cloneRoot, { recursive: true, force: true }));
+  await execFileAsync('git', ['clone', remoteRoot, cloneRoot]);
+  await fs.promises.writeFile(
+    path.join(cloneRoot, 'upstream.txt'),
+    'upstream\n',
+  );
+  await execFileAsync('git', ['add', 'upstream.txt'], { cwd: cloneRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'upstream'],
+    { cwd: cloneRoot },
+  );
+  await execFileAsync('git', ['push', 'origin', 'main'], { cwd: cloneRoot });
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'main'], {
+    cwd: cloneRoot,
+  });
+  return stdout.trim();
+};
+
+test('makeGitRemote produces a paired (remote, controller) facet', async t => {
+  const { git } = await provisionGitContext(t);
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+      pushRefspecs: [],
+    },
+  });
+  t.truthy(remote);
+  t.truthy(controller);
+  t.is(getGitRemoteController(remote), controller);
+  t.is(getGitRemoteController({}), undefined);
+});
+
+test('GitRemote.inspect returns the current policy snapshot', async t => {
+  const { git } = await provisionGitContext(t);
+  const { remote } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch', 'push'],
+      fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+      pushRefspecs: [],
+      allowedBranches: ['refs/heads/agent/*'],
+      allowForcePush: false,
+      allowTags: false,
+      allowDelete: false,
+    },
+  });
+  const snapshot = await E(remote).inspect();
+  t.is(snapshot.name, 'origin');
+  t.is(snapshot.url, 'https://github.com/example/repo.git');
+  t.deepEqual([...snapshot.allowedDirections].sort(), ['fetch', 'push']);
+  t.deepEqual(
+    [...snapshot.pushRefspecs],
+    ['refs/heads/agent/*:refs/heads/agent/*'],
+  );
+  t.false(snapshot.allowForcePush);
+});
+
+test('GitRemote validates endpoint and refspec policy at construction', async t => {
+  const { git } = await provisionGitContext(t);
+  const basePolicy = harden({
+    url: 'https://github.com/example/repo.git',
+    allowedDirections: /** @type {Array<'fetch' | 'push'>} */ (['fetch']),
+    fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+    pushRefspecs: /** @type {string[]} */ ([]),
+  });
+
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: { ...basePolicy, url: 'http://github.com/example/repo.git' },
+      }),
+    { message: /must use https/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          ...basePolicy,
+          url: 'file:///tmp/repo.git',
+        },
+      }),
+    { message: /must use https/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          ...basePolicy,
+          url: 'https://token@github.com/example/repo.git',
+        },
+      }),
+    { message: /embedded credentials/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: { ...basePolicy, fetchRefspecs: ['main:origin/main'] },
+      }),
+    { message: /fully qualified/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          ...basePolicy,
+          fetchRefspecs: ['refs/heads/main:refs/heads/main'],
+        },
+      }),
+    { message: /refs\/remotes\/origin/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          ...basePolicy,
+          allowedDirections: ['push'],
+          pushRefspecs: [],
+        },
+      }),
+    { message: /allows push but has no pushRefspecs/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          ...basePolicy,
+          allowedDirections: ['push'],
+          pushRefspecs: ['+refs/heads/agent/x:refs/heads/agent/x'],
+        },
+      }),
+    { message: /force-push/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          ...basePolicy,
+          allowedDirections: ['push'],
+          pushRefspecs: ['refs/tags/v1:refs/tags/v1'],
+        },
+      }),
+    { message: /tag refs require allowTags/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          ...basePolicy,
+          allowedDirections: ['push'],
+          pushRefspecs: ['refs/heads/agent/*:refs/heads/agent/*'],
+          allowedBranches: ['agent/x'],
+        },
+      }),
+    { message: /choose allowedBranches or pushRefspecs/ },
+  );
+});
+
+test('GitRemote requires matching credential authority for HTTPS', async t => {
+  const { git } = await provisionGitContext(t);
+  const policy = harden({
+    url: 'https://github.com/example/repo.git',
+    allowedDirections: /** @type {Array<'fetch' | 'push'>} */ (['fetch']),
+    fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+    pushRefspecs: /** @type {string[]} */ ([]),
+  });
+
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        policy,
+      }),
+    { message: /HTTPS remotes require a Git credential cap/ },
+  );
+
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        credential: makeBearerCredential({
+          audience: 'https://gitlab.com',
+          token: 'wrong-host',
+        }),
+        policy,
+      }),
+    { message: /audience .* does not match remote origin/ },
+  );
+
+  const credential = exampleCredential();
+  const { remote } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential,
+    policy,
+  });
+  const snapshot = await E(remote).inspect();
+  t.false(Object.hasOwn(snapshot, 'credential'));
+
+  revokeGitCredential(credential);
+  await t.throwsAsync(E(remote).fetch({}), {
+    message: /credential .* revoked/,
+  });
+});
+
+test('GitRemote passes HTTPS credential material to backend transport only', async t => {
+  /** @type {object[]} */
+  const fetchCalls = [];
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remoteFetch: async input => {
+      fetchCalls.push(input);
+      return harden({ updatedRefs: harden([]), text: 'ok' });
+    },
+  });
+  const git = makeGit({ mount: Far('FakeMount', {}), backend });
+  const credential = exampleCredential();
+  const { remote } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential,
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+      pushRefspecs: [],
+    },
+  });
+
+  t.false(JSON.stringify(await E(remote).inspect()).includes('test-token'));
+  await E(remote).fetch();
+  t.is(fetchCalls.length, 1);
+  t.deepEqual(
+    /** @type {{ credential?: unknown }} */ (fetchCalls[0]).credential,
+    harden({ kind: 'bearer', material: harden({ token: 'test-token' }) }),
+  );
+});
+
+test('GitCredentialController rotates material used by existing remotes', async t => {
+  /** @type {object[]} */
+  const fetchCalls = [];
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remoteFetch: async input => {
+      fetchCalls.push(input);
+      return harden({ updatedRefs: harden([]), text: 'ok' });
+    },
+  });
+  const git = makeGit({ mount: Far('FakeMount', {}), backend });
+  const credential = exampleCredential();
+  const controller = getGitCredentialController(credential);
+  t.truthy(controller);
+  const { remote } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential,
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+      pushRefspecs: [],
+    },
+  });
+
+  await E(remote).fetch();
+  await E(controller).rotate({ token: 'new-token' });
+  await E(remote).fetch();
+  await E(controller).revoke();
+
+  t.deepEqual(
+    /** @type {{ credential?: unknown }} */ (fetchCalls[0]).credential,
+    harden({ kind: 'bearer', material: harden({ token: 'test-token' }) }),
+  );
+  t.deepEqual(
+    /** @type {{ credential?: unknown }} */ (fetchCalls[1]).credential,
+    harden({ kind: 'bearer', material: harden({ token: 'new-token' }) }),
+  );
+  await t.throwsAsync(E(remote).fetch(), {
+    message: /credential .* revoked/,
+  });
+  const view = await E(controller).inspect();
+  t.like(view, {
+    kind: 'bearer',
+    audience: 'https://github.com',
+    available: false,
+    revoked: true,
+  });
+});
+
+test('GitRemoteController.revoke during in-flight fetch prevents stale success', async t => {
+  /** @type {AbortSignal | undefined} */
+  let fetchSignal;
+  /** @type {(value?: unknown) => void} */
+  let fetchStartedResolve = () => {};
+  const fetchStarted = new Promise(resolve => {
+    fetchStartedResolve = resolve;
+  });
+  /** @type {(value: unknown) => void} */
+  let fetchResolve = () => {};
+  const fetchResult = new Promise(resolve => {
+    fetchResolve = resolve;
+  });
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remoteFetch: async input => {
+      fetchSignal = /** @type {{ signal?: AbortSignal }} */ (input).signal;
+      fetchStartedResolve();
+      return fetchResult;
+    },
+  });
+  const git = makeGit({ mount: Far('FakeMount', {}), backend });
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+      pushRefspecs: [],
+    },
+  });
+
+  const fetchP = E(remote).fetch();
+  await fetchStarted;
+  t.false(fetchSignal?.aborted);
+  await E(controller).revoke();
+  t.true(fetchSignal?.aborted);
+  fetchResolve(harden({ updatedRefs: harden([]), text: 'ok' }));
+
+  await t.throwsAsync(fetchP, { message: /revoked during fetch/ });
+  const audit = await E(controller).audit();
+  t.deepEqual(
+    audit.map(event => event.type),
+    ['create', 'revoke', 'fetch'],
+  );
+  t.like(audit[2], { type: 'fetch', outcome: 'error' });
+});
+
+test('GitCredentialController.rotate during in-flight fetch prevents stale success', async t => {
+  /** @type {object[]} */
+  const fetchCalls = [];
+  /** @type {AbortSignal | undefined} */
+  let fetchSignal;
+  /** @type {(value?: unknown) => void} */
+  let fetchStartedResolve = () => {};
+  const fetchStarted = new Promise(resolve => {
+    fetchStartedResolve = resolve;
+  });
+  /** @type {(value: unknown) => void} */
+  let fetchResolve = () => {};
+  const fetchResult = new Promise(resolve => {
+    fetchResolve = resolve;
+  });
+  let callCount = 0;
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remoteFetch: async input => {
+      fetchCalls.push(input);
+      fetchSignal = /** @type {{ signal?: AbortSignal }} */ (input).signal;
+      callCount += 1;
+      if (callCount === 1) {
+        fetchStartedResolve();
+        return fetchResult;
+      }
+      return harden({ updatedRefs: harden([]), text: 'ok' });
+    },
+  });
+  const git = makeGit({ mount: Far('FakeMount', {}), backend });
+  const credential = exampleCredential();
+  const credentialController = getGitCredentialController(credential);
+  t.truthy(credentialController);
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential,
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+      pushRefspecs: [],
+    },
+  });
+
+  const fetchP = E(remote).fetch();
+  await fetchStarted;
+  t.false(fetchSignal?.aborted);
+  await E(credentialController).rotate({ token: 'new-token' });
+  t.true(fetchSignal?.aborted);
+  fetchResolve(harden({ updatedRefs: harden([]), text: 'ok' }));
+
+  await t.throwsAsync(fetchP, {
+    message: /credential .* changed during fetch/,
+  });
+  t.deepEqual(
+    /** @type {{ credential?: unknown }} */ (fetchCalls[0]).credential,
+    harden({ kind: 'bearer', material: harden({ token: 'test-token' }) }),
+  );
+
+  await E(remote).fetch();
+  t.deepEqual(
+    /** @type {{ credential?: unknown }} */ (fetchCalls[1]).credential,
+    harden({ kind: 'bearer', material: harden({ token: 'new-token' }) }),
+  );
+  const audit = await E(controller).audit();
+  t.deepEqual(
+    audit.map(event => event.type),
+    ['create', 'fetch', 'fetch'],
+  );
+  t.like(audit[1], { type: 'fetch', outcome: 'error' });
+  t.like(audit[2], { type: 'fetch', outcome: 'ok' });
+});
+
+test('GitRemoteController.revoke during in-flight pull aborts before local integration', async t => {
+  /** @type {AbortSignal | undefined} */
+  let fetchSignal;
+  /** @type {(value?: unknown) => void} */
+  let fetchStartedResolve = () => {};
+  const fetchStarted = new Promise(resolve => {
+    fetchStartedResolve = resolve;
+  });
+  /** @type {(value: unknown) => void} */
+  let fetchResolve = () => {};
+  const fetchResult = new Promise(resolve => {
+    fetchResolve = resolve;
+  });
+  let mergeCalled = false;
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remoteFetch: async input => {
+      fetchSignal = /** @type {{ signal?: AbortSignal }} */ (input).signal;
+      fetchStartedResolve();
+      return fetchResult;
+    },
+    merge: async () => {
+      mergeCalled = true;
+      return 'merged';
+    },
+  });
+  const git = makeGit({ mount: Far('FakeMount', {}), backend });
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: ['refs/heads/main:refs/remotes/origin/main'],
+      pushRefspecs: [],
+    },
+  });
+
+  const pullP = E(remote).pull({
+    branch: 'refs/remotes/origin/main',
+    strategy: 'ff-only',
+  });
+  await fetchStarted;
+  t.false(fetchSignal?.aborted);
+  await E(controller).revoke();
+  t.true(fetchSignal?.aborted);
+  fetchResolve(harden({ updatedRefs: harden([]), text: 'ok' }));
+
+  await t.throwsAsync(pullP, { message: /revoked during pull/ });
+  t.false(mergeCalled);
+  const audit = await E(controller).audit();
+  t.deepEqual(
+    audit.map(event => event.type),
+    ['create', 'revoke', 'pull'],
+  );
+  t.like(audit[2], { type: 'pull', outcome: 'error' });
+});
+
+test('GitRemote fetch / pull / push use the bounded native data plane', async t => {
+  const { git, mount, root } = await provisionGitContext(t);
+  const remoteRoot = await provisionBareRemote(t, root);
+  const remoteUrl = pathToFileURL(remoteRoot).href;
+  const remoteHead = await advanceRemoteMain(t, remoteRoot);
+
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    policy: {
+      url: remoteUrl,
+      allowLocalFileTransport: true,
+      allowedDirections: ['fetch', 'push'],
+      fetchRefspecs: ['+refs/heads/main:refs/remotes/origin/main'],
+      pushRefspecs: ['refs/heads/agent/*:refs/heads/agent/*'],
+      allowDelete: true,
+    },
+  });
+
+  const fetchResult = await E(remote).fetch({ prune: true });
+  const fetchUpdates = [...fetchResult.updatedRefs];
+  t.is(fetchUpdates.length, 1);
+  t.deepEqual(fetchUpdates[0], {
+    local: {
+      name: 'refs/remotes/origin/main',
+      kind: 'branch',
+      oid: remoteHead,
+    },
+    remote: 'refs/heads/main',
+    result: 'created',
+  });
+  const fetched = await E(git).revParse('refs/remotes/origin/main');
+  t.is(fetched.oid, remoteHead);
+
+  const pullResult = await E(remote).pull({
+    branch: 'refs/remotes/origin/main',
+    strategy: 'ff-only',
+  });
+  t.is(pullResult.integration, 'ff-only');
+  t.deepEqual(
+    [...pullResult.fetch.updatedRefs],
+    [
+      {
+        local: {
+          name: 'refs/remotes/origin/main',
+          kind: 'branch',
+          oid: remoteHead,
+        },
+        remote: 'refs/heads/main',
+        result: 'up-to-date',
+      },
+    ],
+  );
+  t.is(await E(mount).readText(['upstream.txt']), 'upstream\n');
+
+  await E(git).createBranch('agent/topic', { switchAfterCreate: true });
+  const note = await E(mount).entry(['agent.txt']);
+  await E(mount).writeText(note, 'agent\n');
+  await E(git).add([note]);
+  await E(git).commit('test: agent branch');
+  const pushResult = await E(remote).push({
+    source: 'refs/heads/agent/topic',
+    destination: 'refs/heads/agent/topic',
+    setUpstream: true,
+  });
+  const { stdout: pushedRef } = await execFileAsync(
+    'git',
+    ['show-ref', '--hash', 'refs/heads/agent/topic'],
+    { cwd: remoteRoot },
+  );
+  const pushedOid = pushedRef.trim();
+  t.regex(pushedOid, /^[0-9a-f]{40}$/u);
+  t.deepEqual(
+    [...pushResult.updatedRefs],
+    [
+      {
+        local: {
+          name: 'refs/heads/agent/topic',
+          kind: 'branch',
+          oid: pushedOid,
+        },
+        remote: 'refs/heads/agent/topic',
+        result: 'created',
+      },
+    ],
+  );
+  const { stdout: upstreamRemote } = await execFileAsync(
+    'git',
+    ['config', '--get', 'branch.agent/topic.remote'],
+    { cwd: root },
+  );
+  const { stdout: upstreamMerge } = await execFileAsync(
+    'git',
+    ['config', '--get', 'branch.agent/topic.merge'],
+    { cwd: root },
+  );
+  t.is(upstreamRemote.trim(), remoteUrl);
+  t.is(upstreamMerge.trim(), 'refs/heads/agent/topic');
+
+  const audit = await E(controller).audit();
+  t.deepEqual(
+    audit.map(event => event.type),
+    ['create', 'fetch', 'pull', 'push'],
+  );
+  t.like(audit[1], { type: 'fetch', outcome: 'ok' });
+  t.like(audit[2], { type: 'pull', outcome: 'ok', integration: 'ff-only' });
+  t.like(audit[3], { type: 'push', outcome: 'ok' });
+  t.deepEqual([...audit[3].updatedRefs], [...pushResult.updatedRefs]);
+});
+
+test('GitRemote enforces allowedDirections at the call boundary', async t => {
+  const { git } = await provisionGitContext(t);
+  // Fetch-only policy: push must be refused before transport is reached.
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: [],
+      pushRefspecs: [],
+    },
+  });
+  await t.throwsAsync(E(remote).push({}), {
+    message: /does not permit "push"/,
+  });
+  const audit = await E(controller).audit();
+  t.deepEqual(
+    audit.map(event => event.type),
+    ['create', 'push'],
+  );
+  t.like(audit[1], { type: 'push', outcome: 'error' });
+  t.regex(audit[1].message, /does not permit "push"/);
+});
+
+test('GitRemote enforces tag and prune policy at the call boundary', async t => {
+  const { mount } = await provisionGitContext(t);
+  /** @type {unknown[]} */
+  const fetchCalls = [];
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remoteFetch: async input => {
+      fetchCalls.push(input);
+      return harden({ updatedRefs: [] });
+    },
+  });
+  const git = makeGit({ mount, backend });
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+      pushRefspecs: [],
+    },
+  });
+
+  await t.throwsAsync(E(remote).fetch({ tags: true }), {
+    message: /tags require allowTags/,
+  });
+  await t.throwsAsync(E(remote).pull({ prune: true }), {
+    message: /prune requires allowDelete/,
+  });
+  t.deepEqual(fetchCalls, []);
+
+  await E(controller).setAllowTags(true);
+  await E(controller).setAllowDelete(true);
+  await E(remote).fetch({ tags: true, prune: true });
+  t.like(/** @type {{ tags?: boolean, prune?: boolean }} */ (fetchCalls[0]), {
+    tags: true,
+    prune: true,
+  });
+});
+
+test('GitRemote wildcard push policy binds source and destination names', async t => {
+  const { mount } = await provisionGitContext(t);
+  /** @type {unknown[]} */
+  const pushCalls = [];
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remotePush: async input => {
+      pushCalls.push(input);
+      return harden({ updatedRefs: [] });
+    },
+  });
+  const git = makeGit({ mount, backend });
+  const { remote } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['push'],
+      fetchRefspecs: [],
+      pushRefspecs: ['refs/heads/safe/*:refs/heads/safe/*'],
+    },
+  });
+
+  await t.throwsAsync(
+    E(remote).push({
+      source: 'refs/heads/safe/topic-a',
+      destination: 'refs/heads/safe/topic-b',
+    }),
+    { message: /outside policy/ },
+  );
+  t.deepEqual(pushCalls, []);
+
+  await E(remote).push({
+    source: 'refs/heads/safe/topic-a',
+    destination: 'refs/heads/safe/topic-a',
+  });
+  t.like(/** @type {{ refspecs?: string[] }} */ (pushCalls[0]), {
+    refspecs: ['refs/heads/safe/topic-a:refs/heads/safe/topic-a'],
+  });
+});
+
+test('makeGitRemote rejects a read-only Git cap', async t => {
+  const { git } = await provisionGitContext(t);
+  const readOnlyGit = await E(git).readOnly();
+  t.throws(
+    () =>
+      makeGitRemote({
+        git: readOnlyGit,
+        name: 'origin',
+        credential: exampleCredential(),
+        policy: {
+          url: 'https://github.com/example/repo.git',
+          allowedDirections: ['fetch'],
+          fetchRefspecs: [],
+          pushRefspecs: [],
+        },
+      }),
+    { message: /read-only Git/ },
+  );
+});
+
+test('GitRemoteController mutates policy, snapshot reflects the change', async t => {
+  const { git } = await provisionGitContext(t);
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: [],
+      pushRefspecs: [],
+    },
+  });
+  // Configure a push target, widen to allow push, then narrow back.
+  await E(controller).setAllowedBranches(['agent/x']);
+  await E(controller).setAllowedDirections(['fetch', 'push']);
+  let snapshot = await E(remote).inspect();
+  t.deepEqual([...snapshot.allowedDirections].sort(), ['fetch', 'push']);
+  t.deepEqual(
+    [...snapshot.pushRefspecs],
+    ['refs/heads/agent/x:refs/heads/agent/x'],
+  );
+
+  await E(controller).setAllowedDirections(['fetch']);
+  snapshot = await E(remote).inspect();
+  t.deepEqual([...snapshot.allowedDirections], ['fetch']);
+
+  // The controller's inspect also reports the revoked flag.
+  const controllerView = await E(controller).inspect();
+  t.false(controllerView.revoked);
+  const audit = await E(controller).audit();
+  t.deepEqual(
+    audit.map(event => event.type),
+    ['create', 'policy', 'policy', 'policy'],
+  );
+  t.deepEqual(audit.map(event => event.method).slice(1), [
+    'setAllowedBranches',
+    'setAllowedDirections',
+    'setAllowedDirections',
+  ]);
+});
+
+test('GitRemoteController.revoke makes all remote ops refuse', async t => {
+  const { git } = await provisionGitContext(t);
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: [],
+      pushRefspecs: [],
+    },
+  });
+  await E(controller).revoke();
+
+  // Every guest-visible operation now refuses.  The controller still
+  // works so the host can inspect after revocation.
+  await t.throwsAsync(E(remote).inspect(), { message: /has been revoked/ });
+  await t.throwsAsync(E(remote).fetch({}), { message: /has been revoked/ });
+  const view = await E(controller).inspect();
+  t.true(view.revoked);
+  const audit = await E(controller).audit();
+  t.deepEqual(
+    audit.map(event => event.type),
+    ['create', 'revoke', 'fetch'],
+  );
+  t.like(audit[2], { type: 'fetch', outcome: 'error' });
+});
+
+test('makeGitRemote rejects an empty url or empty name', async t => {
+  const { git } = await provisionGitContext(t);
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: '',
+        policy: {
+          url: 'https://x',
+          allowedDirections: ['fetch'],
+          fetchRefspecs: [],
+          pushRefspecs: [],
+        },
+      }),
+    { message: /non-empty string/ },
+  );
+  t.throws(
+    () =>
+      makeGitRemote({
+        git,
+        name: 'origin',
+        policy: {
+          url: '',
+          allowedDirections: ['fetch'],
+          fetchRefspecs: [],
+          pushRefspecs: [],
+        },
+      }),
+    { message: /non-empty url/ },
+  );
+});
+
+test('getGitRemoteController rejects fabricated remote exos', async t => {
+  // A spoof exo cannot recover the controller — the WeakMap is the
+  // only entry point, and spoofs never landed in it.
+  const fake = Far('FakeGitRemote', {
+    inspect: () => Promise.resolve({}),
+    fetch: () => Promise.reject(new Error('spoof')),
+    pull: () => Promise.reject(new Error('spoof')),
+    push: () => Promise.reject(new Error('spoof')),
+  });
+  t.is(getGitRemoteController(fake), undefined);
+});

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -853,6 +853,64 @@ test('GitRemote wildcard push policy binds source and destination names', async 
   });
 });
 
+test('GitRemote.pull rejects an integration branch outside fetch policy', async t => {
+  // P2-1: a fetch-only policy that may populate refs/remotes/origin/main
+  // must not let the holder integrate an unrelated existing local ref
+  // (refs/heads/private) it never fetched.  The fetch succeeds; the
+  // local merge/rebase step must reject the out-of-policy branch before
+  // E(git).merge is ever reached.
+  const { mount } = await provisionGitContext(t);
+  /** @type {unknown[]} */
+  const fetchCalls = [];
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    remoteFetch: async input => {
+      fetchCalls.push(input);
+      return harden({ updatedRefs: [] });
+    },
+  });
+  const git = makeGit({ mount, backend });
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    credential: exampleCredential(),
+    policy: {
+      url: 'https://github.com/example/repo.git',
+      allowedDirections: ['fetch'],
+      fetchRefspecs: ['+refs/heads/main:refs/remotes/origin/main'],
+      pushRefspecs: [],
+    },
+  });
+
+  // The out-of-policy branch is rejected by the policy gate before the
+  // local integration (merge) is reached.
+  await t.throwsAsync(
+    E(remote).pull({ branch: 'refs/heads/private', strategy: 'merge' }),
+    { message: /pull branch is outside fetch policy/ },
+  );
+  // The fetch ran (it is within policy).
+  t.is(fetchCalls.length, 1);
+
+  // A branch matching the fetch destination passes the policy gate and
+  // proceeds to the integration step, where it fails for a non-policy
+  // reason (the fake fetch populated no real ref to merge).  The error
+  // must NOT be the out-of-policy rejection — that proves the gate let
+  // the in-policy branch through.
+  const passedGate = await E(remote)
+    .pull({ branch: 'refs/remotes/origin/main', strategy: 'merge' })
+    .then(
+      () => undefined,
+      err => /** @type {Error} */ (err),
+    );
+  t.truthy(passedGate);
+  t.notRegex(/** @type {Error} */ (passedGate).message, /outside fetch policy/);
+
+  const audit = await E(controller).audit();
+  const firstPull = audit.find(event => event.type === 'pull');
+  t.like(firstPull, { type: 'pull', outcome: 'error' });
+  t.regex(firstPull.message, /outside fetch policy/);
+});
+
 test('makeGitRemote rejects non-boolean allow flags at construction', async t => {
   // P2-2: allow* flags are policy authority gates.  A non-boolean must
   // be rejected, not truthiness-coerced — allowLocalFileTransport:

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -853,6 +853,62 @@ test('GitRemote wildcard push policy binds source and destination names', async 
   });
 });
 
+test('makeGitRemote rejects non-boolean allow flags at construction', async t => {
+  // P2-2: allow* flags are policy authority gates.  A non-boolean must
+  // be rejected, not truthiness-coerced — allowLocalFileTransport:
+  // 'false' is a string and would otherwise enable file: transport.
+  const { git } = await provisionGitContext(t);
+  const basePolicy = harden({
+    url: 'https://github.com/example/repo.git',
+    allowedDirections: /** @type {Array<'fetch' | 'push'>} */ (['fetch']),
+    fetchRefspecs: ['+refs/heads/*:refs/remotes/origin/*'],
+    pushRefspecs: /** @type {string[]} */ ([]),
+  });
+  /** @type {Array<[string, RegExp]>} */
+  const cases = [
+    ['allowLocalFileTransport', /allowLocalFileTransport must be a boolean/],
+    ['allowForcePush', /allowForcePush must be a boolean/],
+    ['allowTags', /allowTags must be a boolean/],
+    ['allowDelete', /allowDelete must be a boolean/],
+  ];
+  for (const [flag, message] of cases) {
+    // The string 'false' is truthy; without a type-check it would
+    // enable the flag.
+    t.throws(
+      () =>
+        makeGitRemote({
+          git,
+          name: 'origin',
+          credential: exampleCredential(),
+          policy: /** @type {any} */ ({ ...basePolicy, [flag]: 'false' }),
+        }),
+      { message },
+      `${flag} 'false' rejected`,
+    );
+    // A numeric 1 is truthy too.
+    t.throws(
+      () =>
+        makeGitRemote({
+          git,
+          name: 'origin',
+          credential: exampleCredential(),
+          policy: /** @type {any} */ ({ ...basePolicy, [flag]: 1 }),
+        }),
+      { message },
+      `${flag} 1 rejected`,
+    );
+  }
+  // Real booleans and omitted flags still construct.
+  t.notThrows(() =>
+    makeGitRemote({
+      git,
+      name: 'origin',
+      credential: exampleCredential(),
+      policy: { ...basePolicy, allowTags: true, allowDelete: false },
+    }),
+  );
+});
+
 test('makeGitRemote rejects a read-only Git cap', async t => {
   const { git } = await provisionGitContext(t);
   const readOnlyGit = await E(git).readOnly();

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -288,7 +288,8 @@ test('Git.readOnly allows immutable tree reads', async t => {
 
 test('Git scaffold methods all surface a clear "not yet implemented"', async t => {
   const mount = await provisionMount(t);
-  const git = makeGit({ mount, backend: makeNotYetImplementedBackend() });
+  const backend = makeNotYetImplementedBackend();
+  const git = makeGit({ mount, backend });
 
   // A representative sample across category boundaries; the stub backend
   // throws for every op except the formula-instantiation-time
@@ -300,6 +301,18 @@ test('Git scaffold methods all surface a clear "not yet implemented"', async t =
   });
   await t.throwsAsync(E(git).branches(), { message: /not yet implemented/ });
   await t.throwsAsync(E(git).tree('HEAD'), {
+    message: /not yet implemented/,
+  });
+
+  // The remote-transport methods are not on the Git exo; they are
+  // called by GitRemote directly against the backend.  The stub
+  // backend reports the same not-yet-implemented error so a remote
+  // mounted against an under-development backend fails closed rather
+  // than appearing to fetch / push silently.
+  await t.throwsAsync(backend.remoteFetch({}), {
+    message: /not yet implemented/,
+  });
+  await t.throwsAsync(backend.remotePush({}), {
     message: /not yet implemented/,
   });
 

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -5,6 +5,7 @@ import test from '@endo/ses-ava/prepare-endo.js';
 
 import { Buffer } from 'node:buffer';
 import fs from 'node:fs';
+import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -623,6 +624,86 @@ test('NativeGitBackend version parser enforces the documented git floor', t => {
   t.throws(() => assertSupportedGitVersion('git version 2.29.9'), {
     message: /requires git >= 2\.30\.0/,
   });
+});
+
+test('NativeGitBackend credential transport satisfies git HTTP auth challenge', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const backend = makeNativeGitBackend({ repoRoot });
+  /** @type {string[]} */
+  const authorizations = [];
+  const server = http.createServer((req, res) => {
+    const authorization = req.headers.authorization;
+    if (authorization !== undefined) {
+      authorizations.push(authorization);
+      res.writeHead(404);
+      res.end('not a git repository');
+      return;
+    }
+    res.writeHead(401, {
+      'WWW-Authenticate': 'Basic realm="Endo Git Test"',
+    });
+    res.end('auth required');
+  });
+  await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve(undefined));
+  });
+  const address = /** @type {import('node:net').AddressInfo} */ (
+    server.address()
+  );
+  try {
+    await t.throwsAsync(
+      backend.remoteFetch({
+        url: `http://127.0.0.1:${address.port}/repo.git`,
+        refspecs: [],
+        credential: harden({
+          kind: 'bearer',
+          material: harden({ token: 'test-token' }),
+        }),
+      }),
+      { message: /git fetch failed/ },
+    );
+  } finally {
+    await new Promise(resolve => {
+      server.close(() => resolve(undefined));
+    });
+  }
+
+  const expected = `Basic ${Buffer.from('x-access-token:test-token').toString(
+    'base64',
+  )}`;
+  t.true(authorizations.includes(expected));
+});
+
+test('NativeGitBackend.remoteFetch rejects repo-local URL rewrites', async t => {
+  const sourceRepo = await provisionGitWorktree(t);
+  const remoteParent = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'native-git-remote-'),
+  );
+  t.teardown(() =>
+    fs.promises.rm(remoteParent, { recursive: true, force: true }),
+  );
+  const remoteRoot = path.join(remoteParent, 'remote.git');
+  await execFileAsync('git', ['clone', '--bare', sourceRepo, remoteRoot]);
+
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync(
+    'git',
+    [
+      'config',
+      `url.file://${remoteRoot}.insteadOf`,
+      'https://trusted.example/repo',
+    ],
+    { cwd: repoRoot },
+  );
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await t.throwsAsync(
+    backend.remoteFetch({
+      url: 'https://trusted.example/repo',
+      refspecs: ['refs/heads/main:refs/remotes/origin/main'],
+    }),
+    { message: /repository config can alter remote transport.*url\./ },
+  );
 });
 
 test('NativeGitBackend.diff returns worktree changes by default', async t => {


### PR DESCRIPTION
Implements `designs/daemon-git-remotes.md`. Stacks on #364.

## Description

`GitRemote` is the remote half of the daemon git story, built as an explicit composition rather than ambient configuration: the local `Git` capability from #364, a separately authorized HTTPS transport, and a non-extractable credential, bundled into one capability that an agent calls directly for `fetch` / `pull` / `push`. Each of the three authorities is granted, revoked, and audited independently; a guest holding `GitRemote` never holds raw network sockets or readable secrets. `provideGitRemote(gitCap, name, opts)` validates the per-remote policy, refuses construction from a read-only `Git` (even `fetch` mutates object and ref state), and wires the binding through the formula table so policy survives daemon restart.

The `GitCredential` subsystem supplies the authentication-use authority: `provideBearerCredential(name, { audience, token })` and `provideBasicCredential(name, { audience, username, password })` mint credential caps whose secret material is held in daemon-process-local state, keyed by formula id, and never handed to the holder. Host-only controllers (`GitCredentialController`, `GitRemoteController`, reached via `getGitCredentialController` / `getGitRemoteController`) let the operator inspect, rotate, or revoke without invalidating an outstanding `GitRemote`. After a daemon restart the credential's `audience` and `kind` persist but the material does not; reincarnation routes the binding to an unavailable-credential cap until the originating host method re-provides it.

Policy is enforced at the call boundary, before any `git` invocation: per-remote fetch and push refspec policy, allowed directions, allowed branches, and wildcard / force / tag / delete gating. Recent P2 hardening closed three enforcement gaps — pull integration now restricted to fetch-policy refs, `allow*` flags type-checked so a truthy non-boolean cannot enable a transport, and concrete push overrides revalidated against tag/delete policy after a wildcard match. Credential material reaches `git` only through a daemon-owned `GIT_ASKPASS` helper fed over an anonymous pipe (fd-only), never via argv or env; repository-local `url.*.insteadOf` / `protocol.*` / `http.*` / `credential.*` / `core.sshcommand` / `core.gitproxy` / `ssh.*` / `include.*` config is refused so it cannot redirect the policy-bound endpoint.

### Security Considerations

Three authorities — local repository (`Git`), remote endpoint (the policy URL bound at construction), and credential (held as host-private material reachable only through the askpass socket) — are composed and separately granted. All refspec, direction, branch, tag, force-push, delete, and local-file-transport gates are checked at the call boundary; the P2 hardening above closed the pull-integration-ref, non-boolean-flag, and concrete-push-override gaps. Each gate is covered by a load-bearing regression test that fails closed against pre-fix code.

### Scaling Considerations

Git's bounded HTTPS data plane carries packfile bytes outside CapTP; only the policy-bound control-plane shape crosses CapTP. No per-call resource cost beyond the underlying `git` invocation.

### Documentation Considerations

The design lives at `designs/daemon-git-remotes.md` and depends on the public Git cap from #364. The askpass envelope ships fd-only in this phase; migrating credential sourcing to the capability bank for unattended multi-repo post-restart workflows is the design's tracked follow-up, as are SSH-transport, `provideGitClone` bootstrap, and the IPv6 / Windows host-matrix spike notes.

### Testing Considerations

`packages/daemon/test/git-remote.test.js` covers construction validation, every policy axis at the call boundary, credential rotation and revocation during an in-flight `fetch` / `pull`, the bounded native data plane against a local git server, refusal against a read-only or spoofed `Git`, and the three P2 gates (each fails closed against pre-fix code).

### Compatibility Considerations

N/A — new surface.

### Upgrade Considerations

`git-remote` policy survives restart; the controller rejects updates that would resurrect a non-remote formula at the same id. `git-credential` persists `audience` and `kind`; the secret is daemon-process-local and re-provided through the originating host method after restart.
