### PR TITLE
fix(daemon): correctness and authority-boundary fixes for the git capability

### DIFF
--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -392,8 +392,13 @@ export type GitStashPushOptions = {
  * worktree mount.
  */
 export interface EndoGit {
-  /** The `EndoMount` carrying the public worktree authority. */
-  worktree(): EndoMount;
+  /**
+   * The worktree authority this cap carries.  A writable Git returns
+   * the writable `EndoMount`; a read-only Git returns a structural
+   * read-only `ReadableTree` view so the attenuated cap cannot hand a
+   * caller a writable worktree.
+   */
+  worktree(): Promise<EndoMount | ReadableTreeView>;
   status(): Promise<GitStatusEntry[]>;
   diff(options?: GitDiffOptions): Promise<string>;
   log(options?: GitLogOptions): Promise<GitCommit[]>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -301,10 +301,15 @@ export type GitStatusEntry = {
   index: GitIndexStatus;
   worktree: GitWorktreeStatus;
   /**
-   * Present when a live worktree object currently exists for the path
-   * (an `EndoMountFile` or `EndoMount` sub-mount).
+   * Present when a live worktree object currently exists for the path.
+   * A writable `Git` mints the node through the writable worktree mount
+   * (an `EndoMount` sub-mount or `EndoMountFile`); a read-only `Git`
+   * mints it through the structural read-only worktree view, so the
+   * node is then a `ReadableTreeView` or `ReadableBlobView`.  The wider
+   * union keeps the read-only case from type-checking a `writeText`
+   * that would reject at runtime.
    */
-  node?: EndoMount | EndoMountFile;
+  node?: EndoMount | EndoMountFile | ReadableTreeView | ReadableBlobView;
   renamedFrom?: string;
 };
 

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -183,7 +183,7 @@ test('Git.readOnly() worktree and status nodes carry no write authority', async 
   await fs.promises.writeFile(path.join(repoRoot, 'tracked.txt'), 'before');
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   const git = makeGit({ mount, backend, lineageOf });
 
   const readOnlyGit = await E(git).readOnly();
@@ -1911,7 +1911,7 @@ test('Git.stashPop applies and drops in one step', async t => {
 
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   const git = makeGit({ mount, backend, lineageOf });
 
   await fs.promises.writeFile(path.join(repoRoot, 'tracked.txt'), 'after\n');
@@ -1944,7 +1944,7 @@ test('Git.stashPush accepts repo-relative paths in lieu of mount entries', async
 
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   const git = makeGit({ mount, backend, lineageOf });
 
   await fs.promises.writeFile(path.join(repoRoot, 'a.txt'), 'changed-a\n');
@@ -1978,7 +1978,7 @@ test('Git.stashPush with neither entries nor paths stashes the whole worktree', 
 
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   const git = makeGit({ mount, backend, lineageOf });
 
   await fs.promises.writeFile(path.join(repoRoot, 'whole.txt'), 'dirty\n');
@@ -2010,7 +2010,7 @@ test('Git.diff accepts plain string paths and string refs', async t => {
 
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   const git = makeGit({ mount, backend, lineageOf });
 
   // The `paths` branch passes string[] straight through; `base` and
@@ -2051,7 +2051,7 @@ test('Git.diff with GitRef objects for base and head collapses to strings', asyn
 
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   const git = makeGit({ mount, backend, lineageOf });
 
   // The git.js wrapper's `typeof opts.base === 'string'` check picks
@@ -2084,7 +2084,7 @@ test('NativeGitBackend.status reports rename detection with renamedFrom', async 
     cwd: repoRoot,
   });
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   const entries = await backend.status();
   const renamed = entries.find(e => e.index === 'renamed');
   if (renamed === undefined) {
@@ -2109,7 +2109,7 @@ test('NativeGitBackend.assertNoExecutableRepoConfig refuses filter clean drivers
     { cwd: repoRoot },
   );
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   await t.throwsAsync(backend.add(['staged.txt']), {
     message:
       /Refusing git operation because repository config can execute commands/,
@@ -2124,7 +2124,7 @@ test('NativeGitBackend.assertNoExecutableRepoConfig refuses merge driver config'
     { cwd: repoRoot },
   );
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   // Any mutation triggers the guard; `commit` of an empty index also
   // travels through assertNoExecutableRepoConfig first.
   await t.throwsAsync(backend.commit('should refuse'), {
@@ -2146,7 +2146,7 @@ test('NativeGitBackend.remoteFetch refuses url.<base>.insteadOf rewrites', async
     { cwd: repoRoot },
   );
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   // assertNoRemoteTransportRepoConfig fires before any network IO, so
   // we can use a placeholder URL and trust the guard to refuse first.
   await t.throwsAsync(
@@ -2169,7 +2169,7 @@ test('NativeGitBackend.remotePush refuses core.sshCommand override', async t => 
     { cwd: repoRoot },
   );
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   await t.throwsAsync(
     backend.remotePush({
       url: 'https://benign.example/repo.git',
@@ -2184,7 +2184,7 @@ test('NativeGitBackend.remotePush refuses core.sshCommand override', async t => 
 
 test('NativeGitBackend.remoteFetch rejects an unsupported URL protocol', async t => {
   const repoRoot = await provisionGitWorktree(t);
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
 
   // git: and ssh: are intentionally not in the supported set; the
   // backend collapses every accepted protocol into an exact -c
@@ -2203,7 +2203,7 @@ test('NativeGitBackend.remoteFetch rejects an unsupported URL protocol', async t
 
 test('NativeGitBackend.remoteFetch rejects a malformed remote URL', async t => {
   const repoRoot = await provisionGitWorktree(t);
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
 
   // requireRevision accepts the string; the URL parse inside
   // remoteProtocolArgs is the second boundary that refuses garbage.
@@ -2259,7 +2259,7 @@ test('NativeGitBackend.assertNoExecutableRepoConfig refuses an include.path that
   );
   t.true(effective.includes('true'), 'git honors the included filter driver');
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   await t.throwsAsync(backend.add(['data.secret']), {
     message:
       /Refusing git operation because repository config can execute commands/,
@@ -2308,7 +2308,7 @@ test('NativeGitBackend.diff and show never invoke a .gitattributes textconv driv
   // A pending worktree change so the default (worktree) diff is non-empty.
   await fs.promises.writeFile(path.join(repoRoot, 'data.secret'), 'second\n');
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
 
   await backend.diff();
   t.false(fs.existsSync(marker), 'diff() must not invoke the textconv driver');
@@ -2330,7 +2330,7 @@ test('NativeGitBackend stays usable when the first commit lands on an empty repo
   await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
   await fs.promises.writeFile(path.join(repoRoot, 'first.txt'), 'hello\n');
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   await backend.assertRepositoryRoot();
   await backend.add(['first.txt']);
 
@@ -2377,7 +2377,7 @@ test('NativeGitBackend read paths do not mutate .git/index metadata', async t =>
   await fs.promises.utimes(path.join(repoRoot, 'tracked.txt'), future, future);
   const before = (await fs.promises.stat(indexPath)).mtimeMs;
 
-  const backend = makeNativeGitBackend({ repoRoot });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
   await backend.status();
 
   const after = (await fs.promises.stat(indexPath)).mtimeMs;

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -2270,3 +2270,50 @@ test('NativeGitBackend.assertNoExecutableRepoConfig refuses an include.path that
   });
 });
 
+test('NativeGitBackend.diff and show never invoke a .gitattributes textconv driver', async t => {
+  // Bar-proving regression for the textconv host-exec on read paths
+  // (Codex P1c).  An in-tree `.gitattributes` binding a diff driver
+  // plus a `diff.<driver>.textconv` command runs that command while
+  // git renders a diff or `git show`.  `core.attributesFile=/dev/null`
+  // only disables the *external* attributes file, not the in-tree one,
+  // and `--no-ext-diff` suppresses only `diff.external`; the read paths
+  // must additionally pass `--no-textconv`.
+  const repoRoot = await provisionGitWorktree(t);
+  const marker = path.join(repoRoot, 'TEXTCONV-RAN');
+
+  // A textconv driver whose mere invocation writes a sentinel file.
+  await fs.promises.writeFile(
+    path.join(repoRoot, 'textconv.sh'),
+    `#!/bin/sh\ntouch ${JSON.stringify(marker)}\ncat "$1"\n`,
+  );
+  await fs.promises.chmod(path.join(repoRoot, 'textconv.sh'), 0o755);
+  await execFileAsync(
+    'git',
+    ['config', '--local', 'diff.evil.textconv', `${repoRoot}/textconv.sh`],
+    { cwd: repoRoot },
+  );
+  await fs.promises.writeFile(
+    path.join(repoRoot, '.gitattributes'),
+    '*.secret diff=evil\n',
+  );
+  // Commit a *.secret blob so both `show <commit>` and a worktree
+  // `diff` have a textconv-covered path to render.
+  await fs.promises.writeFile(path.join(repoRoot, 'data.secret'), 'first\n');
+  await execFileAsync('git', ['add', '.'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'secret'],
+    { cwd: repoRoot },
+  );
+  // A pending worktree change so the default (worktree) diff is non-empty.
+  await fs.promises.writeFile(path.join(repoRoot, 'data.secret'), 'second\n');
+
+  const backend = makeNativeGitBackend({ repoRoot });
+
+  await backend.diff();
+  t.false(fs.existsSync(marker), 'diff() must not invoke the textconv driver');
+
+  await backend.show('HEAD');
+  t.false(fs.existsSync(marker), 'show() must not invoke the textconv driver');
+});
+

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -2345,3 +2345,41 @@ test('NativeGitBackend stays usable when the first commit lands on an empty repo
   t.is(commits[0].oid, commit.oid);
 });
 
+test('NativeGitBackend read paths do not mutate .git/index metadata', async t => {
+  // Regression for the missing GIT_OPTIONAL_LOCKS=0 on read paths
+  // (Codex P2b).  `git status` opportunistically refreshes and rewrites
+  // `.git/index` when a worktree stat differs from the recorded one, so
+  // a "read-only" inspection mutated repo metadata and would fail on a
+  // read-only filesystem.  `GIT_OPTIONAL_LOCKS=0` (set in the sanitized
+  // env) suppresses that write.
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'tracked.txt'), 'one\n');
+  await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'add tracked',
+    ],
+    { cwd: repoRoot },
+  );
+
+  const indexPath = path.join(repoRoot, '.git', 'index');
+  // Touch the tracked file so the worktree stat differs from the index,
+  // which is exactly the condition that provokes the opportunistic
+  // index refresh.
+  const future = new Date(Date.now() + 5_000);
+  await fs.promises.utimes(path.join(repoRoot, 'tracked.txt'), future, future);
+  const before = (await fs.promises.stat(indexPath)).mtimeMs;
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await backend.status();
+
+  const after = (await fs.promises.stat(indexPath)).mtimeMs;
+  t.is(after, before, 'status must not rewrite .git/index');
+});

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -154,7 +154,6 @@ test('Git.readOnly() attenuates mutating operations but preserves reads', async 
   const git = makeGit({ mount, backend, lineageOf });
 
   const readOnlyGit = await E(git).readOnly();
-  t.is(await E(readOnlyGit).worktree(), mount);
 
   const entries = await E(readOnlyGit).status();
   t.is(entries.length, 1);
@@ -172,6 +171,59 @@ test('Git.readOnly() attenuates mutating operations but preserves reads', async 
   });
 
   t.is(await E(readOnlyGit).readOnly(), readOnlyGit);
+});
+
+test('Git.readOnly() worktree and status nodes carry no write authority', async t => {
+  // Regression for the read-only attenuation leak (Codex P1a): a
+  // read-only Git reused the writable mount, so `worktree()` and the
+  // `node`s minted by `status()` still exposed `writeText` / `remove` /
+  // `makeFile`.  A read-only cap must surface a read-only worktree view
+  // whose nodes reject writes.
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'tracked.txt'), 'before');
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  const readOnlyGit = await E(git).readOnly();
+
+  // The worktree exposed by a read-only Git is a structural read-only
+  // view: it advertises only the ReadableTree surface (no `writeText`,
+  // `makeFile`, `remove`, or `move`).
+  const worktree = await E(readOnlyGit).worktree();
+  // eslint-disable-next-line no-underscore-dangle
+  const worktreeMethods = await E(
+    /** @type {any} */ (worktree),
+  ).__getMethodNames__();
+  for (const writeMethod of ['writeText', 'makeFile', 'remove', 'move']) {
+    t.false(
+      worktreeMethods.includes(writeMethod),
+      `read-only worktree must not expose ${writeMethod}`,
+    );
+  }
+
+  // Each status row's `node` is minted through the read-only worktree,
+  // so it likewise rejects mutation.  Before the fix the node was a
+  // writable EndoMountFile and this write would succeed.
+  const rows = await E(readOnlyGit).status();
+  const trackedRow = rows.find(row => row.path === 'tracked.txt');
+  t.truthy(trackedRow, 'status should report the tracked file');
+  t.truthy(trackedRow && trackedRow.node, 'status row should carry a node');
+  if (trackedRow === undefined || trackedRow.node === undefined) {
+    return;
+  }
+  await t.throwsAsync(
+    E(/** @type {any} */ (trackedRow.node)).writeText('after'),
+    {
+      message: /read-only|not a function|no method/i,
+    },
+  );
+  // The on-disk content is untouched by the rejected write.
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'tracked.txt'), 'utf8'),
+    'before',
+  );
 });
 
 test('makeGit can be constructed directly as read-only', async t => {

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -2217,3 +2217,56 @@ test('NativeGitBackend.remoteFetch rejects a malformed remote URL', async t => {
     },
   );
 });
+
+test('NativeGitBackend.assertNoExecutableRepoConfig refuses an include.path that injects a filter driver', async t => {
+  // Bar-proving regression for the include bypass (Codex P1b).  The
+  // executable-config guard lists keys with `git config --local
+  // --name-only --list`, which reports only the `include.path` key and
+  // NOT the `filter.<name>.clean` key the included file contributes —
+  // yet git honors that included driver on the next add/commit.  The
+  // direct-key tests above are tautological with the listing: they set
+  // the key the listing reports.  This test sets the dangerous key
+  // *indirectly* through an in-tree include, which the unpatched guard
+  // never sees.
+  const repoRoot = await provisionGitWorktree(t);
+
+  // The included config file lives in the worktree and defines an
+  // executable filter driver.
+  await fs.promises.writeFile(
+    path.join(repoRoot, 'evil.inc'),
+    '[filter "evil"]\n\tclean = /usr/bin/env true\n',
+  );
+  // .git/config points at it via a relative include.path.
+  await execFileAsync(
+    'git',
+    ['config', '--local', 'include.path', '../evil.inc'],
+    { cwd: repoRoot },
+  );
+  // A .gitattributes binds the filter to a path, so the driver would
+  // actually run on add/commit.
+  await fs.promises.writeFile(
+    path.join(repoRoot, '.gitattributes'),
+    '*.secret filter=evil\n',
+  );
+  await fs.promises.writeFile(path.join(repoRoot, 'data.secret'), 'x\n');
+
+  // Sanity: git itself honors the included driver key, while the
+  // name-only listing the guard relies on does not surface it.
+  const { stdout: effective } = await execFileAsync(
+    'git',
+    ['config', '--get', 'filter.evil.clean'],
+    { cwd: repoRoot },
+  );
+  t.true(effective.includes('true'), 'git honors the included filter driver');
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await t.throwsAsync(backend.add(['data.secret']), {
+    message:
+      /Refusing git operation because repository config can execute commands/,
+  });
+  await t.throwsAsync(backend.commit('should refuse'), {
+    message:
+      /Refusing git operation because repository config can execute commands/,
+  });
+});
+

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -1846,3 +1846,322 @@ const collectReader = async readerRef => {
   }
   return out;
 };
+
+test('Git.stashPop applies and drops in one step', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'tracked.txt'), 'before\n');
+  await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'track file'],
+    { cwd: repoRoot },
+  );
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await fs.promises.writeFile(path.join(repoRoot, 'tracked.txt'), 'after\n');
+  await E(git).stashPush({ message: 'pop me' });
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'tracked.txt'), 'utf8'),
+    'before\n',
+  );
+  // stashPop combines apply + drop; verify the working-tree restoration
+  // and that the stash list is empty afterwards (distinct from stashApply,
+  // which leaves the stash entry in place).
+  await E(git).stashPop(0);
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'tracked.txt'), 'utf8'),
+    'after\n',
+  );
+  t.deepEqual(await E(git).stashList(), []);
+});
+
+test('Git.stashPush accepts repo-relative paths in lieu of mount entries', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'a.txt'), 'orig-a\n');
+  await fs.promises.writeFile(path.join(repoRoot, 'b.txt'), 'orig-b\n');
+  await execFileAsync('git', ['add', 'a.txt', 'b.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'two files'],
+    { cwd: repoRoot },
+  );
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await fs.promises.writeFile(path.join(repoRoot, 'a.txt'), 'changed-a\n');
+  await fs.promises.writeFile(path.join(repoRoot, 'b.txt'), 'changed-b\n');
+
+  // `paths` (string[]) bypasses the EndoMountEntry lineage resolution
+  // and lands at the backend directly.  Only `a.txt` is stashed; `b.txt`
+  // must stay dirty.
+  await E(git).stashPush({ message: 'subset', paths: ['a.txt'] });
+
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'a.txt'), 'utf8'),
+    'orig-a\n',
+  );
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'b.txt'), 'utf8'),
+    'changed-b\n',
+  );
+  await E(git).stashDrop(0);
+});
+
+test('Git.stashPush with neither entries nor paths stashes the whole worktree', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'whole.txt'), 'baseline\n');
+  await execFileAsync('git', ['add', 'whole.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'whole'],
+    { cwd: repoRoot },
+  );
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await fs.promises.writeFile(path.join(repoRoot, 'whole.txt'), 'dirty\n');
+
+  // Both `entries` and `paths` omitted: the wrapper takes the third
+  // branch in git.js (no resolved.paths set) and the backend stashes
+  // the full worktree diff.
+  const result = await E(git).stashPush({});
+  t.regex(result, /Saved working directory/);
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'whole.txt'), 'utf8'),
+    'baseline\n',
+  );
+  await E(git).stashDrop(0);
+});
+
+test('Git.diff accepts plain string paths and string refs', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'a.txt'), 'a1\n');
+  await fs.promises.writeFile(path.join(repoRoot, 'b.txt'), 'b1\n');
+  await execFileAsync('git', ['add', 'a.txt', 'b.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'baseline'],
+    { cwd: repoRoot },
+  );
+  await fs.promises.writeFile(path.join(repoRoot, 'a.txt'), 'a2\n');
+  await fs.promises.writeFile(path.join(repoRoot, 'b.txt'), 'b2\n');
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  // The `paths` branch passes string[] straight through; `base` and
+  // `head` accept either a string or a structured GitRef and collapse
+  // to the backend's string-named-ref input.  Only the named path
+  // shows up; the other file's diff stays out.
+  const out = await E(git).diff({
+    paths: ['a.txt'],
+    base: 'HEAD',
+  });
+  t.regex(out, /a\.txt/);
+  t.notRegex(out, /b\.txt/);
+});
+
+test('Git.diff with GitRef objects for base and head collapses to strings', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'evolves.txt'), 'v1\n');
+  await execFileAsync('git', ['add', 'evolves.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'v1'],
+    { cwd: repoRoot },
+  );
+  const v1Sha = (
+    await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot })
+  ).stdout.trim();
+
+  await fs.promises.writeFile(path.join(repoRoot, 'evolves.txt'), 'v2\n');
+  await execFileAsync('git', ['add', 'evolves.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'v2'],
+    { cwd: repoRoot },
+  );
+  const v2Sha = (
+    await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot })
+  ).stdout.trim();
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  // The git.js wrapper's `typeof opts.base === 'string'` check picks
+  // the structured-ref branch when given a `{ name, kind }` record.
+  const out = await E(git).diff({
+    base: harden({ name: v1Sha, kind: /** @type {'commit'} */ ('commit') }),
+    head: harden({ name: v2Sha, kind: /** @type {'commit'} */ ('commit') }),
+  });
+  t.regex(out, /-v1\n\+v2/);
+});
+
+test('NativeGitBackend.status reports rename detection with renamedFrom', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  // Commit a large file: rename detection only fires for similar content
+  // above a threshold, so a tiny single-line file would round-trip as
+  // delete+add.
+  const original = Array.from({ length: 32 }, (_, i) => `line ${i + 1}\n`).join(
+    '',
+  );
+  await fs.promises.writeFile(path.join(repoRoot, 'before.txt'), original);
+  await execFileAsync('git', ['add', 'before.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'baseline'],
+    { cwd: repoRoot },
+  );
+
+  // Rename via git mv so the rename is recorded in the index.
+  await execFileAsync('git', ['mv', 'before.txt', 'after.txt'], {
+    cwd: repoRoot,
+  });
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  const entries = await backend.status();
+  const renamed = entries.find(e => e.index === 'renamed');
+  if (renamed === undefined) {
+    throw t.fail('expected a renamed status row');
+  }
+  t.is(renamed.path, 'after.txt');
+  t.is(renamed.renamedFrom, 'before.txt');
+});
+
+test('NativeGitBackend.assertNoExecutableRepoConfig refuses filter clean drivers', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'staged.txt'), 'x\n');
+  await execFileAsync('git', ['add', 'staged.txt'], { cwd: repoRoot });
+
+  // Set a filter.<name>.clean entry directly in .git/config; that is
+  // exactly the pattern EXECUTABLE_REPO_CONFIG refuses, because git
+  // would shell out to the named program on `git add` of any path
+  // covered by .gitattributes.
+  await execFileAsync(
+    'git',
+    ['config', '--local', 'filter.evil.clean', '/usr/bin/env true'],
+    { cwd: repoRoot },
+  );
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await t.throwsAsync(backend.add(['staged.txt']), {
+    message:
+      /Refusing git operation because repository config can execute commands/,
+  });
+});
+
+test('NativeGitBackend.assertNoExecutableRepoConfig refuses merge driver config', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync(
+    'git',
+    ['config', '--local', 'merge.evil.driver', '/usr/bin/env true'],
+    { cwd: repoRoot },
+  );
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  // Any mutation triggers the guard; `commit` of an empty index also
+  // travels through assertNoExecutableRepoConfig first.
+  await t.throwsAsync(backend.commit('should refuse'), {
+    message:
+      /Refusing git operation because repository config can execute commands.*merge\.evil\.driver/,
+  });
+});
+
+test('NativeGitBackend.remoteFetch refuses url.<base>.insteadOf rewrites', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync(
+    'git',
+    [
+      'config',
+      '--local',
+      'url.https://attacker.example/.insteadof',
+      'https://benign.example/',
+    ],
+    { cwd: repoRoot },
+  );
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  // assertNoRemoteTransportRepoConfig fires before any network IO, so
+  // we can use a placeholder URL and trust the guard to refuse first.
+  await t.throwsAsync(
+    backend.remoteFetch({
+      url: 'https://benign.example/repo.git',
+      refspecs: ['+refs/heads/main:refs/remotes/origin/main'],
+    }),
+    {
+      message:
+        /repository config can alter remote transport.*url\..*\.insteadof/i,
+    },
+  );
+});
+
+test('NativeGitBackend.remotePush refuses core.sshCommand override', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync(
+    'git',
+    ['config', '--local', 'core.sshCommand', '/bin/false'],
+    { cwd: repoRoot },
+  );
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await t.throwsAsync(
+    backend.remotePush({
+      url: 'https://benign.example/repo.git',
+      refspecs: ['refs/heads/main:refs/heads/main'],
+    }),
+    {
+      message:
+        /repository config can alter remote transport.*core\.sshcommand/i,
+    },
+  );
+});
+
+test('NativeGitBackend.remoteFetch rejects an unsupported URL protocol', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const backend = makeNativeGitBackend({ repoRoot });
+
+  // git: and ssh: are intentionally not in the supported set; the
+  // backend collapses every accepted protocol into an exact -c
+  // protocol.<scheme>.allow=always flag, so a missing scheme has to
+  // be refused at the boundary rather than relayed to git.
+  await t.throwsAsync(
+    backend.remoteFetch({
+      url: 'git://attacker.example/repo.git',
+      refspecs: ['+refs/heads/main:refs/remotes/origin/main'],
+    }),
+    {
+      message: /remote URL protocol is not supported/,
+    },
+  );
+});
+
+test('NativeGitBackend.remoteFetch rejects a malformed remote URL', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const backend = makeNativeGitBackend({ repoRoot });
+
+  // requireRevision accepts the string; the URL parse inside
+  // remoteProtocolArgs is the second boundary that refuses garbage.
+  await t.throwsAsync(
+    backend.remoteFetch({
+      url: 'not-a-url',
+      refspecs: ['+refs/heads/main:refs/remotes/origin/main'],
+    }),
+    {
+      message: /remote URL is not a valid URL/,
+    },
+  );
+});

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -2317,3 +2317,31 @@ test('NativeGitBackend.diff and show never invoke a .gitattributes textconv driv
   t.false(fs.existsSync(marker), 'show() must not invoke the textconv driver');
 });
 
