### PR TITLE
docs(designs): daemon-git follow-ups: panel notes fold-in, in-flight acknowledgement, next-steps roadmap

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -25,21 +25,33 @@ original 1164-line monolith is repurposed; this layer carries
 `makeFromPackage` host method, `makeFromMount` dispatcher, worker
 dispatch body, CLI shape, XS bridging, and the architecture diagram
 that stitches the three preceding layers),
+[daemon-git-next-steps](daemon-git-next-steps.md) (added 2026-05-27,
+reframed 2026-05-29, slimmed 2026-06-03 to its forward-looking kernel;
+the version-controlled filesystem loop milestone
+roadmap over the canonical git trio — the north-star agent loop
+(provide workspace → read/list/edit → status/diff → commit → pull/push
+→ inspect history via `filesystemAt(ref)`) and an explicit
+content/versioning/network/historical-read/bulk-storage layer split.
+The genuinely-future work is now `- [ ]` items: the worked end-to-end
+bot-fork reference flow, the `provideGitClone` bootstrap + identity
+boundary (→ a future `daemon-git-clone.md`), and the
+`tree(ref)`/`filesystemAt(ref)` reconciliation into one canonical
+vocabulary (a focused edit to `daemon-git-capability`). The agent-tools
+layer is deferred to #416; shipped-code follow-ups live in issue #378),
+[daemon-git-capability](daemon-git-capability.md) (added 2026-05-18,
+revised 2026-05-29; implementation progress section reads the trio as
+shipped (Phases 0-5 + bulk-archive via #364/#365/#367), keeps the
+pin-algorithm caching forward-design note, and points the fix/test/
+legibility follow-ups to issue #378),
+[daemon-git-remotes](daemon-git-remotes.md) (added 2026-05-18, revised
+2026-05-29; implementation progress section reads #365 + #368 as shipped,
+keeps the `LC_ALL=C` and porcelain-flag-gating design spec and the
+`setUrl` / Windows-port forward-design, and points the fix/test/
+legibility follow-ups to issue #378),
 [daemon-mount-capabilities](daemon-mount-capabilities.md) (added
 2026-05-18, revised 2026-05-20; concrete completion plan for
 `EndoMount`, mount-scoped entry descriptors as values, snapshotting,
 and trusted physical-backing provenance as a hidden Exo facet),
-[daemon-git-capability](daemon-git-capability.md) (added 2026-05-18,
-revised 2026-05-20; revised git design over `EndoMount` /
-`EndoMountFile`; `tree(ref)` for historical reads and `readOnly()`
-for attenuation both live on the `Git` cap; `NativeGitBackend`
-hardening envelope split off the essential `GitBackend` contract;
-structured result shapes deferred to Phase 7),
-[daemon-git-remotes](daemon-git-remotes.md) (added 2026-05-18, revised
-2026-05-20; MVP remote-git companion for fetch, pull, push, bounded HTTPS
-transport, phase-conditional endpoint policy (formula-owned in Phase 1;
-controller-owned once Phase 5 lands), and non-extractable
-credentials with a `GIT_ASKPASS`-fed-by-anonymous-pipe injection mechanism),
 [patterns-diagnostic-feedback](patterns-diagnostic-feedback.md) (added
 2026-05-19, revised 2026-05-20; opt-in
 `@endo/patterns/explain-mismatch.js` submodule with a Rust-compiler-style
@@ -123,8 +135,9 @@ LLM-agent stack).*
 | [daemon-checkin-checkout](daemon-checkin-checkout.md) | 2026-03-17 | 2026-05-19 | **Complete** |
 | [daemon-capability-filesystem](daemon-capability-filesystem.md) | 2026-02-15 | 2026-05-19 | Reference |
 | [daemon-content-store-gc](daemon-content-store-gc.md) | 2026-03-20 | 2026-05-08 | **Complete** |
-| [daemon-git-capability](daemon-git-capability.md) | 2026-05-18 | 2026-05-27 | Proposed |
-| [daemon-git-remotes](daemon-git-remotes.md) | 2026-05-18 | 2026-05-21 | Proposed |
+| [daemon-git-capability](daemon-git-capability.md) | 2026-05-18 | 2026-05-29 | Proposed |
+| [daemon-git-remotes](daemon-git-remotes.md) | 2026-05-18 | 2026-05-29 | Proposed |
+| [daemon-git-next-steps](daemon-git-next-steps.md) | 2026-05-27 | 2026-06-03 | Proposed |
 | [endo-fs-from-git](endo-fs-from-git.md) | 2026-05-28 | 2026-05-28 | In Progress |
 | [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-05-19 | In Progress (PR #287) |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-05-27 | In Progress |
@@ -230,7 +243,7 @@ LLM-agent stack).*
 | [endo-app-sharing](endo-app-sharing.md) | 2026-06-01 | 2026-06-01 | Proposed |
 | [familiar-app-ui-hosting](familiar-app-ui-hosting.md) | 2026-06-01 | 2026-06-01 | Proposed |
 
-**Totals:** 39 Complete/Implemented, 18 In Progress, 37 Not Started, 28 Proposed, 2 Active, 7 Reference, 2 Deprecated, 1 Superseded (134 designs). Refreshed 2026-06-02 by the daemon-worker-import-from-mount decomposition: three new Proposed designs (`registry-capability`, `mvs-resolver`, `snapshot-mapper`) land as siblings of the repurposed integration-layer doc. The 2026-06-01 pass adds the **Peer App Sharing** milestone (formerly "Milestone A"; now Milestone 8 after the 2026-06-03 renumbering pass) including `app-sharing-milestone` and its three new Proposed designs (`familiar-deep-link-invitations`, `endo-app-sharing`, `familiar-app-ui-hosting`); see "Milestone 8: Peer App Sharing" below. Refreshed 2026-05-19 by a status-only sweep (consolidating the 2026-05-18 sweep with the 2026-05-19 batch update for 11 additional designs from closed PR #302) plus the patterns-diagnostic-feedback and ocapn-noise-session-reconnect Proposed entries; the 12-design jump in Complete/Implemented over the 2026-05-08 snapshot reflects shipped work whose Status field had not previously been updated, not new completions in that pass; see the corresponding "## Status" sections in each design file for evidence pointers (commit SHA or PR number). Totals reflect the 16 design files added on `llm` since the sweep's branch point (the endopi raft of `endopi` + 8 `endopi-*` gap-closing designs, `hardened-text-codecs-shim`, `hardened-url-shim`, namehub-interface-unification (Proposed) added by PR #117 on rebase, forge-gap-analysis (Reference) added 2026-05-20, and the daemon mount and git capability trio: `daemon-mount-capabilities` + `daemon-git-capability` + `daemon-git-remotes`), plus the endo-gateway-mcp (Not Started) entry added 2026-05-29, the `daemon-worker-import-from-mount` (Proposed) entry added 2026-05-22, and the three layer-split designs from the 2026-06-02 refresh.
+**Totals:** 39 Complete/Implemented, 18 In Progress, 37 Not Started, 29 Proposed, 2 Active, 7 Reference, 2 Deprecated, 1 Superseded (135 designs). 2026-05-27 adds `daemon-git-next-steps` (Proposed) as the forward-looking roadmap over the canonical git trio. Refreshed 2026-06-02 by the daemon-worker-import-from-mount decomposition: three new Proposed designs (`registry-capability`, `mvs-resolver`, `snapshot-mapper`) land as siblings of the repurposed integration-layer doc. The 2026-06-01 pass adds the **Peer App Sharing** milestone (formerly "Milestone A"; now Milestone 8 after the 2026-06-03 renumbering pass) including `app-sharing-milestone` and its three new Proposed designs (`familiar-deep-link-invitations`, `endo-app-sharing`, `familiar-app-ui-hosting`); see "Milestone 8: Peer App Sharing" below. Refreshed 2026-05-19 by a status-only sweep (consolidating the 2026-05-18 sweep with the 2026-05-19 batch update for 11 additional designs from closed PR #302) plus the patterns-diagnostic-feedback and ocapn-noise-session-reconnect Proposed entries; the 12-design jump in Complete/Implemented over the 2026-05-08 snapshot reflects shipped work whose Status field had not previously been updated, not new completions in that pass; see the corresponding "## Status" sections in each design file for evidence pointers (commit SHA or PR number). Totals reflect the 17 design files added on `llm` since the sweep's branch point (the endopi raft of `endopi` + 8 `endopi-*` gap-closing designs, `hardened-text-codecs-shim`, `hardened-url-shim`, namehub-interface-unification (Proposed) added by PR #117 on rebase, forge-gap-analysis (Reference) added 2026-05-20, the daemon mount and git capability trio: `daemon-mount-capabilities` + `daemon-git-capability` + `daemon-git-remotes`, and `daemon-git-next-steps` (added 2026-05-27)), plus the endo-gateway-mcp (Not Started) entry added 2026-05-29, the `daemon-worker-import-from-mount` (Proposed) entry added 2026-05-22, and the three layer-split designs from the 2026-06-02 refresh.
 
 ## Roadmap
 
@@ -354,6 +367,7 @@ flowchart TD
         dmcap[daemon-mount-capabilities]
         dgit[daemon-git-capability]
         dgitremote[daemon-git-remotes]
+        dgitnext[daemon-git-next-steps]
         dfsw[filesystem-watchers]
         dcsgc[daemon-content-store-gc]
         dpers[daemon-capability-persona]
@@ -372,6 +386,8 @@ flowchart TD
         dmount --> dmcap
         dmcap --> dgit
         dgit --> dgitremote
+        dgit --> dgitnext
+        dgitremote --> dgitnext
         pfs --> dci
         pfs --> dfsw
         dmount --> dfsw
@@ -525,6 +541,7 @@ capabilities available to agents.
 | snapshot-mapper | Proposed | Layer 3 of 4. `mapSnapshot` lane in `packages/daemon/` that translates `(RegistryResolution, EndoMount)` into a `CompartmentMap` via `compartment-mapper`'s package-descriptor walker (one new extension point in `compartment-mapper`). `makeMountReadPowers` and the compartment-mapper archive-precedent layout (top-level `compartment-map.json` plus peer directories named by package; `<name>@<version>/` for registry-resolved entries, bare `<name>/` for workspace members) |
 | daemon-git-capability | Proposed | Revised git design over `EndoMount` / `EndoMountEntry`; `tree(ref)` and `readOnly()` both live on the `Git` cap |
 | daemon-git-remotes | Proposed | MVP remote-git companion: fetch / pull / push composed from local `Git`, bounded HTTPS transport, endpoint policy, and credential caps |
+| daemon-git-next-steps | Proposed | The version-controlled filesystem loop milestone over the canonical trio: north-star agent loop (provide workspace → read/list/edit → status/diff → commit → pull/push → inspect history via `filesystemAt(ref)`) and the content/versioning/network/historical-read/bulk-storage layer split. Open `- [ ]` work: worked bot-fork reference flow, `provideGitClone` + identity boundary (→ `daemon-git-clone.md`), `tree(ref)`/`filesystemAt(ref)` reconciliation. Agent-tools layer deferred to #416 |
 | filesystem-watchers | Not Started | `EndoMount.followNameChanges` parity with `EndoDirectory`; Node `fs.watch` adapter on `FilePowers` |
 | daemon-locator-terminology | Not Started | Clean locator API; unblocked |
 | daemon-rename-to-manager | Not Started | Rename `daemon.js`/`Daemon`/`MignonicPowers` to `manager.js`/`Manager`/`WorkerPowers` to align JS with Rust `endor` nomenclature |

--- a/designs/daemon-git-capability.md
+++ b/designs/daemon-git-capability.md
@@ -3,9 +3,9 @@
 | | |
 |---|---|
 | **Created** | 2026-05-18 |
-| **Updated** | 2026-05-27 |
+| **Updated** | 2026-05-29 |
 | **Author** | 0xPatrick (prompted) |
-| **Status** | Proposed |
+| **Status** | Proposed (Phases 0-5 + bulk-archive landed via #364/#365/#367, hardening via #371) |
 
 > **Read in order.**
 > This is doc 2 of 3.
@@ -762,6 +762,27 @@ Complete the required phases from [daemon-mount-capabilities](daemon-mount-capab
 4. Move agent adapters onto `Git`.
 5. Retire path-configured wrappers after the capability path is exercised in real workflows.
 6. Land the structured-shape phase (Phase 7 of the Implementation Plan) alongside `*Text` siblings; migrate in-tree consumers to the structured shapes.
+
+## Implementation Progress and Notes
+
+This section records how the design is realized in shipped code.
+It is not part of the normative design.
+
+### Shipped
+
+- **#364** (`feat(daemon): Git capability over EndoMount`) — Phases 1-5 of the Implementation Plan: `GitBackend` contract and `git` formula, local inspection surface (`status`, `diff`, `log`, `show`, `revParse`), local mutation surface (`add`, `restore`, `commit`, branch operations), integration workflows (`merge`, `rebase`, `stash*`), and the read surface (`tree(ref)`, `readOnly()`).
+  The native backend ships as `NativeGitBackend` with the hardening envelope from Design Decision 4.
+- **#367** (`feat(daemon): archive immutable Git trees`) — the bulk-tree-data-plane optimization named in § Bulk Tree Data Plane.
+  Adds an `archiveTar()` method to the immutable-tree exo that streams `git archive --format=tar` of the tree's commit, plus a daemon-side tar parser and a pull-integration fast path that uses it when a remote-tree reference advertises `archiveTar`.
+  The advertisement is detected at runtime: remote trees that do not implement it continue to use the existing per-entry checkin path, so the bulk path is a strict optimization.
+  The tar parser obeys the authority and validation rules in § Bulk Tree Data Plane: archive entry names are treated as untrusted input (absolute paths, `..`, NUL bytes, duplicate entries, and unsupported modes are rejected), and extraction is performed by trusted code into CAS formulas without giving the guest a destination path.
+- **#371** (`fix(daemon): correctness and authority-boundary fixes for the git capability`) — correctness and authority-boundary hardening on the shipped `Git` surface.
+
+### Forward-design notes
+
+- The pin algorithm's caching/throttling (Design Decision 7 § Verification cadence and caching surface) is licensed forward-design, deferred: it is a backend-private optimization the contract permits but no shipped code has taken up.
+
+Fix, test-coverage, and legibility follow-ups on the shipped trio code (issue #378) are tracked there, not here.
 
 ## Open Questions
 

--- a/designs/daemon-git-next-steps.md
+++ b/designs/daemon-git-next-steps.md
@@ -1,0 +1,147 @@
+# Roadmap: The Version-Controlled Filesystem Loop
+
+| | |
+|---|---|
+| **Created** | 2026-05-27 |
+| **Updated** | 2026-06-03 |
+| **Author** | 0xPatrick (prompted) |
+| **Status** | Proposed |
+
+> **Read in order.**
+> This is the milestone roadmap that sits on top of the canonical Git trio.
+> It requires [daemon-mount-capabilities](daemon-mount-capabilities.md), [daemon-git-capability](daemon-git-capability.md), and [daemon-git-remotes](daemon-git-remotes.md) as prerequisites.
+
+## Summary
+
+The canonical trio defines the capabilities; this document defines the **milestone** they add up to: a *version-controlled filesystem loop* an agent can drive end to end, without ever holding a host path, a shell, ambient network, or a credential it can read.
+
+The north-star loop is one sentence:
+
+> The operator provides a workspace; the agent reads, lists, and edits files through filesystem tools; asks Git for status and diff; commits; pulls and pushes through a bounded `GitRemote`; and inspects history — `HEAD~1`, other branches, the remote-tracking refs — by opening a read-only filesystem view of any ref.
+
+This document orders the work that still sits between "the trio's capabilities are shipped" and "an agent runs that loop."
+It invents no new capabilities of its own: each item links the canonical design where the capability shape is decided, or names the one new sibling design that item needs.
+
+The shipped state of the underlying capabilities is not tracked here.
+Per the doc-vs-issue split, follow-ups on the *landed* trio code (fixes, test coverage, legibility) live in issue #378, and the canonical trio docs ([daemon-git-capability](daemon-git-capability.md), [daemon-git-remotes](daemon-git-remotes.md)) carry their own implementation-progress notes.
+
+## The Layer Split
+
+The loop's authority decomposes into five layers.
+Naming them explicitly is the load-bearing contribution of this roadmap, because every next step lands in exactly one layer and the priority order falls out of which layers gate which.
+
+| Layer | Capability | Authority it carries | Canonical source |
+|---|---|---|---|
+| **Content** | `EndoMount` / `EndoMountFile` / `EndoMountEntry` | The live worktree: read, list, edit, stat, snapshot one confined physical subtree. The filesystem is the content authority — Git never becomes the way you edit a file. | [daemon-mount-capabilities](daemon-mount-capabilities.md) |
+| **Versioning** | `Git` | Status, diff, log, stage, commit, branch, merge, rebase, stash over the content layer's worktree. Derived from an `EndoMount`, never from a path. | [daemon-git-capability](daemon-git-capability.md) |
+| **Network + credential** | `GitRemote` | Bounded fetch / pull / push against one host-chosen endpoint, with non-extractable credentials and policy-fixed refspecs. The only layer that crosses the daemon boundary. | [daemon-git-remotes](daemon-git-remotes.md) |
+| **Historical read** | git-tree views — `Git.tree(ref)` / `Git.filesystemAt(ref)` | Read-only snapshots of any ref: `HEAD~1`, a branch tip, a remote-tracking ref. The agent "looks at" history as an ordinary filesystem; it cannot mutate through this view. | [daemon-git-capability](daemon-git-capability.md) § Git-Tree Backend (`tree(ref)`); [endo-fs-from-git](endo-fs-from-git.md) (`filesystemAt(ref)`) |
+| **Bulk storage (detail)** | archive / CAS / git-as-backend | How many files from one revision move efficiently into a sink (content store, scratch mount). A backend-private data plane, never a guest-visible API. | [daemon-git-capability](daemon-git-capability.md) § Bulk Tree Data Plane |
+
+The split is the discipline that keeps the loop honest:
+
+- **Content is not versioning.**
+  An agent edits files through `EndoMount`, not through a git command.
+  Git observes and records changes; it is not the editor.
+- **Versioning is not network.**
+  `Git` never reaches the wire.
+  `GitRemote` is a separate, separately-revocable composition that bundles `Git` + transport + credential.
+- **Historical read is not worktree mutation.**
+  `Git.tree(ref)` / `filesystemAt(ref)` return read-only filesystem views; a holder of a history view cannot commit, stage, or push through it.
+- **Bulk storage is an implementation detail, not a layer the agent sees.**
+  The archive / CAS path exists so a whole-tree materialization does not degenerate into one subprocess per file.
+  The guest still receives object capabilities and structured results, never tar bytes or host paths.
+
+```mermaid
+flowchart TD
+  mount["EndoMount — content authority"]
+  git["Git — versioning"]
+  remote["GitRemote — bounded network + credential"]
+  hist["Git.tree(ref) / filesystemAt(ref) — historical read-only views"]
+  bulk["archive / CAS — bulk storage data plane (private)"]
+
+  mount --> git
+  git --> remote
+  git --> hist
+  git -.->|materialization fast path| bulk
+  hist -.->|whole-tree reads| bulk
+```
+
+## Open Work
+
+The items below are the genuinely-future work that closes the loop, ordered by how directly each closes it.
+Each is a dispatchable work item or a pointer to the design that owns it.
+
+- [ ] **Agent tool adapters over `Git` and `GitRemote` — deferred to #416.**
+  A thin tool layer that exposes the `Git` and `GitRemote` methods through the agent harness's tool-call interface (Fae / Lal / Genie), converting path-bearing inputs to `EndoMountEntry` at the boundary so the agent sees `status` / `diff` / `add` / `commit` / `fetch` / `pull` / `push` as tool calls over a host-chosen mount, endpoint, transport, and credential.
+  This is the loop's first work: every other item is the agent *calling* these tools.
+  It is no longer specified here — PR #416 (the `endo-agent-tools` + `agentry-agent-builder` design pair) makes it concrete and wires this roadmap.
+  The agent-tools `extra` seam ([endo-gateway-mcp](endo-gateway-mcp.md)) and the capability-tool model ([daemon-agent-tools](daemon-agent-tools.md)) are the surfaces it plugs into.
+
+- [ ] **A worked end-to-end reference flow (bot-fork roadmap).**
+  One worked example, run end to end: a maintainer's prompt → branch off `llm` via `Git` → edit files via `EndoMount` → `status` / `diff` / `commit` via `Git` → `push` a draft-PR branch via `GitRemote` → inspect the pushed ref via `filesystemAt`.
+  This is exactly the bot-fork-roadmap pattern this garden already exercises by hand, which makes it the canonical real-world workload: a single pass touches the content, versioning, network, and historical-read layers at once, surfaces missing seams cheaply, then stands as a regression target.
+  Depends on the agent tool adapters (#416, above).
+  See [daemon-git-remotes](daemon-git-remotes.md) § Agent MVP Profile for the default remote profile the example runs under.
+
+- [ ] **Repository bootstrap (`provideGitClone`) and the commit-author / identity boundary → a future `daemon-git-clone.md`.**
+  Today the loop starts only from a worktree the operator pre-mounted; `GitRemote` is intentionally bound to an existing local `Git`, so cloning has no home on it.
+  `provideGitClone(...)` — named in [daemon-git-remotes](daemon-git-remotes.md) § Repository Bootstrap and `clone` — composes mount creation + endpoint policy + sealed credential authority + clone-into-the-new-mount before a local `Git` exists, returning the resulting `EndoMount` + `Git`.
+  Paired with it is the **commit-author / identity boundary**: the agent's commits must be attributed from a policy it does not control, which wants a capability shape rather than per-dispatch out-of-band knowledge.
+  Together these close the "you give me a URL, the agent runs, and its commits are attributed correctly" gap.
+  The bootstrap design (and the identity boundary as a section or sibling) lives in its own `daemon-git-clone.md`; depends on the `GitRemote` composition being stable.
+
+- [ ] **Reconcile `tree(ref)` and `filesystemAt(ref)` into one canonical vocabulary — a focused edit to [daemon-git-capability](daemon-git-capability.md).**
+  `tree(ref)` (returning `ReadableTree`) is specified in [daemon-git-capability](daemon-git-capability.md) § Git-Tree Backend and Design Decision 3; `filesystemAt(ref)` (returning an `@endo/endo-fs` `Filesystem`) is specified in [endo-fs-from-git](endo-fs-from-git.md).
+  They are not two competing names for one thing — they are two methods in a projection relationship: `tree(ref)` projects the narrower `ReadableTree`, `filesystemAt(ref)` lifts the same git tree into the richer `Filesystem` (the same shape the content layer exposes for the live worktree).
+  The edit names `filesystemAt(ref)` as the historical-read method and `tree(ref)` as its `ReadableTree` projection, cross-linking [endo-fs-from-git](endo-fs-from-git.md), so the canonical doc carries one historical-read API, not two.
+  It must carry `filesystemAt`'s two documented trade-offs into the canonical vocabulary so they are not silently lost: the `Filesystem` view's QID is **path-based, not the git OID**, and its `BlobRef.algorithm` is **`'sha256'`, not the git tree's `git-sha1`** (both reintroducible if `wrapBackend` grows a backend-supplied QID / hash hook — see [endo-fs-from-git](endo-fs-from-git.md) § Status).
+  This is a documentation merge, not a new design; it is listed because letting the two names drift apart in the canonical corpus is the failure this roadmap exists to prevent.
+  Small, but it must happen in the same window the canonical doc next moves.
+
+## Beyond the Loop
+
+The following are real follow-ups that compose with the loop but are not on its critical path.
+They are named so a builder dispatch does not mistake them for gaps in the milestone.
+
+- [ ] **CLI git verbs** (`endo git status` / `log` / `diff`).
+  The substrate for headless harnesses and the operator's debug loop; sibling of [cli-edit-verb](cli-edit-verb.md) / [cli-store-verb-text-modes](cli-store-verb-text-modes.md).
+  The loop closes through the tool adapters (#416) without it; the CLI is a parallel surface, not a prerequisite.
+- [ ] **Bank-backed credential durability.**
+  Once [daemon-capability-bank](daemon-capability-bank.md) lands, the fd-pipe askpass helper sources credentials from the bank instead of the daemon-process-local map, surviving restart for multi-repo / scheduled workflows ([daemon-git-remotes](daemon-git-remotes.md) § Initial Backend).
+- [ ] **Provider advisory layer.**
+  An opt-in layer that *queries* (does not enforce) GitHub / GitLab / Forgejo branch-protection, draft-state, required-checks — useful when the agent needs to know "is this PR un-drafted?" before acting.
+  Design Decision 10 of [daemon-git-remotes](daemon-git-remotes.md) keeps the *enforcement* boundary server-side; this only reads the provider API.
+- [ ] **Linked-worktree and submodule worked example.**
+  The pin algorithm ([daemon-git-capability](daemon-git-capability.md) Design Decision 7) handles `git worktree add` and submodules in theory; a worked example pins the contract.
+- [ ] **Audit-log surfaces, timing observability, editor / patch-apply integration.**
+  Operator-facing audit exports, the `captpMs` / `transportMs` timing fields ([daemon-git-remotes](daemon-git-remotes.md) § Spike Tasks), and composing `Git` with the chat / endopi edit tools so a proposed patch applies to the worktree as a real reviewable change.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [daemon-mount-capabilities](daemon-mount-capabilities.md) | Content layer (mount-scoped descriptors, snapshot, host-private backing). |
+| [daemon-git-capability](daemon-git-capability.md) | Versioning + historical-read layers (`Git`, `tree(ref)`, `readOnly()`, bulk data plane, Phase 7 structured shapes). The `tree(ref)`/`filesystemAt(ref)` reconciliation is a focused edit here. |
+| [endo-fs-from-git](endo-fs-from-git.md) | Historical-read foundation: `Git.filesystemAt(ref)` returning an `@endo/endo-fs` `Filesystem` over the git object database. The reconciliation item merges its vocabulary with `tree(ref)`. |
+| [daemon-git-remotes](daemon-git-remotes.md) | Network + credential layer (`GitRemote`, credential injection, `provideGitClone` bootstrap, audit). |
+| [endo-gateway-mcp](endo-gateway-mcp.md) | Defines `@endo/agent-tools` and the `extra` seam (`makeAgentTools(powers, { extra })`) that the agent tool adapters (#416) plug into. |
+| [daemon-agent-tools](daemon-agent-tools.md) | Conceptual parent of the agent-tool capability model — names which capabilities (`Dir` / `Shell` / `Git`, now mount-derived) surface as agent tools. |
+| [daemon-capability-bank](daemon-capability-bank.md) | Future home for durable credential authority (Beyond the Loop). |
+| [cli-edit-verb](cli-edit-verb.md), [cli-store-verb-text-modes](cli-store-verb-text-modes.md) | CLI-side blob editing / storage; the CLI git verbs compose with them. |
+| [endopi-edit-tool](endopi-edit-tool.md) | Endopi raft's edit-tool design; informs the agent-side edit-and-commit loop. |
+
+## Design Decisions
+
+1. **The roadmap is a milestone, not a capability catalogue.**
+   It orders the work that turns the canonical trio into a loop an agent can drive; it invents no new capabilities.
+   New capability designs (the clone bootstrap, the provider advisory layer) are named here but designed in their own documents.
+2. **The layer split is the load-bearing contribution.**
+   Content / versioning / network / historical-read / bulk-storage each carry a distinct authority; every roadmap item lands in exactly one layer, and the priority order falls out of which layers gate which.
+   Keeping the layers distinct is what keeps the agent from editing through git, reaching the wire through `Git`, or mutating through a history view.
+3. **Historical read is two methods in a projection relationship.**
+   `filesystemAt(ref)` (returns a `Filesystem`) is the historical-read method; `tree(ref)` (returns the narrower `ReadableTree`) is its predecessor / projection.
+   The canonical doc carries one API, reconciled rather than forked.
+4. **The agent-tools layer belongs to #416, not here.**
+   The agent tool adapters were this roadmap's "item 1"; PR #416 makes them concrete (`endo-agent-tools` + `agentry-agent-builder`) and wires this roadmap.
+   This document defers to #416 rather than re-specifying the tool surface.

--- a/designs/daemon-git-remotes.md
+++ b/designs/daemon-git-remotes.md
@@ -3,9 +3,9 @@
 | | |
 |---|---|
 | **Created** | 2026-05-18 |
-| **Updated** | 2026-05-21 |
+| **Updated** | 2026-05-29 |
 | **Author** | 0xPatrick (prompted) |
-| **Status** | Proposed |
+| **Status** | Proposed (Phases 1-5 landed via #365; fd-pipe askpass landed via #368) |
 
 > **Read in order.**
 > This is doc 3 of 3.
@@ -280,6 +280,11 @@ interface GitRemoteController {
 
 The controller can narrow or widen policy after creation.
 The guest-held `GitRemote` cannot.
+
+The controller surface above intentionally does **not** include a `setUrl(newUrl)` method.
+Adding one is plausible forward-design (rotating an `origin` from `https://github.com/org/repo` to a successor URL without re-issuing the bundle), but it interacts with construction-time-captured locals in the remote's closure: the URL, the audience-derived `requiresCredential` flag, and the bound `credentialRecord` are early-bound at construction.
+A future `setUrl` must re-anchor those locals (re-run the audience-match against the new URL, re-validate the new origin against the granted transport, and either reject the change or atomically refresh the captured credential reference) or it will silently leave the in-memory state divergent from the policy.
+Until the use case surfaces, the operator's path to changing a remote's URL is `revoke()` plus `provideGitRemote(...)` with the new URL — a discrete identity boundary the audit log will record explicitly.
 
 ## Capability Construction
 
@@ -587,10 +592,18 @@ That means:
 
 - a daemon-shipped `GIT_ASKPASS` helper binary, exec'd by `git` and fed the credential through an anonymous pipe whose read-end fd is inherited by the helper (the secret is passed via fd-pointer, never via argv or process env);
 - `GIT_TERMINAL_PROMPT=0` so a missed askpass does not hang waiting for a TTY;
+- `LC_ALL=C` on the subprocess env so askpass prompts and porcelain output are routed against a stable English locale (the askpass helper's prompt-routing regex assumes English `"Username"` / `"Password"` strings; a localized git would otherwise route the wrong response);
 - sanitized git environment that drops `GIT_*_HELPER`, `GIT_PROXY_COMMAND`, and other credential / process-shell vectors;
 - repo config and ambient-credential-helper suppression (`-c credential.helper=` empties the ambient helper list for the invocation; the daemon-shipped `GIT_ASKPASS` above remains the controlled injection path);
 - explicit remote URL supplied from controller state, written into the invocation as a positional argument never derived from a guest input;
 - no shell interpolation; argv-array spawn only.
+
+**Porcelain-output parser robustness.**
+The native backend parses git's `push --porcelain` output to populate `GitPushResult.updatedRefs`.
+The current parser treats every line with a recognized leading flag character as an update record, and defaults an unknown flag to `'updated'`.
+The defensible posture is to gate the parser on the documented flag alphabet (`'*=  +-!'` per `git-push`'s porcelain documentation) before treating the line as an update record, and to surface a structured warning (preserving the raw flag in the audit-log entry) when an unknown flag arrives.
+This defends the parser against future git-cli format drift without silently mis-classifying a refusal as an update.
+Forward-defense; not a current correctness gap.
 
 These two concerns are orthogonal and should not be conflated.
 A **secret manager** answers *where durable secret authority lives*: a daemon-owned (or external) capability that holds, rotates, and revokes credentials across restarts and across multiple repos.
@@ -600,6 +613,12 @@ Until then, Phase 1 ships the askpass envelope on its own and treats bank-backed
 
 The safe target for credential injection is: **no secret in argv, in process environment, in formula state, in inspect output, in logs, or in any persisted or durable temp file.**
 The askpass-fed-by-anonymous-pipe mechanism above is the only path that meets that bar for the basic (username/password) case.
+
+**Portability.**
+The anonymous-pipe / fd-inheritance path is POSIX-specific.
+A Windows port of the askpass transport would need to substitute a named pipe (or another in-process IPC primitive available on Windows) for the fd-3 inheritance pattern.
+The capability contract is portable; the transport primitive is not.
+This is licenced as forward-design work and is out of scope for the HTTPS MVP — the daemon ships POSIX-only today, so the askpass implementation can use POSIX-only primitives without immediate cross-platform constraint.
 
 For bearer-token HTTPS remotes, native git also supports `http.extraHeader`.
 Passing the header through `-c "http.extraHeader=Authorization: Bearer ..."` leaks the token to `/proc/*/cmdline` (and is the standard reason public guides warn against the flag).
@@ -736,6 +755,20 @@ The public `GitRemote` contract should survive those swaps.
 - guest-provided URLs are never accepted by call-time methods;
 - backend never falls back to ambient SSH or shell.
 - remote packfile transport is only started after endpoint, direction, ref, and credential policy checks pass.
+
+## Implementation Progress and Notes
+
+This section records how the design is realized in shipped code.
+It is not part of the normative design.
+
+### Shipped
+
+- **#365** (`feat(daemon): GitRemote capability composing Git + transport + credentials`) — Phases 1-5 of the Implementation Plan: `GitRemote` + credential types (`BearerCredential`, `BasicCredential`), the `git-remote` formula bound to a local `Git`, HTTPS bearer/basic credential injection, `fetch` / `pull` / branch-limited `push`, in-flight revoke fencing on `fetch` and `pull`, audit-log on the controller, and the `GitRemoteController` + `GitCredentialController` surface for post-construction policy updates and revocation.
+- **#368** (`feat(daemon): use fd askpass for Git credentials`) — the design-compliant fd-pipe askpass helper described in § Initial Backend ("a daemon-shipped `GIT_ASKPASS` helper binary, exec'd by `git` and fed the credential through an anonymous pipe whose read-end fd is inherited by the helper").
+  The daemon-shipped helper lives at `packages/daemon/src/git-askpass-helper.cjs`, exec'd by `git` and reading from fd 3; the fd number (`ENDO_GIT_ASKPASS_FD`) is the only credential-related value reaching the child env, so the secret never appears in argv, the process env, `/proc/<git>/environ`, or a temp file.
+  The anonymous-pipe transport has no socket to keep open, so the askpass-socket-lifetime narrowing is structurally satisfied; the OS-user-account boundary (`mkdtemp` 0o700 parent directory) remains the trust model.
+
+Fix, test-coverage, and legibility follow-ups on the shipped trio code (issue #378) are tracked there, not here.
 
 ## Relationship to Existing Git Designs
 


### PR DESCRIPTION
Refs: #364 #365 #367 #368 #371 #374 #378 #416

## Description

Design-only changes to the daemon-git corpus.

1. `designs/daemon-git-next-steps.md` (new) — a lean milestone roadmap for the version-controlled filesystem loop, carrying the whole-loop synthesis no single trio doc states: the north-star agent loop (provide workspace → read/list/edit via filesystem tools → Git status/diff → commit → pull/push via `GitRemote` → inspect history via `filesystemAt(ref)`) and the five-layer authority split (content / versioning / network / historical-read / bulk-storage). Future work is captured as `- [ ]` items (worked end-to-end reference flow; `provideGitClone` bootstrap + identity boundary → future `daemon-git-clone.md`; `tree(ref)`/`filesystemAt(ref)` reconciliation). Agent-tools layer deferred to #416; shipped-code follow-ups tracked in #378.

2. `designs/daemon-git-capability.md`, `designs/daemon-git-remotes.md` — fold in surviving #365-panel design intent (`LC_ALL=C` askpass-env and porcelain push-parser gating as spec lines; `setUrl`, Windows askpass, pin-algorithm caching as forward-design) and mark the trio (#364/#365/#367/#368, plus #371 correctness/authority hardening) shipped.

3. `designs/README.md` — `daemon-git-next-steps` added to summary table, dependency graph, and milestone table; trio rows redated.

### Security / Scaling / Testing / Compatibility / Upgrade Considerations

N/A — documentation-only; no capability surface or hardening invariant moves.
