### PR TITLE
SPIKE docs(daemon): draft daemon-git-backbone substrate-swap design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,8 +1088,10 @@ dependencies = [
  "criterion",
  "endo_iroh",
  "gix-hash",
+ "gix-lock",
  "gix-object",
  "gix-odb",
+ "gix-ref",
  "hex",
  "libc",
  "rusqlite",
@@ -1507,6 +1509,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-lock"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-object"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1597,38 @@ dependencies = [
  "bstr",
  "gix-error",
  "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
+dependencies = [
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,12 +210,6 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -271,27 +265,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde_core",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -355,6 +332,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -827,38 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
-dependencies = [
- "defmt-parser",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,7 +930,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "block2",
  "libc",
  "objc2",
@@ -1087,11 +1034,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "endo_iroh",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-odb",
- "gix-ref",
+ "git2",
  "hex",
  "libc",
  "rusqlite",
@@ -1152,16 +1095,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "faster-hex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
-dependencies = [
- "heapless",
- "serde",
-]
 
 [[package]]
 name = "fastrand"
@@ -1389,6 +1322,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -1396,7 +1341,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -1414,246 +1359,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-actor"
-version = "0.41.1"
+name = "git2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bstr",
- "gix-date",
- "gix-error",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
-dependencies = [
- "gix-error",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
-dependencies = [
- "bstr",
- "gix-error",
- "itoa",
- "jiff",
-]
-
-[[package]]
-name = "gix-error"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
-dependencies = [
- "crc32fast",
- "gix-path",
- "gix-trace",
- "gix-utils",
+ "bitflags",
  "libc",
- "prodash",
- "thiserror 2.0.18",
- "walkdir",
- "zlib-rs",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features",
- "gix-path",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
-dependencies = [
- "faster-hex",
- "gix-features",
- "sha1-checked",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
-dependencies = [
- "gix-hash",
- "hashbrown 0.17.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-lock"
-version = "23.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525"
-dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-utils",
- "gix-validate",
- "itoa",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.81.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d"
-dependencies = [
- "arc-swap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-pack",
- "gix-path",
- "gix-quote",
- "memmap2",
- "parking_lot",
- "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pack"
-version = "0.71.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174"
-dependencies = [
- "gix-chunk",
- "gix-error",
- "gix-features",
- "gix-hash",
- "gix-object",
- "gix-path",
- "memmap2",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
-dependencies = [
- "bstr",
- "gix-error",
- "gix-utils",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b"
-dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-utils",
- "gix-validate",
- "memmap2",
- "thiserror",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "23.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
-dependencies = [
- "gix-fs",
- "libc",
- "parking_lot",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
-
-[[package]]
-name = "gix-utils"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
-dependencies = [
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
-dependencies = [
- "bstr",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -1699,15 +1413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,16 +1448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -2382,48 +2077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
-dependencies = [
- "defmt",
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-link",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,6 +2151,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,12 +2191,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.5+1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2619,15 +2306,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memmap2"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2768,7 +2446,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "log",
  "netlink-packet-core",
@@ -2780,7 +2458,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "log",
  "netlink-packet-core",
@@ -3006,7 +2684,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "block2",
  "dispatch2",
  "libc",
@@ -3019,7 +2697,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3039,7 +2717,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "block2",
  "libc",
  "objc2",
@@ -3052,7 +2730,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3073,7 +2751,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "dispatch2",
  "libc",
  "objc2",
@@ -3326,15 +3004,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "portmapper"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,43 +3111,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prodash"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]
@@ -3498,6 +3136,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -3587,7 +3231,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3682,7 +3326,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3711,7 +3355,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3851,7 +3495,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3954,27 +3598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1-checked"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
-dependencies = [
- "digest 0.10.7",
- "sha1",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,7 +3693,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4214,7 +3837,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4503,7 +4126,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -4606,15 +4229,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -4868,7 +4482,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5242,7 +4856,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "windows-sys 0.59.0",
 ]
 
@@ -5304,7 +4918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -5555,12 +5169,6 @@ dependencies = [
  "thiserror 2.0.18",
  "zopfli",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -265,10 +271,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -804,6 +827,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,7 +983,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -1032,6 +1087,9 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "endo_iroh",
+ "gix-hash",
+ "gix-object",
+ "gix-odb",
  "hex",
  "libc",
  "rusqlite",
@@ -1092,6 +1150,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "fastrand"
@@ -1344,6 +1412,206 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-actor"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
+dependencies = [
+ "crc32fast",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.17.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.81.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.71.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174"
+dependencies = [
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+
+[[package]]
+name = "gix-utils"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
+dependencies = [
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1421,6 +1698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1804,7 +2091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2050,6 +2337,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,9 +2478,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2210,7 +2539,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2245,6 +2574,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2385,7 +2723,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -2397,7 +2735,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -2623,7 +2961,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "block2",
  "dispatch2",
  "libc",
@@ -2636,7 +2974,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2656,7 +2994,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -2669,7 +3007,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2690,7 +3028,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "dispatch2",
  "libc",
  "objc2",
@@ -2943,6 +3281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portmapper"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,12 +3397,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -3164,7 +3542,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3259,7 +3637,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3288,7 +3666,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3428,7 +3806,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3531,6 +3909,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,7 +4025,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3770,7 +4169,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4059,7 +4458,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4162,6 +4561,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -4415,7 +4823,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4789,7 +5197,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "windows-sys 0.59.0",
 ]
 
@@ -4851,7 +5259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -5102,6 +5510,12 @@ dependencies = [
  "thiserror 2.0.18",
  "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/designs/README.md
+++ b/designs/README.md
@@ -174,6 +174,7 @@ LLM-agent stack).*
 | [daemon-git-remotes](daemon-git-remotes.md) | 2026-05-18 | 2026-05-29 | Proposed |
 | [daemon-git-next-steps](daemon-git-next-steps.md) | 2026-05-27 | 2026-06-03 | Proposed |
 | [endo-fs-from-git](endo-fs-from-git.md) | 2026-05-28 | 2026-05-28 | In Progress |
+| [daemon-git-backbone](daemon-git-backbone.md) | 2026-05-27 | 2026-05-28 | Proposed |
 | [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-05-19 | In Progress (PR #287) |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-05-27 | In Progress |
 | [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-05-27 | **Complete** |
@@ -417,6 +418,7 @@ flowchart TD
         dgit[daemon-git-capability]
         dgitremote[daemon-git-remotes]
         dgitnext[daemon-git-next-steps]
+        dgitback[daemon-git-backbone]
         dfsw[filesystem-watchers]
         dcsgc[daemon-content-store-gc]
         dpers[daemon-capability-persona]
@@ -444,6 +446,8 @@ flowchart TD
         dgitremote --> dtools
         enetfetch --> dgitremote
         dmount --> dcsgc
+        ercas --> dgitback
+        dcsgc --> dgitback
         dsand --> dbank
         dfs --> dbank
         dpers --> dbank
@@ -593,6 +597,7 @@ capabilities available to agents.
 | daemon-git-capability | Proposed | Revised git design over `EndoMount` / `EndoMountEntry`; `tree(ref)` and `readOnly()` both live on the `Git` cap |
 | daemon-git-remotes | Proposed | MVP remote-git companion: fetch / pull / push composed from local `Git`, bounded HTTPS transport, endpoint policy, and credential caps |
 | daemon-git-next-steps | Proposed | The version-controlled filesystem loop milestone over the canonical trio: north-star agent loop (provide workspace → read/list/edit → status/diff → commit → pull/push → inspect history via `filesystemAt(ref)`) and the content/versioning/network/historical-read/bulk-storage layer split. Open `- [ ]` work: worked bot-fork reference flow, `provideGitClone` + identity boundary (→ `daemon-git-clone.md`), `tree(ref)`/`filesystemAt(ref)` reconciliation. Agent-tools layer deferred to #416 |
+| daemon-git-backbone | Proposed | Back the existing Rust CAS (`rust/endo/src/cas.rs`) with git, all four axes: objects → git object DB (sha256-keyed), `TreeManifest` → git trees, bulk transport off CapTP onto pack/smart-protocol, retention → `refs/formulas/<id>` + `git gc`. In-process `gix` (recommended) in the `endor` supervisor; sha256 stays the content key behind a sha256→oid index. Migrations out of scope. Four axes; each probe-able separately |
 | filesystem-watchers | Not Started | `EndoMount.followNameChanges` parity with `EndoDirectory`; Node `fs.watch` adapter on `FilePowers` |
 | daemon-locator-terminology | Not Started | Clean locator API; unblocked |
 | daemon-rename-to-manager | Not Started | Rename `daemon.js`/`Daemon`/`MignonicPowers` to `manager.js`/`Manager`/`WorkerPowers` to align JS with Rust `endor` nomenclature |
@@ -1181,6 +1186,7 @@ have been remapped: 0 → 1, ½ → 2, 1 → 3, 2 → 4, 3 → 7, 4 → 9,
 | ~~platform-fs~~ | S-M | — | 3 | ✅ Complete; `@endo/platform` package landed on `llm` (commit `e0dda06fb`); PR #122 carried review-cycle fixups |
 | daemon-capability-filesystem | L | — | 3 | Reference sketch; narrower mount slice ships via daemon-mount |
 | ~~daemon-content-store-gc~~ | S | — | 3 | ✅ Complete (PR #99, ~2 days actual vs 1 day estimate) |
+| daemon-git-backbone | XL | TBD | 3 | Back the existing Rust CAS with git across four axes (objects, trees, transport, GC-via-refs); maintainer-call dominant (gix-vs-git2, sha256-key-vs-object-format). Size XL pending per-axis probe; each axis lands as its own probe-then-build cycle on the Rust substrate |
 | daemon-mount | M-L | 1.5 weeks | 3 | Mount exo, symlink confinement; Phase 4 in PR #135 forwarded under bot |
 | daemon-worker-import-from-mount | S-M | 3-4 days | 3 | **Integration layer** of the four-layer stack (decomposed 2026-06-02). `makeFromPackage` host method + `makeFromMount` dispatcher + CLI `endo run <mount>` / `endo make <mount>` + XS bridging deferral. Driven by the three preceding layers (`registry-capability`, `mvs-resolver`, `snapshot-mapper`); first cut limited to MVS; lockfile honoring deferred. Does not depend on the Rust subsystem (separate lane). |
 | registry-capability | S-M | 3 days | 3 | Layer 1 of 4. `EndoRegistry` exo + `@registry` host special name + `HostFormula.registry` migration pass. Structured `@endo/errors` failure surface. JS reference backend default; Rust drop-in deferred to Phase 5 |

--- a/designs/README.md
+++ b/designs/README.md
@@ -174,7 +174,7 @@ LLM-agent stack).*
 | [daemon-git-remotes](daemon-git-remotes.md) | 2026-05-18 | 2026-05-29 | Proposed |
 | [daemon-git-next-steps](daemon-git-next-steps.md) | 2026-05-27 | 2026-06-03 | Proposed |
 | [endo-fs-from-git](endo-fs-from-git.md) | 2026-05-28 | 2026-05-28 | In Progress |
-| [daemon-git-backbone](daemon-git-backbone.md) | 2026-05-27 | 2026-05-28 | Proposed |
+| [daemon-git-backbone](daemon-git-backbone.md) | 2026-05-27 | 2026-05-29 | In Progress |
 | [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-05-19 | In Progress (PR #287) |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-05-27 | In Progress |
 | [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-05-27 | **Complete** |
@@ -597,7 +597,7 @@ capabilities available to agents.
 | daemon-git-capability | Proposed | Revised git design over `EndoMount` / `EndoMountEntry`; `tree(ref)` and `readOnly()` both live on the `Git` cap |
 | daemon-git-remotes | Proposed | MVP remote-git companion: fetch / pull / push composed from local `Git`, bounded HTTPS transport, endpoint policy, and credential caps |
 | daemon-git-next-steps | Proposed | The version-controlled filesystem loop milestone over the canonical trio: north-star agent loop (provide workspace → read/list/edit → status/diff → commit → pull/push → inspect history via `filesystemAt(ref)`) and the content/versioning/network/historical-read/bulk-storage layer split. Open `- [ ]` work: worked bot-fork reference flow, `provideGitClone` + identity boundary (→ `daemon-git-clone.md`), `tree(ref)`/`filesystemAt(ref)` reconciliation. Agent-tools layer deferred to #416 |
-| daemon-git-backbone | Proposed | Back the existing Rust CAS (`rust/endo/src/cas.rs`) with git, all four axes: objects → git object DB (sha256-keyed), `TreeManifest` → git trees, bulk transport off CapTP onto pack/smart-protocol, retention → `refs/formulas/<id>` + `git gc`. In-process `gix` (recommended) in the `endor` supervisor; sha256 stays the content key behind a sha256→oid index. Migrations out of scope. Four axes; each probe-able separately |
+| daemon-git-backbone | In Progress | Back the existing Rust CAS (`rust/endo/src/cas.rs`) with git, all four axes: objects → git object DB (sha256-keyed), `TreeManifest` → git trees, bulk transport off CapTP onto pack/smart-protocol, retention → `refs/formulas/<id>` + git GC. The crux is GC: a `refs/formulas/<id>` ↔ sqlite formula-graph mirror so git's own GC collects what no live formula roots. In-process `git2` (libgit2, vendored) in the `endor` supervisor; bare repo at `{dir}/cas.git`; sha256 stays the content key behind a sha256→oid index. Axes 1+4-substrate shipped on PR #369; the formula-graph mirror is blocked on a JS/Rust seam (formula graph lives in the JS daemon, not reachable from the Rust CAS). Migrations out of scope. Four axes; each probe-able separately |
 | filesystem-watchers | Not Started | `EndoMount.followNameChanges` parity with `EndoDirectory`; Node `fs.watch` adapter on `FilePowers` |
 | daemon-locator-terminology | Not Started | Clean locator API; unblocked |
 | daemon-rename-to-manager | Not Started | Rename `daemon.js`/`Daemon`/`MignonicPowers` to `manager.js`/`Manager`/`WorkerPowers` to align JS with Rust `endor` nomenclature |

--- a/designs/daemon-git-backbone.md
+++ b/designs/daemon-git-backbone.md
@@ -1,0 +1,497 @@
+# Daemon Git Backbone
+
+| | |
+|---|---|
+| **Created** | 2026-05-27 |
+| **Updated** | 2026-05-28 |
+| **Author** | 0xPatrick (prompted) |
+| **Status** | Proposed |
+
+## Summary
+
+Back the daemon's **existing Rust content-addressed store** with git.
+
+`endor` — the Rust daemon ([daemon-endor-architecture](daemon-endor-architecture.md),
+**Active**) — already owns a SHA-256 content store in
+`rust/endo/src/cas.rs` ([daemon-cas-management](daemon-cas-management.md),
+**In Progress**, Phases 1–4 shipped).
+That store hand-rolls four things git already does well: a flat
+`{dir}/{hex-sha256}` blob directory, JSON tree manifests with
+structural sharing, a `.meta` refcount, and a mark/sweep garbage
+collector.
+This design replaces the hand-rolled substrate underneath the existing
+`ContentStore` API with a git object database, git trees, git refs +
+`git gc`, and git's pack format / smart-protocol — **all four axes on
+git** — while keeping the daemon's content identity, its CapTP control
+plane, and the `cas-*` verb surface unchanged.
+
+The load-bearing motivation is **axis 3**: get bulk data *out of the
+CapTP data plane*.
+Whole-tree reads, archive ingestion, and cross-peer content sync are
+the wrong shape for one-object-per-CapTP-turn; git's pack/smart-protocol
+is purpose-built for exactly that traffic.
+The other three axes are the substrate that makes axis 3 mechanical:
+once blobs and trees *are* git objects (axis 1, axis 2) and retention
+*is* refs (axis 4), shipping them over the git wire is free.
+
+The four axes map almost 1:1 onto the existing CAS's four phases:
+
+| Axis | This design | Existing `cas.rs` it backs |
+|---|---|---|
+| 1 — objects | `store`/`fetch`/`has` over a git object DB, sha256-keyed | Phase 1 flat-dir `ContentStore`, `.meta` sidecars, atomic write-rename |
+| 2 — trees | `TreeManifest` → native git tree objects | Phase 3 `TreeManifest`/`TreeEntry`, `read_tree`/`fetch_from_tree`, structural sharing |
+| 4 — GC | retention → `refs/formulas/<id>` + `git gc` | Phases 2+4 in-memory refcount + mark/sweep (`cas-gc` / `endor gc`) |
+| 3 — transport | bulk reads ride pack/smart-protocol; CapTP stays control plane | `cas_archive.rs` (ZIP → CAS blobs+trees); PR #367 `archiveTar` precedent |
+
+Migrations are **out of scope** (see Non-Goals).
+
+## What is the Problem Being Solved?
+
+The existing Rust CAS reimplements git's core machinery from scratch:
+
+- **Objects.**
+  `ContentStore::store` writes `{dir}/{hex-sha256}` with a
+  write-tmp-then-rename atomic step (`cas.rs:88`); git's loose-object
+  writer already does content-addressing, zlib compression, and
+  atomic placement.
+- **Trees.**
+  `TreeManifest` is a JSON `{ entries: { name → {type, hash, size} } }`
+  document, itself stored as a CAS blob (`cas.rs:48`,
+  `store_tree`).
+  `fetch_from_tree` walks it path-component by path-component
+  (`cas.rs:162`).
+  A git tree object *is* this — mode + type + oid + name per entry —
+  with `git read-tree` / `git cat-file -p` doing the walk.
+- **Refcounts.**
+  `retain`/`release` keep an in-memory `HashMap<String, u32>` flushed
+  best-effort to `.meta` (`cas.rs:116`).
+  This is a refcounting GC root scheme; git refs are the same idea with
+  crash-safe `update-ref` atomicity instead of best-effort flushes.
+- **Mark/sweep.**
+  `ContentStore::gc` unions the live-roots argument with the
+  in-memory refcount cache, walks tree children transitively, then
+  sweeps the directory (`cas.rs:202`).
+  This is exactly `git gc --prune=now` over reachable refs.
+
+These reimplementations predate `endor`'s git ambitions and were the
+pragmatic floor for a no-dependency CAS (today `cas.rs` pulls only
+`sha2` + `serde`).
+The reframe: rather than grow the hand-rolled scheme — packing for
+disk savings, a crash-safe refcount, a pack-shaped wire format — adopt
+the one mature implementation that already does all of it.
+
+### What surprised us in the substrate
+
+Three properties of the live `cas.rs` are load-bearing for the design,
+and one of them argues *against* a naive git adoption:
+
+1. **GC is not yet wired to formula liveness.**
+   `endo.rs:602` calls `cas.gc(&HashSet::new())` — an **empty**
+   live-roots set.
+   Today the only thing keeping a blob alive across a GC is a non-zero
+   in-memory `refs` count (set by `cas-retain`), and that cache does
+   **not survive a daemon restart** (it is rebuilt empty on
+   `ContentStore::open`).
+   So the current GC is effectively "collect everything not explicitly
+   retained this session."
+   Axis 4 is therefore not just a swap — it is the first time CAS GC
+   becomes durably reachability-driven.
+   That makes axis 4 the highest-value *and* highest-risk axis, and it
+   means the maintainer's "all four on git" ruling is the cleanest way
+   to give the CAS a crash-safe live set at all.
+
+2. **Tree hashes are content-stable but encoding-fragile.**
+   A `TreeManifest` hashes the **serde JSON serialization** of the
+   manifest (`store_tree` → `store(tree_json, "tree")`).
+   `HashMap` iteration order is unspecified, so two semantically equal
+   trees can serialize to different bytes and thus different hashes.
+   The shipped tests dodge this by storing the exact JSON they assert
+   on.
+   Git tree objects are canonical (entries sorted by name, fixed binary
+   encoding), so moving to git trees *fixes* a latent
+   non-determinism — a point in git's favor for axis 2.
+
+3. **Structural sharing is blob-level, not subtree-deduplicated by
+   identity.**
+   `cas.rs`'s `structural_sharing` test shares a *blob* between two
+   trees, but the two trees themselves get distinct hashes even when
+   they would be identical git trees, because the JSON carries
+   per-entry `size` and the map order differs.
+   Git deduplicates whole subtrees by oid for free.
+   No axis is a poor fit on this account; it strengthens axis 2.
+
+None of these contradict the four-axes-on-git framing.
+The one genuine *tension* is the dependency posture (see § The Rust
+lever) — `cas.rs` is deliberately dependency-light, and any git library
+is a meaningful addition.
+
+## Goals
+
+1. Name each axis concretely enough that a builder dispatch can take it
+   through the gap-revealing-build skill against the live `cas.rs`
+   without re-deriving the shape.
+2. Keep the daemon's **content identity** sha256 (locked; see
+   § Hash identity) and the **`cas-*` verb surface**
+   ([daemon-cas-management](daemon-cas-management.md) § Envelope verbs)
+   unchanged — only the bytes-on-disk substrate moves.
+3. Keep CapTP / OCapN as the **control plane**; move only the **bulk
+   data plane** to git transport (axis 3).
+4. Surface the open questions the maintainer must rule on before any
+   axis becomes a buildable feature PR — chiefly the git-library
+   choice and the sha256-key-vs-object-format call.
+
+## Non-Goals
+
+- **Migrations.**
+  Per the maintainer (2026-05-28): "we don't need to worry about
+  migrations right now."
+  No design here for importing existing on-disk `store-sha256/` blobs
+  or `.meta` state into the git object DB.
+  A fresh daemon starts on the git substrate; an upgrading daemon's
+  pre-existing CAS is a deferred concern.
+- **No implementation code.**
+  Implementation arrives in later builder cycles on this branch.
+- Changing the `cas-*` envelope verbs, the CBOR codec, or the JS
+  manager's `controlPowers`
+  ([daemon-cas-management](daemon-cas-management.md) Phase 5).
+  Those are the stable API above the substrate.
+- Replacing the OCapN session machinery
+  ([ocapn-network-transport-separation](ocapn-network-transport-separation.md)).
+  Axis 3 is a *data plane* move; the control plane stays on CapTP.
+
+## The Rust lever — the git work lives inside `endor`
+
+Because the daemon is the Rust binary, the git work belongs **in
+`endor` via a Rust git library**, not shelled to a `git` subprocess and
+not a libgit2-in-JS port.
+`cas.rs` is supervisor-owned, in-process, and on the hot path for
+module loading and snapshot I/O
+([daemon-cas-management](daemon-cas-management.md) § Supervisor-owned);
+a per-operation `git` fork/exec would regress that.
+The library choice is a **key open call** (Open Question 1):
+
+| Option | For | Against |
+|---|---|---|
+| **`gix` (gitoxide)** | Pure Rust, **no C toolchain** — preserves `cas.rs`'s no-C posture; modern, async-friendly, `cargo`-native; object DB + pack + ref + tree APIs are mature and used in production tooling | Younger API surface; smart-protocol *client* coverage is broad but the *server*/`upload-pack` side (axis 3) is less complete than libgit2's |
+| **`git2` (libgit2 bindings)** | Mature, broad coverage incl. transport; battle-tested | Adds a **C build dependency** to a crate that today links only `sha2`+`serde`; cross-compilation and the XS C-build interaction (`build.rs` already drives `cc` for XS) add burden and audit surface |
+
+**Recommendation: `gix`, staged.**
+Reasoning:
+
+- The dependency-posture tension above is the real constraint.
+  `endor`'s `xsnap` crate already compiles C (XS via `cc`), but the
+  `endo` crate where `cas.rs` lives is pure-Rust + `tokio`; adding
+  libgit2's C dependency *there* widens the build/audit surface of the
+  daemon core specifically.
+  `gix` keeps the daemon core C-free.
+- Axes 1, 2, 4 need only the object DB, tree, ref, and local-pack APIs
+  — `gix`'s strongest, most production-proven surface (`gix-object`,
+  `gix-ref`, `gix-odb`, `gix-pack`).
+- Axis 3's *remote* server side (`upload-pack` over a sideband) is the
+  one place libgit2 is more complete.
+  Stage it: build axes 1/2/4 on `gix`; if the axis-3 server side proves
+  thin in `gix`, axis 3 can either (a) run a constrained in-process
+  pack-negotiation using `gix-protocol`, or (b) ship as the narrow
+  exception where a vetted `git upload-pack` subprocess is acceptable
+  *for the remote hop only* — not the hot local path.
+
+Flag both the choice and the staging for the maintainer to ratify.
+
+## Hash identity — sha256 is the content key, git's object format is separable
+
+The daemon's content identity is **sha256**, and that is locked.
+Grounded in existing behavior: `cas.rs` stores `{dir}/{hex-sha256}`,
+the JS `packages/endo-fs/src/cas.js` keys by `algorithm:hash`, and
+every formula JSON field that names content names a sha256.
+A substrate swap must **not** change the identity Endo formulas, the
+`cas-*` verbs, and cross-peer references already speak.
+
+Git's *internal* object format is a **separate, lower call**:
+
+- Git's default object hash is **SHA-1** (cryptographically weak,
+  universal tooling).
+- Git's **SHA-256 object format** (`--object-format=sha256`) exists
+  but is still experimental; interop with SHA-1 repos requires
+  translation, smart-protocol negotiation for it is young, and `gix`
+  SHA-256-mode coverage trails its SHA-1 coverage.
+
+**Recommendation: keep Endo's sha256 as the content key; let git's
+object DB run in its default (SHA-1) object format internally, behind a
+sha256→oid index.**
+Reasoning:
+
+- The Endo content key (sha256 of the bytes) is what the verbs and
+  formulas reference; it must be stable regardless of git's internal
+  oid.
+  A small persistent map `sha256 → git-oid` (or sha256-named refs, see
+  axis 4) bridges them.
+  Writing a blob computes both the Endo sha256 and the git oid; lookups
+  go sha256 → git-oid → object.
+- This decouples the locked decision (sha256 identity) from the
+  immature one (git SHA-256 mode), and lets the project adopt git's
+  SHA-256 object format later, transparently, if and when it matures —
+  the Endo-facing key never changes.
+- Do **not** block the swap on git SHA-256 maturity.
+  Adopting it now would couple a shipped substrate to an experimental
+  git feature with thin library support.
+
+Flag this for the maintainer (Open Question 2); the alternative
+(git's SHA-256 object mode directly, no mapping) is viable later but
+not today.
+
+## Axis 1 — CAS objects become git objects
+
+`ContentStore`'s `store`/`fetch`/`has` map onto a git object database:
+
+| `cas.rs` | Git object DB (via `gix`) |
+|---|---|
+| `store(data, "blob")` → hex-sha256 | write loose/packed blob → git oid; record `sha256 → oid` |
+| `fetch(hash)` | sha256 → oid → read object bytes |
+| `has(hash)` | sha256 → oid lookup + object existence |
+| `.meta` `type` field | git object type tag (`blob`/`tree`/`commit`) |
+| `.meta` `refs` count | superseded by refs (axis 4) |
+
+The flat `{dir}/{hex-sha256}` directory and `.meta` sidecars disappear;
+`{statePath}/store/.git/objects/` holds every blob and tree.
+The `type` advisory in `.meta`
+([daemon-cas-management](daemon-cas-management.md) § Content types)
+folds into git's native type tag, except for the daemon-specific
+distinction `snapshot` vs. `archive` vs. `blob` (all git blobs), which
+moves into the formula metadata or a thin sidecar keyed by oid.
+
+**Why this is the cheapest, lowest-risk axis:** the `ContentStore` API
+is small and well-tested (`cas.rs` tests cover store/fetch/has,
+dedup, missing-key error). A `gix`-backed implementation that passes
+the same tests is a drop-in.
+
+## Axis 2 — tree manifests become git tree objects
+
+`TreeManifest` (`cas.rs:48`) — `{ entries: { name → {type, hash,
+size} } }` serialized to JSON and stored as a blob — becomes a native
+git tree object:
+
+- `store_tree(tree_json)` → `gix` tree builder writing canonical git
+  tree entries (mode, type, oid, name), returning the tree's git oid
+  (mapped to its Endo sha256 key).
+- `read_tree`/`list_tree`/`fetch_from_tree` (`cas.rs:145`–`189`)
+  become git tree reads and path walks.
+- `cas_archive.rs`'s ZIP-ingest (`ingest_archive`,
+  `load_archive_from_cas`) builds the same compartment-tree shape, but
+  emits git trees instead of JSON manifests — and `fetch_from_tree`
+  during archive load (`cas_archive.rs:167`) becomes a git tree walk.
+
+Two properties improve on the swap (see § What surprised us):
+
+- **Canonical encoding** removes the `HashMap`-order non-determinism
+  in today's JSON tree hashing.
+- **Whole-subtree dedup** by git oid generalizes the blob-level sharing
+  the `structural_sharing` test demonstrates.
+
+Axis 2 is mechanical once axis 1 lands; it has no new external
+contract.
+
+## Axis 3 — bulk transport off the CapTP data plane (load-bearing)
+
+CapTP / OCapN stays the **control plane**: capability handshakes,
+eventual sends, retention subscriptions, GC negotiation
+([ocapn-network-transport-separation](ocapn-network-transport-separation.md)).
+The **bulk data plane** moves to git's pack / smart-protocol.
+
+| Today | Under the swap |
+|---|---|
+| `cas-fetch` returns blob bytes inside the CapTP response envelope | `cas-fetch` resolves a `(sha256, git-oid)`; bytes ride a pack/sideband — local peers read the shared object DB directly, remote peers pull via pack negotiation |
+| `cas_archive.rs` ingests a ZIP into per-file CAS blobs; whole-archive transfer would be N envelopes | a compartment tree ships as one packfile (delta-compressed, structurally shared) |
+| PR #367 `archiveTar` — a backend-private `git archive` tar data plane under `ReadableTree` | generalized: any object bounded by "number of files in a tree" rides the git wire, not CapTP turns |
+
+PR #367 (`archiveTar`, open) is the standing precedent: it already
+concedes that turning a 10k-file tree into 10k CapTP turns is the wrong
+cost shape and routes it through a native archive stream.
+Axis 3 promotes that concession to a general rule and unifies it with
+the daemon's own substrate.
+
+Local single-daemon bulk reads stop crossing the worker/supervisor
+envelope boundary: a worker holding a CapTP handle to a tree reads the
+git objects directly from the supervisor-owned object DB
+([daemon-cas-management](daemon-cas-management.md) § Supervisor-owned).
+Remote cross-peer bulk reads use pack negotiation over an OCapN-carried
+sideband (see Open Question 4).
+
+**`streamReply`** ([daemon-message-streaming](daemon-message-streaming.md))
+is **unchanged** — small token-streamed text is exactly what CapTP is
+for; axis 3 targets only bulk transfers.
+
+This is the axis the whole design is *for*: axes 1/2/4 are the
+substrate that makes the data plane git-shaped, and axis 3 is the
+payoff of getting bulk bytes out of the capability envelopes.
+
+## Axis 4 — retention becomes `refs/formulas/<id>` + `git gc`
+
+Replace the in-memory refcount + empty-rooted mark/sweep
+(`cas.rs:202`, `endo.rs:602`) with git refs and `git gc`.
+
+A live formula's content is exactly what is reachable from a ref under
+`refs/formulas/`:
+
+```
+refs/formulas/local/<formulaNumber>        # held by local agent
+refs/formulas/peer/<publicKey>/<id>        # held by a remote peer
+refs/formulas/transient/<requestId>        # in-flight host op
+```
+
+- `cas-retain` → `git update-ref refs/formulas/.../<id> <oid>`
+  (crash-safe via git's ref-lock discipline — fixing the "refcount
+  cache lost on restart" gap noted above).
+- `cas-release` → `git update-ref -d`.
+- `cas-gc` / `endor gc` → `git gc --prune=now` over reachable refs;
+  the transitive tree-walk in `ContentStore::gc` becomes git's
+  reachability algorithm.
+
+The supervisor's link to **formula liveness** is the key new wire.
+Today `cas.gc` gets an empty root set; under the swap the supervisor
+publishes the live formula set as refs.
+The natural source is the **formula graph**, persisted in SQLite
+([daemon-endo-rust-sqlite](daemon-endo-rust-sqlite.md), **Complete** —
+the Rust XS sqlite host methods).
+The reframe couples cleanly here: the daemon already keeps the formula
+graph and the cross-peer retention table in sqlite; axis 4 mirrors that
+durable graph into `refs/formulas/`, so that `git gc` and the sqlite
+graph agree on the live set.
+**How that mirror stays atomic with respect to formula-graph writes is
+Open Question 3.**
+
+Cross-peer retention ([daemon-cross-peer-gc](daemon-cross-peer-gc.md),
+**Complete**) fits without changing its wire semantics: the shipped
+design is a one-way streaming retention-set sync (`followRetentionSet`,
+`retention-accumulator.js`, SQLite `retention` table).
+Under the swap, that retention set is mirrored to
+`refs/formulas/peer/<publicKey>/<id>`, and the reconciliation primitive
+becomes **`git fetch --prune`** — which is the exact shape of the
+"publisher re-sends its current set, subscriber prunes" semantics the
+cross-peer-gc design already specifies (its "crash and reconnect" rule
+maps to fetch/prune one-for-one).
+Public-key keying (matching the shipped `retention(guest_public_key,
+...)` schema) is preferred over node-number keying for the ref
+namespace, for the same node-rotation-robustness reason the sqlite
+schema chose it.
+
+Axis 4 is the **highest-value, highest-risk** axis: highest-value
+because it gives the CAS a durable, reachability-driven live set it
+does not have today; highest-risk because it touches the live system's
+GC correctness invariant.
+
+## Composition
+
+```mermaid
+flowchart TD
+  a1[Axis 1: objects = git objects]
+  a2[Axis 2: trees = git trees]
+  a3[Axis 3: bulk transport off CapTP]
+  a4[Axis 4: retention = refs + git gc]
+
+  a1 --> a2
+  a1 --> a4
+  a2 --> a3
+  a4 --> a3
+```
+
+Axis 1 (objects) is the dependency for the rest: every other axis
+assumes the object DB is git.
+Axes 2 (trees) and 4 (refs/GC) are otherwise independent and can land
+in either order on top of axis 1.
+Axis 3 (transport) is the payoff — it compounds 2 and 4 and is the
+design's motivating goal — but it benefits from the substrate (1/2/4)
+being stable first.
+
+Practical order, each as a probe-then-build cycle
+([gap-revealing-build](../../skills/gap-revealing-build/SKILL.md)),
+because the git-library integration and the GC-correctness swap carry
+real unknowns:
+
+1. Axis 1 — `gix`-backed object DB behind the existing `ContentStore`
+   API; passes the current `cas.rs` test suite. Lowest risk, validates
+   the library choice.
+2. Axis 2 — git tree objects behind `TreeManifest` and
+   `cas_archive.rs`. Mechanical once axis 1 lands.
+3. Axis 4 — `refs/formulas/` + `git gc`, mirroring the sqlite formula
+   graph. Highest risk; the GC-correctness piece.
+4. Axis 3 — pack/smart-protocol data plane. Newest mechanism; the
+   motivating payoff; benefits from 1/2/4 stable.
+
+## Relationship to the existing `cas.rs` scheme during rollout
+
+The swap can land axis by axis behind a feature flag with the existing
+flat-dir `ContentStore` as the implementation behind the unchanged
+`cas-*` verbs.
+Because migrations are out of scope, the rollout assumption is a
+*fresh* git-backed store on the flag; coexistence of a live flat-dir
+store and a git store on the same daemon is **Open Question 5**.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [daemon-endor-architecture](daemon-endor-architecture.md) | The substrate. The git work lives inside the `endor` Rust supervisor that owns the CAS; `gix` is the proposed in-process library. |
+| [daemon-cas-management](daemon-cas-management.md) | Primary swap target. Axes 1/2/4 replace the flat-dir `ContentStore`, JSON `TreeManifest`, in-memory refcount, and mark/sweep GC with git objects/trees/refs/`git gc`, behind the unchanged `cas-*` verbs. |
+| [daemon-endo-rust-sqlite](daemon-endo-rust-sqlite.md) | Axis 4's live-set source. The formula graph persisted in sqlite is mirrored into `refs/formulas/`; the atomicity of that mirror is Open Question 3. |
+| [daemon-cross-peer-gc](daemon-cross-peer-gc.md) | Axis 4. The shipped one-way retention-set sync maps onto `refs/formulas/peer/<publicKey>/<id>` + `git fetch --prune`; public-key keying carries over from the `retention` table. |
+| [daemon-content-store-gc](daemon-content-store-gc.md) | Prior (JS-side) GC thinking, **Complete**; context only. The live GC being swapped is the Rust mark/sweep in `cas.rs`, not the JS collector. |
+| [ocapn-network-transport-separation](ocapn-network-transport-separation.md) | Axis 3. The OCapN-Noise network carries CapTP frames (control plane) and git pack/protocol frames (data plane). |
+| [daemon-message-streaming](daemon-message-streaming.md) | Unchanged. `streamReply` stays CapTP; axis 3 targets bulk, not token-streamed text. |
+| PR [#367](https://github.com/endojs/endo-but-for-bots/pull/367) (`archiveTar`) | Axis 3 transport-out-of-CapTP precedent: a native archive data plane under `ReadableTree`. Still valid; axis 3 generalizes it. |
+
+## Open Questions
+
+1. **Git library: `gix` vs. `git2`.**
+   Recommendation `gix` (pure Rust, keeps the daemon core C-free,
+   strongest where axes 1/2/4 need it), staged so axis 3's remote
+   server side can fall back to `gix-protocol` in-process or a vetted
+   `git upload-pack` subprocess for the remote hop only.
+   Maintainer to ratify the choice and the staging.
+
+2. **sha256 content key vs. git object format.**
+   Recommendation: keep Endo's sha256 as the content key (locked),
+   run git's object DB in its default SHA-1 format internally behind a
+   `sha256 → git-oid` index, and *not* block on git's experimental
+   SHA-256 object mode.
+   Maintainer to ratify; git SHA-256 mode remains a transparent future
+   adoption since the Endo-facing key never changes.
+
+3. **Atomic mirror of the sqlite formula graph into
+   `refs/formulas/`.**
+   Axis 4 needs the git ref set and the sqlite formula graph to agree
+   on the live set across crashes.
+   Is the ref the source of truth and sqlite the cache, or vice versa?
+   What is the atomic write order (`update-ref` + sqlite txn) so a
+   crash mid-update never collects live content?
+
+4. **Pack/smart-protocol inside or beside OCapN-Noise (axis 3).**
+   Does OCapN-Noise multiplex CapTP frames and git-protocol frames on
+   one stream (header-discriminated), or does git-protocol run on a
+   separately negotiated transport?
+   And does `gix`'s server side cover in-process pack negotiation, or
+   does the remote hop need the staged subprocess fallback?
+
+5. **Coexistence with the hand-rolled `cas.rs` scheme during rollout.**
+   With migrations out of scope, a flagged git store starts fresh.
+   Does a daemon ever run both the flat-dir store and the git store
+   simultaneously (e.g., flat-dir read-fallback), or is the flag a hard
+   either/or per daemon instance?
+
+6. **Daemon-specific content types under git's type tag.**
+   Git distinguishes blob/tree/commit; the CAS additionally
+   distinguishes `snapshot` and `archive`
+   ([daemon-cas-management](daemon-cas-management.md) § Content types),
+   all of which are git blobs.
+   Does that distinction move into formula metadata, a thin oid-keyed
+   sidecar, or git notes?
+
+## Prompt
+
+> Redesign `designs/daemon-git-backbone.md` against the live Rust
+> `endor` daemon and its existing Rust CAS (`rust/endo/src/cas.rs`),
+> with all four axes backed by git. Cycle 1 mis-targeted the legacy JS
+> daemon; reframe it as "back the existing Rust CAS with git." Address
+> the gix-vs-git2 library choice and the sha256-content-key-vs-git-
+> object-format call, and recommend on each. Migrations are out of
+> scope. Design only, no implementation code; surface the maintainer-
+> ruling open questions explicitly.

--- a/designs/daemon-git-backbone.md
+++ b/designs/daemon-git-backbone.md
@@ -3,9 +3,43 @@
 | | |
 |---|---|
 | **Created** | 2026-05-27 |
-| **Updated** | 2026-05-28 |
+| **Updated** | 2026-05-29 |
 | **Author** | 0xPatrick (prompted) |
-| **Status** | Proposed |
+| **Status** | In Progress |
+
+## Status
+
+Axes 1 and 4 are built on PR
+[#369](https://github.com/endojs/endo-but-for-bots/pull/369) (`endo`
+crate).
+The git library is **`git2` (libgit2 bindings)**, not the `gix`
+recommendation in Open Question 1 / § The Rust lever below — the
+maintainer ratified the mature, broadly-covered library; libgit2 is
+vendored (bundled C, no system dependency), so the no-C rationale for
+`gix` was moot because the `endo` crate already links bundled C
+(rusqlite's SQLite, xsnap's XS).
+The substrate is a **bare git repository at `{dir}/cas.git`**: objects
+at `{dir}/cas.git/objects/`, retention refs at
+`{dir}/cas.git/refs/cas/<sha256>`, with the `sha256 → git-oid`
+resolution index kept flat at `{dir}` (Open Question 2's sha256 content
+key behind a SHA-1 git object DB).
+GC is an in-process manual reachability sweep (libgit2 ships no
+`git gc` porcelain) seeded from the `refs/cas/*` refs.
+
+**Axis 4 is not yet complete.** Its highest-value piece — the
+`refs/formulas/<id>` ↔ sqlite formula-graph mirror that makes GC
+reachability-driven *from formula liveness* — is not built. The shipped
+`refs/cas/<sha256>` refs are keyed by content hash, not formula id, and
+nothing connects the formula graph to retain/release calls; the `cas-gc`
+call sites still pass an empty caller-root set (now harmless only
+because the durable `refs/cas/*` refs seed the live set). The mirror is
+blocked on an architecture seam: the formula graph lives in the **JS**
+daemon (`packages/daemon/src/daemon-database.js`, the SQLite `formula`
+table), mutated by JS (`daemon.js` → `persistencePowers.writeFormula` /
+`deleteFormula`); the Rust supervisor sees only opaque SQL strings
+crossing the XS FFI and cannot observe formula liveness. The mirror wire
+must live in JS, and no JS code calls the `cas-*` verbs today. See the
+journal seam report (2026-05-29) for the recommended landing site.
 
 ## Summary
 
@@ -25,14 +59,20 @@ This design replaces the hand-rolled substrate underneath the existing
 git** — while keeping the daemon's content identity, its CapTP control
 plane, and the `cas-*` verb surface unchanged.
 
-The load-bearing motivation is **axis 3**: get bulk data *out of the
-CapTP data plane*.
-Whole-tree reads, archive ingestion, and cross-peer content sync are
-the wrong shape for one-object-per-CapTP-turn; git's pack/smart-protocol
-is purpose-built for exactly that traffic.
-The other three axes are the substrate that makes axis 3 mechanical:
-once blobs and trees *are* git objects (axis 1, axis 2) and retention
-*is* refs (axis 4), shipping them over the git wire is free.
+The load-bearing motivation is **GC** — axis 4, plus the axis-1
+substrate it needs: a `refs/formulas/<id>` ↔ sqlite-formula-graph mirror
+so git itself can do the garbage collection.
+The retention roots are the formula graph; the most straightforward way
+to maintain the relationship is for git to hold a ref per live formula
+identifier, kept in sync with the formula rows, and to let git's own GC
+collect everything no ref keeps reachable.
+The other axes are extensions, not the crux: getting bulk data *out of
+the CapTP data plane* (axis 3 — whole-tree reads, archive ingestion,
+cross-peer content sync, the wrong shape for one-object-per-CapTP-turn)
+and native git trees (axis 2) are valuable payoffs that the same git
+substrate makes mechanical, but the reason to adopt git at all is the
+crash-safe, reachability-driven live set the hand-rolled CAS does not
+have.
 
 The four axes map almost 1:1 onto the existing CAS's four phases:
 
@@ -252,7 +292,8 @@ not today.
 | `.meta` `refs` count | superseded by refs (axis 4) |
 
 The flat `{dir}/{hex-sha256}` directory and `.meta` sidecars disappear;
-`{statePath}/store/.git/objects/` holds every blob and tree.
+the bare git repository at `{dir}/cas.git/objects/` holds every blob
+and tree.
 The `type` advisory in `.meta`
 ([daemon-cas-management](daemon-cas-management.md) § Content types)
 folds into git's native type tag, except for the daemon-specific
@@ -290,7 +331,7 @@ Two properties improve on the swap (see § What surprised us):
 Axis 2 is mechanical once axis 1 lands; it has no new external
 contract.
 
-## Axis 3 — bulk transport off the CapTP data plane (load-bearing)
+## Axis 3 — bulk transport off the CapTP data plane (extension)
 
 CapTP / OCapN stays the **control plane**: capability handshakes,
 eventual sends, retention subscriptions, GC negotiation
@@ -320,9 +361,11 @@ sideband (see Open Question 4).
 is **unchanged** — small token-streamed text is exactly what CapTP is
 for; axis 3 targets only bulk transfers.
 
-This is the axis the whole design is *for*: axes 1/2/4 are the
-substrate that makes the data plane git-shaped, and axis 3 is the
-payoff of getting bulk bytes out of the capability envelopes.
+This is a high-value extension once the substrate is git-shaped: axes
+1/2/4 make the data plane git-shaped, and axis 3 is the payoff of
+getting bulk bytes out of the capability envelopes. It is not the crux
+(that is axis 4's reachability-driven GC); it is the largest payoff the
+crux's substrate unlocks.
 
 ## Axis 4 — retention becomes `refs/formulas/<id>` + `git gc`
 

--- a/rust/endo/Cargo.toml
+++ b/rust/endo/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 [dependencies]
 endo_iroh = { path = "../endo_iroh" }
 gix-hash = { version = "0.25", features = ["sha1"] }
+gix-lock = "23"
 gix-object = "0.61"
 gix-odb = { version = "0.81", features = ["sha1"] }
+gix-ref = "0.64"
 hex = "0.4"
 libc = "0.2"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/rust/endo/Cargo.toml
+++ b/rust/endo/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [dependencies]
 endo_iroh = { path = "../endo_iroh" }
+gix-hash = { version = "0.25", features = ["sha1"] }
+gix-object = "0.61"
+gix-odb = { version = "0.81", features = ["sha1"] }
 hex = "0.4"
 libc = "0.2"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/rust/endo/Cargo.toml
+++ b/rust/endo/Cargo.toml
@@ -5,11 +5,7 @@ edition = "2021"
 
 [dependencies]
 endo_iroh = { path = "../endo_iroh" }
-gix-hash = { version = "0.25", features = ["sha1"] }
-gix-lock = "23"
-gix-object = "0.61"
-gix-odb = { version = "0.81", features = ["sha1"] }
-gix-ref = "0.64"
+git2 = "0.21"
 hex = "0.4"
 libc = "0.2"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/rust/endo/src/cas.rs
+++ b/rust/endo/src/cas.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
-use gix_object::Write as _;
+use git2::{Oid, Repository};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -68,44 +68,50 @@ pub struct TreeEntry {
 /// SHA-256 content-addressed store backed by a git object database.
 ///
 /// The Endo-facing content identity is the hex SHA-256 of the bytes, exactly
-/// as before; the bytes themselves live as git (loose) objects under
-/// `{dir}/objects/`, and a persistent `sha256 -> git-oid` index
-/// (`{dir}/sha256-oid.idx`) bridges the Endo key to git's internal object id.
-/// Git's object DB runs in its default (SHA-1) object format internally; the
-/// experimental git SHA-256 object mode is deliberately not used (the
-/// Endo-facing key stays SHA-256 regardless).
+/// as before; the bytes themselves live as git (loose) objects inside a **bare
+/// git repository** at `{dir}/cas.git`, and a persistent `sha256 -> git-oid`
+/// index (`{dir}/sha256-oid.idx`) bridges the Endo key to git's internal
+/// object id. Git's object DB runs in its default (SHA-1) object format
+/// internally; the experimental git SHA-256 object mode is deliberately not
+/// used (the Endo-facing key stays SHA-256 regardless).
 ///
 /// Optional `.meta` sidecars in `{dir}` carry the advisory content type.
 ///
 /// Retention is **reachability-driven and crash-safe** (axis 4): a retained
 /// object is recorded as a git ref under `refs/cas/<sha256>` pointing at the
-/// object's git oid, written through git's own ref-lock discipline (lock-file
-/// + atomic rename, via `gix-ref`). `gc` computes the live set from those refs
-/// — git reachability over the retained roots — rather than from an in-memory
+/// object's git oid, written through libgit2's own ref-lock discipline
+/// (lock-file + atomic rename). `gc` computes the live set from those refs —
+/// git reachability over the retained roots — rather than from an in-memory
 /// refcount that was lost on every restart. This replaces the hand-rolled
 /// `HashMap<String, u32>` refcount the store used to flush best-effort to
 /// `.meta`; the maintainer's ruling is to lean on git's ref machinery instead
 /// of rolling our own retention cache.
+///
+/// The store holds no live `git2::Repository` handle as a field:
+/// `git2::Repository` is `Send` but not `Sync`, while `ContentStore` is shared
+/// across threads via `Arc` (the daemon's control thread clones it). Opening a
+/// bare repo is cheap, so each operation opens a fresh `Repository` against
+/// `repo_dir`, which keeps `ContentStore` `Send + Sync` without an interior
+/// mutex on the git handle. (libgit2 already serializes the on-disk
+/// object/ref writes through its own locking.)
 pub struct ContentStore {
     dir: PathBuf,
-    /// Git loose-object database rooted at `{dir}/objects/`.
-    odb: gix_odb::loose::Store,
+    /// Path to the bare git repository (`{dir}/cas.git`) that holds every CAS
+    /// object and the `refs/cas/*` retention refs. A fresh `Repository` is
+    /// opened against this per operation (see the type doc for why no handle
+    /// is held).
+    repo_dir: PathBuf,
     /// Persistent `sha256-hex -> git-oid` index, loaded on open and appended
     /// on every newly stored object. Endo references the SHA-256 key; this
     /// resolves it to the git object id used by the object DB.
-    index: RwLock<HashMap<String, gix_hash::ObjectId>>,
-    // Retention is recorded as git refs under `{dir}/refs/cas/<sha256>`. The
-    // `gix_ref::file::Store` that reads/writes them is built on demand in
-    // `ref_store()` rather than held as a field: it carries a non-`Send`
-    // `Rc` packed-refs cache, and `ContentStore` is shared across threads via
-    // `Arc`. Constructing it is cheap (a path + options; packed refs load
-    // lazily), so per-operation construction costs nothing on the hot path.
+    index: RwLock<HashMap<String, Oid>>,
 }
 
 /// Basename of the persistent sha256 -> git-oid index inside the store dir.
 const INDEX_FILE: &str = "sha256-oid.idx";
-/// Subdirectory of the store dir holding the git loose-object database.
-const OBJECTS_DIR: &str = "objects";
+/// Subdirectory of the store dir holding the bare git repository (object DB +
+/// retention refs).
+const REPO_DIR: &str = "cas.git";
 /// Ref-namespace prefix for retained CAS objects. A ref
 /// `refs/cas/<sha256>` -> git-oid is the liveness record for one retained
 /// content hash.
@@ -115,13 +121,17 @@ impl ContentStore {
     /// Open (or create) a content store at `dir`.
     pub fn open(dir: &Path) -> io::Result<Self> {
         fs::create_dir_all(dir)?;
-        let objects_dir = dir.join(OBJECTS_DIR);
-        fs::create_dir_all(&objects_dir)?;
-        let odb = gix_odb::loose::Store::at(&objects_dir, gix_hash::Kind::Sha1, None);
+        let repo_dir = dir.join(REPO_DIR);
+        // Initialize the bare repository if it is not already present.
+        // `Repository::open` is the fast path on an existing store; we only
+        // pay `init_bare` on first creation.
+        if Repository::open_bare(&repo_dir).is_err() {
+            Repository::init_bare(&repo_dir).map_err(git_err("init bare repo"))?;
+        }
         let index = RwLock::new(load_index(dir)?);
         Ok(ContentStore {
             dir: dir.to_path_buf(),
-            odb,
+            repo_dir,
             index,
         })
     }
@@ -137,10 +147,8 @@ impl ContentStore {
         // given SHA-256 — preserves dedup. Git's own loose writer is
         // content-addressed and atomic (tempfile + rename) under the hood.
         if !self.index_contains(&hash) {
-            let oid = self
-                .odb
-                .write_buf(gix_object::Kind::Blob, data)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("git write: {e}")))?;
+            let repo = self.open_repo()?;
+            let oid = repo.blob(data).map_err(git_err("git write"))?;
             self.record_index(&hash, oid)?;
         }
         // Write .meta if content type is not blob (default).
@@ -155,31 +163,30 @@ impl ContentStore {
         let oid = self.oid_for(hash).ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, format!("no object for {hash}"))
         })?;
-        let mut buf = Vec::new();
-        match self
-            .odb
-            .try_find(&oid, &mut buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("git read: {e}")))?
-        {
-            Some(obj) => Ok(obj.data.to_vec()),
-            None => Err(io::Error::new(
+        let repo = self.open_repo()?;
+        let blob = repo.find_blob(oid).map_err(|e| {
+            io::Error::new(
                 io::ErrorKind::NotFound,
-                format!("git object missing for {hash}"),
-            )),
-        }
+                format!("git object missing for {hash}: {e}"),
+            )
+        })?;
+        Ok(blob.content().to_vec())
     }
 
     /// Check whether a hash exists in the store.
     pub fn has(&self, hash: &str) -> bool {
-        match self.oid_for(hash) {
-            Some(oid) => self.odb.contains(&oid),
-            None => false,
-        }
+        let Some(oid) = self.oid_for(hash) else {
+            return false;
+        };
+        let Ok(repo) = self.open_repo() else {
+            return false;
+        };
+        repo.odb().map(|odb| odb.exists(oid)).unwrap_or(false)
     }
 
     /// Retain a hash: record it as a live root via `refs/cas/<sha256>`.
     ///
-    /// The ref points at the object's git oid and is written through git's
+    /// The ref points at the object's git oid and is written through libgit2's
     /// ref-lock discipline (lock-file + atomic rename), so it survives a daemon
     /// restart and a crash mid-write. A retained object is reachable from a
     /// ref, which is what keeps it out of `gc`'s sweep. Best-effort: an unknown
@@ -272,11 +279,17 @@ impl ContentStore {
     /// - every retained object recorded as a durable `refs/cas/<sha256>` ref.
     ///
     /// The ref-derived roots are the crash-safe replacement for the old
-    /// in-memory refcount: because they live on disk through git's ref-lock
+    /// in-memory refcount: because they live on disk through libgit2's ref-lock
     /// discipline, retention survives a daemon restart, and a `gc` after a
     /// restart no longer collects everything that was retained in a prior
     /// session. The transitive tree walk below expands those roots over their
     /// children, which is git reachability over the retained ref set.
+    ///
+    /// libgit2 (unlike the `git` porcelain) ships no `git gc` / loose-object
+    /// prune; the sweep here is the same in-process manual reachability sweep
+    /// the store has always done — compute the live set, then delete the
+    /// unreachable loose objects directly. This keeps GC in-process with no
+    /// runtime dependency on a `git` binary.
     ///
     /// Returns a report of what was collected.
     pub fn gc(&self, live_roots: &HashSet<String>) -> io::Result<GcReport> {
@@ -314,7 +327,7 @@ impl ContentStore {
 
         // Snapshot the hashes to collect so we don't hold the index read lock
         // while mutating it.
-        let to_collect: Vec<(String, gix_hash::ObjectId)> = {
+        let to_collect: Vec<(String, Oid)> = {
             let index = self.index.read().unwrap_or_else(|e| e.into_inner());
             index
                 .iter()
@@ -324,8 +337,11 @@ impl ContentStore {
         };
 
         for (hash, oid) in to_collect {
-            // Size of the on-disk git object (compressed), best-effort.
-            let object_path = self.odb.object_path(&oid);
+            // The loose-object file for this oid. libgit2 has no loose-object
+            // delete API, so we reconstruct git's standard loose path
+            // (`objects/<oid[0:2]>/<oid[2:]>`) and remove it directly — the
+            // same filesystem-side deletion the manual sweep has always done.
+            let object_path = self.loose_object_path(&oid);
             let size = fs::metadata(&object_path).map(|m| m.len()).unwrap_or(0);
             // Delete the git object file. It is shared by oid, so only remove
             // it if no other indexed hash maps to the same oid.
@@ -366,6 +382,28 @@ impl ContentStore {
     // Internal helpers
     // -----------------------------------------------------------------------
 
+    /// Open the bare git repository for one operation. `git2::Repository` is
+    /// `Send` but not `Sync`, so it cannot be held as a shared field on the
+    /// `Arc`-shared `ContentStore`; opening it per call sidesteps that. The
+    /// open is cheap (a path probe + handle), and libgit2 serializes the
+    /// on-disk object/ref writes through its own locking.
+    fn open_repo(&self) -> io::Result<Repository> {
+        Repository::open_bare(&self.repo_dir).map_err(git_err("open bare repo"))
+    }
+
+    /// The on-disk path of the loose object for `oid` inside the bare repo:
+    /// `{dir}/cas.git/objects/<oid[0:2]>/<oid[2:]>`. This is git's standard
+    /// loose-object layout (libgit2 exposes no path/delete API for loose
+    /// objects, so we compute it for the GC sweep).
+    fn loose_object_path(&self, oid: &Oid) -> PathBuf {
+        let hex = oid.to_string();
+        let (prefix, rest) = hex.split_at(2);
+        self.repo_dir
+            .join("objects")
+            .join(prefix)
+            .join(rest)
+    }
+
     /// Write the advisory `.meta` sidecar carrying the content type.
     ///
     /// The old `refs` field is gone: retention is now a git ref under
@@ -376,77 +414,37 @@ impl ContentStore {
         fs::write(&meta_path, json.as_bytes())
     }
 
-    /// Open the git ref store rooted at `{dir}`. Built per-call rather than
-    /// held as a field because `gix_ref::file::Store` is `!Send` (it caches
-    /// packed refs behind an `Rc`) while `ContentStore` is shared across
-    /// threads. Construction is cheap; the reflog is disabled because these
-    /// refs are pure liveness markers (no history, no committer identity).
-    fn ref_store(&self) -> gix_ref::file::Store {
-        gix_ref::file::Store::at(
-            self.dir.clone(),
-            gix_ref::store::init::Options {
-                write_reflog: gix_ref::store::WriteReflog::Disable,
-                object_hash: gix_hash::Kind::Sha1,
-                precompose_unicode: false,
-                prohibit_windows_device_names: false,
-            },
-        )
+    /// The full ref name of the retention ref for a content hash.
+    fn cas_ref_name(hash: &str) -> String {
+        format!("{CAS_REF_PREFIX}{hash}")
     }
 
-    /// Build the `FullName` of the retention ref for a content hash.
-    fn cas_ref_name(hash: &str) -> io::Result<gix_ref::FullName> {
-        gix_ref::FullName::try_from(format!("{CAS_REF_PREFIX}{hash}"))
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("ref name: {e}")))
-    }
-
-    /// Create or update `refs/cas/<hash>` -> `oid` through git's ref-lock
-    /// discipline. Crash-safe: the lock-file + atomic-rename commit means a
-    /// crash either leaves the old ref state or the new one, never a torn
-    /// write.
-    fn set_cas_ref(&self, hash: &str, oid: gix_hash::ObjectId) -> io::Result<()> {
-        let edit = gix_ref::transaction::RefEdit {
-            change: gix_ref::transaction::Change::Update {
-                log: gix_ref::transaction::LogChange {
-                    mode: gix_ref::transaction::RefLog::AndReference,
-                    force_create_reflog: false,
-                    message: Default::default(),
-                },
-                expected: gix_ref::transaction::PreviousValue::Any,
-                new: gix_ref::Target::Object(oid),
-            },
-            name: Self::cas_ref_name(hash)?,
-            deref: false,
-        };
-        self.commit_ref_edit(edit)
+    /// Create or update `refs/cas/<hash>` -> `oid` through libgit2's ref-lock
+    /// discipline. Crash-safe: libgit2 writes the ref via a `.lock` file and an
+    /// atomic rename, so a crash either leaves the old ref state or the new one,
+    /// never a torn write — git's `update-ref` guarantee. These refs are pure
+    /// liveness markers, so no reflog is requested (`reference` with an empty
+    /// log message and `force = true`).
+    fn set_cas_ref(&self, hash: &str, oid: Oid) -> io::Result<()> {
+        let repo = self.open_repo()?;
+        repo.reference(&Self::cas_ref_name(hash), oid, true, "")
+            .map_err(git_err("ref update"))?;
+        Ok(())
     }
 
     /// Delete `refs/cas/<hash>` if present. Deleting an absent ref is a no-op.
     fn delete_cas_ref(&self, hash: &str) -> io::Result<()> {
-        let edit = gix_ref::transaction::RefEdit {
-            change: gix_ref::transaction::Change::Delete {
-                expected: gix_ref::transaction::PreviousValue::Any,
-                log: gix_ref::transaction::RefLog::AndReference,
-            },
-            name: Self::cas_ref_name(hash)?,
-            deref: false,
-        };
-        self.commit_ref_edit(edit)
-    }
-
-    /// Run a single ref edit through prepare + commit. The committer is `None`
-    /// because the reflog is disabled for the CAS ref store.
-    fn commit_ref_edit(&self, edit: gix_ref::transaction::RefEdit) -> io::Result<()> {
-        self.ref_store()
-            .transaction()
-            .prepare(
-                std::iter::once(edit),
-                gix_lock::acquire::Fail::Immediately,
-                gix_lock::acquire::Fail::Immediately,
-            )
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref prepare: {e}")))?
-            .commit(None)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref commit: {e}")))?;
-        Ok(())
+        let repo = self.open_repo()?;
+        let found = repo.find_reference(&Self::cas_ref_name(hash));
+        match found {
+            Ok(mut reference) => {
+                reference.delete().map_err(git_err("ref delete"))?;
+                Ok(())
+            }
+            // Not found — nothing to delete.
+            Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
+            Err(e) => Err(git_err("ref find")(e)),
+        }
     }
 
     /// The set of content hashes currently retained via a `refs/cas/<sha256>`
@@ -455,30 +453,30 @@ impl ContentStore {
     /// after a restart no longer treats every previously-retained object as
     /// collectable.
     fn retained_hashes(&self) -> io::Result<Vec<String>> {
-        let store = self.ref_store();
-        let iter = store
-            .iter()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref iter: {e}")))?;
-        let all = iter
-            .all()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref iter all: {e}")))?;
+        let repo = self.open_repo()?;
+        // `references_glob` over the CAS namespace; the glob is rooted at the
+        // ref prefix so unrelated refs (none, in this bare store) are skipped.
+        let glob = format!("{CAS_REF_PREFIX}*");
+        let refs = repo
+            .references_glob(&glob)
+            .map_err(git_err("ref iter"))?;
         let mut out = Vec::new();
-        for reference in all {
-            let reference =
-                reference.map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref: {e}")))?;
-            let name_bytes: &[u8] = reference.name.as_bstr().as_ref();
-            if let Some(rest) = std::str::from_utf8(name_bytes)
-                .ok()
-                .and_then(|s| s.strip_prefix(CAS_REF_PREFIX))
-            {
-                out.push(rest.to_string());
+        for reference in refs {
+            let reference = reference.map_err(git_err("ref"))?;
+            // `name()` is `Err` when the ref name is not valid UTF-8; CAS refs
+            // are always valid UTF-8 (`refs/cas/<hex>`), so a non-UTF-8 name is
+            // simply skipped.
+            if let Ok(name) = reference.name() {
+                if let Some(rest) = name.strip_prefix(CAS_REF_PREFIX) {
+                    out.push(rest.to_string());
+                }
             }
         }
         Ok(out)
     }
 
     /// Resolve an Endo SHA-256 key to its git object id, if indexed.
-    fn oid_for(&self, hash: &str) -> Option<gix_hash::ObjectId> {
+    fn oid_for(&self, hash: &str) -> Option<Oid> {
         let index = self.index.read().unwrap_or_else(|e| e.into_inner());
         index.get(hash).copied()
     }
@@ -490,7 +488,7 @@ impl ContentStore {
     }
 
     /// Record a `sha256 -> git-oid` mapping in memory and persist it.
-    fn record_index(&self, hash: &str, oid: gix_hash::ObjectId) -> io::Result<()> {
+    fn record_index(&self, hash: &str, oid: Oid) -> io::Result<()> {
         {
             let mut index = self.index.write().unwrap_or_else(|e| e.into_inner());
             index.insert(hash.to_string(), oid);
@@ -505,7 +503,7 @@ impl ContentStore {
         for (hash, oid) in index.iter() {
             body.push_str(hash);
             body.push(' ');
-            body.push_str(&oid.to_hex().to_string());
+            body.push_str(&oid.to_string());
             body.push('\n');
         }
         let path = self.dir.join(INDEX_FILE);
@@ -520,7 +518,7 @@ impl ContentStore {
 /// Each line is `<sha256-hex> <git-oid-hex>`. A missing file yields an empty
 /// index (a fresh store). Malformed lines are skipped rather than failing the
 /// whole open.
-fn load_index(dir: &Path) -> io::Result<HashMap<String, gix_hash::ObjectId>> {
+fn load_index(dir: &Path) -> io::Result<HashMap<String, Oid>> {
     let path = dir.join(INDEX_FILE);
     let mut map = HashMap::new();
     let body = match fs::read_to_string(&path) {
@@ -533,11 +531,17 @@ fn load_index(dir: &Path) -> io::Result<HashMap<String, gix_hash::ObjectId>> {
         let (Some(hash), Some(oid_hex)) = (parts.next(), parts.next()) else {
             continue;
         };
-        if let Ok(oid) = gix_hash::ObjectId::from_hex(oid_hex.as_bytes()) {
+        if let Ok(oid) = Oid::from_str(oid_hex) {
             map.insert(hash.to_string(), oid);
         }
     }
     Ok(map)
+}
+
+/// Build an `io::Error`-producing closure that frames a `git2::Error` with a
+/// short operation label. Keeps the call sites terse.
+fn git_err(op: &'static str) -> impl Fn(git2::Error) -> io::Error {
+    move |e| io::Error::new(io::ErrorKind::Other, format!("{op}: {e}"))
 }
 
 /// Report from a GC run.
@@ -630,7 +634,12 @@ mod tests {
         assert!(cas.retained_hashes().unwrap().is_empty());
 
         cas.retain(&hash);
-        let ref_path = tmp.path().join(format!("{CAS_REF_PREFIX}{hash}"));
+        // The retention ref lives inside the bare repo at
+        // `{dir}/cas.git/refs/cas/<sha256>`.
+        let ref_path = tmp
+            .path()
+            .join(REPO_DIR)
+            .join(format!("{CAS_REF_PREFIX}{hash}"));
         assert!(ref_path.exists(), "retain must write refs/cas/<sha256>");
         assert!(cas.retained_hashes().unwrap().contains(&hash));
 
@@ -894,9 +903,10 @@ mod tests {
 
     // -- Axis 1: git object-DB substrate ----------------------------------
 
-    /// The bytes are stored as git objects under `{dir}/objects/`, and a
-    /// persistent `sha256 -> git-oid` index file is written. This asserts the
-    /// substrate is the git object DB (not the old flat `{dir}/{hex-sha256}`).
+    /// The bytes are stored as git objects inside the bare repo at
+    /// `{dir}/cas.git`, and a persistent `sha256 -> git-oid` index file is
+    /// written. This asserts the substrate is the git object DB (not the old
+    /// flat `{dir}/{hex-sha256}`).
     #[test]
     fn store_uses_git_object_db_and_index() {
         let tmp = tempfile::tempdir().unwrap();
@@ -909,8 +919,8 @@ mod tests {
             !tmp.path().join(&hash).exists(),
             "blob must not be stored as a flat {{dir}}/{{hex-sha256}} file"
         );
-        // The git object DB directory holds the object.
-        let objects_dir = tmp.path().join(OBJECTS_DIR);
+        // The bare repo's object DB directory holds the object.
+        let objects_dir = tmp.path().join(REPO_DIR).join("objects");
         assert!(objects_dir.is_dir(), "git objects/ dir must exist");
         // The persistent index records the mapping.
         let index_path = tmp.path().join(INDEX_FILE);
@@ -935,7 +945,8 @@ mod tests {
 
         let oid = cas.oid_for(&hash).expect("hash must be indexed");
         // The git object DB contains an object at that oid.
-        assert!(cas.odb.contains(&oid));
+        let repo = cas.open_repo().unwrap();
+        assert!(repo.odb().unwrap().exists(oid));
         // Reading via the public API returns the exact bytes.
         assert_eq!(cas.fetch(&hash).unwrap(), data);
     }
@@ -993,7 +1004,7 @@ mod tests {
         cas.retain(&keep);
 
         let drop_oid = cas.oid_for(&drop).expect("indexed before gc");
-        let drop_object_path = cas.odb.object_path(&drop_oid);
+        let drop_object_path = cas.loose_object_path(&drop_oid);
         assert!(drop_object_path.exists(), "git object present before gc");
 
         let report = cas.gc(&HashSet::new()).unwrap();

--- a/rust/endo/src/cas.rs
+++ b/rust/endo/src/cas.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
+use gix_object::Write as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -64,35 +65,68 @@ pub struct TreeEntry {
 // ContentStore
 // ---------------------------------------------------------------------------
 
-/// SHA-256 content-addressed store backed by a flat directory.
+/// SHA-256 content-addressed store backed by a git object database.
 ///
-/// Files are stored as `{dir}/{hex-sha256}`.
-/// Optional `.meta` sidecars carry advisory type and ref count.
+/// The Endo-facing content identity is the hex SHA-256 of the bytes, exactly
+/// as before; the bytes themselves live as git (loose) objects under
+/// `{dir}/objects/`, and a persistent `sha256 -> git-oid` index
+/// (`{dir}/sha256-oid.idx`) bridges the Endo key to git's internal object id.
+/// Git's object DB runs in its default (SHA-1) object format internally; the
+/// experimental git SHA-256 object mode is deliberately not used (the
+/// Endo-facing key stays SHA-256 regardless).
+///
+/// Optional `.meta` sidecars in `{dir}` carry advisory type and ref count, as
+/// before. Retention (`retain`/`release`/`gc`) is unchanged in this pass; the
+/// design's axis 4 replaces it with `refs/formulas/<id>` + `git gc`.
 pub struct ContentStore {
     dir: PathBuf,
+    /// Git loose-object database rooted at `{dir}/objects/`.
+    odb: gix_odb::loose::Store,
+    /// Persistent `sha256-hex -> git-oid` index, loaded on open and appended
+    /// on every newly stored object. Endo references the SHA-256 key; this
+    /// resolves it to the git object id used by the object DB.
+    index: RwLock<HashMap<String, gix_hash::ObjectId>>,
     /// In-memory ref count cache (flushed to `.meta` on release/retain).
     refs: RwLock<HashMap<String, u32>>,
 }
+
+/// Basename of the persistent sha256 -> git-oid index inside the store dir.
+const INDEX_FILE: &str = "sha256-oid.idx";
+/// Subdirectory of the store dir holding the git loose-object database.
+const OBJECTS_DIR: &str = "objects";
 
 impl ContentStore {
     /// Open (or create) a content store at `dir`.
     pub fn open(dir: &Path) -> io::Result<Self> {
         fs::create_dir_all(dir)?;
+        let objects_dir = dir.join(OBJECTS_DIR);
+        fs::create_dir_all(&objects_dir)?;
+        let odb = gix_odb::loose::Store::at(&objects_dir, gix_hash::Kind::Sha1, None);
+        let index = RwLock::new(load_index(dir)?);
         Ok(ContentStore {
             dir: dir.to_path_buf(),
+            odb,
+            index,
             refs: RwLock::new(HashMap::new()),
         })
     }
 
     /// Store bytes in the CAS and return the hex SHA-256 hash.
+    ///
+    /// The bytes are written as a git blob; the returned identity is the hex
+    /// SHA-256 of the bytes (unchanged contract). A `sha256 -> git-oid` entry
+    /// is recorded so subsequent `fetch`/`has` resolve back to the object.
     pub fn store(&self, data: &[u8], content_type: &str) -> io::Result<String> {
         let hash = hex_sha256(data);
-        let path = self.dir.join(&hash);
-        if !path.exists() {
-            // Write atomically: write to .tmp, then rename.
-            let tmp = self.dir.join(format!("{hash}.tmp"));
-            fs::write(&tmp, data)?;
-            fs::rename(&tmp, &path)?;
+        // Only write the git object (and index entry) the first time we see a
+        // given SHA-256 — preserves dedup. Git's own loose writer is
+        // content-addressed and atomic (tempfile + rename) under the hood.
+        if !self.index_contains(&hash) {
+            let oid = self
+                .odb
+                .write_buf(gix_object::Kind::Blob, data)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("git write: {e}")))?;
+            self.record_index(&hash, oid)?;
         }
         // Write .meta if content type is not blob (default).
         if content_type != "blob" {
@@ -103,13 +137,29 @@ impl ContentStore {
 
     /// Fetch content by hex hash.
     pub fn fetch(&self, hash: &str) -> io::Result<Vec<u8>> {
-        let path = self.dir.join(hash);
-        fs::read(&path)
+        let oid = self.oid_for(hash).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotFound, format!("no object for {hash}"))
+        })?;
+        let mut buf = Vec::new();
+        match self
+            .odb
+            .try_find(&oid, &mut buf)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("git read: {e}")))?
+        {
+            Some(obj) => Ok(obj.data.to_vec()),
+            None => Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("git object missing for {hash}"),
+            )),
+        }
     }
 
     /// Check whether a hash exists in the store.
     pub fn has(&self, hash: &str) -> bool {
-        self.dir.join(hash).exists()
+        match self.oid_for(hash) {
+            Some(oid) => self.odb.contains(&oid),
+            None => false,
+        }
     }
 
     /// Increment ref count for a hash.
@@ -229,32 +279,57 @@ impl ContentStore {
             // If read_tree fails, it's a blob — no children to walk.
         }
 
-        // Sweep: iterate store directory, delete unreferenced entries.
+        // Sweep: walk the sha256 -> oid index, collecting unreferenced
+        // objects. The set of CAS objects is exactly the index keyset (every
+        // stored object recorded an entry); the git object DB may hold extra
+        // intermediate objects, but the CAS only owns those it indexed.
         let mut freed_count = 0u64;
         let mut freed_bytes = 0u64;
 
-        for entry in fs::read_dir(&self.dir)? {
-            let entry = entry?;
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            // Skip .meta sidecars and .tmp files.
-            if name_str.ends_with(".meta") || name_str.ends_with(".tmp") {
-                continue;
-            }
-            if !live.contains(name_str.as_ref()) {
-                let meta = entry.metadata()?;
-                let size = meta.len();
-                // Delete the blob and its meta sidecar.
-                fs::remove_file(entry.path())?;
-                let meta_path = self.dir.join(format!("{name_str}.meta"));
-                let _ = fs::remove_file(&meta_path);
-                freed_count += 1;
+        // Snapshot the hashes to collect so we don't hold the index read lock
+        // while mutating it.
+        let to_collect: Vec<(String, gix_hash::ObjectId)> = {
+            let index = self.index.read().unwrap_or_else(|e| e.into_inner());
+            index
+                .iter()
+                .filter(|(hash, _)| !live.contains(hash.as_str()))
+                .map(|(hash, oid)| (hash.clone(), *oid))
+                .collect()
+        };
+
+        for (hash, oid) in to_collect {
+            // Size of the on-disk git object (compressed), best-effort.
+            let object_path = self.odb.object_path(&oid);
+            let size = fs::metadata(&object_path).map(|m| m.len()).unwrap_or(0);
+            // Delete the git object file. It is shared by oid, so only remove
+            // it if no other indexed hash maps to the same oid.
+            let still_referenced = {
+                let index = self.index.read().unwrap_or_else(|e| e.into_inner());
+                index
+                    .iter()
+                    .any(|(other_hash, other_oid)| other_hash != &hash && *other_oid == oid)
+            };
+            if !still_referenced {
+                let _ = fs::remove_file(&object_path);
                 freed_bytes += size;
-                // Remove from in-memory refs.
-                let mut refs = self.refs.write().unwrap_or_else(|e| e.into_inner());
-                refs.remove(name_str.as_ref());
             }
+            // Drop the meta sidecar.
+            let meta_path = self.dir.join(format!("{hash}.meta"));
+            let _ = fs::remove_file(&meta_path);
+            // Drop the index entry and any in-memory ref count.
+            {
+                let mut index = self.index.write().unwrap_or_else(|e| e.into_inner());
+                index.remove(&hash);
+            }
+            {
+                let mut refs = self.refs.write().unwrap_or_else(|e| e.into_inner());
+                refs.remove(&hash);
+            }
+            freed_count += 1;
         }
+
+        // Persist the pruned index.
+        self.persist_index()?;
 
         Ok(GcReport {
             freed_count,
@@ -273,6 +348,68 @@ impl ContentStore {
         );
         fs::write(&meta_path, json.as_bytes())
     }
+
+    /// Resolve an Endo SHA-256 key to its git object id, if indexed.
+    fn oid_for(&self, hash: &str) -> Option<gix_hash::ObjectId> {
+        let index = self.index.read().unwrap_or_else(|e| e.into_inner());
+        index.get(hash).copied()
+    }
+
+    /// Whether the SHA-256 key already has an index entry.
+    fn index_contains(&self, hash: &str) -> bool {
+        let index = self.index.read().unwrap_or_else(|e| e.into_inner());
+        index.contains_key(hash)
+    }
+
+    /// Record a `sha256 -> git-oid` mapping in memory and persist it.
+    fn record_index(&self, hash: &str, oid: gix_hash::ObjectId) -> io::Result<()> {
+        {
+            let mut index = self.index.write().unwrap_or_else(|e| e.into_inner());
+            index.insert(hash.to_string(), oid);
+        }
+        self.persist_index()
+    }
+
+    /// Rewrite the persistent index file atomically (`.tmp` then rename).
+    fn persist_index(&self) -> io::Result<()> {
+        let index = self.index.read().unwrap_or_else(|e| e.into_inner());
+        let mut body = String::with_capacity(index.len() * 110);
+        for (hash, oid) in index.iter() {
+            body.push_str(hash);
+            body.push(' ');
+            body.push_str(&oid.to_hex().to_string());
+            body.push('\n');
+        }
+        let path = self.dir.join(INDEX_FILE);
+        let tmp = self.dir.join(format!("{INDEX_FILE}.tmp"));
+        fs::write(&tmp, body.as_bytes())?;
+        fs::rename(&tmp, &path)
+    }
+}
+
+/// Load the persistent `sha256 -> git-oid` index from `{dir}/sha256-oid.idx`.
+///
+/// Each line is `<sha256-hex> <git-oid-hex>`. A missing file yields an empty
+/// index (a fresh store). Malformed lines are skipped rather than failing the
+/// whole open.
+fn load_index(dir: &Path) -> io::Result<HashMap<String, gix_hash::ObjectId>> {
+    let path = dir.join(INDEX_FILE);
+    let mut map = HashMap::new();
+    let body = match fs::read_to_string(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(map),
+        Err(e) => return Err(e),
+    };
+    for line in body.lines() {
+        let mut parts = line.split_whitespace();
+        let (Some(hash), Some(oid_hex)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        if let Ok(oid) = gix_hash::ObjectId::from_hex(oid_hex.as_bytes()) {
+            map.insert(hash.to_string(), oid);
+        }
+    }
+    Ok(map)
 }
 
 /// Report from a GC run.
@@ -608,5 +745,124 @@ mod tests {
         let b2 = cas.read_tree(&h2).unwrap().entries["also-shared.js"].hash.clone();
         assert_eq!(b1, b2);
         assert_eq!(b1, shared_blob);
+    }
+
+    // -- Axis 1: git object-DB substrate ----------------------------------
+
+    /// The bytes are stored as git objects under `{dir}/objects/`, and a
+    /// persistent `sha256 -> git-oid` index file is written. This asserts the
+    /// substrate is the git object DB (not the old flat `{dir}/{hex-sha256}`).
+    #[test]
+    fn store_uses_git_object_db_and_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cas = ContentStore::open(tmp.path()).unwrap();
+
+        let hash = cas.store(b"git substrate", "blob").unwrap();
+
+        // The Endo key never appears as a raw flat-dir file.
+        assert!(
+            !tmp.path().join(&hash).exists(),
+            "blob must not be stored as a flat {{dir}}/{{hex-sha256}} file"
+        );
+        // The git object DB directory holds the object.
+        let objects_dir = tmp.path().join(OBJECTS_DIR);
+        assert!(objects_dir.is_dir(), "git objects/ dir must exist");
+        // The persistent index records the mapping.
+        let index_path = tmp.path().join(INDEX_FILE);
+        assert!(index_path.exists(), "sha256 -> oid index must be persisted");
+        let index_body = fs::read_to_string(&index_path).unwrap();
+        assert!(
+            index_body.starts_with(&hash),
+            "index must record the sha256 key"
+        );
+    }
+
+    /// The git oid the index maps to is a real, resolvable git blob whose
+    /// bytes equal the stored bytes. This proves the `sha256 -> git-oid`
+    /// bridge actually resolves through the git object DB.
+    #[test]
+    fn index_oid_resolves_to_git_blob() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cas = ContentStore::open(tmp.path()).unwrap();
+
+        let data = b"resolvable via oid";
+        let hash = cas.store(data, "blob").unwrap();
+
+        let oid = cas.oid_for(&hash).expect("hash must be indexed");
+        // The git object DB contains an object at that oid.
+        assert!(cas.odb.contains(&oid));
+        // Reading via the public API returns the exact bytes.
+        assert_eq!(cas.fetch(&hash).unwrap(), data);
+    }
+
+    /// The persistent index makes the store survive a reopen: a second
+    /// `ContentStore::open` on the same dir resolves content stored by the
+    /// first. (The in-memory refcount cache never survived restart; the index
+    /// is what gives the substrate durable lookups — see axis-4 framing.)
+    #[test]
+    fn index_survives_reopen() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let (hash, snapshot_hash);
+        {
+            let cas = ContentStore::open(tmp.path()).unwrap();
+            hash = cas.store(b"persisted blob", "blob").unwrap();
+            snapshot_hash = cas.store(b"persisted snapshot", "snapshot").unwrap();
+        } // drop the first store — in-memory index is gone.
+
+        let reopened = ContentStore::open(tmp.path()).unwrap();
+        assert!(reopened.has(&hash), "blob must resolve after reopen");
+        assert_eq!(reopened.fetch(&hash).unwrap(), b"persisted blob");
+        assert!(reopened.has(&snapshot_hash));
+        assert_eq!(
+            reopened.fetch(&snapshot_hash).unwrap(),
+            b"persisted snapshot"
+        );
+    }
+
+    /// Two distinct SHA-256 keys never collide in the index, and fetching one
+    /// does not return the other's bytes.
+    #[test]
+    fn distinct_keys_distinct_objects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cas = ContentStore::open(tmp.path()).unwrap();
+
+        let a = cas.store(b"alpha", "blob").unwrap();
+        let b = cas.store(b"beta", "blob").unwrap();
+        assert_ne!(a, b);
+        assert_eq!(cas.fetch(&a).unwrap(), b"alpha");
+        assert_eq!(cas.fetch(&b).unwrap(), b"beta");
+        assert_ne!(cas.oid_for(&a), cas.oid_for(&b));
+    }
+
+    /// GC removes the underlying git object (not a flat-dir file) and prunes
+    /// the index entry; the index is re-persisted so the collection survives a
+    /// reopen.
+    #[test]
+    fn gc_prunes_git_object_and_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cas = ContentStore::open(tmp.path()).unwrap();
+
+        let keep = cas.store(b"keep via retain", "blob").unwrap();
+        let drop = cas.store(b"drop via gc", "blob").unwrap();
+        cas.retain(&keep);
+
+        let drop_oid = cas.oid_for(&drop).expect("indexed before gc");
+        let drop_object_path = cas.odb.object_path(&drop_oid);
+        assert!(drop_object_path.exists(), "git object present before gc");
+
+        let report = cas.gc(&HashSet::new()).unwrap();
+        assert_eq!(report.freed_count, 1);
+
+        // The git object file is gone, and the index no longer maps it.
+        assert!(!drop_object_path.exists(), "git object removed by gc");
+        assert!(cas.oid_for(&drop).is_none(), "index entry pruned by gc");
+        assert!(!cas.has(&drop));
+        assert!(cas.has(&keep));
+
+        // The pruned index is durable across reopen.
+        let reopened = ContentStore::open(tmp.path()).unwrap();
+        assert!(!reopened.has(&drop));
+        assert!(reopened.has(&keep));
     }
 }

--- a/rust/endo/src/cas.rs
+++ b/rust/endo/src/cas.rs
@@ -75,9 +75,17 @@ pub struct TreeEntry {
 /// experimental git SHA-256 object mode is deliberately not used (the
 /// Endo-facing key stays SHA-256 regardless).
 ///
-/// Optional `.meta` sidecars in `{dir}` carry advisory type and ref count, as
-/// before. Retention (`retain`/`release`/`gc`) is unchanged in this pass; the
-/// design's axis 4 replaces it with `refs/formulas/<id>` + `git gc`.
+/// Optional `.meta` sidecars in `{dir}` carry the advisory content type.
+///
+/// Retention is **reachability-driven and crash-safe** (axis 4): a retained
+/// object is recorded as a git ref under `refs/cas/<sha256>` pointing at the
+/// object's git oid, written through git's own ref-lock discipline (lock-file
+/// + atomic rename, via `gix-ref`). `gc` computes the live set from those refs
+/// — git reachability over the retained roots — rather than from an in-memory
+/// refcount that was lost on every restart. This replaces the hand-rolled
+/// `HashMap<String, u32>` refcount the store used to flush best-effort to
+/// `.meta`; the maintainer's ruling is to lean on git's ref machinery instead
+/// of rolling our own retention cache.
 pub struct ContentStore {
     dir: PathBuf,
     /// Git loose-object database rooted at `{dir}/objects/`.
@@ -86,14 +94,22 @@ pub struct ContentStore {
     /// on every newly stored object. Endo references the SHA-256 key; this
     /// resolves it to the git object id used by the object DB.
     index: RwLock<HashMap<String, gix_hash::ObjectId>>,
-    /// In-memory ref count cache (flushed to `.meta` on release/retain).
-    refs: RwLock<HashMap<String, u32>>,
+    // Retention is recorded as git refs under `{dir}/refs/cas/<sha256>`. The
+    // `gix_ref::file::Store` that reads/writes them is built on demand in
+    // `ref_store()` rather than held as a field: it carries a non-`Send`
+    // `Rc` packed-refs cache, and `ContentStore` is shared across threads via
+    // `Arc`. Constructing it is cheap (a path + options; packed refs load
+    // lazily), so per-operation construction costs nothing on the hot path.
 }
 
 /// Basename of the persistent sha256 -> git-oid index inside the store dir.
 const INDEX_FILE: &str = "sha256-oid.idx";
 /// Subdirectory of the store dir holding the git loose-object database.
 const OBJECTS_DIR: &str = "objects";
+/// Ref-namespace prefix for retained CAS objects. A ref
+/// `refs/cas/<sha256>` -> git-oid is the liveness record for one retained
+/// content hash.
+const CAS_REF_PREFIX: &str = "refs/cas/";
 
 impl ContentStore {
     /// Open (or create) a content store at `dir`.
@@ -107,7 +123,6 @@ impl ContentStore {
             dir: dir.to_path_buf(),
             odb,
             index,
-            refs: RwLock::new(HashMap::new()),
         })
     }
 
@@ -130,7 +145,7 @@ impl ContentStore {
         }
         // Write .meta if content type is not blob (default).
         if content_type != "blob" {
-            self.write_meta(&hash, content_type, 0)?;
+            self.write_meta(&hash, content_type)?;
         }
         Ok(hash)
     }
@@ -162,22 +177,29 @@ impl ContentStore {
         }
     }
 
-    /// Increment ref count for a hash.
+    /// Retain a hash: record it as a live root via `refs/cas/<sha256>`.
+    ///
+    /// The ref points at the object's git oid and is written through git's
+    /// ref-lock discipline (lock-file + atomic rename), so it survives a daemon
+    /// restart and a crash mid-write. A retained object is reachable from a
+    /// ref, which is what keeps it out of `gc`'s sweep. Best-effort: an unknown
+    /// hash (never stored) has no oid to point at and is silently ignored, and
+    /// a write failure leaves retention as it was rather than panicking on the
+    /// CapTP control path.
     pub fn retain(&self, hash: &str) {
-        let mut refs = self.refs.write().unwrap_or_else(|e| e.into_inner());
-        let count = refs.entry(hash.to_string()).or_insert(0);
-        *count += 1;
-        // Best-effort flush to .meta.
-        let _ = self.write_meta(hash, "blob", *count);
+        let Some(oid) = self.oid_for(hash) else {
+            return;
+        };
+        let _ = self.set_cas_ref(hash, oid);
     }
 
-    /// Decrement ref count for a hash.
+    /// Release a hash: drop its `refs/cas/<sha256>` retention ref.
+    ///
+    /// After release the object is collectable on the next `gc` unless some
+    /// other live root (a tree, an explicit `gc` root, another retain) keeps it
+    /// reachable. Deleting a ref that does not exist is a no-op.
     pub fn release(&self, hash: &str) {
-        let mut refs = self.refs.write().unwrap_or_else(|e| e.into_inner());
-        if let Some(count) = refs.get_mut(hash) {
-            *count = count.saturating_sub(1);
-            let _ = self.write_meta(hash, "blob", *count);
-        }
+        let _ = self.delete_cas_ref(hash);
     }
 
     /// Store a tree entry (JSON manifest) in the CAS.
@@ -243,24 +265,28 @@ impl ContentStore {
         &self.dir
     }
 
-    /// Run garbage collection. Deletes entries that:
-    /// - Have zero ref count in the in-memory cache.
-    /// - Are not in `live_roots`.
-    /// - Are not transitively referenced by a live tree.
+    /// Run garbage collection. Deletes entries that are not reachable from a
+    /// live root, where the live roots are:
+    /// - the explicit `live_roots` argument (caller-supplied, e.g. the formula
+    ///   graph the supervisor knows is live this session), and
+    /// - every retained object recorded as a durable `refs/cas/<sha256>` ref.
+    ///
+    /// The ref-derived roots are the crash-safe replacement for the old
+    /// in-memory refcount: because they live on disk through git's ref-lock
+    /// discipline, retention survives a daemon restart, and a `gc` after a
+    /// restart no longer collects everything that was retained in a prior
+    /// session. The transitive tree walk below expands those roots over their
+    /// children, which is git reachability over the retained ref set.
     ///
     /// Returns a report of what was collected.
     pub fn gc(&self, live_roots: &HashSet<String>) -> io::Result<GcReport> {
-        // Build the full live set by walking trees from live_roots.
+        // Build the full live set, seeded by the caller's explicit roots.
         let mut live = live_roots.clone();
 
-        // Also include anything with refs > 0.
-        {
-            let refs = self.refs.read().unwrap_or_else(|e| e.into_inner());
-            for (hash, count) in refs.iter() {
-                if *count > 0 {
-                    live.insert(hash.clone());
-                }
-            }
+        // Add every object retained via a `refs/cas/<sha256>` ref. These are
+        // durable across restart — the load-bearing reachability source.
+        for hash in self.retained_hashes()? {
+            live.insert(hash);
         }
 
         // Expand tree references: walk all live trees and mark children.
@@ -316,15 +342,14 @@ impl ContentStore {
             // Drop the meta sidecar.
             let meta_path = self.dir.join(format!("{hash}.meta"));
             let _ = fs::remove_file(&meta_path);
-            // Drop the index entry and any in-memory ref count.
+            // Drop the index entry.
             {
                 let mut index = self.index.write().unwrap_or_else(|e| e.into_inner());
                 index.remove(&hash);
             }
-            {
-                let mut refs = self.refs.write().unwrap_or_else(|e| e.into_inner());
-                refs.remove(&hash);
-            }
+            // A collected object is unreachable, so it carries no retention ref
+            // (refs seed the live set). Drop any stale ref defensively anyway.
+            let _ = self.delete_cas_ref(&hash);
             freed_count += 1;
         }
 
@@ -341,12 +366,115 @@ impl ContentStore {
     // Internal helpers
     // -----------------------------------------------------------------------
 
-    fn write_meta(&self, hash: &str, content_type: &str, ref_count: u32) -> io::Result<()> {
+    /// Write the advisory `.meta` sidecar carrying the content type.
+    ///
+    /// The old `refs` field is gone: retention is now a git ref under
+    /// `refs/cas/<sha256>`, not a count flushed into `.meta`.
+    fn write_meta(&self, hash: &str, content_type: &str) -> io::Result<()> {
         let meta_path = self.dir.join(format!("{hash}.meta"));
-        let json = format!(
-            "{{\"type\":\"{content_type}\",\"refs\":{ref_count}}}"
-        );
+        let json = format!("{{\"type\":\"{content_type}\"}}");
         fs::write(&meta_path, json.as_bytes())
+    }
+
+    /// Open the git ref store rooted at `{dir}`. Built per-call rather than
+    /// held as a field because `gix_ref::file::Store` is `!Send` (it caches
+    /// packed refs behind an `Rc`) while `ContentStore` is shared across
+    /// threads. Construction is cheap; the reflog is disabled because these
+    /// refs are pure liveness markers (no history, no committer identity).
+    fn ref_store(&self) -> gix_ref::file::Store {
+        gix_ref::file::Store::at(
+            self.dir.clone(),
+            gix_ref::store::init::Options {
+                write_reflog: gix_ref::store::WriteReflog::Disable,
+                object_hash: gix_hash::Kind::Sha1,
+                precompose_unicode: false,
+                prohibit_windows_device_names: false,
+            },
+        )
+    }
+
+    /// Build the `FullName` of the retention ref for a content hash.
+    fn cas_ref_name(hash: &str) -> io::Result<gix_ref::FullName> {
+        gix_ref::FullName::try_from(format!("{CAS_REF_PREFIX}{hash}"))
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("ref name: {e}")))
+    }
+
+    /// Create or update `refs/cas/<hash>` -> `oid` through git's ref-lock
+    /// discipline. Crash-safe: the lock-file + atomic-rename commit means a
+    /// crash either leaves the old ref state or the new one, never a torn
+    /// write.
+    fn set_cas_ref(&self, hash: &str, oid: gix_hash::ObjectId) -> io::Result<()> {
+        let edit = gix_ref::transaction::RefEdit {
+            change: gix_ref::transaction::Change::Update {
+                log: gix_ref::transaction::LogChange {
+                    mode: gix_ref::transaction::RefLog::AndReference,
+                    force_create_reflog: false,
+                    message: Default::default(),
+                },
+                expected: gix_ref::transaction::PreviousValue::Any,
+                new: gix_ref::Target::Object(oid),
+            },
+            name: Self::cas_ref_name(hash)?,
+            deref: false,
+        };
+        self.commit_ref_edit(edit)
+    }
+
+    /// Delete `refs/cas/<hash>` if present. Deleting an absent ref is a no-op.
+    fn delete_cas_ref(&self, hash: &str) -> io::Result<()> {
+        let edit = gix_ref::transaction::RefEdit {
+            change: gix_ref::transaction::Change::Delete {
+                expected: gix_ref::transaction::PreviousValue::Any,
+                log: gix_ref::transaction::RefLog::AndReference,
+            },
+            name: Self::cas_ref_name(hash)?,
+            deref: false,
+        };
+        self.commit_ref_edit(edit)
+    }
+
+    /// Run a single ref edit through prepare + commit. The committer is `None`
+    /// because the reflog is disabled for the CAS ref store.
+    fn commit_ref_edit(&self, edit: gix_ref::transaction::RefEdit) -> io::Result<()> {
+        self.ref_store()
+            .transaction()
+            .prepare(
+                std::iter::once(edit),
+                gix_lock::acquire::Fail::Immediately,
+                gix_lock::acquire::Fail::Immediately,
+            )
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref prepare: {e}")))?
+            .commit(None)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref commit: {e}")))?;
+        Ok(())
+    }
+
+    /// The set of content hashes currently retained via a `refs/cas/<sha256>`
+    /// ref. This is the durable, crash-safe live-root set read straight off
+    /// disk — the heart of axis 4: it survives a daemon restart, so a `gc`
+    /// after a restart no longer treats every previously-retained object as
+    /// collectable.
+    fn retained_hashes(&self) -> io::Result<Vec<String>> {
+        let store = self.ref_store();
+        let iter = store
+            .iter()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref iter: {e}")))?;
+        let all = iter
+            .all()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref iter all: {e}")))?;
+        let mut out = Vec::new();
+        for reference in all {
+            let reference =
+                reference.map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ref: {e}")))?;
+            let name_bytes: &[u8] = reference.name.as_bstr().as_ref();
+            if let Some(rest) = std::str::from_utf8(name_bytes)
+                .ok()
+                .and_then(|s| s.strip_prefix(CAS_REF_PREFIX))
+            {
+                out.push(rest.to_string());
+            }
+        }
+        Ok(out)
     }
 
     /// Resolve an Endo SHA-256 key to its git object id, if indexed.
@@ -486,22 +614,39 @@ mod tests {
         assert!(meta.contains("\"type\":\"snapshot\""));
     }
 
+    /// Axis 4: retain records a durable git ref under `refs/cas/<sha256>`, and
+    /// release deletes it. The ref's presence — not an in-memory count — is the
+    /// liveness record, so a retained object survives a `gc` and a released one
+    /// is collectable. (The old counted-`.meta` contract is replaced by
+    /// reachability over refs per the maintainer's ruling.)
     #[test]
-    fn retain_release_updates_refs() {
+    fn retain_release_manage_cas_refs() {
         let tmp = tempfile::tempdir().unwrap();
         let cas = ContentStore::open(tmp.path()).unwrap();
 
-        let hash = cas.store(b"ref counted", "blob").unwrap();
-        cas.retain(&hash);
-        cas.retain(&hash);
+        let hash = cas.store(b"ref retained", "blob").unwrap();
 
-        let meta_path = tmp.path().join(format!("{hash}.meta"));
-        let meta = fs::read_to_string(&meta_path).unwrap();
-        assert!(meta.contains("\"refs\":2"));
+        // No ref yet — the object is collectable.
+        assert!(cas.retained_hashes().unwrap().is_empty());
+
+        cas.retain(&hash);
+        let ref_path = tmp.path().join(format!("{CAS_REF_PREFIX}{hash}"));
+        assert!(ref_path.exists(), "retain must write refs/cas/<sha256>");
+        assert!(cas.retained_hashes().unwrap().contains(&hash));
+
+        // Retained content survives GC with an empty caller root set.
+        let report = cas.gc(&HashSet::new()).unwrap();
+        assert_eq!(report.freed_count, 0);
+        assert!(cas.has(&hash));
 
         cas.release(&hash);
-        let meta = fs::read_to_string(&meta_path).unwrap();
-        assert!(meta.contains("\"refs\":1"));
+        assert!(!ref_path.exists(), "release must delete the ref");
+        assert!(cas.retained_hashes().unwrap().is_empty());
+
+        // Now collectable.
+        let report = cas.gc(&HashSet::new()).unwrap();
+        assert_eq!(report.freed_count, 1);
+        assert!(!cas.has(&hash));
     }
 
     #[test]
@@ -864,5 +1009,78 @@ mod tests {
         let reopened = ContentStore::open(tmp.path()).unwrap();
         assert!(!reopened.has(&drop));
         assert!(reopened.has(&keep));
+    }
+
+    // -- Axis 4: reachability-driven, crash-safe retention ----------------
+
+    /// The crash-safety fix. Today's bug: `retain` kept an in-memory refcount
+    /// that was rebuilt empty on `ContentStore::open`, so a `gc` after a daemon
+    /// restart collected everything that had been retained in a prior session
+    /// (the live system calls `cas.gc(&HashSet::new())`). With retention stored
+    /// as a durable `refs/cas/<sha256>` ref, the retained object survives the
+    /// reopen and the subsequent empty-root-set GC; the unretained one is
+    /// collected. This asserts the durable-liveness contract, not a mechanism.
+    #[test]
+    fn retention_survives_reopen_and_empty_root_gc() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let (retained, unretained);
+        {
+            let cas = ContentStore::open(tmp.path()).unwrap();
+            retained = cas.store(b"retained across restart", "blob").unwrap();
+            unretained = cas.store(b"only this session", "blob").unwrap();
+            cas.retain(&retained);
+        } // Drop the store — the in-memory state is gone, only disk survives.
+
+        // A fresh daemon process reopens the store and runs GC the way the live
+        // system does: with an empty caller-supplied root set.
+        let reopened = ContentStore::open(tmp.path()).unwrap();
+        let report = reopened.gc(&HashSet::new()).unwrap();
+
+        // The retained object is preserved purely because its ref persisted.
+        assert!(
+            reopened.has(&retained),
+            "retained content must survive restart + empty-root GC"
+        );
+        // The unretained object is collected.
+        assert_eq!(report.freed_count, 1);
+        assert!(!reopened.has(&unretained));
+    }
+
+    /// Retention refs act as GC roots that reach transitively into tree
+    /// children: retaining only a tree root keeps the tree's blobs alive even
+    /// though those blobs were never themselves retained. This is git
+    /// reachability over the retained ref set.
+    #[test]
+    fn retained_tree_root_keeps_children_alive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cas = ContentStore::open(tmp.path()).unwrap();
+
+        let child = cas.store(b"reachable child", "blob").unwrap();
+        let tree = TreeManifest {
+            entries: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "child.js".to_string(),
+                    TreeEntry {
+                        entry_type: "blob".to_string(),
+                        hash: child.clone(),
+                        size: Some(15),
+                    },
+                );
+                m
+            },
+        };
+        let tree_hash = cas.store_tree(&serde_json::to_vec(&tree).unwrap()).unwrap();
+        let orphan = cas.store(b"unreachable orphan", "blob").unwrap();
+
+        // Retain only the tree root — via a ref, not a caller root set.
+        cas.retain(&tree_hash);
+
+        let report = cas.gc(&HashSet::new()).unwrap();
+        assert_eq!(report.freed_count, 1, "only the orphan is collected");
+        assert!(cas.has(&tree_hash), "retained tree root preserved");
+        assert!(cas.has(&child), "child reachable from the retained tree");
+        assert!(!cas.has(&orphan), "orphan collected");
     }
 }


### PR DESCRIPTION
Backs the Rust `endor` daemon's content-addressed store (`rust/endo/src/cas.rs`) with git, sha256-keyed, replacing its hand-rolled flat-dir object store and in-memory refcount GC. The crux is **garbage collection**: with content as git objects and retention roots as git refs, GC reduces to git's own reachability, giving the CAS the durable, crash-safe live set it lacks today.

Adds the design `designs/daemon-git-backbone.md` (four axes, all backed by git) and lands the first two.

**The four axes** (each backs a shipped CAS phase):

- **Axis 4 — GC (the crux).** Retention roots live in the sqlite formula graph; mirror each to a git ref and reclaim the rest by reachability. Replaces the refcount that was rebuilt empty on every restart.
- **Axis 1 — objects.** `ContentStore` `store`/`fetch`/`has` over a git object DB, keyed by Endo's sha256.
- **Axis 2 — directories.** `TreeManifest` JSON → canonical git tree objects (fixes a latent JSON-ordering non-determinism; gains whole-subtree dedup).
- **Axis 3 — transport.** Bulk reads ride git pack/smart-protocol; CapTP/OCapN stays the control plane (generalizes the #367 `archiveTar` precedent).

Axes 2 and 3 are extensions on top of the GC crux. Migrations of existing on-disk state are out of scope.

## Implementation status

Landed on this branch:

- **Axis 1 — git object DB.** The flat `{dir}/{hex-sha256}` blob store under `ContentStore` is a git object DB inside a **bare git repository** at `{dir}/cas.git`, backed by libgit2 (the `git2` crate), with a persistent `sha256 → git-oid` index (`{dir}/sha256-oid.idx`). Public API and sha256 content identity unchanged; git runs its default SHA-1 object format internally.
- **Axis 4 — crash-safe, reachability-driven GC.** Retention is durable git refs (`refs/cas/<sha256>`) written through libgit2's ref-lock discipline (lock-file + atomic rename). `gc()` seeds its roots from those refs read off disk, so retentions survive a restart and the prior empty-root-set GC is no longer destructive. libgit2 ships no `git gc` / loose-object prune, so the sweep is an in-process manual reachability sweep — no runtime dependency on a `git` binary.

Pending: the crux mechanism — wiring the **formula graph to retention roots** via a `refs/formulas/<id>` per live formula, kept in sync. The CAS-level ref plumbing above is ready for it, but the formula graph lives in the **JS** daemon (`packages/daemon/src/daemon-database.js`, the SQLite `formula` table mutated by `daemon.js`), not in the Rust supervisor, which sees only opaque SQL across the XS FFI. The mirror wire therefore belongs in JS and drives the `cas-*` verbs (no JS code calls them today). Axes 2 and 3 not started.

`rust/endo` builds; `cargo test` green (75 tests).

## Maintainer rulings (provisional — ratify or correct)

1. **Git library — `git2`** (libgit2 bindings, battle-tested). The crate already links bundled C (rusqlite's SQLite, xsnap's XS build), so a C git library carries no new "C-free" cost; `git2` bundles libgit2.
2. **Hash — sha256 stays the content key**; git's default SHA-1 object format internally behind the `sha256 → git-oid` index; no git experimental SHA-256 mode.
3. **Retention encoding — presence-based git refs** (a ref means live), not a count.
4. **Ref namespace** landed as `refs/cas/<sha256>` at the CAS layer; the formula-keyed `refs/formulas/<id>` ⟺ sqlite mirror is pending and belongs in the JS daemon (which owns the formula graph), not the Rust supervisor.
5. **Store layout — a bare git repository** at `{dir}/cas.git` (objects + `refs/cas/*`), per the originator's "bare Git repository" framing.
6. **GC mechanism — in-process manual reachability sweep**, not a `git gc` / `git prune` subprocess: libgit2 has no GC porcelain, and an in-process sweep keeps the hot CAS path free of a runtime `git` binary dependency.

Remaining open questions (pack/smart-protocol placement for axis 3; `cas.rs` coexistence during a migration-free rollout) are tracked in the design doc.

## Description

1. `docs(daemon): redesign daemon-git-backbone on the Rust endor CAS substrate`
2. `chore(endo): depend on git2 (libgit2) for the CAS git backbone`
3. `chore: Update Cargo.lock`
4. `feat(endo): back the CAS object DB and retention on libgit2 via git2`
5. `docs(designs): correct git-backbone crux to GC, not axis-3 transport`

### Security Considerations

N/A — local on-disk substrate; no new network, transport, or capability surface. The `cas-*` verb surface is unchanged.

### Scaling Considerations

Git object writes are content-addressed and atomic like the prior flat-dir writer; the added cost is a `sha256 → oid` index lookup per access, an index rewrite per newly stored object, and one libgit2 ref transaction per retain/release. The store opens a fresh bare-repo handle per operation (libgit2 handles are not `Sync`); the open is cheap. Packing and the pack/smart-protocol data plane are axis 3 (not yet implemented).

### Testing Considerations

The existing `cas` tests are contract-level (sha256 round-trip, dedup, missing-key error, GC reachability) and pass unchanged. Tests cover the git-DB layout, the `sha256 → oid` bridge, index durability across reopen, retention surviving reopen + empty-root GC, and retained-tree children staying alive; each was proven load-bearing by breaking the path and observing the targeted failure.

### Compatibility Considerations

The `cas-*` verb surface and Endo's sha256 content identity are preserved; only the bytes-on-disk substrate moves.

### Upgrade Considerations

Migrations of pre-existing flat-dir on-disk state are out of scope; a fresh daemon starts on the git substrate.

### Documentation Considerations

The design lives at `designs/daemon-git-backbone.md`; the substrate is documented inline in `rust/endo/src/cas.rs`.