+test('NativeGitBackend stays usable when the first commit lands on an empty repo', async t => {
+  // Regression for the empty-repo identity throw (Codex P2).  A backend
+  // constructed over a repo with no commits caches rootCommit='EMPTY'.
+  // After the first commit() the follow-up identity check sees a real
+  // root SHA and used to throw "Git repository identity changed" even
+  // though the commit succeeded.
+  const repoRoot = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'native-git-empty-'),
+  );
+  t.teardown(() => fs.promises.rm(repoRoot, { recursive: true, force: true }));
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'first.txt'), 'hello\n');
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await backend.assertRepositoryRoot();
+  await backend.add(['first.txt']);
+
+  const commit = await backend.commit('first commit on an empty repo');
+  t.truthy(commit.oid, 'commit should resolve with a real oid');
+  t.is(commit.summary, 'first commit on an empty repo');
+
+  // The capability remains usable for subsequent operations against the
+  // now-non-empty repository.
+  const commits = await backend.log();
+  t.is(commits.length, 1);
+  t.is(commits[0].oid, commit.oid);
+});
+

--- a/packages/endo-git/src/native-git-backend.js
+++ b/packages/endo-git/src/native-git-backend.js
@@ -163,6 +163,13 @@ const makeGitEnv = repoRoot => ({
   GIT_CONFIG_GLOBAL: gitNullDevice,
   // No interactive prompts.
   GIT_TERMINAL_PROMPT: '0',
+  // Suppress the opportunistic index refresh that read commands
+  // (status, diff) otherwise perform.  Without this, a "read-only"
+  // inspection rewrites `.git/index` metadata as a side effect and
+  // fails outright on a genuinely read-only filesystem.  Mutating
+  // commands take their real locks regardless of this flag, so it is
+  // safe to set for every invocation.
+  GIT_OPTIONAL_LOCKS: '0',
   // Force the pager to a passthrough.
   GIT_PAGER: 'cat',
   // Stable locale for deterministic parsing.

--- a/packages/endo-git/src/native-git-backend.js
+++ b/packages/endo-git/src/native-git-backend.js
@@ -316,8 +316,17 @@ harden(normalizeTreePath);
 // commit, createBranch, deleteBranch, renameBranch, switchBranch,
 // detach, switch, merge, rebase, stashPush, stashApply, stashPop,
 // stashDrop) gate on `assertNoExecutableRepoConfig` first.
+//
+// `include.path` / `includeIf.*` are refused outright: git honors an
+// included file's `filter.*`/`merge.*` driver keys, but
+// `git config --local --name-only --list` reports only the `include`
+// key itself, not the keys the included file contributes.  Without
+// this clause a committed-in `.git/config` `include.path` pointing at
+// an in-tree file that defines `filter.<name>.clean` would slip past
+// the listing-based check and run on the next add/commit.  The
+// remote-transport guard already refuses the same keys.
 const EXECUTABLE_REPO_CONFIG =
-  /^(filter\..*\.(clean|smudge|process)|merge\..*\.driver)$/u;
+  /^(filter\..*\.(clean|smudge|process)|merge\..*\.driver|include(\.|if\.))/u;
 
 // Repository-local configurations that can redirect or alter an
 // explicitly-policy-bound remote URL. Remote operations pass a URL
@@ -1057,7 +1066,8 @@ export const makeNativeGitBackend = ({
     );
     const offending = stdout
       .split('\n')
-      .filter(name => EXECUTABLE_REPO_CONFIG.test(name));
+      .map(name => name.trim())
+      .filter(name => EXECUTABLE_REPO_CONFIG.test(name.toLowerCase()));
     if (offending.length > 0) {
       throw new Error(
         `Refusing git operation because repository config can execute commands: ${offending.join(', ')}`,

--- a/packages/endo-git/src/native-git-backend.js
+++ b/packages/endo-git/src/native-git-backend.js
@@ -504,6 +504,27 @@ const sameRepositoryIdentity = (left, right) =>
   left.rootCommit === right.rootCommit;
 harden(sameRepositoryIdentity);
 
+/**
+ * A repository constructed before its first commit captures
+ * `rootCommit: 'EMPTY'`.  When a commit lands through this capability the
+ * repository gains its first root commit, and a later re-capture sees a
+ * real root SHA.  That transition is not the "repository swapped out from
+ * under us" event the identity check guards against — the repo did not
+ * change identity, it gained its inaugural commit through us.  Treat the
+ * `'EMPTY' -> <sha>` transition as identity-stable (commonDir and
+ * configHash must still match); every other `rootCommit` change remains a
+ * real identity change.
+ *
+ * @param {RepositoryIdentity} prior
+ * @param {RepositoryIdentity} current
+ */
+const isEmptyRepoFirstCommit = (prior, current) =>
+  prior.rootCommit === 'EMPTY' &&
+  current.rootCommit !== 'EMPTY' &&
+  prior.commonDir === current.commonDir &&
+  prior.configHash === current.configHash;
+harden(isEmptyRepoFirstCommit);
+
 const UNMERGED_STATUS_CODES = harden(
   new Set(['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']),
 );
@@ -882,14 +903,26 @@ export const makeNativeGitBackend = ({
     await verifyRepositoryRoot();
     const resolvedRoot = await fs.promises.realpath(repoRoot);
     const currentIdentity = await captureRepositoryIdentity(resolvedRoot);
-    if (
-      repositoryIdentity === undefined ||
-      !sameRepositoryIdentity(repositoryIdentity, currentIdentity)
-    ) {
+    if (repositoryIdentity === undefined) {
       throw new Error(
         'Git repository identity changed since this capability was constructed; re-derive Git from the mount',
       );
     }
+    if (sameRepositoryIdentity(repositoryIdentity, currentIdentity)) {
+      return;
+    }
+    // A capability constructed over an empty repository whose first
+    // commit landed through us sees its `rootCommit` transition from
+    // 'EMPTY' to a real SHA.  Accept that transition and adopt the
+    // resolved identity so subsequent operations verify against the
+    // now-non-empty repository rather than re-throwing on every call.
+    if (isEmptyRepoFirstCommit(repositoryIdentity, currentIdentity)) {
+      repositoryIdentity = currentIdentity;
+      return;
+    }
+    throw new Error(
+      'Git repository identity changed since this capability was constructed; re-derive Git from the mount',
+    );
   };
 
   /**

--- a/packages/endo-git/src/native-git-backend.js
+++ b/packages/endo-git/src/native-git-backend.js
@@ -1586,14 +1586,19 @@ export const makeNativeGitBackend = ({
     /**
      * Render a textual diff in `git diff` form.  `--no-ext-diff` suppresses
      * any external diff program a guest may have committed into the repo
-     * config.  Combined with the rest of the hardening envelope (hooks off,
+     * config; `--no-textconv` suppresses a `diff.<driver>.textconv` command
+     * that an in-tree `.gitattributes` could otherwise bind to a path and
+     * have git exec while rendering the diff.  `core.attributesFile=/dev/null`
+     * (in `GIT_BASE_ARGS`) only disables the *external* attributes file, not
+     * the in-tree `.gitattributes`, so the per-command flag is load-bearing
+     * here.  Combined with the rest of the hardening envelope (hooks off,
      * filters off), guests cannot make `git diff` execute arbitrary code.
      *
      * @param {GitBackendDiffOptions} [options]
      * @returns {Promise<string>}
      */
     diff: async (options = {}) => {
-      const args = ['diff', '--no-ext-diff'];
+      const args = ['diff', '--no-ext-diff', '--no-textconv'];
       if (options.cached) args.push('--cached');
       // `--end-of-options` separates option-shaped flags from the
       // revisions that follow.  `requireRevision` already rejects
@@ -1671,12 +1676,19 @@ export const makeNativeGitBackend = ({
     },
 
     /**
+     * Render `git show` for a ref.  `--no-textconv` suppresses a
+     * `diff.<driver>.textconv` command that an in-tree `.gitattributes`
+     * could bind to a shown path; without it, `git show` of a commit or
+     * blob would exec the configured textconv program just as `diff`
+     * would (see the `diff` method's note on why the in-tree attributes
+     * file is not neutralized by `core.attributesFile=/dev/null`).
+     *
      * @param {string} ref
      * @returns {Promise<string>}
      */
     show: async ref => {
       const revision = requireRevision(ref, 'show.ref');
-      return runGit(['show', '--end-of-options', revision]);
+      return runGit(['show', '--no-textconv', '--end-of-options', revision]);
     },
 
     /**

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -228,6 +228,28 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
   /** @type {Map<string, object>} */
   const filesystemByTreeOid = new Map();
 
+  // The worktree authority a read-only Git exposes.  A writable Git
+  // hands out the writable `mount`; a read-only Git must not, or its
+  // `worktree()` and the per-entry `node`s minted by `status()` would
+  // carry full write authority (`writeText`, `remove`, `move`,
+  // `makeFile`) despite the cap's read-only intent.  `mount.readOnly()`
+  // yields a structural read-only view that shares the same mount
+  // lineage, so entries minted by the writable mount still resolve
+  // through it but no write method survives the attenuation.  Resolved
+  // lazily because `readOnly()` is a synchronous attenuation method and
+  // the read-only view is only needed once a read flows through it.
+  /** @type {Promise<object> | undefined} */
+  let readOnlyWorktreeP;
+  const worktreeAuthority = () => {
+    if (!readOnly) {
+      return mount;
+    }
+    if (readOnlyWorktreeP === undefined) {
+      readOnlyWorktreeP = Promise.resolve(E(mount).readOnly());
+    }
+    return readOnlyWorktreeP;
+  };
+
   /**
    * Translate an array of EndoMountEntry caps into the repo-relative
    * path strings that the backend (and the underlying git binary)
@@ -281,7 +303,7 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
 
   const exo = makeExo('Git', GitInterface, {
     worktree() {
-      return mount;
+      return worktreeAuthority();
     },
 
     async status() {
@@ -290,14 +312,27 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
       // produced repo-relative path strings; here we mint the
       // authority-bearing EndoMountEntry through the bound mount so
       // a caller can hold a path-bearing reference that's confined
-      // to this worktree.
+      // to this worktree.  The `entry` descriptor is inert (it carries
+      // no I/O authority of its own), so it is always minted from the
+      // writable mount.  The `node` carries the actual read/write
+      // authority, so it is resolved through `worktreeAuthority()`: a
+      // read-only Git resolves nodes through the read-only worktree
+      // view, ensuring a status row never hands a caller a writable
+      // node out of an attenuated cap.
+      const worktree = await worktreeAuthority();
       const wrapped = await Promise.all(
         raw.map(async r => {
           const segments = r.path === '' ? [] : r.path.split('/');
           const entry = await E(mount).entry(segments);
           let node;
           try {
-            node = await E(mount).lookup(entry);
+            // Resolve the node by repo-relative segments rather than by
+            // the `entry` descriptor: the read-only worktree view exposes
+            // the structural `ReadableTree` surface whose `lookup` accepts
+            // only string / string[] paths (not an EndoMountEntry).
+            // Segments are equivalent and work for both the writable mount
+            // and the read-only view.
+            node = await E(worktree).lookup(segments);
           } catch (lookupError) {
             node = undefined;
             // A deleted path (in either the index or the worktree)

--- a/packages/exo-git/src/interfaces.js
+++ b/packages/exo-git/src/interfaces.js
@@ -65,7 +65,11 @@ const GitCommitShape = M.splitRecord(
 // #endregion
 
 export const GitInterface = M.interface('Git', {
-  worktree: M.call().returns(M.remotable('EndoMount')),
+  // `callWhen` so a read-only Git may resolve its worktree authority
+  // through `mount.readOnly()` (which yields a promise of the
+  // structural read-only view) before the return shape is matched; a
+  // writable Git returns its mount synchronously and is unaffected.
+  worktree: M.callWhen().returns(M.remotable('EndoMount')),
   status: M.callWhen().returns(M.arrayOf(GitStatusEntryShape)),
   diff: M.callWhen()
     .optional(M.recordOf(M.string(), M.any()))


### PR DESCRIPTION
Refs: #366, #364

## Description

Fixes five correctness and security defects in the daemon's git capability surface (`Git` exo and `NativeGitBackend`), each landed with an adversarial regression test that fails on the unpatched code and passes after the fix.

- A read-only `Git` reused the writable mount, so `worktree()` and the per-row nodes minted by `status()` still exposed write authority (`writeText`, `remove`, `move`, `makeFile`). A read-only cap now resolves its worktree authority through the mount's structural read-only view, so neither the worktree nor a status node can mutate the tree.
- The executable-config guard listed repository-local keys with `git config --local --name-only --list`, which reports only an `include.path` key and not the `filter.*`/`merge.*` driver keys an included file contributes, while git honors those included drivers on the next mutating operation. The guard now refuses `include.path`/`includeIf.*` keys outright, matching the remote-transport guard.
- The read paths `diff()` and `show()` were ungated, but git still executes a `diff.<driver>.textconv` command bound to a path by an in-tree `.gitattributes`, letting even a read-only cap run an arbitrary host command. Both read paths now pass `--no-textconv`.
- A backend constructed over a repository with no commits cached an `EMPTY` root identity; the first commit through the cap then failed its own post-commit identity check even though the commit succeeded. The `EMPTY` to first-commit transition is now treated as identity-stable.
- The read paths ran without `GIT_OPTIONAL_LOCKS=0`, so `git status` rewrote `.git/index` metadata as a side effect of an inspection and would fail on a read-only filesystem. The sanitized environment now sets the flag.

The branch retains the prior coverage additions for the stash variants, rename-status parsing, and the diff ref-collapse paths that exercise real translation branches.

### Security Considerations

The first three items are authority-escalation defects: a read-only `Git` capability could mutate its worktree, and a guest could provoke arbitrary host-command execution through a committed-in `.gitattributes`/`.git/config` either on a mutating operation (`include.path` driver injection) or on a read (`textconv`). The fixes close those vectors at the capability boundary. The reviewer's attention is best spent on whether the read-only worktree view is the only surface through which a node escapes the attenuation, and on whether the `include`/`includeIf` refusal is broad enough given that git resolves includes recursively.

### Scaling Considerations

N/A.

### Documentation Considerations

N/A.

### Testing Considerations

Each fix ships with a regression test that was confirmed to fail against the unpatched predicate and pass after, per `regression-evidence` discipline: the include-bypass and textconv tests drive the capability (a committed-in driver must not run) rather than the guard's own listing mechanism, the empty-repo test constructs a backend over a commit-less repository, and the read-path test asserts `git status` leaves `.git/index` untouched.

### Compatibility Considerations

`Git.worktree()` on a read-only capability now returns a structural read-only `ReadableTree` view rather than the writable `EndoMount`; callers that relied on holding a writable worktree through a read-only cap were relying on the leak this PR closes.

### Upgrade Considerations

N/A.
