### PR TITLE
feat(daemon): Git.filesystemAt(ref) — endo-fs Filesystem over a git tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ api-docs
 !packages/daemon/src/bus-xs-host-globals.d.ts
 !packages/daemon/src/types.d.ts
 !packages/daemon/types.d.ts
+!packages/endo-fs/types.d.ts
 !packages/eventual-send/src/exports.d.ts
 !packages/eventual-send/src/types.d.ts
 !packages/exo/src/types.d.ts

--- a/designs/README.md
+++ b/designs/README.md
@@ -103,6 +103,7 @@ LLM-agent stack).*
 | [daemon-content-store-gc](daemon-content-store-gc.md) | 2026-03-20 | 2026-05-08 | **Complete** |
 | [daemon-git-capability](daemon-git-capability.md) | 2026-05-18 | 2026-05-27 | Proposed |
 | [daemon-git-remotes](daemon-git-remotes.md) | 2026-05-18 | 2026-05-21 | Proposed |
+| [endo-fs-from-git](endo-fs-from-git.md) | 2026-05-28 | 2026-05-28 | Proposed |
 | [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-05-19 | In Progress (PR #287) |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-05-27 | In Progress |
 | [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-05-27 | **Complete** |

--- a/designs/README.md
+++ b/designs/README.md
@@ -103,7 +103,7 @@ LLM-agent stack).*
 | [daemon-content-store-gc](daemon-content-store-gc.md) | 2026-03-20 | 2026-05-08 | **Complete** |
 | [daemon-git-capability](daemon-git-capability.md) | 2026-05-18 | 2026-05-27 | Proposed |
 | [daemon-git-remotes](daemon-git-remotes.md) | 2026-05-18 | 2026-05-21 | Proposed |
-| [endo-fs-from-git](endo-fs-from-git.md) | 2026-05-28 | 2026-05-28 | Proposed |
+| [endo-fs-from-git](endo-fs-from-git.md) | 2026-05-28 | 2026-05-28 | In Progress |
 | [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-05-19 | In Progress (PR #287) |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-05-27 | In Progress |
 | [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-05-27 | **Complete** |

--- a/designs/endo-fs-from-git.md
+++ b/designs/endo-fs-from-git.md
@@ -39,7 +39,10 @@ Both can be reintroduced as a Phase 5 follow-up (a `synthQidFromOid` option on `
 
 Add a method `Git.filesystemAt(ref)` to `EndoGit` that returns an `@endo/endo-fs` `Filesystem` lazily backed by the git object database at the given ref's tree.
 The Filesystem is immutable: blob reads stream via `git cat-file blob` and directory listings stream via `git ls-tree`.
-QIDs use the git OID as the stable identity (two paths to the same blob report the same QID), and `File.snapshot()` returns a `BlobRef` whose hash IS the git blob OID — making CAS-backed read caches (`withCachedReads`) hit-zero-RTT for repeat reads.
+
+> The text below describes the original design intent — Section §1 in the prompt was for the version that hand-rolled the `Filesystem` / `Directory` / `File` / `OpenFile` exo graph.
+> The shipped implementation targets the upstream `wrapBackend(...)` seam instead and is described in the `## Status` section above; the QID-from-OID and `git-sha1` BlobRef claims in this section are NOT what shipped.
+> See the Status section for the authoritative current contract.
 
 `Git.filesystemAt` is the first daemon-side bridge between the `Git` capability and the `@endo/endo-fs` filesystem vocabulary.
 The daemon's `EndoMount` and `@endo/endo-fs`'s `Filesystem` remain separate surfaces — the existing one-way `from-mount.js` adapter in `endo-fs` is the only bridge between them, and this design does not unify them.
@@ -137,6 +140,15 @@ Blob bytes are NOT cached at this layer; callers that want a CAS-backed cache co
 
 ### QID and BlobRef contracts
 
+> **Superseded by the `## Status` section.**
+> The shipped implementation delegates QID and `BlobRef` synthesis to `wrapBackend`, so:
+> - `qid.pathId` is the path hash from `synthQid(path, kind)`, not the git OID.
+> - `BlobRef.getInfo()` reports `algorithm: 'sha256'` (SHA-256 of the captured bytes), not `git-sha1`; the git OID is not exposed through the `BlobRef` shape.
+>
+> The original design called for the shape below, which would require either a hand-rolled exo graph (the wrap-backend rewrite eliminated) or a backend-supplied QID / hash hook on `wrapBackend` (deferred).
+
+The original intent was:
+
 ```ts
 // File QID
 {
@@ -160,9 +172,8 @@ Blob bytes are NOT cached at this layer; callers that want a CAS-backed cache co
 }
 ```
 
-The `git-sha1` vs `sha256` distinction is load-bearing: git's hash is over the framed payload (`blob <size>\0<bytes>`), not the raw bytes, so a downstream consumer comparing hashes across sources must distinguish `git-sha1(framed)` from `sha256(raw)`.
-
-QIDs match across path-equivalent caps: `lookup('a/b').getQid()` returns the same value as `root().lookup('a').lookup('b').getQid()`, because both resolve to the same OID.
+The `git-sha1` vs `sha256` distinction would have been load-bearing: git's hash is over the framed payload (`blob <size>\0<bytes>`), not the raw bytes, so a downstream consumer comparing hashes across sources must distinguish `git-sha1(framed)` from `sha256(raw)`.
+With the shipped shape, callers that need git-OID identity must consult the parent `Git` cap or the design's deferred backend-hook follow-up.
 
 ### Brands
 

--- a/designs/endo-fs-from-git.md
+++ b/designs/endo-fs-from-git.md
@@ -1,0 +1,386 @@
+# `@endo/endo-fs` from-git Adapter
+
+| | |
+|---|---|
+| **Created** | 2026-05-28 |
+| **Author** | kumavis (prompted) |
+| **Status** | Proposed |
+
+> **Read after:**
+> - [daemon-git-capability](daemon-git-capability.md) — the `Git` cap this design extends with one method.
+> - The `@endo/endo-fs` `README.md` and `DESIGN.md` — the `Filesystem` / `Directory` / `File` / `OpenFile` shape this adapts to.
+
+## Summary
+
+Add a method `Git.filesystemAt(ref)` to `EndoGit` that returns an `@endo/endo-fs` `Filesystem` lazily backed by the git object database at the given ref's tree.
+The Filesystem is immutable: blob reads stream via `git cat-file blob` and directory listings stream via `git ls-tree`.
+QIDs use the git OID as the stable identity (two paths to the same blob report the same QID), and `File.snapshot()` returns a `BlobRef` whose hash IS the git blob OID — making CAS-backed read caches (`withCachedReads`) hit-zero-RTT for repeat reads.
+
+`Git.filesystemAt` is the first daemon-side bridge between the `Git` capability and the `@endo/endo-fs` filesystem vocabulary.
+The daemon's `EndoMount` and `@endo/endo-fs`'s `Filesystem` remain separate surfaces — the existing one-way `from-mount.js` adapter in `endo-fs` is the only bridge between them, and this design does not unify them.
+The new method bypasses `EndoMount` entirely; it builds the `Filesystem` view directly from git's object database via the daemon's existing `GitBackend` primitives.
+
+## What is the Problem Being Solved?
+
+The current `Git.tree(ref)` method returns an `EndoReadableTree` — the minimal `has`/`list`/`lookup` read-surface vocabulary from `@endo/daemon`.
+It is sufficient for compartment-mapper imports and other generic tree consumers, but it is structurally lossy for callers that already speak `@endo/endo-fs`:
+
+- no range reads — full-blob fetch per `lookup`-then-read pair;
+- no QID identity — callers cannot deduplicate references to the same content;
+- no `BlobRef` — no path into `@endo/endo-fs`'s CAS-backed read cache (`withCachedReads`);
+- no `Cursor` paginated listing — large directories materialize their full entry list per call;
+- no `brands()` — cannot participate in `compose` / `bind` cycle detection;
+- the `from-mount.js` adapter (Mount → endo-fs) uses path-hashed QIDs and `version: 0n`, which is a sound choice for a *live* worktree but a worse fit for an immutable historical tree where the natural QID source is the OID itself.
+
+The `@endo/endo-fs` README already names the gap:
+
+> | Immutable snapshot | `@endo/daemon` `ReadableTree` | `Node.snapshot() → BlobRef` for content-addressed sub-trees. |
+
+This design fills that row, for the git case specifically.
+
+## Goals
+
+1. Expose a git commit's tree as an `@endo/endo-fs` `Filesystem` without materializing entries that are not read.
+2. Make blob OIDs the QID and `BlobRef` hash — give content-addressed callers a strong identity to dedupe and cache against.
+3. Stay backend-agnostic at the daemon-internal contract level — `NativeGitBackend` is the first implementation, but a future JS git backend or HTTPS smart-protocol client should be able to implement the same backend method set.
+4. Reject mutation cleanly. Git history is immutable, so the Filesystem is natively read-only — no `readOnly(writableFs)` wrapper needed.
+
+## Non-Goals
+
+- Unifying `EndoMount` and `@endo/endo-fs` `Filesystem`. The two surfaces remain parallel; `from-mount.js` is the only bridge and is not extended here.
+- Exposing the worktree as an endo-fs Filesystem. That is a separate adapter and is out of scope.
+- Live history watchers — `NodeWatcher.events()` on a git-FS Directory always yields zero events (historical trees do not change).
+- Submodule traversal — `lookup` into a submodule entry throws; callers obtain a separate `Git` for the submodule's repository.
+- Symlink target resolution. Symlinks are exposed as files whose content IS the link target (a single line of bytes), matching how git stores them. Following them is out of scope.
+
+## Design
+
+### Public Method
+
+```ts
+interface EndoGit {
+  // existing methods...
+
+  /**
+   * Returns an `@endo/endo-fs` Filesystem lazily backed by the git object
+   * database at the resolved tree of `ref`. The Filesystem is immutable;
+   * every mutating verb throws `EACCES`.
+   */
+  filesystemAt(ref: GitRef | string): Promise<Filesystem>;
+}
+```
+
+Sample use:
+
+```js
+const fs = await E(git).filesystemAt('HEAD');
+const root = await E(fs).root();
+const readme = await E(root).lookup('README.md');
+
+// Range read — one `cat-file` call.
+const opener = await E(readme).open({ read: true });
+const reader = await E(opener).read(0n, 4096n);
+// reader: PassableBytesReader
+
+// Snapshot — hash is the git blob OID.
+const blob = await E(readme).snapshot();
+const info = await E(blob).getInfo();
+// { algorithm: 'git-sha1', hash: '<40-hex-oid>', size: <bytes> }
+
+// Compose with a writable layer in endo-fs.
+const layered = compose([fs, scratchFs]);
+```
+
+### Lazy resolution
+
+`filesystemAt(ref)` does one synchronous-shaped piece of work at construction:
+
+1. Resolve `ref` to a canonical tree OID via the new backend method `resolveTree(ref)`.
+   This is one `git rev-parse --verify --end-of-options <ref>^{tree}` call.
+2. Mint a brand for this Filesystem instance.
+3. Return the `Filesystem` exo.
+
+All subsequent navigation is on-demand:
+
+- `Directory.lookup(name)` triggers one `ls-tree` of the current tree OID, finds the named entry, and minted a new `File` or `Directory` exo for it.
+- `Directory.list()` returns a `Cursor` over the `ls-tree` results, lazily streamed.
+- `File.open({ read: true })` returns an `OpenFile` whose `read(offset, length)` invokes `cat-file blob <oid>` once and slices the result.
+- `File.snapshot()` returns a `BlobRef` that defers the bytes-fetch until `fetch(offset, length)` is called.
+
+Tree entries are cached per tree OID within the Filesystem instance — they are immutable, so caching is safe.
+Blob bytes are NOT cached at this layer; callers that want a CAS-backed cache compose `withCachedReads(gitFs, cas)` in endo-fs.
+
+### QID and BlobRef contracts
+
+```ts
+// File QID
+{
+  type: 'file',
+  pathId: BigInt('0x' + blobOid),  // git OID as BigInt
+  version: 0n,                      // never changes — blob is immutable
+}
+
+// Directory QID
+{
+  type: 'directory',
+  pathId: BigInt('0x' + treeOid),
+  version: 0n,
+}
+
+// BlobRef.getInfo()
+{
+  algorithm: 'git-sha1',   // or 'git-sha256' for sha256-formatted repos
+  hash: blobOid,           // hex string, the git OID itself
+  size: blobSize,          // from ls-tree --long
+}
+```
+
+The `git-sha1` vs `sha256` distinction is load-bearing: git's hash is over the framed payload (`blob <size>\0<bytes>`), not the raw bytes, so a downstream consumer comparing hashes across sources must distinguish `git-sha1(framed)` from `sha256(raw)`.
+
+QIDs match across path-equivalent caps: `lookup('a/b').getQid()` returns the same value as `root().lookup('a').lookup('b').getQid()`, because both resolve to the same OID.
+
+### Brands
+
+Per `@endo/endo-fs`'s brand contract, every primitive Filesystem mints a passable `bigint` brand via `mintBrand()`.
+For this adapter:
+
+- A fresh brand is minted per `(Git instance, canonical tree OID)` pair.
+- Repeated calls to `filesystemAt(sameOid)` on the same `Git` are memoized and return the same Filesystem cap (same brand). HEAD moving causes the next call to mint a new Filesystem.
+- Two different `Git` capabilities pointing at the same repo do NOT share brands. Brand sharing across distinct authority boundaries would leak the implication that the two `Git` caps come from the same repo, which is information the public surface does not otherwise expose.
+
+This makes `compose` cycle detection and cross-Filesystem `rename` (`EXDEV`) work without further plumbing.
+
+### Mutating verbs
+
+The Filesystem is natively read-only; mutating verbs throw `EACCES` with a structured error citing the read-only posture:
+
+- `Directory.create`, `Directory.mkdir`, `Directory.unlink`, `Directory.rename`, `Directory.materialise`, `Directory.fsync` → `EACCES`.
+- `Directory.setAttrs`, `File.setAttrs` → `EACCES`.
+- `OpenFile.write`, `OpenFile.truncate`, `OpenFile.lock`, `OpenFile.fsync` → `EACCES`.
+- `Xattrs.set`, `Xattrs.remove` → `EACCES`.
+
+The exo throws `EACCES` directly rather than wrapping the Filesystem through `readOnly()` — there is no underlying writable cap to attenuate, so the wrapper would add a round-trip per call with no benefit.
+
+### Unsupported endo-fs surface
+
+These methods exist in the endo-fs contract but have no meaningful mapping for an immutable tree; they return empty streams or throw `ENOSYS`:
+
+- `Xattrs.{get, list}` — empty stream / empty reader. Git has no xattrs.
+- `NodeWatcher.events()` — empty reader. Historical trees never change.
+- `Directory.watchFrom()` — returns `{ cursor, watcher }` where the cursor enumerates current entries and the watcher's events are always empty. The TOCTOU contract holds vacuously.
+- `Filesystem.named(viewName)` — `ENOTSUP`. Git-FS has one root.
+
+`Filesystem.statfs()` returns zeros (`totalBytes: 0n`, `freeBytes: 0n`, `availableBytes: 0n`) matching `from-mount.js`.
+
+### Submodule and symlink behavior
+
+A tree entry whose `type` field is `commit` denotes a submodule pointer (a 40-char OID into a different repository's object DB).
+`Directory.lookup(name)` for such an entry throws:
+
+```
+EIO: lookup of submodule 'name' is not supported; obtain a separate Git
+capability for the submodule's repository
+```
+
+A tree entry whose `mode` begins with `120` is a symlink blob whose content is the target path string.
+`Directory.lookup(name)` returns a `File` whose `open()` and `snapshot()` yield the link target text.
+The git-FS does NOT follow symlinks — symbolic-link semantics are deferred to a higher layer (or to a future enhancement).
+
+### Backend contract additions
+
+The `GitBackend` typedef in `git.js` gains four primitives.
+These are not novel — `NativeGitBackend` already implements them as internal helpers (`listTreeEntries`, `readBlobBytes`, `streamBlobBytes`, and the rev-parse used inside `tree()`); this design lifts them to the public backend contract so any future backend can implement them with the same shape:
+
+```ts
+/**
+ * @typedef {object} GitTreeEntry
+ * @property {string} mode    e.g. '100644', '040000', '120000', '160000'
+ * @property {'blob' | 'tree' | 'commit'} type
+ * @property {string} oid
+ * @property {number} [size]  present for blobs, undefined for trees / commits
+ * @property {string} name
+ */
+
+interface GitBackend {
+  // existing methods...
+
+  /**
+   * Resolve a ref to a tree OID and (when applicable) the commit OID
+   * that points at it. Used at filesystemAt(ref) construction.
+   */
+  resolveTree(ref: string): Promise<{ treeOid: string; commitOid?: string }>;
+
+  /** Enumerate entries at a tree OID. */
+  lsTree(treeOid: string): Promise<GitTreeEntry[]>;
+
+  /** Read full bytes of a blob. */
+  readBlobBytes(blobOid: string): Promise<Uint8Array>;
+
+  /** Stream blob bytes for range reads. */
+  streamBlobBytes(blobOid: string): AsyncIterable<Uint8Array>;
+}
+```
+
+The existing `backend.tree(ref) → ReadableTree` keeps its shape unchanged; `filesystemAt` does not consume it.
+
+### No formula type
+
+`Git.filesystemAt(ref)` returns an ephemeral exo (no formula persistence), matching `Git.tree(ref)`.
+Daemon restart causes any cap holders to re-derive the Filesystem from the parent `Git` formula by calling `filesystemAt(ref)` again.
+The brand changes across restart — callers that need cross-restart identity should use the BlobRef hashes (which are stable git OIDs) rather than the Filesystem's brand.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [daemon-git-capability](daemon-git-capability.md) | The `EndoGit` capability this method lives on; the backend primitives are also wired here. |
+| [platform-fs](platform-fs.md) | Parallel read-surface vocabulary in `@endo/platform`. Not consumed; named for orientation. |
+
+The daemon package takes a new dependency on `@endo/endo-fs` to import its interface guards (`FilesystemInterface`, `DirectoryInterface`, etc.) and shared helpers.
+
+## Phased Implementation
+
+### Phase 1: Backend primitives and public shape
+
+- [ ] Add `resolveTree`, `lsTree`, `readBlobBytes`, `streamBlobBytes` to the `GitBackend` typedef in `src/git.js`.
+- [ ] Stub the four methods in `makeNotYetImplementedBackend`.
+- [ ] Expose the four methods on `NativeGitBackend` by promoting the existing internal helpers.
+- [ ] Add `filesystemAt` to `GitInterface` in `src/interfaces.js` and `EndoGit` in `src/types.d.ts`.
+- [ ] Tests: method advertised on the exo; `filesystemAt` is rejected on a backend that throws "not yet implemented".
+
+### Phase 2: Filesystem, Directory, File construction
+
+- [ ] New `src/git-filesystem.js` module exporting `makeGitFilesystem({ backend, treeOid, commitOid })`.
+- [ ] Implement `Filesystem.{ root, named, statfs, brands, help }`.
+- [ ] Implement `Directory.{ getQid, getAttrs, watch, xattrs, lookup, list, watchFrom, fsync, help }` and the EACCES-throwing mutating verbs.
+- [ ] Implement `File.{ getQid, getAttrs, watch, xattrs, open, snapshot, help }` and EACCES-throwing `setAttrs`.
+- [ ] Tests: navigate root → subdirectory → blob; QIDs equal across path-equivalent caps; mutation methods throw EACCES.
+
+### Phase 3: OpenFile, Cursor, BlobRef
+
+- [ ] Implement `OpenFile.read(offset, length)` over `readBlobBytes`. Caching: single buffer per OpenFile instance; subsequent reads slice it.
+- [ ] Implement `Cursor.{ stream, skip, rewind, help }` over a snapshotted `lsTree` result.
+- [ ] Implement `BlobRef.{ getInfo, fetch, help }` with `algorithm: 'git-sha1'` and `hash: blobOid`.
+- [ ] Tests: range reads return correct bytes; large blob streaming completes; BlobRef.fetch returns matching bytes; Cursor pagination via skip.
+
+### Phase 4: Compose interop and integration
+
+- [ ] Verify `compose([gitFs, scratchFs])` works end-to-end.
+- [ ] Verify `withCachedReads(gitFs, cas)` short-circuits on second read of the same blob.
+- [ ] Cross-FS `rename` throws `EXDEV` from brand mismatch.
+- [ ] Document the integration patterns in the package README or DESIGN.
+
+### Phase 5 (deferred): SHA-256 repo support
+
+- [ ] Detect `extensions.objectFormat = sha256` in `.git/config` and set `BlobRef.algorithm = 'git-sha256'` accordingly.
+- [ ] Adjust `pathId` derivation if needed (sha256 OIDs are 64 hex chars, fits in BigInt fine).
+
+## Design Decisions
+
+1. **`Git.filesystemAt(ref)` returns `Filesystem`, not `Directory`.**
+   The Filesystem level is the conventional endo-fs entry point; it carries `brands()` and `statfs()` which `Directory` cannot.
+   Callers that want the root Directory walk one method: `await E(fs).root()`.
+2. **Filesystem is natively read-only, not `readOnly(writableFs)`.**
+   Git history is immutable; there is no underlying writable cap to attenuate.
+   Throwing `EACCES` from the exo directly avoids one wrapper layer per call.
+3. **QID `pathId` is the git OID as `BigInt`.**
+   Two paths to the same blob share a QID.
+   This matches git's content-addressed identity and is the strongest stability the protocol allows.
+4. **`BlobRef.algorithm` is `'git-sha1'` (or `'git-sha256'`), not `'sha256'`.**
+   Git's hash is over the framed payload `blob <size>\0<bytes>`, not raw bytes.
+   A consumer comparing hashes across sources must distinguish.
+5. **Brands are per `(Git, treeOid)`, memoized within one `Git`.**
+   Repeated `filesystemAt(sameOid)` on the same `Git` returns the same cap.
+   Different `Git` caps over the same repo do not share brands — that would leak co-repository identity.
+6. **The daemon depends on `@endo/endo-fs`.**
+   The new method is on the daemon-side `Git` exo, so the daemon takes the dependency.
+   The alternative (an adapter in endo-fs consuming a public `LazyTreeView` from the daemon) is deferred — see "Alternatives Considered".
+7. **No formula type for the Filesystem.**
+   `Git.filesystemAt(ref)` returns an ephemeral exo matching `Git.tree(ref)`.
+   Restart re-derives via the parent `Git` formula.
+
+## Alternatives Considered
+
+### Adapter lives in `endo-fs` (parallel to `from-mount.js`)
+
+`endo-fs/src/from-git.js` would export `gitTreeAsFilesystem(lazyTreeView)`.
+The daemon would add a public `Git.lazyTree(ref) → LazyTreeView` exposing the four backend primitives via a small public exo.
+
+**Pros:** No daemon → endo-fs dependency; the public `LazyTreeView` shape becomes reusable by other lazy tree providers (HTTPS smart-protocol clients, isomorphic-git, daemon-local CAS-backed commit storage).
+
+**Cons:** Two-step caller path; no obvious second `LazyTreeView` consumer today; the public `LazyTreeView` vocabulary would need its own design and version bump if it ever evolved.
+
+Rejected for now in favor of the direct method.
+If a second provider surfaces, the public `LazyTreeView` can be extracted later without breaking the `Git.filesystemAt` surface.
+
+### Return a `Directory` directly (skip the Filesystem wrapper)
+
+`Git.filesystemAt(ref) → Directory`.
+
+**Pros:** Fewer wrappers; one-step lookup.
+
+**Cons:** Loses `brands()` (breaks compose cycle detection) and `statfs()`.
+Callers who want to compose would have to wrap a synthetic Filesystem around the Directory.
+
+Rejected.
+
+### Build on top of `Git.tree(ref) → ReadableTree`
+
+Reuse the existing tree method and lift the result into an endo-fs Filesystem on the caller side.
+
+**Pros:** No backend changes.
+
+**Cons:** `ReadableTree` does not expose OIDs, sizes, or range reads, so the adapter would have to fetch and hash each blob client-side to populate `BlobRef.getInfo()` — defeating the content-addressing benefit.
+
+Rejected.
+
+## Testing Plan
+
+In `packages/daemon/test/git.test.js`:
+
+### Shape and authority
+
+- `Git.filesystemAt('HEAD')` returns an exo advertising the `Filesystem` interface methods.
+- `Filesystem.brands()` returns an array with exactly one passable `bigint`.
+- Two `filesystemAt` calls with the same canonical OID on the same `Git` return caps whose `brands()` arrays match.
+- Two `filesystemAt` calls across an intervening commit return caps whose `brands()` differ.
+
+### QID and content addressing
+
+- `Filesystem.root().getQid()` has `type === 'directory'` and `pathId === BigInt('0x' + headTreeOid)`.
+- `Directory.lookup('README.md').getQid()` has `type === 'file'` and `pathId === BigInt('0x' + readmeBlobOid)`.
+- Two paths pointing at the same blob report identical `getQid()` values.
+
+### Reads
+
+- `File.open({ read: true }).read(0n, 4096n)` returns the first 4 KB of the blob.
+- Reading a blob larger than the cat-file buffer succeeds (full bytes returned via streaming).
+- `File.snapshot().getInfo()` reports `algorithm === 'git-sha1'`, `hash === blobOid`, `size === blobSize`.
+- `File.snapshot().fetch(0n, length).next()` returns bytes matching `git cat-file blob <oid>`.
+
+### Listing
+
+- `Directory.list()` returns a `Cursor`.
+- `Cursor.stream().next()` yields `{ name, qid }` entries in `git ls-tree` order.
+- `Cursor.skip(2n)` advances; the next `stream().next()` skips the first two.
+- `Cursor.rewind()` resets the position.
+
+### Mutation rejection
+
+- `Directory.create`, `Directory.mkdir`, `Directory.unlink`, `Directory.rename`, `Directory.materialise`, `Directory.fsync`, `Directory.setAttrs`, `File.setAttrs`, `OpenFile.write`, `OpenFile.truncate`, `OpenFile.lock`, `OpenFile.fsync` all throw with a message matching `/EACCES/`.
+
+### Submodule and symlink
+
+- Looking up a submodule entry (mode `160000`, type `commit`) throws with `/submodule/`.
+- Looking up a symlink (mode `120000`) returns a File whose `open().read()` contains the link target text; `snapshot().getInfo().algorithm === 'git-sha1'`.
+
+### Compose interop
+
+- `compose([gitFs, scratchFs]).root()` works.
+- Cross-FS `rename` from a git-FS Directory to a scratch-FS Directory throws `EXDEV`.
+
+## Prompt
+
+> plan a new interface method for exposing a lazy read-only endo-fs tree at a git commit
+
+Authored 2026-05-28 in response to the prompt after a clarifying exchange that distinguished `@endo/daemon` `EndoMount` (the existing live-mount cap) from `@endo/endo-fs` `Filesystem` (a separate package), and selected the placement option "method on `Git` directly" with a focused adapter-only design doc.

--- a/designs/endo-fs-from-git.md
+++ b/designs/endo-fs-from-git.md
@@ -268,7 +268,9 @@ The existing `backend.tree(ref) → ReadableTree` keeps its shape unchanged; `fi
 
 `Git.filesystemAt(ref)` returns an ephemeral exo (no formula persistence), matching `Git.tree(ref)`.
 Daemon restart causes any cap holders to re-derive the Filesystem from the parent `Git` formula by calling `filesystemAt(ref)` again.
-The brand changes across restart — callers that need cross-restart identity should use the BlobRef hashes (which are stable git OIDs) rather than the Filesystem's brand.
+The brand changes across restart.
+The shipped `wrapBackend` implementation hashes captured bytes with SHA-256 and does NOT expose the git blob OID through `BlobRef` (see the `## Status` section), so callers that need cross-restart identity cannot rely on `BlobRef.getInfo().hash` matching the git OID directly.
+Pair `Git.filesystemAt(ref)` with `Git.resolveTree(ref)` / `lsTree(treeOid)` from the backend contract (or hold the parent `Git` cap) to recover OID-level identity until the Phase 5 wrap-backend hook lets the git-FS supply its own hashes.
 
 ## Dependencies
 

--- a/designs/endo-fs-from-git.md
+++ b/designs/endo-fs-from-git.md
@@ -3,12 +3,37 @@
 | | |
 |---|---|
 | **Created** | 2026-05-28 |
+| **Updated** | 2026-05-28 |
 | **Author** | kumavis (prompted) |
-| **Status** | Proposed |
+| **Status** | In Progress |
 
 > **Read after:**
 > - [daemon-git-capability](daemon-git-capability.md) — the `Git` cap this design extends with one method.
+> - [endo-fs-backend-seam](endo-fs-backend-seam.md) — the `FsBackend` + `wrapBackend(...)` architecture this adapter targets.
 > - The `@endo/endo-fs` `README.md` and `DESIGN.md` — the `Filesystem` / `Directory` / `File` / `OpenFile` shape this adapts to.
+
+## Status
+
+Phase 1 + 2 + 3 + a slice of Phase 4 landed on `claude/adoring-planck-GmRX2`, rebased on `claude/keen-bell-W1acD`:
+
+- `Git.filesystemAt(ref)` exposed on `EndoGit` (`packages/daemon/src/interfaces.js`, `packages/daemon/src/types.d.ts`).
+- `GitBackend` contract extended with `resolveTree`, `lsTree`, `readBlobBytes`, `streamBlobBytes` (`packages/daemon/src/git.js`); native git backend exposes the same as public methods (`packages/daemon/src/native-git-backend.js`).
+- Adapter lives at `packages/daemon/src/git-filesystem.js` and exports `makeGitFsBackend({ backend, treeOid })` — an `FsBackend` implementation (per `endo-fs/src/backend-types.js`).
+  The daemon wraps it as `readOnly(wrapBackend(makeGitFsBackend(...), { description }))` so write verbs reject with `EACCES` at the cap boundary.
+- Tests in `packages/daemon/test/git.test.js` cover shape, lookup, range reads, BlobRef, directory listing, mutation rejection, OID memoization, and submodule hiding.
+
+The on-disk design was revised after rebase: the upstream `@endo/endo-fs` seam refactor introduced `FsBackend` + `wrapBackend(...)`.
+The original plan called for hand-rolling the full `Filesystem` / `Directory` / `File` / `OpenFile` exo graph; that turned into a tiny `FsBackend` adapter (6 required + 2 optional methods, ~150 lines) and the upstream `wrapBackend` builds the rest.
+
+Two original design choices were dropped as a consequence:
+
+1. **QID `pathId` is no longer the git OID as BigInt.**
+   `wrapBackend` synthesizes QIDs via `synthQid(path, kind)` from a path hash.
+   Two paths pointing at the same blob therefore report different QIDs — git-style content-address equivalence is not preserved at this layer.
+2. **`BlobRef.algorithm` is `'sha256'`, not `'git-sha1'`.**
+   The shared `makeBlobRefExo` SHA-256s the captured bytes; the git blob OID is not exposed through the `BlobRef` surface.
+
+Both can be reintroduced as a Phase 5 follow-up (a `synthQidFromOid` option on `wrapBackend`, or a wrap-backend extension hook that lets a backend supply its own QID / hash), but the trade-off — ~200 lines of bespoke exo plumbing versus reusing the shared seam — went the other way given the seam refactor's recent simplification.
 
 ## Summary
 

--- a/designs/endo-fs-from-git.md
+++ b/designs/endo-fs-from-git.md
@@ -211,7 +211,12 @@ These methods exist in the endo-fs contract but have no meaningful mapping for a
 ### Submodule and symlink behavior
 
 A tree entry whose `type` field is `commit` denotes a submodule pointer (a 40-char OID into a different repository's object DB).
-`Directory.lookup(name)` for such an entry throws:
+
+**Shipped behavior (wrap-backend rewrite):** the git-FS backend filters submodule entries out of `list()` and reports `kind('sub') → undefined` for them, so `Directory.lookup('sub')` surfaces as `ENOENT`.
+Base endo-fs only knows file and directory kinds; introducing a third "submodule" kind would require widening the `FsBackend` contract and the wrapBackend exo plumbing.
+Callers that need submodule traversal obtain a separate `Git` capability for the submodule's repository, exactly as the original design intended.
+
+The original design described a distinct `EIO` error:
 
 ```
 EIO: lookup of submodule 'name' is not supported; obtain a separate Git

--- a/designs/endo-fs-from-git.md
+++ b/designs/endo-fs-from-git.md
@@ -318,6 +318,16 @@ The daemon package takes a new dependency on `@endo/endo-fs` to import its inter
 - [ ] Detect `extensions.objectFormat = sha256` in `.git/config` and set `BlobRef.algorithm = 'git-sha256'` accordingly.
 - [ ] Adjust `pathId` derivation if needed (sha256 OIDs are 64 hex chars, fits in BigInt fine).
 
+### Phase 6 (deferred): Paged directory listing
+
+The shipped `Directory.list()` calls `backend.lsTree(treeOid)` and `await`s the full entry array before yielding the first `DirEntry`.
+`listTreeEntries` no longer hits the 1 MiB `runGitRaw` cap (it streams via `streamGitBuffer` and concatenates locally), but the in-memory materialization is bounded only by tree size — a directory with hundreds of thousands of entries still allocates a buffer proportional to the listing.
+The paged-Filesystem contract that wrapBackend exposes via `Cursor.read(limit)` can carry one page at a time once the backend supports it.
+
+- [ ] Add a `streamLsTree(treeOid)` async iterable to `GitBackend` that yields parsed `GitTreeEntryRecord` values one at a time.
+- [ ] Rewire `git-filesystem.list()` to consume the iterator directly, retaining `lsTreeCached` only as the random-access cache `resolvePath` needs (or split the two paths: cached-for-lookup, streamed-for-list).
+- [ ] Cursor pagination test that asserts `read(limit)` returns after `limit` entries on a tree with several thousand blobs without materializing the whole listing.
+
 ## Design Decisions
 
 1. **`Git.filesystemAt(ref)` returns `Filesystem`, not `Directory`.**

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -59,6 +59,7 @@
     "@endo/bytes": "workspace:^",
     "@endo/captp": "workspace:^",
     "@endo/compartment-mapper": "workspace:^",
+    "@endo/endo-fs": "workspace:^",
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
     "@endo/exo": "workspace:^",

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2732,7 +2732,16 @@ const makeDaemonCore = async (
         repoRoot: backing.physicalRoot,
       });
       await backend.assertRepositoryRoot();
-      return makeGit({ mount, backend, readOnly: backing.readOnly });
+      // `provide(mountId)` returns a union of cap types; the
+      // `getMountBacking` check above ensures it's an `EndoMount`,
+      // but TS can't narrow through that. Cast at the boundary so
+      // `makeGit`'s `mount: object` parameter is satisfied without
+      // widening the parameter type to the same union here.
+      return makeGit({
+        mount: /** @type {object} */ (mount),
+        backend,
+        readOnly: backing.readOnly,
+      });
     },
     'git-credential': ({ kind, audience }, _context, id) => {
       const material = gitCredentialMaterialForId.get(id);

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2732,7 +2732,15 @@ const makeDaemonCore = async (
         repoRoot: backing.physicalRoot,
       });
       await backend.assertRepositoryRoot();
-      return makeGit({ mount, backend, readOnly: backing.readOnly });
+      return makeGit({
+        // `provide(mountId)` returns a union of cap types; the
+        // `getMountBacking` check above guarantees an `EndoMount`,
+        // but TS can't narrow through it.
+        // eslint-disable-next-line object-shorthand
+        mount: /** @type {object} */ (mount),
+        backend,
+        readOnly: backing.readOnly,
+      });
     },
     'git-credential': ({ kind, audience }, _context, id) => {
       const material = gitCredentialMaterialForId.get(id);
@@ -2804,8 +2812,15 @@ const makeDaemonCore = async (
       const credential =
         credentialId === undefined ? undefined : await provide(credentialId);
       const { remote } = makeGitRemote({
-        git,
-        credential,
+        // `provide(gitId)` returns a union; `makeGitRemote` accepts a
+        // bare `object` and asserts the shape internally.
+        // eslint-disable-next-line object-shorthand
+        git: /** @type {object} */ (git),
+        // eslint-disable-next-line object-shorthand
+        credential:
+          credential === undefined
+            ? undefined
+            : /** @type {object} */ (credential),
         name,
         policy,
         revoked,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2732,16 +2732,7 @@ const makeDaemonCore = async (
         repoRoot: backing.physicalRoot,
       });
       await backend.assertRepositoryRoot();
-      // `provide(mountId)` returns a union of cap types; the
-      // `getMountBacking` check above ensures it's an `EndoMount`,
-      // but TS can't narrow through that. Cast at the boundary so
-      // `makeGit`'s `mount: object` parameter is satisfied without
-      // widening the parameter type to the same union here.
-      return makeGit({
-        mount: /** @type {object} */ (mount),
-        backend,
-        readOnly: backing.readOnly,
-      });
+      return makeGit({ mount, backend, readOnly: backing.readOnly });
     },
     'git-credential': ({ kind, audience }, _context, id) => {
       const material = gitCredentialMaterialForId.get(id);

--- a/packages/daemon/src/git-filesystem.js
+++ b/packages/daemon/src/git-filesystem.js
@@ -56,6 +56,39 @@ const rejectMutation = method => {
 };
 
 /**
+ * Coerce a bigint or number to a non-negative safe-integer Number.
+ * The `FsBackend.read` contract types `offset`/`length` as bigint
+ * (the protocol must survive 64-bit file sizes), but Uint8Array
+ * indexing is Number-based.  This boundary check rejects values
+ * that would silently lose precision (`> Number.MAX_SAFE_INTEGER`)
+ * or flow as wrong-direction window math (negatives).
+ *
+ * @param {bigint | number} value
+ * @param {string} name
+ * @returns {number}
+ */
+const toSafeIndex = (value, name) => {
+  if (typeof value === 'bigint') {
+    if (value < 0n) {
+      throw makeError(X`EINVAL: ${q(name)} must be non-negative`);
+    }
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw makeError(X`EINVAL: ${q(name)} exceeds Number.MAX_SAFE_INTEGER`);
+    }
+    return Number(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw makeError(
+        X`EINVAL: ${q(name)} must be a non-negative safe integer`,
+      );
+    }
+    return value;
+  }
+  throw makeError(X`EINVAL: ${q(name)} must be bigint or number`);
+};
+
+/**
  * Build an `FsBackend` over an immutable git tree at `treeOid`.
  *
  * @param {object} args
@@ -72,6 +105,10 @@ export const makeGitFsBackend = ({ backend, treeOid }) => {
     if (cached !== undefined) return cached;
     const promise = backend.lsTree(oid);
     lsCache.set(oid, promise);
+    // Evict on rejection so a transient git failure (timeout, etc.)
+    // doesn't poison the cache for the lifetime of the backend.
+    // The successful resolution path is the cache contract.
+    promise.catch(() => lsCache.delete(oid));
     return promise;
   };
 
@@ -121,6 +158,9 @@ export const makeGitFsBackend = ({ backend, treeOid }) => {
       });
     })();
     pathCache.set(key, promise);
+    // Same rejection-eviction rule as `lsTreeCached`: a transient
+    // failure mid-walk must not pin a poisoned promise.
+    promise.catch(() => pathCache.delete(key));
     return promise;
   };
 
@@ -169,8 +209,12 @@ export const makeGitFsBackend = ({ backend, treeOid }) => {
       if (entry.kind !== 'file') {
         throw makeError(X`EISDIR: ${q(path.join('/'))}`);
       }
-      const off = offset === undefined ? 0 : Number(offset);
-      const len = length === undefined ? undefined : Number(length);
+      // Validate before coercion: the contract types are bigint, and
+      // values above MAX_SAFE_INTEGER (or negatives) must not flow
+      // into Number-shaped window math silently.
+      const off = offset === undefined ? 0 : toSafeIndex(offset, 'offset');
+      const len =
+        length === undefined ? undefined : toSafeIndex(length, 'length');
       if (len === 0) {
         return EMPTY_BYTES;
       }

--- a/packages/daemon/src/git-filesystem.js
+++ b/packages/daemon/src/git-filesystem.js
@@ -180,6 +180,11 @@ export const makeGitFsBackend = ({ backend, treeOid }) => {
       if (entry.kind !== 'directory') {
         throw makeError(X`ENOTDIR: ${q(dirPath.join('/'))}`);
       }
+      // Materializes the full `lsTree` array before yielding the
+      // first entry: bounded by tree size (not by `runGitRaw`'s
+      // 1 MiB cap, since `listTreeEntries` streams), but not by
+      // a page count.  True paged streaming through wrap-backend's
+      // `Cursor.read(limit)` is Phase 6 in `designs/endo-fs-from-git.md`.
       const entries = await lsTreeCached(entry.oid);
       for (const e of entries) {
         if (e.type === 'commit') {

--- a/packages/daemon/src/git-filesystem.js
+++ b/packages/daemon/src/git-filesystem.js
@@ -32,6 +32,8 @@ import { makeError, X, q } from '@endo/errors';
  * @import { FsBackend, DirEntry, NodeKind } from '@endo/endo-fs/src/backend-types.js'
  */
 
+const EMPTY_BYTES = harden(new Uint8Array(0));
+
 /**
  * Resolved path → entry result.  `null` means "definitively absent"
  * (cache the negative lookup so successive `kind('/missing')` calls
@@ -167,13 +169,46 @@ export const makeGitFsBackend = ({ backend, treeOid }) => {
       if (entry.kind !== 'file') {
         throw makeError(X`EISDIR: ${q(path.join('/'))}`);
       }
-      const bytes = await backend.readBlobBytes(entry.oid);
       const off = offset === undefined ? 0 : Number(offset);
-      if (length === undefined) {
-        return bytes.slice(off);
+      const len = length === undefined ? undefined : Number(length);
+      // Stream `cat-file blob <oid>` and stop accumulating once we
+      // have the bytes the caller asked for.  For an `OpenFile.read`
+      // of a small range over a multi-MiB blob, this returns after
+      // pulling only `offset + length` bytes from git rather than
+      // the whole blob (`backend.readBlobBytes` would buffer
+      // everything via the same stream — saving the trailing chunks
+      // is the optimization).
+      const needBytes = len === undefined ? Infinity : off + len;
+      /** @type {Uint8Array[]} */
+      const chunks = [];
+      let collected = 0;
+      // eslint-disable-next-line no-restricted-syntax
+      for await (const chunk of backend.streamBlobBytes(entry.oid)) {
+        chunks.push(chunk);
+        collected += chunk.length;
+        if (collected >= needBytes) break;
       }
-      const end = off + Number(length);
-      return bytes.slice(off, end);
+      // Coalesce.  Fast path for the common single-chunk case.
+      const buffer =
+        chunks.length === 1
+          ? chunks[0]
+          : (() => {
+              const out = new Uint8Array(collected);
+              let writeOff = 0;
+              for (const c of chunks) {
+                out.set(c, writeOff);
+                writeOff += c.length;
+              }
+              return out;
+            })();
+      if (len === undefined) {
+        return off === 0 ? buffer : buffer.slice(off);
+      }
+      const end = Math.min(off + len, buffer.length);
+      if (off >= buffer.length) {
+        return EMPTY_BYTES;
+      }
+      return buffer.slice(off, end);
     },
 
     /** @param {string[]} _path */
@@ -195,12 +230,14 @@ export const makeGitFsBackend = ({ backend, treeOid }) => {
       if (entry === null) {
         throw makeError(X`ENOENT: ${q(path.join('/'))}`);
       }
-      // Git trees do not record per-entry timestamps; omit `mtime`
-      // and `atime` so wrapBackend's `readStatNow` falls back to its
-      // vat-local stat table (which synthesizes consistent times via
-      // the `?? local.mtime` / `?? local.atime` merge).  Returning
-      // `0n` would override that fallback because the merge treats
-      // any defined value — including zero — as authoritative.
+      // `size` is the only field we can answer from git: blob entries
+      // carry it inline (`ls-tree --long`); tree entries report `0n`
+      // (no size for directories in this layer, matching node-fs).
+      // `mtime` and `atime` are deliberately omitted so wrapBackend's
+      // `readStatNow` falls back to its vat-local stat table via the
+      // `?? local.mtime` / `?? local.atime` merge — returning `0n`
+      // there would override the fallback because the merge treats
+      // any defined value as authoritative.
       return harden({
         size: BigInt(entry.size),
       });

--- a/packages/daemon/src/git-filesystem.js
+++ b/packages/daemon/src/git-filesystem.js
@@ -2,598 +2,216 @@
 /// <reference types="ses"/>
 
 /**
- * `@endo/endo-fs` Filesystem adapter over an immutable git tree.
+ * `FsBackend` adapter for an immutable git tree.
  *
- * `Git.filesystemAt(ref)` resolves the ref to a canonical tree OID and
- * passes it here.  The resulting exo graph satisfies the `Filesystem` →
- * `Directory` → `File` → `OpenFile` contract from `@endo/endo-fs`, with
- * a few git-specific affordances:
+ * `wrapBackend(makeGitFsBackend({ backend, treeOid }))` produces a
+ * full `@endo/endo-fs` `Filesystem` lazily backed by the git object
+ * database at `treeOid`.  The daemon wraps that result with
+ * `readOnly()` so the public cap rejects every mutating verb — git
+ * history is immutable.
  *
- * - QID `pathId` is the git OID (tree or blob) as a BigInt, so two paths
- *   to the same content report the same QID — the strongest stability
- *   the protocol allows.
- * - `BlobRef.getInfo()` reports `algorithm: 'git-sha1'` and `hash:
- *   blobOid`, surfacing the content-address that the underlying git
- *   object store already maintains.  A CAS-backed read cache
- *   (`withCachedReads`) can dedupe against the OID directly.
- * - The Filesystem is natively read-only.  Mutating verbs throw
- *   `EACCES` without going through `readOnly()` — there is no underlying
- *   writable cap to attenuate.
+ * The backend exposes only the read surface (`kind`, `list`, `read`,
+ * `getStat`, `statfs`).  Mutating verbs (`write`, `makeDirectory`,
+ * `remove`) throw `EROFS`; they exist because the `FsBackend`
+ * contract requires them, but they should never be reached at runtime
+ * because `readOnly()` intercepts before the backend is asked.
  *
- * Tree-entry listings are cached per tree OID for the lifetime of the
- * Filesystem (trees are immutable).  Blob bytes are not cached at this
- * layer; callers that want caching compose `withCachedReads(gitFs,
- * cas)` in endo-fs.
+ * Tree-entry listings are cached per tree OID and path-resolution
+ * results are cached per path — both safe because the tree is
+ * immutable for the lifetime of this backend instance.  Blob bytes
+ * are not cached here; callers that want CAS-backed caching compose
+ * `withCachedReads(fs, cas)` in endo-fs.
  *
  * See `designs/endo-fs-from-git.md` for the contract.
  */
 
-import { makeExo } from '@endo/exo';
 import { makeError, X, q } from '@endo/errors';
-import {
-  BlobRefInterface,
-  CursorInterface,
-  DirectoryInterface,
-  FileInterface,
-  FilesystemInterface,
-  NodeWatcherInterface,
-  OpenFileInterface,
-  XattrsInterface,
-} from '@endo/endo-fs/src/type-guards.js';
-import { bytesReaderFromIterator } from '@endo/exo-stream/bytes-reader-from-iterator.js';
-import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 
 /**
  * @import { GitBackend, GitTreeEntryRecord } from './git.js'
+ * @import { FsBackend, DirEntry, NodeKind } from '@endo/endo-fs/src/backend-types.js'
  */
 
-const EMPTY_BYTES = harden(new Uint8Array(0));
+/**
+ * Resolved path → entry result.  `null` means "definitively absent"
+ * (cache the negative lookup so successive `kind('/missing')` calls
+ * don't re-walk).  A submodule (`type: 'commit'` in git) resolves to
+ * `null` here — `wrapBackend` then reports the path as missing,
+ * which is the cheapest signal the public surface can give without
+ * a dedicated "submodule" QID variant.
+ *
+ * @typedef {{
+ *   kind: NodeKind,
+ *   oid: string,
+ *   size: number,
+ * } | null} ResolvedEntry
+ */
 
-// Process-unique brand counter.  Brands survive CapTP marshalling
-// (BigInt is passable) so the same primitive Filesystem reports the
-// same brand on either side of a CapTP boundary.
-let nextBrand = 0n;
-const mintBrand = () => {
-  nextBrand += 1n;
-  return nextBrand;
-};
-
-const denied = method =>
-  makeError(
-    X`EACCES: ${q(method)} not permitted on a read-only git-tree Filesystem`,
+const rejectMutation = method => {
+  throw makeError(
+    X`EROFS: ${q(method)} not permitted on a read-only git-tree FsBackend`,
   );
-
-/**
- * Reject names that would either alias a tree traversal or carry path
- * separators.  Mirrors the endo-fs helper without an inter-package
- * import for one ten-line check.
- *
- * @param {string} name
- */
-const assertChildName = name => {
-  if (typeof name !== 'string' || name.length === 0) {
-    throw makeError(X`EINVAL: invalid name ${q(name)}`);
-  }
-  if (name === '.' || name === '..') {
-    throw makeError(X`EINVAL: name ${q(name)} reserved`);
-  }
-  if (name.includes('/') || name.includes('\0')) {
-    throw makeError(X`EINVAL: name ${q(name)} contains path separator`);
-  }
 };
 
 /**
- * Convert a bigint or number to a safe non-negative Number for use as a
- * `Uint8Array` index or slice bound.
- *
- * @param {bigint | number} value
- * @param {string} name
- */
-const toSafeNumber = (value, name) => {
-  if (typeof value === 'bigint') {
-    if (value < 0n) {
-      throw makeError(X`EINVAL: ${q(name)} must be non-negative`);
-    }
-    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
-      throw makeError(X`EINVAL: ${q(name)} exceeds safe integer range`);
-    }
-    return Number(value);
-  }
-  if (typeof value === 'number') {
-    if (!Number.isSafeInteger(value) || value < 0) {
-      throw makeError(
-        X`EINVAL: ${q(name)} must be a non-negative safe integer`,
-      );
-    }
-    return value;
-  }
-  throw makeError(X`EINVAL: ${q(name)} must be bigint or number`);
-};
-
-/**
- * Convert a hex git OID into a BigInt suitable for `qid.pathId`.
- *
- * @param {string} oid
- */
-const oidToBigInt = oid => BigInt(`0x${oid}`);
-
-/**
- * Wrap a `Uint8Array` as a `PassableBytesReader` yielding the bytes in
- * one chunk.
- *
- * @param {Uint8Array} bytes
- */
-const bytesReaderFromBytes = bytes => {
-  const generator = async function* () {
-    if (bytes.length > 0) {
-      yield bytes;
-    }
-  };
-  return bytesReaderFromIterator(generator());
-};
-
-const ZERO_ATTRS = harden({
-  size: 0n,
-  mtime: 0n,
-  atime: 0n,
-  ctime: 0n,
-  btime: null,
-});
-
-/**
- * Build an `Attrs` record for a blob.  `mtime` / `atime` / `ctime` are
- * zero because git trees do not record per-entry timestamps.
- *
- * @param {number} sizeBytes
- */
-const blobAttrs = sizeBytes =>
-  harden({
-    size: BigInt(sizeBytes),
-    mtime: 0n,
-    atime: 0n,
-    ctime: 0n,
-    btime: null,
-  });
-
-/**
- * Watcher stub — historical git trees never change.
- */
-const makeEmptyWatcher = () =>
-  makeExo('NodeWatcher', NodeWatcherInterface, {
-    async events() {
-      const empty = async function* () {
-        // never yields
-      };
-      return readerFromIterator(empty());
-    },
-    async cancel() {
-      // no-op
-    },
-  });
-
-/**
- * Xattrs stub — git does not carry xattrs.  Reads return empty / not-
- * found; writes throw EACCES.
- */
-const makeReadOnlyXattrs = () =>
-  makeExo('Xattrs', XattrsInterface, {
-    async get(_name) {
-      throw makeError(X`ENODATA: xattrs not supported on git-tree Filesystem`);
-    },
-    async set(_name, _opts) {
-      throw denied('xattrs.set');
-    },
-    async list() {
-      const empty = async function* () {
-        // no xattrs
-      };
-      return readerFromIterator(empty());
-    },
-    async remove(_name) {
-      throw denied('xattrs.remove');
-    },
-    help(method) {
-      if (method === undefined) {
-        return 'Xattrs (git-tree): no xattrs exposed.';
-      }
-      return `No documentation for method ${q(method)}.`;
-    },
-  });
-
-/**
- * Mint a `BlobRef` for a git blob.  The hash IS the git OID (hex),
- * exposed with `algorithm: 'git-sha1'` so a downstream consumer
- * comparing hashes across sources knows the hash is over git's framed
- * payload (`blob <size>\0<bytes>`), not the raw bytes.
- *
- * Sha256-formatted repositories will report `'git-sha256'` when that
- * support lands (Phase 5 of the design doc).
- *
- * @param {object} args
- * @param {GitBackend} args.backend
- * @param {string} args.blobOid
- * @param {number} args.sizeBytes
- */
-const makeGitBlobRef = ({ backend, blobOid, sizeBytes }) => {
-  const info = harden({
-    algorithm: 'git-sha1',
-    hash: blobOid,
-    size: BigInt(sizeBytes),
-  });
-  return makeExo('BlobRef', BlobRefInterface, {
-    getInfo() {
-      return info;
-    },
-    async fetch(offset, length) {
-      const off = toSafeNumber(offset, 'offset');
-      const len = toSafeNumber(length, 'length');
-      const bytes = await backend.readBlobBytes(blobOid);
-      if (off >= bytes.length) {
-        return bytesReaderFromBytes(EMPTY_BYTES);
-      }
-      const end = len === 0 ? bytes.length : Math.min(off + len, bytes.length);
-      const slice = bytes.slice(off, end);
-      return bytesReaderFromBytes(slice);
-    },
-    help(method) {
-      if (method === undefined) {
-        return 'BlobRef (git-tree): hash is the git blob OID; algorithm is git-sha1.';
-      }
-      return `No documentation for method ${q(method)}.`;
-    },
-  });
-};
-harden(makeGitBlobRef);
-
-/**
- * Build a read-only `OpenFile` over a git blob.  The first read
- * triggers a single `cat-file blob <oid>` and caches the bytes for the
- * OpenFile's lifetime; subsequent reads slice the cached buffer.
- *
- * @param {object} args
- * @param {GitBackend} args.backend
- * @param {string} args.blobOid
- * @param {{ read: boolean, write: boolean }} args.mode
- */
-const makeGitOpenFile = ({ backend, blobOid, mode }) => {
-  let closed = false;
-  /** @type {Uint8Array | undefined} */
-  let cached;
-
-  const requireOpen = () => {
-    if (closed) {
-      throw makeError(X`EBADF: OpenFile closed`);
-    }
-  };
-
-  const ensureBytes = async () => {
-    if (cached === undefined) {
-      cached = await backend.readBlobBytes(blobOid);
-    }
-    return cached;
-  };
-
-  return makeExo('OpenFile', OpenFileInterface, {
-    async read(offset, length) {
-      requireOpen();
-      if (!mode.read) {
-        throw makeError(X`EBADF: OpenFile not opened for reading`);
-      }
-      const off = toSafeNumber(offset, 'offset');
-      const len = toSafeNumber(length, 'length');
-      const bytes = await ensureBytes();
-      if (off >= bytes.length) {
-        return bytesReaderFromBytes(EMPTY_BYTES);
-      }
-      const end = len === 0 ? bytes.length : Math.min(off + len, bytes.length);
-      return bytesReaderFromBytes(bytes.slice(off, end));
-    },
-    async write(_offset) {
-      throw denied('write');
-    },
-    async truncate(_length) {
-      throw denied('truncate');
-    },
-    async fsync(_opts) {
-      throw denied('fsync');
-    },
-    async lock(_opts) {
-      throw denied('lock');
-    },
-    async getLock(_opts) {
-      return null;
-    },
-    async close() {
-      closed = true;
-    },
-    help(method) {
-      if (method === undefined) {
-        return 'OpenFile (git-tree): read-only; backed by a cached blob fetch.';
-      }
-      return `No documentation for method ${q(method)}.`;
-    },
-  });
-};
-harden(makeGitOpenFile);
-
-/**
- * Build a `Cursor` over a snapshotted `lsTree` result.  The entry list
- * is captured at cursor-construction time; for a git tree this is
- * equivalent to a live cursor because the tree is immutable.
- *
- * @param {object} args
- * @param {readonly GitTreeEntryRecord[]} args.entries
- */
-const makeGitCursor = ({ entries }) => {
-  let position = 0n;
-  return makeExo('Cursor', CursorInterface, {
-    async stream() {
-      const start = Number(position);
-      const captured = entries;
-      const generator = async function* () {
-        for (let i = start; i < captured.length; i += 1) {
-          const entry = captured[i];
-          position += 1n;
-          const kind =
-            entry.type === 'tree'
-              ? 'directory'
-              : entry.type === 'commit'
-                ? 'submodule'
-                : 'file';
-          yield harden({
-            name: entry.name,
-            qid: harden({
-              type: kind,
-              pathId: oidToBigInt(entry.oid),
-              version: 0n,
-            }),
-          });
-        }
-      };
-      return readerFromIterator(generator());
-    },
-    async skip(n) {
-      if (typeof n !== 'bigint' || n < 0n) {
-        throw makeError(X`EINVAL: skip(${q(n)}) must be a non-negative bigint`);
-      }
-      const max = BigInt(entries.length);
-      position = position + n > max ? max : position + n;
-    },
-    async rewind() {
-      position = 0n;
-    },
-    help(method) {
-      if (method === undefined) {
-        return 'Cursor (git-tree): immutable snapshot of git ls-tree output.';
-      }
-      return `No documentation for method ${q(method)}.`;
-    },
-  });
-};
-harden(makeGitCursor);
-
-/**
- * Construct the full Filesystem / Directory / File exo graph rooted at
- * a tree OID.  All mutating verbs throw `EACCES`.
+ * Build an `FsBackend` over an immutable git tree at `treeOid`.
  *
  * @param {object} args
  * @param {GitBackend} args.backend
  * @param {string} args.treeOid
- * @param {string} [args.commitOid]
+ * @returns {FsBackend}
  */
-export const makeGitFilesystem = ({ backend, treeOid, commitOid }) => {
-  // Per-tree-OID lsTree memoization.  Trees are immutable, so caching
-  // is correct for the Filesystem's lifetime.  Caching at this layer
-  // is purely a latency optimization: re-walking the same subtree
-  // (e.g. multiple sibling lookups) avoids repeated subprocess turns.
+export const makeGitFsBackend = ({ backend, treeOid }) => {
   /** @type {Map<string, Promise<readonly GitTreeEntryRecord[]>>} */
   const lsCache = new Map();
-
   /** @param {string} oid */
   const lsTreeCached = oid => {
     const cached = lsCache.get(oid);
-    if (cached !== undefined) {
-      return cached;
-    }
+    if (cached !== undefined) return cached;
     const promise = backend.lsTree(oid);
     lsCache.set(oid, promise);
     return promise;
   };
 
-  const brand = mintBrand();
-  const brands = harden([brand]);
-
-  // Forward declarations for the mutually-recursive exo builders.
-  /** @type {(oid: string) => object} */
-  // eslint-disable-next-line no-use-before-define
-  const makeDirectory = oid => makeDirectoryImpl(oid);
-  /** @type {(entry: GitTreeEntryRecord) => object} */
-  // eslint-disable-next-line no-use-before-define
-  const makeFile = entry => makeFileImpl(entry);
+  /** @type {Map<string, Promise<ResolvedEntry>>} */
+  const pathCache = new Map();
 
   /**
-   * @param {GitTreeEntryRecord} entry
+   * Walk the tree from the root to `path`, returning the
+   * content-addressed entry record (kind + OID + size) or `null`
+   * for ENOENT / submodule.
+   *
+   * @param {readonly string[]} path
+   * @returns {Promise<ResolvedEntry>}
    */
-  const makeFileImpl = entry => {
-    const qid = harden({
-      type: 'file',
-      pathId: oidToBigInt(entry.oid),
-      version: 0n,
-    });
-    const size = entry.size ?? 0;
-    return makeExo('File', FileInterface, {
-      getQid() {
-        return qid;
-      },
-      async getAttrs() {
-        return blobAttrs(size);
-      },
-      async setAttrs(_updates) {
-        throw denied('setAttrs');
-      },
-      async watch() {
-        return makeEmptyWatcher();
-      },
-      async xattrs() {
-        return makeReadOnlyXattrs();
-      },
-      async open(opts) {
-        // `opts` is `Passable` per the FileInterface guard; cast
-        // through `any` at the boundary to reach the OpenOpts shape
-        // (write/append/truncate/read).  The same pattern is used in
-        // `endo-fs/src/from-mount.js`.
-        const o = /** @type {any} */ (opts) || {};
-        const write = !!o.write || !!o.append || !!o.truncate;
-        if (write) {
-          throw denied('open(write|append|truncate)');
-        }
-        // Default to read=true when neither is explicitly set; mirrors
-        // the endo-fs convention.
-        const read = o.read !== false;
-        if (!read) {
-          throw makeError(
-            X`EINVAL: open requires at least one of read or write to be true`,
-          );
-        }
-        return makeGitOpenFile({
-          backend,
-          blobOid: entry.oid,
-          mode: { read: true, write: false },
+  const resolvePath = path => {
+    // Encode the path as a NUL-joined string so two different
+    // arrays with the same segments share a cache entry.
+    const key = path.join('\0');
+    const cached = pathCache.get(key);
+    if (cached !== undefined) return cached;
+    const promise = (async () => {
+      if (path.length === 0) {
+        return /** @type {ResolvedEntry} */ ({
+          kind: 'directory',
+          oid: treeOid,
+          size: 0,
         });
-      },
-      async snapshot() {
-        return makeGitBlobRef({
-          backend,
-          blobOid: entry.oid,
-          sizeBytes: size,
-        });
-      },
-      help(method) {
-        if (method === undefined) {
-          return `File (git-tree): blob ${entry.oid}.`;
-        }
-        return `No documentation for method ${q(method)}.`;
-      },
-    });
+      }
+      const parent = await resolvePath(path.slice(0, -1));
+      if (parent === null || parent.kind !== 'directory') {
+        return null;
+      }
+      const entries = await lsTreeCached(parent.oid);
+      const last = path[path.length - 1];
+      const entry = entries.find(e => e.name === last);
+      if (entry === undefined) return null;
+      if (entry.type === 'commit') {
+        // Submodule pointer; surface as missing (the base endo-fs
+        // contract only knows file / directory).  See the design
+        // doc for the rationale.
+        return null;
+      }
+      return /** @type {ResolvedEntry} */ ({
+        kind: entry.type === 'tree' ? 'directory' : 'file',
+        oid: entry.oid,
+        size: entry.size ?? 0,
+      });
+    })();
+    pathCache.set(key, promise);
+    return promise;
   };
 
-  /**
-   * @param {string} dirTreeOid
-   */
-  const makeDirectoryImpl = dirTreeOid => {
-    const qid = harden({
-      type: 'directory',
-      pathId: oidToBigInt(dirTreeOid),
-      version: 0n,
-    });
-    return makeExo('Directory', DirectoryInterface, {
-      getQid() {
-        return qid;
-      },
-      async getAttrs() {
-        return ZERO_ATTRS;
-      },
-      async setAttrs(_updates) {
-        throw denied('setAttrs');
-      },
-      async watch() {
-        return makeEmptyWatcher();
-      },
-      async xattrs() {
-        return makeReadOnlyXattrs();
-      },
-      async lookup(name) {
-        assertChildName(name);
-        const entries = await lsTreeCached(dirTreeOid);
-        const entry = entries.find(e => e.name === name);
-        if (entry === undefined) {
-          throw makeError(X`ENOENT: ${q(name)}`);
+  return harden({
+    /** @param {string[]} path */
+    async kind(path) {
+      const entry = await resolvePath(path);
+      return entry === null ? undefined : entry.kind;
+    },
+
+    /** @param {string[]} dirPath */
+    async *list(dirPath) {
+      const entry = await resolvePath(dirPath);
+      if (entry === null) {
+        throw makeError(X`ENOENT: ${q(dirPath.join('/'))}`);
+      }
+      if (entry.kind !== 'directory') {
+        throw makeError(X`ENOTDIR: ${q(dirPath.join('/'))}`);
+      }
+      const entries = await lsTreeCached(entry.oid);
+      for (const e of entries) {
+        if (e.type === 'commit') {
+          // Submodules are not part of the visible tree at this layer.
+          // eslint-disable-next-line no-continue
+          continue;
         }
-        if (entry.type === 'tree') {
-          return makeDirectory(entry.oid);
-        }
-        if (entry.type === 'blob') {
-          return makeFile(entry);
-        }
-        // Submodule: a 'commit' entry is a pointer into another
-        // repository's object DB.  We do not transitively traverse;
-        // callers obtain a separate Git capability for the submodule.
-        throw makeError(
-          X`EIO: lookup of submodule ${q(
-            name,
-          )} is not supported; obtain a separate Git capability for the submodule`,
+        yield /** @type {DirEntry} */ (
+          harden({
+            name: e.name,
+            kind: e.type === 'tree' ? 'directory' : 'file',
+          })
         );
-      },
-      async list() {
-        const entries = await lsTreeCached(dirTreeOid);
-        return makeGitCursor({ entries });
-      },
-      async create(_name, _opts) {
-        throw denied('create');
-      },
-      async mkdir(_name, _opts) {
-        throw denied('mkdir');
-      },
-      async unlink(_name) {
-        throw denied('unlink');
-      },
-      async rename(_oldName, _newParent, _newName) {
-        throw denied('rename');
-      },
-      async fsync() {
-        throw denied('fsync');
-      },
-      async materialise(_path, _opts) {
-        throw denied('materialise');
-      },
-      async watchFrom() {
-        const entries = await lsTreeCached(dirTreeOid);
-        return harden({
-          cursor: makeGitCursor({ entries }),
-          watcher: makeEmptyWatcher(),
-        });
-      },
-      help(method) {
-        if (method === undefined) {
-          return `Directory (git-tree): tree ${dirTreeOid}.`;
-        }
-        return `No documentation for method ${q(method)}.`;
-      },
-    });
-  };
-
-  const helpText =
-    commitOid !== undefined
-      ? `Filesystem (git-tree): commit ${commitOid}, tree ${treeOid}.`
-      : `Filesystem (git-tree): tree ${treeOid}.`;
-
-  return makeExo('Filesystem', FilesystemInterface, {
-    async root() {
-      return makeDirectory(treeOid);
+      }
     },
-    async named(viewName) {
-      throw makeError(
-        X`ENOTSUP: git-tree Filesystem has a single root, not ${q(viewName)}`,
-      );
+
+    /**
+     * @param {string[]} path
+     * @param {bigint} [offset]
+     * @param {bigint} [length]
+     */
+    async read(path, offset, length) {
+      const entry = await resolvePath(path);
+      if (entry === null) {
+        throw makeError(X`ENOENT: ${q(path.join('/'))}`);
+      }
+      if (entry.kind !== 'file') {
+        throw makeError(X`EISDIR: ${q(path.join('/'))}`);
+      }
+      const bytes = await backend.readBlobBytes(entry.oid);
+      const off = offset === undefined ? 0 : Number(offset);
+      if (length === undefined) {
+        return bytes.slice(off);
+      }
+      const end = off + Number(length);
+      return bytes.slice(off, end);
     },
+
+    /** @param {string[]} _path */
+    write(_path) {
+      return rejectMutation('write');
+    },
+    /** @param {string[]} _path */
+    makeDirectory(_path) {
+      return rejectMutation('makeDirectory');
+    },
+    /** @param {string[]} _path */
+    remove(_path) {
+      return rejectMutation('remove');
+    },
+
+    /** @param {string[]} path */
+    async getStat(path) {
+      const entry = await resolvePath(path);
+      if (entry === null) {
+        throw makeError(X`ENOENT: ${q(path.join('/'))}`);
+      }
+      return harden({
+        size: BigInt(entry.size),
+        // Git trees do not record per-entry timestamps; use zeros so
+        // the wrapBackend stat layer fills in synthesized vat-local
+        // times consistently across reads.
+        mtime: 0n,
+        atime: 0n,
+      });
+    },
+
     async statfs() {
-      // Git trees have no concept of free / total bytes; report zeros
-      // to match the from-mount.js convention.
+      // No "free / used" notion for an immutable historical tree.
       return harden({
         totalBytes: 0n,
         freeBytes: 0n,
-        availableBytes: 0n,
       });
-    },
-    async brands() {
-      return brands;
-    },
-    help(method) {
-      if (method === undefined) {
-        return helpText;
-      }
-      return `No documentation for method ${q(method)}.`;
     },
   });
 };
-harden(makeGitFilesystem);
+harden(makeGitFsBackend);

--- a/packages/daemon/src/git-filesystem.js
+++ b/packages/daemon/src/git-filesystem.js
@@ -1,0 +1,599 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * `@endo/endo-fs` Filesystem adapter over an immutable git tree.
+ *
+ * `Git.filesystemAt(ref)` resolves the ref to a canonical tree OID and
+ * passes it here.  The resulting exo graph satisfies the `Filesystem` →
+ * `Directory` → `File` → `OpenFile` contract from `@endo/endo-fs`, with
+ * a few git-specific affordances:
+ *
+ * - QID `pathId` is the git OID (tree or blob) as a BigInt, so two paths
+ *   to the same content report the same QID — the strongest stability
+ *   the protocol allows.
+ * - `BlobRef.getInfo()` reports `algorithm: 'git-sha1'` and `hash:
+ *   blobOid`, surfacing the content-address that the underlying git
+ *   object store already maintains.  A CAS-backed read cache
+ *   (`withCachedReads`) can dedupe against the OID directly.
+ * - The Filesystem is natively read-only.  Mutating verbs throw
+ *   `EACCES` without going through `readOnly()` — there is no underlying
+ *   writable cap to attenuate.
+ *
+ * Tree-entry listings are cached per tree OID for the lifetime of the
+ * Filesystem (trees are immutable).  Blob bytes are not cached at this
+ * layer; callers that want caching compose `withCachedReads(gitFs,
+ * cas)` in endo-fs.
+ *
+ * See `designs/endo-fs-from-git.md` for the contract.
+ */
+
+import { makeExo } from '@endo/exo';
+import { makeError, X, q } from '@endo/errors';
+import {
+  BlobRefInterface,
+  CursorInterface,
+  DirectoryInterface,
+  FileInterface,
+  FilesystemInterface,
+  NodeWatcherInterface,
+  OpenFileInterface,
+  XattrsInterface,
+} from '@endo/endo-fs/src/type-guards.js';
+import { bytesReaderFromIterator } from '@endo/exo-stream/bytes-reader-from-iterator.js';
+import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
+
+/**
+ * @import { GitBackend, GitTreeEntryRecord } from './git.js'
+ */
+
+const EMPTY_BYTES = harden(new Uint8Array(0));
+
+// Process-unique brand counter.  Brands survive CapTP marshalling
+// (BigInt is passable) so the same primitive Filesystem reports the
+// same brand on either side of a CapTP boundary.
+let nextBrand = 0n;
+const mintBrand = () => {
+  nextBrand += 1n;
+  return nextBrand;
+};
+
+const denied = method =>
+  makeError(
+    X`EACCES: ${q(method)} not permitted on a read-only git-tree Filesystem`,
+  );
+
+/**
+ * Reject names that would either alias a tree traversal or carry path
+ * separators.  Mirrors the endo-fs helper without an inter-package
+ * import for one ten-line check.
+ *
+ * @param {string} name
+ */
+const assertChildName = name => {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw makeError(X`EINVAL: invalid name ${q(name)}`);
+  }
+  if (name === '.' || name === '..') {
+    throw makeError(X`EINVAL: name ${q(name)} reserved`);
+  }
+  if (name.includes('/') || name.includes('\0')) {
+    throw makeError(X`EINVAL: name ${q(name)} contains path separator`);
+  }
+};
+
+/**
+ * Convert a bigint or number to a safe non-negative Number for use as a
+ * `Uint8Array` index or slice bound.
+ *
+ * @param {bigint | number} value
+ * @param {string} name
+ */
+const toSafeNumber = (value, name) => {
+  if (typeof value === 'bigint') {
+    if (value < 0n) {
+      throw makeError(X`EINVAL: ${q(name)} must be non-negative`);
+    }
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw makeError(X`EINVAL: ${q(name)} exceeds safe integer range`);
+    }
+    return Number(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw makeError(
+        X`EINVAL: ${q(name)} must be a non-negative safe integer`,
+      );
+    }
+    return value;
+  }
+  throw makeError(X`EINVAL: ${q(name)} must be bigint or number`);
+};
+
+/**
+ * Convert a hex git OID into a BigInt suitable for `qid.pathId`.
+ *
+ * @param {string} oid
+ */
+const oidToBigInt = oid => BigInt(`0x${oid}`);
+
+/**
+ * Wrap a `Uint8Array` as a `PassableBytesReader` yielding the bytes in
+ * one chunk.
+ *
+ * @param {Uint8Array} bytes
+ */
+const bytesReaderFromBytes = bytes => {
+  const generator = async function* () {
+    if (bytes.length > 0) {
+      yield bytes;
+    }
+  };
+  return bytesReaderFromIterator(generator());
+};
+
+const ZERO_ATTRS = harden({
+  size: 0n,
+  mtime: 0n,
+  atime: 0n,
+  ctime: 0n,
+  btime: null,
+});
+
+/**
+ * Build an `Attrs` record for a blob.  `mtime` / `atime` / `ctime` are
+ * zero because git trees do not record per-entry timestamps.
+ *
+ * @param {number} sizeBytes
+ */
+const blobAttrs = sizeBytes =>
+  harden({
+    size: BigInt(sizeBytes),
+    mtime: 0n,
+    atime: 0n,
+    ctime: 0n,
+    btime: null,
+  });
+
+/**
+ * Watcher stub — historical git trees never change.
+ */
+const makeEmptyWatcher = () =>
+  makeExo('NodeWatcher', NodeWatcherInterface, {
+    async events() {
+      const empty = async function* () {
+        // never yields
+      };
+      return readerFromIterator(empty());
+    },
+    async cancel() {
+      // no-op
+    },
+  });
+
+/**
+ * Xattrs stub — git does not carry xattrs.  Reads return empty / not-
+ * found; writes throw EACCES.
+ */
+const makeReadOnlyXattrs = () =>
+  makeExo('Xattrs', XattrsInterface, {
+    async get(_name) {
+      throw makeError(X`ENODATA: xattrs not supported on git-tree Filesystem`);
+    },
+    async set(_name, _opts) {
+      throw denied('xattrs.set');
+    },
+    async list() {
+      const empty = async function* () {
+        // no xattrs
+      };
+      return readerFromIterator(empty());
+    },
+    async remove(_name) {
+      throw denied('xattrs.remove');
+    },
+    help(method) {
+      if (method === undefined) {
+        return 'Xattrs (git-tree): no xattrs exposed.';
+      }
+      return `No documentation for method ${q(method)}.`;
+    },
+  });
+
+/**
+ * Mint a `BlobRef` for a git blob.  The hash IS the git OID (hex),
+ * exposed with `algorithm: 'git-sha1'` so a downstream consumer
+ * comparing hashes across sources knows the hash is over git's framed
+ * payload (`blob <size>\0<bytes>`), not the raw bytes.
+ *
+ * Sha256-formatted repositories will report `'git-sha256'` when that
+ * support lands (Phase 5 of the design doc).
+ *
+ * @param {object} args
+ * @param {GitBackend} args.backend
+ * @param {string} args.blobOid
+ * @param {number} args.sizeBytes
+ */
+const makeGitBlobRef = ({ backend, blobOid, sizeBytes }) => {
+  const info = harden({
+    algorithm: 'git-sha1',
+    hash: blobOid,
+    size: BigInt(sizeBytes),
+  });
+  return makeExo('BlobRef', BlobRefInterface, {
+    getInfo() {
+      return info;
+    },
+    async fetch(offset, length) {
+      const off = toSafeNumber(offset, 'offset');
+      const len = toSafeNumber(length, 'length');
+      const bytes = await backend.readBlobBytes(blobOid);
+      if (off >= bytes.length) {
+        return bytesReaderFromBytes(EMPTY_BYTES);
+      }
+      const end = len === 0 ? bytes.length : Math.min(off + len, bytes.length);
+      const slice = bytes.slice(off, end);
+      return bytesReaderFromBytes(slice);
+    },
+    help(method) {
+      if (method === undefined) {
+        return 'BlobRef (git-tree): hash is the git blob OID; algorithm is git-sha1.';
+      }
+      return `No documentation for method ${q(method)}.`;
+    },
+  });
+};
+harden(makeGitBlobRef);
+
+/**
+ * Build a read-only `OpenFile` over a git blob.  The first read
+ * triggers a single `cat-file blob <oid>` and caches the bytes for the
+ * OpenFile's lifetime; subsequent reads slice the cached buffer.
+ *
+ * @param {object} args
+ * @param {GitBackend} args.backend
+ * @param {string} args.blobOid
+ * @param {{ read: boolean, write: boolean }} args.mode
+ */
+const makeGitOpenFile = ({ backend, blobOid, mode }) => {
+  let closed = false;
+  /** @type {Uint8Array | undefined} */
+  let cached;
+
+  const requireOpen = () => {
+    if (closed) {
+      throw makeError(X`EBADF: OpenFile closed`);
+    }
+  };
+
+  const ensureBytes = async () => {
+    if (cached === undefined) {
+      cached = await backend.readBlobBytes(blobOid);
+    }
+    return cached;
+  };
+
+  return makeExo('OpenFile', OpenFileInterface, {
+    async read(offset, length) {
+      requireOpen();
+      if (!mode.read) {
+        throw makeError(X`EBADF: OpenFile not opened for reading`);
+      }
+      const off = toSafeNumber(offset, 'offset');
+      const len = toSafeNumber(length, 'length');
+      const bytes = await ensureBytes();
+      if (off >= bytes.length) {
+        return bytesReaderFromBytes(EMPTY_BYTES);
+      }
+      const end = len === 0 ? bytes.length : Math.min(off + len, bytes.length);
+      return bytesReaderFromBytes(bytes.slice(off, end));
+    },
+    async write(_offset) {
+      throw denied('write');
+    },
+    async truncate(_length) {
+      throw denied('truncate');
+    },
+    async fsync(_opts) {
+      throw denied('fsync');
+    },
+    async lock(_opts) {
+      throw denied('lock');
+    },
+    async getLock(_opts) {
+      return null;
+    },
+    async close() {
+      closed = true;
+    },
+    help(method) {
+      if (method === undefined) {
+        return 'OpenFile (git-tree): read-only; backed by a cached blob fetch.';
+      }
+      return `No documentation for method ${q(method)}.`;
+    },
+  });
+};
+harden(makeGitOpenFile);
+
+/**
+ * Build a `Cursor` over a snapshotted `lsTree` result.  The entry list
+ * is captured at cursor-construction time; for a git tree this is
+ * equivalent to a live cursor because the tree is immutable.
+ *
+ * @param {object} args
+ * @param {readonly GitTreeEntryRecord[]} args.entries
+ */
+const makeGitCursor = ({ entries }) => {
+  let position = 0n;
+  return makeExo('Cursor', CursorInterface, {
+    async stream() {
+      const start = Number(position);
+      const captured = entries;
+      const generator = async function* () {
+        for (let i = start; i < captured.length; i += 1) {
+          const entry = captured[i];
+          position += 1n;
+          const kind =
+            entry.type === 'tree'
+              ? 'directory'
+              : entry.type === 'commit'
+                ? 'submodule'
+                : 'file';
+          yield harden({
+            name: entry.name,
+            qid: harden({
+              type: kind,
+              pathId: oidToBigInt(entry.oid),
+              version: 0n,
+            }),
+          });
+        }
+      };
+      return readerFromIterator(generator());
+    },
+    async skip(n) {
+      if (typeof n !== 'bigint' || n < 0n) {
+        throw makeError(X`EINVAL: skip(${q(n)}) must be a non-negative bigint`);
+      }
+      const max = BigInt(entries.length);
+      position = position + n > max ? max : position + n;
+    },
+    async rewind() {
+      position = 0n;
+    },
+    help(method) {
+      if (method === undefined) {
+        return 'Cursor (git-tree): immutable snapshot of git ls-tree output.';
+      }
+      return `No documentation for method ${q(method)}.`;
+    },
+  });
+};
+harden(makeGitCursor);
+
+/**
+ * Construct the full Filesystem / Directory / File exo graph rooted at
+ * a tree OID.  All mutating verbs throw `EACCES`.
+ *
+ * @param {object} args
+ * @param {GitBackend} args.backend
+ * @param {string} args.treeOid
+ * @param {string} [args.commitOid]
+ */
+export const makeGitFilesystem = ({ backend, treeOid, commitOid }) => {
+  // Per-tree-OID lsTree memoization.  Trees are immutable, so caching
+  // is correct for the Filesystem's lifetime.  Caching at this layer
+  // is purely a latency optimization: re-walking the same subtree
+  // (e.g. multiple sibling lookups) avoids repeated subprocess turns.
+  /** @type {Map<string, Promise<readonly GitTreeEntryRecord[]>>} */
+  const lsCache = new Map();
+
+  /** @param {string} oid */
+  const lsTreeCached = oid => {
+    const cached = lsCache.get(oid);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const promise = backend.lsTree(oid);
+    lsCache.set(oid, promise);
+    return promise;
+  };
+
+  const brand = mintBrand();
+  const brands = harden([brand]);
+
+  // Forward declarations for the mutually-recursive exo builders.
+  /** @type {(oid: string) => object} */
+  // eslint-disable-next-line no-use-before-define
+  const makeDirectory = oid => makeDirectoryImpl(oid);
+  /** @type {(entry: GitTreeEntryRecord) => object} */
+  // eslint-disable-next-line no-use-before-define
+  const makeFile = entry => makeFileImpl(entry);
+
+  /**
+   * @param {GitTreeEntryRecord} entry
+   */
+  const makeFileImpl = entry => {
+    const qid = harden({
+      type: 'file',
+      pathId: oidToBigInt(entry.oid),
+      version: 0n,
+    });
+    const size = entry.size ?? 0;
+    return makeExo('File', FileInterface, {
+      getQid() {
+        return qid;
+      },
+      async getAttrs() {
+        return blobAttrs(size);
+      },
+      async setAttrs(_updates) {
+        throw denied('setAttrs');
+      },
+      async watch() {
+        return makeEmptyWatcher();
+      },
+      async xattrs() {
+        return makeReadOnlyXattrs();
+      },
+      async open(opts) {
+        // `opts` is `Passable` per the FileInterface guard; cast
+        // through `any` at the boundary to reach the OpenOpts shape
+        // (write/append/truncate/read).  The same pattern is used in
+        // `endo-fs/src/from-mount.js`.
+        const o = /** @type {any} */ (opts) || {};
+        const write = !!o.write || !!o.append || !!o.truncate;
+        if (write) {
+          throw denied('open(write|append|truncate)');
+        }
+        // Default to read=true when neither is explicitly set; mirrors
+        // the endo-fs convention.
+        const read = o.read !== false;
+        if (!read) {
+          throw makeError(
+            X`EINVAL: open requires at least one of read or write to be true`,
+          );
+        }
+        return makeGitOpenFile({
+          backend,
+          blobOid: entry.oid,
+          mode: { read: true, write: false },
+        });
+      },
+      async snapshot() {
+        return makeGitBlobRef({
+          backend,
+          blobOid: entry.oid,
+          sizeBytes: size,
+        });
+      },
+      help(method) {
+        if (method === undefined) {
+          return `File (git-tree): blob ${entry.oid}.`;
+        }
+        return `No documentation for method ${q(method)}.`;
+      },
+    });
+  };
+
+  /**
+   * @param {string} dirTreeOid
+   */
+  const makeDirectoryImpl = dirTreeOid => {
+    const qid = harden({
+      type: 'directory',
+      pathId: oidToBigInt(dirTreeOid),
+      version: 0n,
+    });
+    return makeExo('Directory', DirectoryInterface, {
+      getQid() {
+        return qid;
+      },
+      async getAttrs() {
+        return ZERO_ATTRS;
+      },
+      async setAttrs(_updates) {
+        throw denied('setAttrs');
+      },
+      async watch() {
+        return makeEmptyWatcher();
+      },
+      async xattrs() {
+        return makeReadOnlyXattrs();
+      },
+      async lookup(name) {
+        assertChildName(name);
+        const entries = await lsTreeCached(dirTreeOid);
+        const entry = entries.find(e => e.name === name);
+        if (entry === undefined) {
+          throw makeError(X`ENOENT: ${q(name)}`);
+        }
+        if (entry.type === 'tree') {
+          return makeDirectory(entry.oid);
+        }
+        if (entry.type === 'blob') {
+          return makeFile(entry);
+        }
+        // Submodule: a 'commit' entry is a pointer into another
+        // repository's object DB.  We do not transitively traverse;
+        // callers obtain a separate Git capability for the submodule.
+        throw makeError(
+          X`EIO: lookup of submodule ${q(
+            name,
+          )} is not supported; obtain a separate Git capability for the submodule`,
+        );
+      },
+      async list() {
+        const entries = await lsTreeCached(dirTreeOid);
+        return makeGitCursor({ entries });
+      },
+      async create(_name, _opts) {
+        throw denied('create');
+      },
+      async mkdir(_name, _opts) {
+        throw denied('mkdir');
+      },
+      async unlink(_name) {
+        throw denied('unlink');
+      },
+      async rename(_oldName, _newParent, _newName) {
+        throw denied('rename');
+      },
+      async fsync() {
+        throw denied('fsync');
+      },
+      async materialise(_path, _opts) {
+        throw denied('materialise');
+      },
+      async watchFrom() {
+        const entries = await lsTreeCached(dirTreeOid);
+        return harden({
+          cursor: makeGitCursor({ entries }),
+          watcher: makeEmptyWatcher(),
+        });
+      },
+      help(method) {
+        if (method === undefined) {
+          return `Directory (git-tree): tree ${dirTreeOid}.`;
+        }
+        return `No documentation for method ${q(method)}.`;
+      },
+    });
+  };
+
+  const helpText =
+    commitOid !== undefined
+      ? `Filesystem (git-tree): commit ${commitOid}, tree ${treeOid}.`
+      : `Filesystem (git-tree): tree ${treeOid}.`;
+
+  return makeExo('Filesystem', FilesystemInterface, {
+    async root() {
+      return makeDirectory(treeOid);
+    },
+    async named(viewName) {
+      throw makeError(
+        X`ENOTSUP: git-tree Filesystem has a single root, not ${q(viewName)}`,
+      );
+    },
+    async statfs() {
+      // Git trees have no concept of free / total bytes; report zeros
+      // to match the from-mount.js convention.
+      return harden({
+        totalBytes: 0n,
+        freeBytes: 0n,
+        availableBytes: 0n,
+      });
+    },
+    async brands() {
+      return brands;
+    },
+    help(method) {
+      if (method === undefined) {
+        return helpText;
+      }
+      return `No documentation for method ${q(method)}.`;
+    },
+  });
+};
+harden(makeGitFilesystem);

--- a/packages/daemon/src/git-filesystem.js
+++ b/packages/daemon/src/git-filesystem.js
@@ -195,13 +195,14 @@ export const makeGitFsBackend = ({ backend, treeOid }) => {
       if (entry === null) {
         throw makeError(X`ENOENT: ${q(path.join('/'))}`);
       }
+      // Git trees do not record per-entry timestamps; omit `mtime`
+      // and `atime` so wrapBackend's `readStatNow` falls back to its
+      // vat-local stat table (which synthesizes consistent times via
+      // the `?? local.mtime` / `?? local.atime` merge).  Returning
+      // `0n` would override that fallback because the merge treats
+      // any defined value — including zero — as authoritative.
       return harden({
         size: BigInt(entry.size),
-        // Git trees do not record per-entry timestamps; use zeros so
-        // the wrapBackend stat layer fills in synthesized vat-local
-        // times consistently across reads.
-        mtime: 0n,
-        atime: 0n,
       });
     },
 

--- a/packages/daemon/src/git-filesystem.js
+++ b/packages/daemon/src/git-filesystem.js
@@ -171,44 +171,56 @@ export const makeGitFsBackend = ({ backend, treeOid }) => {
       }
       const off = offset === undefined ? 0 : Number(offset);
       const len = length === undefined ? undefined : Number(length);
-      // Stream `cat-file blob <oid>` and stop accumulating once we
-      // have the bytes the caller asked for.  For an `OpenFile.read`
-      // of a small range over a multi-MiB blob, this returns after
-      // pulling only `offset + length` bytes from git rather than
-      // the whole blob (`backend.readBlobBytes` would buffer
-      // everything via the same stream — saving the trailing chunks
-      // is the optimization).
-      const needBytes = len === undefined ? Infinity : off + len;
-      /** @type {Uint8Array[]} */
-      const chunks = [];
-      let collected = 0;
-      // eslint-disable-next-line no-restricted-syntax
-      for await (const chunk of backend.streamBlobBytes(entry.oid)) {
-        chunks.push(chunk);
-        collected += chunk.length;
-        if (collected >= needBytes) break;
-      }
-      // Coalesce.  Fast path for the common single-chunk case.
-      const buffer =
-        chunks.length === 1
-          ? chunks[0]
-          : (() => {
-              const out = new Uint8Array(collected);
-              let writeOff = 0;
-              for (const c of chunks) {
-                out.set(c, writeOff);
-                writeOff += c.length;
-              }
-              return out;
-            })();
-      if (len === undefined) {
-        return off === 0 ? buffer : buffer.slice(off);
-      }
-      const end = Math.min(off + len, buffer.length);
-      if (off >= buffer.length) {
+      if (len === 0) {
         return EMPTY_BYTES;
       }
-      return buffer.slice(off, end);
+      // Stream `cat-file blob <oid>` and only retain the
+      // `[off, off + len)` window: discard whole chunks that fall
+      // entirely before `off`, trim the chunk that straddles `off`,
+      // and stop once we have `len` bytes (or hit EOF when len is
+      // undefined).  Worst case retains one chunk's worth above the
+      // requested window — a `read(path, 1_000_000_000n, 4096n)` on
+      // a 1 GiB blob no longer pulls the whole prefix into memory.
+      const want = len === undefined ? Infinity : len;
+      /** @type {Uint8Array[]} */
+      const chunks = [];
+      let streamed = 0;
+      let retained = 0;
+      // eslint-disable-next-line no-restricted-syntax
+      for await (const chunk of backend.streamBlobBytes(entry.oid)) {
+        const chunkStart = streamed;
+        const chunkEnd = streamed + chunk.length;
+        streamed = chunkEnd;
+        // Whole chunk is before the requested window.
+        if (chunkEnd <= off) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        // Trim the chunk to the requested window.
+        const sliceFrom = chunkStart < off ? off - chunkStart : 0;
+        const remaining = want - retained;
+        const sliceTo = Math.min(chunk.length, sliceFrom + remaining);
+        const trimmed =
+          sliceFrom === 0 && sliceTo === chunk.length
+            ? chunk
+            : chunk.subarray(sliceFrom, sliceTo);
+        chunks.push(trimmed);
+        retained += trimmed.length;
+        if (retained >= want) break;
+      }
+      if (chunks.length === 0) {
+        return EMPTY_BYTES;
+      }
+      if (chunks.length === 1) {
+        return chunks[0];
+      }
+      const out = new Uint8Array(retained);
+      let writeOff = 0;
+      for (const c of chunks) {
+        out.set(c, writeOff);
+        writeOff += c.length;
+      }
+      return out;
     },
 
     /** @param {string[]} _path */

--- a/packages/daemon/src/git.js
+++ b/packages/daemon/src/git.js
@@ -177,9 +177,11 @@ harden(getGitBackend);
 /**
  * Structural record describing one entry in a git tree object.  Mirrors
  * `git ls-tree -z --long` output: mode is the 6-digit octal string, type
- * is `'blob'` / `'tree'` / `'commit'`, oid is the 40-hex (sha1) or 64-hex
- * (sha256) object identifier, size is present for blobs only, and name
- * is the single-segment entry name (no slashes).
+ * is `'blob'` / `'tree'` / `'commit'`, oid is the 40-hex (sha1) object
+ * identifier — the native backend's `parseLsTreeEntries` regex only
+ * accepts sha1 today; sha256-formatted repos are a Phase 5 follow-up
+ * tracked in `designs/endo-fs-from-git.md` — size is present for blobs
+ * only, and name is the single-segment entry name (no slashes).
  *
  * @typedef {object} GitTreeEntryRecord
  * @property {string} mode

--- a/packages/daemon/src/git.js
+++ b/packages/daemon/src/git.js
@@ -5,6 +5,7 @@ import { q } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { makeExo } from '@endo/exo';
 
+import { makeGitFilesystem } from './git-filesystem.js';
 import { GitInterface } from './interfaces.js';
 import { lineageOf } from './mount.js';
 
@@ -157,6 +158,34 @@ harden(getGitBackend);
  * @property {(input: { url?: unknown, refspecs?: unknown, setUpstream?: boolean, credential?: unknown, signal?: AbortSignal }) => Promise<object>} remotePush
  *   Push to a policy-bound remote URL with the same policy
  *   pre-validation contract as `remoteFetch`.
+ * @property {(ref: string) => Promise<{ treeOid: string, commitOid?: string }>} resolveTree
+ *   Resolve a ref to a canonical tree OID and (when applicable) the
+ *   commit OID that points at it.  Used by `filesystemAt(ref)` at
+ *   construction time so the resulting Filesystem is pinned to a
+ *   specific tree OID and later ref movement does not affect it.
+ * @property {(treeOid: string) => Promise<readonly GitTreeEntryRecord[]>} lsTree
+ *   Enumerate entries at a tree OID.  The records are content-addressed
+ *   and safe to cache per-OID.
+ * @property {(blobOid: string) => Promise<Uint8Array>} readBlobBytes
+ *   Read full bytes of a blob.
+ * @property {(blobOid: string) => AsyncIterable<Uint8Array>} streamBlobBytes
+ *   Stream blob bytes for range-read paths that should not buffer the
+ *   full blob in memory.
+ */
+
+/**
+ * Structural record describing one entry in a git tree object.  Mirrors
+ * `git ls-tree -z --long` output: mode is the 6-digit octal string, type
+ * is `'blob'` / `'tree'` / `'commit'`, oid is the 40-hex (sha1) or 64-hex
+ * (sha256) object identifier, size is present for blobs only, and name
+ * is the single-segment entry name (no slashes).
+ *
+ * @typedef {object} GitTreeEntryRecord
+ * @property {string} mode
+ * @property {'blob' | 'tree' | 'commit'} type
+ * @property {string} oid
+ * @property {number} [size]
+ * @property {string} name
  */
 
 /**
@@ -181,6 +210,15 @@ export const makeGit = ({ mount, backend, readOnly = false }) => {
   // passed to a path-bearing Git method was minted by this Git's bound
   // mount, not by some other mount this guest may also hold.
   const mountLineage = lineageOf(mount);
+
+  // Memoize `filesystemAt(ref)` on the canonical tree OID so repeated
+  // calls within one Git instance return the same Filesystem cap (same
+  // brand).  Brand identity matters for `compose` cycle detection in
+  // `@endo/endo-fs`; without memoization, two `filesystemAt('HEAD')`
+  // calls would compose as distinct participants even when HEAD has
+  // not moved.  See `designs/endo-fs-from-git.md` § Brands.
+  /** @type {Map<string, object>} */
+  const filesystemByTreeOid = new Map();
 
   /**
    * Translate an array of EndoMountEntry caps into the repo-relative
@@ -443,6 +481,21 @@ export const makeGit = ({ mount, backend, readOnly = false }) => {
       return backend.tree(refName(ref));
     },
 
+    async filesystemAt(ref) {
+      const { treeOid, commitOid } = await backend.resolveTree(refName(ref));
+      const cached = filesystemByTreeOid.get(treeOid);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const fs = makeGitFilesystem({
+        backend,
+        treeOid,
+        commitOid,
+      });
+      filesystemByTreeOid.set(treeOid, fs);
+      return fs;
+    },
+
     readOnly() {
       if (readOnly) {
         return selfExo;
@@ -502,6 +555,22 @@ export const makeNotYetImplementedBackend = () => {
     tree: async () => fail('tree'),
     remoteFetch: async () => fail('remoteFetch'),
     remotePush: async () => fail('remotePush'),
+    resolveTree: async () => fail('resolveTree'),
+    lsTree: async () => fail('lsTree'),
+    readBlobBytes: async () => fail('readBlobBytes'),
+    streamBlobBytes: () => {
+      fail('streamBlobBytes');
+      // Unreachable; satisfies the typedef's async-iterable return.
+      return /** @type {AsyncIterable<Uint8Array>} */ ({
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      });
+    },
   });
 };
 harden(makeNotYetImplementedBackend);

--- a/packages/daemon/src/git.js
+++ b/packages/daemon/src/git.js
@@ -4,8 +4,9 @@
 import { q } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { makeExo } from '@endo/exo';
+import { readOnly as readOnlyFs, wrapBackend } from '@endo/endo-fs';
 
-import { makeGitFilesystem } from './git-filesystem.js';
+import { makeGitFsBackend } from './git-filesystem.js';
 import { GitInterface } from './interfaces.js';
 import { lineageOf } from './mount.js';
 
@@ -487,11 +488,12 @@ export const makeGit = ({ mount, backend, readOnly = false }) => {
       if (cached !== undefined) {
         return cached;
       }
-      const fs = makeGitFilesystem({
-        backend,
-        treeOid,
-        commitOid,
-      });
+      const fsBackend = makeGitFsBackend({ backend, treeOid });
+      const description =
+        commitOid !== undefined
+          ? `git-tree (commit ${commitOid}, tree ${treeOid})`
+          : `git-tree (${treeOid})`;
+      const fs = readOnlyFs(wrapBackend(fsBackend, { description }));
       filesystemByTreeOid.set(treeOid, fs);
       return fs;
     },

--- a/packages/daemon/src/git.js
+++ b/packages/daemon/src/git.js
@@ -483,16 +483,20 @@ export const makeGit = ({ mount, backend, readOnly = false }) => {
     },
 
     async filesystemAt(ref) {
-      const { treeOid, commitOid } = await backend.resolveTree(refName(ref));
+      const { treeOid } = await backend.resolveTree(refName(ref));
       const cached = filesystemByTreeOid.get(treeOid);
       if (cached !== undefined) {
         return cached;
       }
       const fsBackend = makeGitFsBackend({ backend, treeOid });
-      const description =
-        commitOid !== undefined
-          ? `git-tree (commit ${commitOid}, tree ${treeOid})`
-          : `git-tree (${treeOid})`;
+      // The cache is keyed only on `treeOid`; two refs that resolve
+      // to the same tree (e.g. cherry-picks, `--allow-empty` commits,
+      // identical branches) intentionally share one Filesystem cap so
+      // brand identity is stable for `compose`.  The description must
+      // therefore reference only the tree — embedding a `commitOid`
+      // would make `statfs().type` lie about which commit the cached
+      // Filesystem was first minted for.
+      const description = `git-tree (${treeOid})`;
       const fs = readOnlyFs(wrapBackend(fsBackend, { description }));
       filesystemByTreeOid.set(treeOid, fs);
       return fs;

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -718,6 +718,7 @@ export const GitInterface = M.interface('Git', {
   stashPop: M.callWhen().optional(M.number()).returns(M.undefined()),
   stashDrop: M.callWhen().optional(M.number()).returns(M.undefined()),
   tree: M.callWhen(RefArgShape).returns(M.remotable('EndoReadableTree')),
+  filesystemAt: M.callWhen(RefArgShape).returns(M.remotable('Filesystem')),
   readOnly: M.call().returns(M.remotable('Git')),
 });
 

--- a/packages/daemon/src/native-git-backend.js
+++ b/packages/daemon/src/native-git-backend.js
@@ -1345,15 +1345,38 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
 
   /**
    * @param {string} blobOid
-   * @returns {Promise<Uint8Array>}
-   */
-  const readBlobBytes = blobOid => runGitBuffer(['cat-file', 'blob', blobOid]);
-
-  /**
-   * @param {string} blobOid
    */
   const streamBlobBytes = blobOid =>
     streamGitBuffer(['cat-file', 'blob', blobOid]);
+
+  /**
+   * Read the full bytes of a blob.  Collects the streaming output of
+   * `cat-file blob <oid>` so the read is not subject to `execFile`'s
+   * `maxBuffer` cap — a blob larger than `GIT_MAX_BUFFER` (1 MiB) is
+   * read correctly rather than failing the entire call.
+   *
+   * @param {string} blobOid
+   * @returns {Promise<Uint8Array>}
+   */
+  const readBlobBytes = async blobOid => {
+    /** @type {Uint8Array[]} */
+    const chunks = [];
+    let total = 0;
+    for await (const chunk of streamBlobBytes(blobOid)) {
+      chunks.push(chunk);
+      total += chunk.length;
+    }
+    if (chunks.length === 1) {
+      return chunks[0];
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      out.set(c, offset);
+      offset += c.length;
+    }
+    return out;
+  };
 
   /**
    * @param {string} blobOid

--- a/packages/daemon/src/native-git-backend.js
+++ b/packages/daemon/src/native-git-backend.js
@@ -1332,6 +1332,11 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
       total += chunk.length;
     }
     if (chunks.length === 1) {
+      // Fast path.  `streamGitBuffer` wraps each child-process stdout
+      // chunk in a fresh `new Uint8Array(Buffer)`, so this return does
+      // not alias the runtime's pooled buffer — Node `child_process`
+      // allocates fresh stdout buffers per chunk, and the wrapping
+      // captures the underlying ArrayBuffer one-to-one.
       return chunks[0];
     }
     const out = new Uint8Array(total);

--- a/packages/daemon/src/native-git-backend.js
+++ b/packages/daemon/src/native-git-backend.js
@@ -943,6 +943,16 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
         resolve({ code, signal });
       });
     });
+    // If a consumer of this async generator breaks out of the
+    // `for await` loop before reaching `await closed`, and the
+    // child later emits an `'error'` event (e.g. SIGTERM-induced),
+    // `reject(error)` would fire on a promise nobody is awaiting →
+    // unhandled rejection.  Attach a noop catch so the promise has
+    // a registered handler even if the happy-path await never runs.
+    // The `finally` block below still kills the child; this just
+    // keeps the post-break error from surfacing as a process-level
+    // unhandled rejection.
+    closed.catch(() => {});
     try {
       if (child.stdout === null) {
         throw new Error('git stdout stream was not available');

--- a/packages/daemon/src/native-git-backend.js
+++ b/packages/daemon/src/native-git-backend.js
@@ -2085,6 +2085,75 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
         await credentialTransport.close();
       }
     },
+
+    /**
+     * Resolve a ref to a canonical tree OID.  Used by the endo-fs
+     * `filesystemAt(ref)` path so the returned Filesystem is pinned to
+     * a specific OID rather than tracking the ref.  Returns the commit
+     * OID alongside when the ref resolves to a commit (the common case);
+     * a bare tree ref leaves `commitOid` undefined.
+     *
+     * @param {string} ref
+     */
+    resolveTree: async ref => {
+      const revision = requireRevision(ref, 'resolveTree.ref');
+      const rawTree = await runGitRaw([
+        'rev-parse',
+        '--verify',
+        '--end-of-options',
+        `${revision}^{tree}`,
+      ]);
+      const treeOid = rawTree.trim();
+      let commitOid;
+      try {
+        const rawCommit = await runGitRaw([
+          'rev-parse',
+          '--verify',
+          '--end-of-options',
+          `${revision}^{commit}`,
+        ]);
+        commitOid = rawCommit.trim();
+      } catch {
+        commitOid = undefined;
+      }
+      return harden({
+        treeOid,
+        ...(commitOid !== undefined ? { commitOid } : {}),
+      });
+    },
+
+    /**
+     * Enumerate entries at a tree OID via `git ls-tree -z --long`.
+     * The records are immutable for a given tree OID and safe to cache.
+     *
+     * @param {string} treeOid
+     */
+    lsTree: async treeOid => {
+      const oid = requireRevision(treeOid, 'lsTree.treeOid');
+      const entries = await listTreeEntries(oid);
+      return harden(entries);
+    },
+
+    /**
+     * Read full bytes of a blob.
+     *
+     * @param {string} blobOid
+     */
+    readBlobBytes: async blobOid => {
+      const oid = requireRevision(blobOid, 'readBlobBytes.blobOid');
+      return readBlobBytes(oid);
+    },
+
+    /**
+     * Stream blob bytes for range-read paths.  Yields chunks; callers
+     * concatenate or slice as needed.
+     *
+     * @param {string} blobOid
+     */
+    streamBlobBytes: blobOid => {
+      const oid = requireRevision(blobOid, 'streamBlobBytes.blobOid');
+      return streamBlobBytes(oid);
+    },
   });
 };
 harden(makeNativeGitBackend);

--- a/packages/daemon/src/native-git-backend.js
+++ b/packages/daemon/src/native-git-backend.js
@@ -910,41 +910,6 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
   };
 
   /**
-   * Run a sanitized git invocation whose stdout is binary data.
-   *
-   * @param {string[]} args
-   * @returns {Promise<Uint8Array>}
-   */
-  const runGitBuffer = async args => {
-    await verifyRepositoryIdentity();
-    try {
-      const { stdout } = await execFileAsync(
-        'git',
-        [...GIT_BASE_ARGS, ...args],
-        {
-          cwd: repoRoot,
-          env: makeGitEnv(repoRoot),
-          timeout: GIT_TIMEOUT_MS,
-          maxBuffer: GIT_MAX_BUFFER,
-          encoding: /** @type {'buffer'} */ ('buffer'),
-        },
-      );
-      return new Uint8Array(/** @type {Buffer | Uint8Array} */ (stdout));
-    } catch (err) {
-      const error =
-        /** @type {Error & { stdout?: Buffer | string, stderr?: Buffer | string, code?: number }} */ (
-          err
-        );
-      const detail = String(
-        error.stderr || error.stdout || error.message || 'unknown git error',
-      );
-      throw new Error(
-        `git ${gitCommandName(args)} failed (exit ${error.code ?? 'unknown'}):\n${truncateOutput(detail.trim())}`,
-      );
-    }
-  };
-
-  /**
    * Run a sanitized git invocation and stream binary stdout chunks.
    *
    * @param {string[]} args

--- a/packages/daemon/src/native-git-backend.js
+++ b/packages/daemon/src/native-git-backend.js
@@ -1304,8 +1304,30 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
    * @returns {Promise<GitTreeEntry[]>}
    */
   const listTreeEntries = async treeOid => {
-    const raw = await runGitRaw(['ls-tree', '-z', '--long', treeOid]);
-    return parseLsTreeEntries(raw);
+    // Collect `git ls-tree -z --long` via streaming so a large tree
+    // listing isn't capped by `runGitRaw`'s `GIT_MAX_BUFFER` (1 MiB).
+    // The whole record table is still materialized into one string
+    // here (parsing needs random access to NUL-delimited records),
+    // but the input bytes flow through `spawn` rather than execFile
+    // — bounded by tree size, not by the runner's stdout cap.
+    const chunks = [];
+    let total = 0;
+    for await (const chunk of streamGitBuffer([
+      'ls-tree',
+      '-z',
+      '--long',
+      treeOid,
+    ])) {
+      chunks.push(chunk);
+      total += chunk.length;
+    }
+    const buffer = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      buffer.set(c, offset);
+      offset += c.length;
+    }
+    return parseLsTreeEntries(utf8Decoder.decode(buffer));
   };
 
   /**

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -427,6 +427,13 @@ export interface EndoGit {
    */
   tree(ref: GitRef | string): Promise<ReadableTreeView>;
   /**
+   * Returns an `@endo/endo-fs` `Filesystem` lazily backed by the git
+   * object database at the resolved tree of `ref`.  The Filesystem is
+   * immutable; mutating verbs throw `EACCES`.  See
+   * `designs/endo-fs-from-git.md`.
+   */
+  filesystemAt(ref: GitRef | string): Promise<unknown>;
+  /**
    * Returns an attenuated `EndoGit` whose mutation methods reject.
    * If this cap is already read-only, returns the same cap.
    */

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -1374,23 +1374,24 @@ test('Git.filesystemAt returns an endo-fs Filesystem with the expected surface',
   t.is(typeof brands[0], 'bigint');
 
   const stats = await E(gitFs).statfs();
-  // Git trees have no statfs surface; zeros match the from-mount convention.
+  // wrapBackend stamps `type` from the description and merges in our
+  // backend.statfs() result; both totalBytes/freeBytes are 0n because
+  // an immutable historical tree has no "free / used" notion.
+  t.true(stats.type.includes(treeOid));
   t.is(stats.totalBytes, 0n);
   t.is(stats.freeBytes, 0n);
-  t.is(stats.availableBytes, 0n);
 
-  // named() throws — git-FS has one root.
-  await t.throwsAsync(E(gitFs).named('alt'), { message: /ENOTSUP/ });
+  // wrapBackend exposes only the configured namedDirs; we pass none,
+  // so any name is "not found."
+  await t.throwsAsync(E(gitFs).named('alt'), { message: /ENOENT/ });
 
   const root = /** @type {any} */ (await E(gitFs).root());
-  const qid = root.getQid();
+  const qid = await E(root).getQid();
   t.is(qid.type, 'directory');
-  t.is(qid.pathId, BigInt(`0x${treeOid}`));
-  t.is(qid.version, 0n);
 });
 
-test('Git.filesystemAt: lookup returns a File whose QID is the blob OID', async t => {
-  const { repoRoot, blobOid } = await provisionGitWorktreeWithFile(
+test('Git.filesystemAt: lookup returns a File', async t => {
+  const { repoRoot } = await provisionGitWorktreeWithFile(
     t,
     'README.md',
     'hello\n',
@@ -1403,9 +1404,8 @@ test('Git.filesystemAt: lookup returns a File whose QID is the blob OID', async 
   const root = /** @type {any} */ (await E(gitFs).root());
 
   const readme = /** @type {any} */ (await E(root).lookup('README.md'));
-  const qid = readme.getQid();
+  const qid = await E(readme).getQid();
   t.is(qid.type, 'file');
-  t.is(qid.pathId, BigInt(`0x${blobOid}`));
 });
 
 test('Git.filesystemAt: OpenFile.read returns blob bytes; range reads slice', async t => {
@@ -1424,9 +1424,9 @@ test('Git.filesystemAt: OpenFile.read returns blob bytes; range reads slice', as
   const file = /** @type {any} */ (await E(root).lookup('data.txt'));
   const opener = /** @type {any} */ (await E(file).open({ read: true }));
 
-  // Read the full blob.  bytesReaderFromIterator wraps a chunk; collect
-  // base64-decoded bytes via the standard exo-stream initiator.
-  const fullReader = await E(opener).read(0n, 0n); // length=0 → to end
+  // Read the full blob.  The OpenFile.read interface requires both
+  // offset and length as bigints; pass the exact content length.
+  const fullReader = await E(opener).read(0n, BigInt(content.length));
   const fullBytes = await collectReader(fullReader);
   t.is(new TextDecoder().decode(fullBytes), content);
 
@@ -1443,8 +1443,8 @@ test('Git.filesystemAt: OpenFile.read returns blob bytes; range reads slice', as
   await E(opener).close();
 });
 
-test('Git.filesystemAt: File.snapshot returns a BlobRef whose hash is the git OID', async t => {
-  const { repoRoot, blobOid } = await provisionGitWorktreeWithFile(
+test('Git.filesystemAt: File.snapshot returns a BlobRef over the blob bytes', async t => {
+  const { repoRoot } = await provisionGitWorktreeWithFile(
     t,
     'README.md',
     'snapshot test\n',
@@ -1458,18 +1458,19 @@ test('Git.filesystemAt: File.snapshot returns a BlobRef whose hash is the git OI
   const file = /** @type {any} */ (await E(root).lookup('README.md'));
 
   const blobRef = /** @type {any} */ (await E(file).snapshot());
-  const info = blobRef.getInfo();
-  t.is(info.algorithm, 'git-sha1');
-  t.is(info.hash, blobOid);
+  const info = await E(blobRef).getInfo();
+  // wrapBackend's BlobRef hashes the captured bytes with SHA-256;
+  // the size matches the blob length.
+  t.is(info.algorithm, 'sha256');
   t.is(info.size, BigInt('snapshot test\n'.length));
 
   // fetch returns the bytes.
-  const reader = await E(blobRef).fetch(0n, 0n);
+  const reader = await E(blobRef).fetch(0n, BigInt('snapshot test\n'.length));
   const bytes = await collectReader(reader);
   t.is(new TextDecoder().decode(bytes), 'snapshot test\n');
 });
 
-test('Git.filesystemAt: Directory.list yields entries with QIDs in tree order', async t => {
+test('Git.filesystemAt: Directory.list yields entries in tree order', async t => {
   const { repoRoot } = await provisionGitWorktreeWithFile(t, 'a.txt', 'a\n');
   await fs.promises.writeFile(path.join(repoRoot, 'b.txt'), 'b\n');
   await execFileAsync('git', ['add', 'b.txt'], { cwd: repoRoot });
@@ -1498,8 +1499,8 @@ test('Git.filesystemAt: Directory.list yields entries with QIDs in tree order', 
   // Git ls-tree returns entries in lexical order.
   t.deepEqual(names, ['a.txt', 'b.txt']);
   for (const entry of collected) {
+    t.is(entry.kind, 'file');
     t.is(entry.qid.type, 'file');
-    t.is(typeof entry.qid.pathId, 'bigint');
   }
 });
 
@@ -1583,7 +1584,7 @@ test('Git.filesystemAt: memoizes by canonical tree OID within one Git', async t 
   t.not(a, c);
 });
 
-test('Git.filesystemAt: submodule lookup throws a structured error', async t => {
+test('Git.filesystemAt: submodule entries are hidden from the tree view', async t => {
   // Provision a worktree, add a fake submodule entry by writing a
   // gitlink directly via update-index --add --cacheinfo.
   const { repoRoot } = await provisionGitWorktreeWithFile(
@@ -1617,7 +1618,11 @@ test('Git.filesystemAt: submodule lookup throws a structured error', async t => 
   const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
   const root = /** @type {any} */ (await E(gitFs).root());
 
-  await t.throwsAsync(E(root).lookup('sub'), { message: /submodule/ });
+  // Submodules surface as missing rather than as a distinct kind —
+  // the base endo-fs vocabulary only knows files and directories.
+  // Callers that need submodule traversal should obtain a separate
+  // Git capability for the submodule's repository.
+  await t.throwsAsync(E(root).lookup('sub'), { message: /ENOENT/ });
 });
 
 /**

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -1478,6 +1478,78 @@ test('Git.filesystemAt: range reads at a high offset discard the prefix', async 
   await E(opener).close();
 });
 
+test('Git.filesystemAt: range reads reject negative / unsafe-integer bounds', async t => {
+  const { repoRoot } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'hi\n',
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+  const file = /** @type {any} */ (await E(root).lookup('README.md'));
+  const opener = /** @type {any} */ (await E(file).open({ read: true }));
+
+  // Negative offset is rejected at the boundary instead of flowing
+  // into the window math as 0.
+  await t.throwsAsync(E(opener).read(-1n, 1n), {
+    message: /EINVAL/,
+  });
+  // Negative length is rejected likewise.
+  await t.throwsAsync(E(opener).read(0n, -1n), {
+    message: /EINVAL/,
+  });
+  // Beyond MAX_SAFE_INTEGER would silently lose precision under
+  // `Number()`; reject explicitly.
+  const beyondSafe = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+  await t.throwsAsync(E(opener).read(beyondSafe, 1n), {
+    message: /EINVAL/,
+  });
+
+  await E(opener).close();
+});
+
+test('Git.filesystemAt: lsTree cache evicts on rejection so a transient failure does not pin', async t => {
+  const { repoRoot } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'hi\n',
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+
+  // Wrap the native backend so the first `lsTree` call rejects (a
+  // simulated transient git timeout) and later calls succeed.
+  const nativeBackend = makeNativeGitBackend({ repoRoot });
+  let failuresRemaining = 1;
+  const flakyBackend = harden({
+    ...nativeBackend,
+    /** @param {string} treeOid */
+    lsTree: async treeOid => {
+      if (failuresRemaining > 0) {
+        failuresRemaining -= 1;
+        throw new Error('simulated transient ls-tree failure');
+      }
+      return nativeBackend.lsTree(treeOid);
+    },
+  });
+  const git = makeGit({ mount, backend: flakyBackend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+
+  // First lookup hits the simulated failure.
+  await t.throwsAsync(E(root).lookup('README.md'), {
+    message: /transient ls-tree/,
+  });
+  // Second lookup must NOT replay the cached rejection — it should
+  // retry through the cleared cache and succeed.
+  const file = await E(root).lookup('README.md');
+  t.truthy(file);
+});
+
 test('Git.filesystemAt: File.snapshot returns a BlobRef over the blob bytes', async t => {
   const { repoRoot } = await provisionGitWorktreeWithFile(
     t,

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -35,6 +35,17 @@ const provisionGitWorktree = async t => {
   const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'native-git-'));
   t.teardown(() => fs.promises.rm(root, { recursive: true, force: true }));
   await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  // Some CI / dev environments enable `commit.gpgSign` at user-global
+  // level; that surfaces here because `provisionGitWorktree` does not
+  // override gpg config per-invocation.  Pin the repo-local config to
+  // disable signing so the test setup is independent of the user's
+  // environment.
+  await execFileAsync('git', ['config', '--local', 'commit.gpgsign', 'false'], {
+    cwd: root,
+  });
+  await execFileAsync('git', ['config', '--local', 'tag.gpgsign', 'false'], {
+    cwd: root,
+  });
   await execFileAsync(
     'git',
     [
@@ -114,6 +125,7 @@ test('Git exo advertises the full GitInterface', async t => {
 
   // Trees + worktree binding
   t.true(methods.includes('tree'));
+  t.true(methods.includes('filesystemAt'));
   t.true(methods.includes('worktree'));
   t.true(methods.includes('readOnly'));
 });
@@ -303,6 +315,9 @@ test('Git scaffold methods all surface a clear "not yet implemented"', async t =
   await t.throwsAsync(E(git).tree('HEAD'), {
     message: /not yet implemented/,
   });
+  await t.throwsAsync(E(git).filesystemAt('HEAD'), {
+    message: /not yet implemented/,
+  });
 
   // The remote-transport methods are not on the Git exo; they are
   // called by GitRemote directly against the backend.  The stub
@@ -362,6 +377,9 @@ test('NativeGitBackend rejects a swapped .git directory after construction', asy
     force: true,
   });
   await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+  await execFileAsync('git', ['config', '--local', 'commit.gpgsign', 'false'], {
+    cwd: repoRoot,
+  });
   await execFileAsync(
     'git',
     [
@@ -1283,3 +1301,345 @@ test('Git accepts both string and structured GitRef arguments', async t => {
   t.deepEqual(showCalls, ['HEAD', 'main']);
   t.deepEqual(revParseCalls, ['v1.0', 'origin/main']);
 });
+
+// ---------------------------------------------------------------------------
+// Git.filesystemAt(ref) — endo-fs Filesystem adapter over a git tree.
+// See designs/endo-fs-from-git.md.
+// ---------------------------------------------------------------------------
+
+/**
+ * Provision a worktree, write a file, commit it, and return the repo
+ * path plus the file's bytes and blob OID.  Used by the
+ * `filesystemAt` tests below.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} fileName
+ * @param {string} content
+ */
+const provisionGitWorktreeWithFile = async (t, fileName, content) => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, fileName), content);
+  await execFileAsync('git', ['add', fileName], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      `add ${fileName}`,
+    ],
+    { cwd: repoRoot },
+  );
+  const { stdout: blobOid } = await execFileAsync(
+    'git',
+    ['rev-parse', `HEAD:${fileName}`],
+    { cwd: repoRoot },
+  );
+  const { stdout: treeOid } = await execFileAsync(
+    'git',
+    ['rev-parse', 'HEAD^{tree}'],
+    { cwd: repoRoot },
+  );
+  return {
+    repoRoot,
+    blobOid: blobOid.trim(),
+    treeOid: treeOid.trim(),
+  };
+};
+
+test('Git.filesystemAt returns an endo-fs Filesystem with the expected surface', async t => {
+  const { repoRoot, treeOid } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'hello\n',
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+
+  // eslint-disable-next-line no-underscore-dangle
+  const methods = await E(gitFs).__getMethodNames__();
+  for (const name of ['root', 'named', 'statfs', 'brands', 'help']) {
+    t.true(methods.includes(name), `Filesystem should advertise ${name}`);
+  }
+
+  const brands = await E(gitFs).brands();
+  t.is(brands.length, 1);
+  t.is(typeof brands[0], 'bigint');
+
+  const stats = await E(gitFs).statfs();
+  // Git trees have no statfs surface; zeros match the from-mount convention.
+  t.is(stats.totalBytes, 0n);
+  t.is(stats.freeBytes, 0n);
+  t.is(stats.availableBytes, 0n);
+
+  // named() throws — git-FS has one root.
+  await t.throwsAsync(E(gitFs).named('alt'), { message: /ENOTSUP/ });
+
+  const root = /** @type {any} */ (await E(gitFs).root());
+  const qid = root.getQid();
+  t.is(qid.type, 'directory');
+  t.is(qid.pathId, BigInt(`0x${treeOid}`));
+  t.is(qid.version, 0n);
+});
+
+test('Git.filesystemAt: lookup returns a File whose QID is the blob OID', async t => {
+  const { repoRoot, blobOid } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'hello\n',
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+
+  const readme = /** @type {any} */ (await E(root).lookup('README.md'));
+  const qid = readme.getQid();
+  t.is(qid.type, 'file');
+  t.is(qid.pathId, BigInt(`0x${blobOid}`));
+});
+
+test('Git.filesystemAt: OpenFile.read returns blob bytes; range reads slice', async t => {
+  const content = 'abcdefghijklmnop\n';
+  const { repoRoot } = await provisionGitWorktreeWithFile(
+    t,
+    'data.txt',
+    content,
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+  const file = /** @type {any} */ (await E(root).lookup('data.txt'));
+  const opener = /** @type {any} */ (await E(file).open({ read: true }));
+
+  // Read the full blob.  bytesReaderFromIterator wraps a chunk; collect
+  // base64-decoded bytes via the standard exo-stream initiator.
+  const fullReader = await E(opener).read(0n, 0n); // length=0 → to end
+  const fullBytes = await collectReader(fullReader);
+  t.is(new TextDecoder().decode(fullBytes), content);
+
+  // Range read: bytes [3, 10).
+  const sliceReader = await E(opener).read(3n, 7n);
+  const sliceBytes = await collectReader(sliceReader);
+  t.is(new TextDecoder().decode(sliceBytes), content.slice(3, 10));
+
+  // Offset past end → empty.
+  const pastReader = await E(opener).read(1000n, 100n);
+  const pastBytes = await collectReader(pastReader);
+  t.is(pastBytes.length, 0);
+
+  await E(opener).close();
+});
+
+test('Git.filesystemAt: File.snapshot returns a BlobRef whose hash is the git OID', async t => {
+  const { repoRoot, blobOid } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'snapshot test\n',
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+  const file = /** @type {any} */ (await E(root).lookup('README.md'));
+
+  const blobRef = /** @type {any} */ (await E(file).snapshot());
+  const info = blobRef.getInfo();
+  t.is(info.algorithm, 'git-sha1');
+  t.is(info.hash, blobOid);
+  t.is(info.size, BigInt('snapshot test\n'.length));
+
+  // fetch returns the bytes.
+  const reader = await E(blobRef).fetch(0n, 0n);
+  const bytes = await collectReader(reader);
+  t.is(new TextDecoder().decode(bytes), 'snapshot test\n');
+});
+
+test('Git.filesystemAt: Directory.list yields entries with QIDs in tree order', async t => {
+  const { repoRoot } = await provisionGitWorktreeWithFile(t, 'a.txt', 'a\n');
+  await fs.promises.writeFile(path.join(repoRoot, 'b.txt'), 'b\n');
+  await execFileAsync('git', ['add', 'b.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'add b'],
+    { cwd: repoRoot },
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+
+  const cursor = /** @type {any} */ (await E(root).list());
+  const readerRef = await E(cursor).stream();
+  // eslint-disable-next-line global-require
+  const { iterateReader } = await import('@endo/exo-stream/iterate-reader.js');
+  /** @type {any[]} */
+  const collected = [];
+  for await (const value of iterateReader(readerRef)) {
+    collected.push(value);
+  }
+  const names = collected.map(e => e.name);
+  // Git ls-tree returns entries in lexical order.
+  t.deepEqual(names, ['a.txt', 'b.txt']);
+  for (const entry of collected) {
+    t.is(entry.qid.type, 'file');
+    t.is(typeof entry.qid.pathId, 'bigint');
+  }
+});
+
+test('Git.filesystemAt: mutating verbs all throw EACCES', async t => {
+  const { repoRoot } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'x\n',
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+
+  for (const call of [
+    () => E(root).create('new.txt', {}),
+    () => E(root).mkdir('newdir', {}),
+    () => E(root).unlink('README.md'),
+    () => E(root).fsync(),
+    () => E(root).setAttrs({}),
+    () => E(root).materialise(['a', 'b'], {}),
+  ]) {
+    // eslint-disable-next-line no-await-in-loop
+    await t.throwsAsync(call(), { message: /EACCES/ });
+  }
+
+  const file = /** @type {any} */ (await E(root).lookup('README.md'));
+  await t.throwsAsync(E(file).setAttrs({}), { message: /EACCES/ });
+
+  const opener = /** @type {any} */ (await E(file).open({ read: true }));
+  await t.throwsAsync(E(opener).write(0n), { message: /EACCES/ });
+  await t.throwsAsync(E(opener).truncate(0n), { message: /EACCES/ });
+  await t.throwsAsync(E(opener).fsync({}), { message: /EACCES/ });
+  await t.throwsAsync(E(opener).lock({}), { message: /EACCES/ });
+});
+
+test('Git.filesystemAt: open({ write: true }) rejects', async t => {
+  const { repoRoot } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'x\n',
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+  const file = /** @type {any} */ (await E(root).lookup('README.md'));
+  await t.throwsAsync(E(file).open({ write: true }), { message: /EACCES/ });
+});
+
+test('Git.filesystemAt: memoizes by canonical tree OID within one Git', async t => {
+  const { repoRoot } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'x\n',
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+
+  const a = await E(git).filesystemAt('HEAD');
+  const b = await E(git).filesystemAt('HEAD');
+  // Same cap; brand stability falls out of cap identity.
+  t.is(a, b);
+
+  // After another commit, HEAD resolves to a different tree OID, so
+  // the cap differs.
+  await fs.promises.writeFile(path.join(repoRoot, 'two.txt'), 'two\n');
+  await execFileAsync('git', ['add', 'two.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'two'],
+    { cwd: repoRoot },
+  );
+  const c = await E(git).filesystemAt('HEAD');
+  t.not(a, c);
+});
+
+test('Git.filesystemAt: submodule lookup throws a structured error', async t => {
+  // Provision a worktree, add a fake submodule entry by writing a
+  // gitlink directly via update-index --add --cacheinfo.
+  const { repoRoot } = await provisionGitWorktreeWithFile(
+    t,
+    'README.md',
+    'x\n',
+  );
+  const fakeCommitOid = '1'.repeat(40);
+  await execFileAsync(
+    'git',
+    ['update-index', '--add', '--cacheinfo', `160000,${fakeCommitOid},sub`],
+    { cwd: repoRoot },
+  );
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'add submodule pointer',
+    ],
+    { cwd: repoRoot },
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+
+  await t.throwsAsync(E(root).lookup('sub'), { message: /submodule/ });
+});
+
+/**
+ * Collect a PassableBytesReader into a single Uint8Array.
+ *
+ * @param {any} readerRef
+ */
+const collectReader = async readerRef => {
+  // eslint-disable-next-line global-require
+  const { iterateBytesReader } =
+    await import('@endo/exo-stream/iterate-bytes-reader.js');
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of iterateBytesReader(readerRef)) {
+    chunks.push(chunk);
+    total += chunk.length;
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+};

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -1440,6 +1440,41 @@ test('Git.filesystemAt: OpenFile.read returns blob bytes; range reads slice', as
   const pastBytes = await collectReader(pastReader);
   t.is(pastBytes.length, 0);
 
+  // length === 0 → empty without streaming.
+  const zeroReader = await E(opener).read(0n, 0n);
+  const zeroBytes = await collectReader(zeroReader);
+  t.is(zeroBytes.length, 0);
+
+  await E(opener).close();
+});
+
+test('Git.filesystemAt: range reads at a high offset discard the prefix', async t => {
+  // Reading a small window from deep inside a multi-KiB blob must not
+  // retain the bytes before `offset` — they should stream by and be
+  // dropped chunk-by-chunk.  We assert correctness; the memory
+  // invariant is upheld by the streaming-skip implementation in
+  // `git-filesystem.js#read`.
+  const content = `${'x'.repeat(8 * 1024)}HELLOWORLD${'y'.repeat(8 * 1024)}`;
+  const { repoRoot } = await provisionGitWorktreeWithFile(
+    t,
+    'data.txt',
+    content,
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+  const file = /** @type {any} */ (await E(root).lookup('data.txt'));
+  const opener = /** @type {any} */ (await E(file).open({ read: true }));
+
+  // Window straddles a likely chunk boundary; correctness here is the
+  // public-API check the perf-claim leans on.
+  const reader = await E(opener).read(8n * 1024n, 10n);
+  const bytes = await collectReader(reader);
+  t.is(new TextDecoder().decode(bytes), 'HELLOWORLD');
+
   await E(opener).close();
 });
 

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -1625,6 +1625,91 @@ test('Git.filesystemAt: submodule entries are hidden from the tree view', async 
   await t.throwsAsync(E(root).lookup('sub'), { message: /ENOENT/ });
 });
 
+test('Git.filesystemAt: an empty tree exposes an empty root', async t => {
+  // Provision an empty-tree commit by amending the init commit with
+  // no tracked files.  `provisionGitWorktree` already left an empty
+  // initial commit; assert the FS surfaces it cleanly.
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+
+  // `list()` returns a Cursor that yields zero entries.
+  const cursor = /** @type {any} */ (await E(root).list());
+  const readerRef = await E(cursor).stream();
+  // eslint-disable-next-line global-require
+  const { iterateReader } = await import('@endo/exo-stream/iterate-reader.js');
+  const collected = [];
+  for await (const value of iterateReader(readerRef)) {
+    collected.push(value);
+  }
+  t.deepEqual(collected, []);
+
+  // `lookup` on any name throws ENOENT.
+  await t.throwsAsync(E(root).lookup('anything'), { message: /ENOENT/ });
+});
+
+test('Git.filesystemAt: directories report size 0n via getStat', async t => {
+  // A subdirectory in the tree should report `kind: 'directory'` and
+  // `size: 0n` (git trees have no inherent size).
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.mkdir(path.join(repoRoot, 'subdir'));
+  await fs.promises.writeFile(path.join(repoRoot, 'subdir', 'a.txt'), 'a\n');
+  await execFileAsync('git', ['add', 'subdir/a.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'subdir'],
+    { cwd: repoRoot },
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+  const subdir = /** @type {any} */ (await E(root).lookup('subdir'));
+  const stat = await E(subdir).getStat();
+  t.is(stat.size, 0n);
+});
+
+test('Git.filesystemAt: lsTree and resolvePath are cached per Filesystem', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'README.md'), 'hi\n');
+  await execFileAsync('git', ['add', 'README.md'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'add'],
+    { cwd: repoRoot },
+  );
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+
+  // Wrap the native backend with a spy that counts `lsTree` calls.
+  const nativeBackend = makeNativeGitBackend({ repoRoot });
+  let lsTreeCalls = 0;
+  const spyBackend = harden({
+    ...nativeBackend,
+    /** @param {string} treeOid */
+    lsTree: async treeOid => {
+      lsTreeCalls += 1;
+      return nativeBackend.lsTree(treeOid);
+    },
+  });
+  const git = makeGit({ mount, backend: spyBackend });
+  const gitFs = /** @type {any} */ (await E(git).filesystemAt('HEAD'));
+  const root = /** @type {any} */ (await E(gitFs).root());
+
+  // First lookup populates the cache.
+  await E(root).lookup('README.md');
+  const afterFirst = lsTreeCalls;
+  // Second lookup of the same path must not re-call lsTree.
+  await E(root).lookup('README.md');
+  t.is(lsTreeCalls, afterFirst, 'lsTree should be cached per tree OID');
+});
+
 /**
  * Collect a PassableBytesReader into a single Uint8Array.
  *

--- a/packages/endo-fs/package.json
+++ b/packages/endo-fs/package.json
@@ -17,9 +17,18 @@
   "type": "module",
   "types": "./types.d.ts",
   "exports": {
-    ".": "./src/index.js",
-    "./src/type-guards.js": "./src/type-guards.js",
-    "./src/backend-types.js": "./src/backend-types.js",
+    ".": {
+      "types": "./types.d.ts",
+      "default": "./src/index.js"
+    },
+    "./src/type-guards.js": {
+      "types": "./types.d.ts",
+      "default": "./src/type-guards.js"
+    },
+    "./src/backend-types.js": {
+      "types": "./types.d.ts",
+      "default": "./src/backend-types.js"
+    },
     "./src/in-memory.js": "./src/in-memory.js",
     "./src/in-memory-module.js": "./src/in-memory-module.js",
     "./src/cas.js": "./src/cas.js",

--- a/packages/endo-fs/package.json
+++ b/packages/endo-fs/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@endo/captp": "workspace:^",
-    "@endo/cli": "workspace:^",
     "@endo/pass-style": "workspace:^",
     "ava": "catalog:dev",
     "eslint": "catalog:dev"

--- a/packages/endo-fs/package.json
+++ b/packages/endo-fs/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/endojs/endo/issues"
   },
   "type": "module",
+  "types": "./types.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./src/type-guards.js": "./src/type-guards.js",

--- a/packages/endo-fs/package.json
+++ b/packages/endo-fs/package.json
@@ -29,16 +29,46 @@
       "types": "./types.d.ts",
       "default": "./src/backend-types.js"
     },
-    "./src/in-memory.js": "./src/in-memory.js",
-    "./src/in-memory-module.js": "./src/in-memory-module.js",
-    "./src/cas.js": "./src/cas.js",
-    "./src/cached-fs.js": "./src/cached-fs.js",
-    "./src/node-fs.js": "./src/node-fs.js",
-    "./src/node-fs-module.js": "./src/node-fs-module.js",
-    "./src/readonly.js": "./src/readonly.js",
-    "./src/from-mount.js": "./src/from-mount.js",
-    "./src/compose.js": "./src/compose.js",
-    "./src/layer.js": "./src/layer.js",
+    "./src/in-memory.js": {
+      "types": "./types.d.ts",
+      "default": "./src/in-memory.js"
+    },
+    "./src/in-memory-module.js": {
+      "types": "./types.d.ts",
+      "default": "./src/in-memory-module.js"
+    },
+    "./src/cas.js": {
+      "types": "./types.d.ts",
+      "default": "./src/cas.js"
+    },
+    "./src/cached-fs.js": {
+      "types": "./types.d.ts",
+      "default": "./src/cached-fs.js"
+    },
+    "./src/node-fs.js": {
+      "types": "./types.d.ts",
+      "default": "./src/node-fs.js"
+    },
+    "./src/node-fs-module.js": {
+      "types": "./types.d.ts",
+      "default": "./src/node-fs-module.js"
+    },
+    "./src/readonly.js": {
+      "types": "./types.d.ts",
+      "default": "./src/readonly.js"
+    },
+    "./src/from-mount.js": {
+      "types": "./types.d.ts",
+      "default": "./src/from-mount.js"
+    },
+    "./src/compose.js": {
+      "types": "./types.d.ts",
+      "default": "./src/compose.js"
+    },
+    "./src/layer.js": {
+      "types": "./types.d.ts",
+      "default": "./src/layer.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/endo-fs/package.json
+++ b/packages/endo-fs/package.json
@@ -18,6 +18,7 @@
   "exports": {
     ".": "./src/index.js",
     "./src/type-guards.js": "./src/type-guards.js",
+    "./src/backend-types.js": "./src/backend-types.js",
     "./src/in-memory.js": "./src/in-memory.js",
     "./src/in-memory-module.js": "./src/in-memory-module.js",
     "./src/cas.js": "./src/cas.js",

--- a/packages/endo-fs/src/compose.js
+++ b/packages/endo-fs/src/compose.js
@@ -1463,7 +1463,14 @@ export const compose = (layer, backing, _opts = {}) => {
         if (!opaque && backingDir) {
           const backingCursor = await E(backingDir).list();
           const stream = await E(backingCursor).stream();
-          for await (const entry of iterateReader(stream)) {
+          for await (const passable of iterateReader(stream)) {
+            // `iterateReader` yields `Passable`; Cursor entries are
+            // `{ name: string, qid: any }` (per `makeCursorExo`).
+            // Narrow at the boundary so the merge / lookup below is
+            // type-checked without per-call assertions.
+            const entry = /** @type {{ name: string, qid: any }} */ (
+              passable
+            );
             if (!layerNames.has(whiteoutName(entry.name))) {
               merged.set(entry.name, entry);
             }

--- a/packages/endo-fs/src/compose.js
+++ b/packages/endo-fs/src/compose.js
@@ -1468,9 +1468,7 @@ export const compose = (layer, backing, _opts = {}) => {
             // `{ name: string, qid: any }` (per `makeCursorExo`).
             // Narrow at the boundary so the merge / lookup below is
             // type-checked without per-call assertions.
-            const entry = /** @type {{ name: string, qid: any }} */ (
-              passable
-            );
+            const entry = /** @type {{ name: string, qid: any }} */ (passable);
             if (!layerNames.has(whiteoutName(entry.name))) {
               merged.set(entry.name, entry);
             }

--- a/packages/endo-fs/types.d.ts
+++ b/packages/endo-fs/types.d.ts
@@ -122,12 +122,7 @@ declare module '@endo/endo-fs/src/backend-types.js' {
     atime?: bigint;
   };
   export type WatchEvent = {
-    kind:
-      | 'changed'
-      | 'created'
-      | 'removed'
-      | 'child-added'
-      | 'child-removed';
+    kind: 'changed' | 'created' | 'removed' | 'child-added' | 'child-removed';
     name?: string;
   };
   export type FsBackend = {

--- a/packages/endo-fs/types.d.ts
+++ b/packages/endo-fs/types.d.ts
@@ -1,0 +1,163 @@
+/**
+ * Hand-written declarations covering the public exports `@endo/endo-fs`
+ * consumers reach for.  The package's runtime is JavaScript with
+ * `@ts-check` JSDoc, but there is no `.d.ts` emission pipeline; without
+ * a `types` entrypoint, downstream packages whose own `tsc --build`
+ * walks into endo-fs source files hit module-resolution failures for
+ * endo-fs's transitive `@endo/eventual-send` / `@endo/patterns`
+ * imports (those packages' `.d.ts` only exist mid-prepack and are
+ * cleaned up by `postpack` before the consumer's pack runs).
+ *
+ * Surface kept narrow on purpose: each declaration matches the
+ * concrete shape consumers depend on today; richer fidelity lives
+ * in the source JSDoc and is recovered at consumer-side runtime
+ * via `__getMethodNames__` and the interface guards.
+ */
+
+// Mirror of `@endo/exo/exo-makers.js`'s `Exo` placeholder; declared
+// here so downstream consumers don't need to depend on that package
+// transitively just for the shape.
+type ExoLike = object;
+
+declare module '@endo/endo-fs' {
+  /**
+   * Build a `Filesystem` exo over an `FsBackend`.  Optional
+   * `opts.description` populates `statfs().type`; `opts.namedDirs`
+   * configures the `Filesystem.named(name)` lookup table.
+   */
+  export const wrapBackend: (
+    backend: object,
+    opts?: {
+      description?: string;
+      namedDirs?: Record<string, string[]>;
+    },
+  ) => ExoLike;
+
+  /**
+   * Recursively wrap a `Filesystem` so every mutating verb rejects
+   * with EACCES at the cap boundary.
+   */
+  export const readOnly: (fs: object) => ExoLike;
+
+  /** Build an in-memory `Filesystem`. */
+  export const makeInMemoryFilesystem: (opts?: object) => ExoLike;
+
+  /** Build a node:fs/promises-backed `Filesystem`. */
+  export const makeNodeFilesystem: (rootPath: string, opts?: object) => ExoLike;
+
+  /** Adapt a daemon `Mount` to a `Filesystem`. */
+  export const mountAsFilesystem: (mount: object, opts?: object) => ExoLike;
+
+  /** Build an in-memory `FsBackend`. */
+  export const makeInMemoryBackend: (opts?: object) => object;
+
+  /** Build a node:fs/promises-backed `FsBackend`. */
+  export const makeNodeFsBackend: (rootPath: string, opts?: object) => object;
+
+  /** Adapt a daemon `Mount` to an `FsBackend`. */
+  export const makeFromMountBackend: (mount: object) => object;
+
+  /** The empty `Filesystem` — a root with no entries. */
+  export const emptyFilesystem: () => ExoLike;
+  export const chroot: (fs: object, subPath: string[]) => ExoLike;
+  export const bind: (
+    host: object,
+    mountPath: string[],
+    guest: object,
+  ) => ExoLike;
+  export const namespace: (mounts: Record<string, object>) => ExoLike;
+  export const compose: (participants: object[]) => ExoLike;
+
+  export const makeLayer: (opts?: object) => ExoLike;
+  export const LayerInterface: object;
+
+  export const makeMemoryCas: () => object;
+  export const cacheBackedRead: (cas: object, fs: object) => object;
+  export const withCachedReads: (fs: object, cas: object) => ExoLike;
+
+  export const walk: (
+    fs: object,
+    path: string[],
+  ) => AsyncIterable<{ path: string[]; kind: 'file' | 'directory' }>;
+  export const collectBytes: (readerRef: object) => Promise<Uint8Array>;
+  export const collectStream: (readerRef: object) => Promise<unknown[]>;
+
+  export const PosixFsInterface: object;
+
+  export const FilesystemInterface: object;
+  export const DirectoryInterface: object;
+  export const FileInterface: object;
+  export const CursorInterface: object;
+  export const OpenFileInterface: object;
+  export const LockInterface: object;
+  export const XattrsInterface: object;
+  export const NodeWatcherInterface: object;
+  export const BlobRefInterface: object;
+  export const PassableReaderInterface: object;
+  export const PassableBytesReaderInterface: object;
+  export const PassableBytesWriterInterface: object;
+}
+
+declare module '@endo/endo-fs/src/type-guards.js' {
+  export const FilesystemInterface: object;
+  export const DirectoryInterface: object;
+  export const FileInterface: object;
+  export const CursorInterface: object;
+  export const OpenFileInterface: object;
+  export const LockInterface: object;
+  export const XattrsInterface: object;
+  export const NodeWatcherInterface: object;
+  export const BlobRefInterface: object;
+  export const PassableReaderInterface: object;
+  export const PassableBytesReaderInterface: object;
+  export const PassableBytesWriterInterface: object;
+}
+
+declare module '@endo/endo-fs/src/backend-types.js' {
+  export type NodeKind = 'file' | 'directory';
+  export type DirEntry = { name: string; kind: NodeKind };
+  export type NodeStat = {
+    size?: bigint;
+    mtime?: bigint;
+    atime?: bigint;
+  };
+  export type WatchEvent = {
+    kind:
+      | 'changed'
+      | 'created'
+      | 'removed'
+      | 'child-added'
+      | 'child-removed';
+    name?: string;
+  };
+  export type FsBackend = {
+    kind: (path: string[]) => Promise<NodeKind | undefined>;
+    list: (dirPath: string[]) => AsyncIterable<DirEntry>;
+    read: (
+      path: string[],
+      offset?: bigint,
+      length?: bigint,
+    ) => Promise<Uint8Array>;
+    write: (
+      path: string[],
+      bytes: Uint8Array,
+      offset?: bigint,
+    ) => Promise<void>;
+    makeDirectory: (path: string[]) => Promise<void>;
+    remove: (path: string[]) => Promise<void>;
+    getStat?: (path: string[]) => Promise<NodeStat>;
+    setStat?: (path: string[], patch: NodeStat) => Promise<void>;
+    fsync?: (path: string[]) => Promise<void>;
+    rename?: (src: string[], dst: string[]) => Promise<void>;
+    watch?: (path: string[]) => AsyncIterable<WatchEvent>;
+    statfs?: () => Promise<{
+      blockSize?: bigint;
+      totalBlocks?: bigint;
+      freeBlocks?: bigint;
+      totalBytes?: bigint;
+      freeBytes?: bigint;
+      files?: bigint;
+      directories?: bigint;
+    }>;
+  };
+}

--- a/packages/endo-fs/types.d.ts
+++ b/packages/endo-fs/types.d.ts
@@ -45,10 +45,13 @@ declare module '@endo/endo-fs' {
   export const readOnly: (fs: object) => object;
 
   /** Build an in-memory `Filesystem`. */
-  export const makeInMemoryFilesystem: (opts?: object) => object;
+  export const makeInMemoryFilesystem: () => object;
 
   /** Build a node:fs/promises-backed `Filesystem`. */
-  export const makeNodeFilesystem: (rootPath: string, opts?: object) => object;
+  export const makeNodeFilesystem: (opts: {
+    rootPath: string;
+    [key: string]: unknown;
+  }) => object;
 
   /** Adapt a daemon `Mount` to a `Filesystem`. */
   export const mountAsFilesystem: (mount: object, opts?: object) => object;
@@ -57,7 +60,10 @@ declare module '@endo/endo-fs' {
   export const makeInMemoryBackend: (opts?: object) => object;
 
   /** Build a node:fs/promises-backed `FsBackend`. */
-  export const makeNodeFsBackend: (rootPath: string, opts?: object) => object;
+  export const makeNodeFsBackend: (opts: {
+    rootPath: string;
+    [key: string]: unknown;
+  }) => object;
 
   /** Adapt a daemon `Mount` to an `FsBackend`. */
   export const makeFromMountBackend: (mount: object) => object;
@@ -70,7 +76,15 @@ declare module '@endo/endo-fs' {
     guest: object,
   ) => object;
   export const namespace: (mounts: Record<string, object>) => object;
-  export const compose: (participants: object[]) => object;
+  /**
+   * CoW union: writes target `layer`, reads merge layer-over-backing.
+   * `opts` is reserved for future composer flags; pass `{}` if needed.
+   */
+  export const compose: (
+    layer: object,
+    backing: object,
+    opts?: object,
+  ) => object;
 
   export const makeLayer: (opts?: object) => object;
   export const LayerInterface: object;
@@ -162,7 +176,7 @@ declare module '@endo/endo-fs/src/backend-types.js' {
 }
 
 declare module '@endo/endo-fs/src/in-memory.js' {
-  export const makeInMemoryFilesystem: (opts?: object) => object;
+  export const makeInMemoryFilesystem: () => object;
 }
 
 declare module '@endo/endo-fs/src/in-memory-module.js' {
@@ -179,7 +193,10 @@ declare module '@endo/endo-fs/src/cached-fs.js' {
 }
 
 declare module '@endo/endo-fs/src/node-fs.js' {
-  export const makeNodeFilesystem: (rootPath: string, opts?: object) => object;
+  export const makeNodeFilesystem: (opts: {
+    rootPath: string;
+    [key: string]: unknown;
+  }) => object;
 }
 
 declare module '@endo/endo-fs/src/node-fs-module.js' {
@@ -203,10 +220,14 @@ declare module '@endo/endo-fs/src/compose.js' {
     guest: object,
   ) => object;
   export const namespace: (mounts: Record<string, object>) => object;
-  export const compose: (participants: object[]) => object;
+  export const compose: (
+    layer: object,
+    backing: object,
+    opts?: object,
+  ) => object;
 }
 
 declare module '@endo/endo-fs/src/layer.js' {
-  export const makeLayer: (opts?: object) => object;
+  export const makeLayer: (layerFs: object, backingFs: object) => object;
   export const LayerInterface: object;
 }

--- a/packages/endo-fs/types.d.ts
+++ b/packages/endo-fs/types.d.ts
@@ -1,24 +1,29 @@
 /**
  * Hand-written declarations covering the public exports `@endo/endo-fs`
  * consumers reach for.  The package's runtime is JavaScript with
- * `@ts-check` JSDoc, but there is no `.d.ts` emission pipeline; without
- * a `types` entrypoint, downstream packages whose own `tsc --build`
- * walks into endo-fs source files hit module-resolution failures for
- * endo-fs's transitive `@endo/eventual-send` / `@endo/patterns`
- * imports (those packages' `.d.ts` only exist mid-prepack and are
- * cleaned up by `postpack` before the consumer's pack runs).
+ * `@ts-check` JSDoc, but it does not have its own `tsc` emission
+ * pipeline; without a `types` entrypoint, downstream packages whose
+ * own `tsc --build` walks into endo-fs source files hit module-
+ * resolution failures for endo-fs's transitive `@endo/eventual-send`
+ * / `@endo/patterns` imports (those packages' `.d.ts` only exist mid-
+ * prepack and are cleaned up by `postpack` before the consumer's
+ * pack runs).
  *
  * Surface kept narrow on purpose: each declaration matches the
- * concrete shape consumers depend on today; richer fidelity lives
- * in the source JSDoc and is recovered at consumer-side runtime
- * via `__getMethodNames__` and the interface guards.
+ * concrete shape consumers depend on today; richer fidelity lives in
+ * the source JSDoc and is recovered at consumer-side runtime via
+ * `__getMethodNames__` and the interface guards.
+ *
+ * Every consumer-facing subpath has a matching `declare module`
+ * stanza so downstream tsc resolves to typed declarations rather
+ * than silently falling back to `any` (or worse: walking into the
+ * endo-fs source files and triggering the resolution chain this
+ * shim exists to short-circuit).
  */
 
 // Mirror of `@endo/exo/exo-makers.js`'s `Exo` placeholder; declared
 // here so downstream consumers don't need to depend on that package
 // transitively just for the shape.
-type ExoLike = object;
-
 declare module '@endo/endo-fs' {
   /**
    * Build a `Filesystem` exo over an `FsBackend`.  Optional
@@ -31,22 +36,22 @@ declare module '@endo/endo-fs' {
       description?: string;
       namedDirs?: Record<string, string[]>;
     },
-  ) => ExoLike;
+  ) => object;
 
   /**
    * Recursively wrap a `Filesystem` so every mutating verb rejects
    * with EACCES at the cap boundary.
    */
-  export const readOnly: (fs: object) => ExoLike;
+  export const readOnly: (fs: object) => object;
 
   /** Build an in-memory `Filesystem`. */
-  export const makeInMemoryFilesystem: (opts?: object) => ExoLike;
+  export const makeInMemoryFilesystem: (opts?: object) => object;
 
   /** Build a node:fs/promises-backed `Filesystem`. */
-  export const makeNodeFilesystem: (rootPath: string, opts?: object) => ExoLike;
+  export const makeNodeFilesystem: (rootPath: string, opts?: object) => object;
 
   /** Adapt a daemon `Mount` to a `Filesystem`. */
-  export const mountAsFilesystem: (mount: object, opts?: object) => ExoLike;
+  export const mountAsFilesystem: (mount: object, opts?: object) => object;
 
   /** Build an in-memory `FsBackend`. */
   export const makeInMemoryBackend: (opts?: object) => object;
@@ -57,23 +62,22 @@ declare module '@endo/endo-fs' {
   /** Adapt a daemon `Mount` to an `FsBackend`. */
   export const makeFromMountBackend: (mount: object) => object;
 
-  /** The empty `Filesystem` — a root with no entries. */
-  export const emptyFilesystem: () => ExoLike;
-  export const chroot: (fs: object, subPath: string[]) => ExoLike;
+  export const emptyFilesystem: () => object;
+  export const chroot: (fs: object, subPath: string[]) => object;
   export const bind: (
     host: object,
     mountPath: string[],
     guest: object,
-  ) => ExoLike;
-  export const namespace: (mounts: Record<string, object>) => ExoLike;
-  export const compose: (participants: object[]) => ExoLike;
+  ) => object;
+  export const namespace: (mounts: Record<string, object>) => object;
+  export const compose: (participants: object[]) => object;
 
-  export const makeLayer: (opts?: object) => ExoLike;
+  export const makeLayer: (opts?: object) => object;
   export const LayerInterface: object;
 
   export const makeMemoryCas: () => object;
   export const cacheBackedRead: (cas: object, fs: object) => object;
-  export const withCachedReads: (fs: object, cas: object) => ExoLike;
+  export const withCachedReads: (fs: object, cas: object) => object;
 
   export const walk: (
     fs: object,
@@ -155,4 +159,54 @@ declare module '@endo/endo-fs/src/backend-types.js' {
       directories?: bigint;
     }>;
   };
+}
+
+declare module '@endo/endo-fs/src/in-memory.js' {
+  export const makeInMemoryFilesystem: (opts?: object) => object;
+}
+
+declare module '@endo/endo-fs/src/in-memory-module.js' {
+  export const make: (powers?: object) => object;
+}
+
+declare module '@endo/endo-fs/src/cas.js' {
+  export const makeMemoryCas: () => object;
+  export const cacheBackedRead: (cas: object, fs: object) => object;
+}
+
+declare module '@endo/endo-fs/src/cached-fs.js' {
+  export const withCachedReads: (fs: object, cas: object) => object;
+}
+
+declare module '@endo/endo-fs/src/node-fs.js' {
+  export const makeNodeFilesystem: (rootPath: string, opts?: object) => object;
+}
+
+declare module '@endo/endo-fs/src/node-fs-module.js' {
+  export const make: (powers?: object) => object;
+}
+
+declare module '@endo/endo-fs/src/readonly.js' {
+  export const readOnly: (fs: object) => object;
+}
+
+declare module '@endo/endo-fs/src/from-mount.js' {
+  export const mountAsFilesystem: (mount: object, opts?: object) => object;
+}
+
+declare module '@endo/endo-fs/src/compose.js' {
+  export const emptyFilesystem: () => object;
+  export const chroot: (fs: object, subPath: string[]) => object;
+  export const bind: (
+    host: object,
+    mountPath: string[],
+    guest: object,
+  ) => object;
+  export const namespace: (mounts: Record<string, object>) => object;
+  export const compose: (participants: object[]) => object;
+}
+
+declare module '@endo/endo-fs/src/layer.js' {
+  export const makeLayer: (opts?: object) => object;
+  export const LayerInterface: object;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,6 +1775,7 @@ __metadata:
     "@endo/bytes": "workspace:^"
     "@endo/captp": "workspace:^"
     "@endo/compartment-mapper": "workspace:^"
+    "@endo/endo-fs": "workspace:^"
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
     "@endo/exo": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,7 +1865,6 @@ __metadata:
   dependencies:
     "@endo/base64": "workspace:^"
     "@endo/captp": "workspace:^"
-    "@endo/cli": "workspace:^"
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
     "@endo/exo": "workspace:^"


### PR DESCRIPTION
## Summary

Adds `Git.filesystemAt(ref)` on the `EndoGit` capability — returns an
`@endo/endo-fs` `Filesystem` lazily backed by the git object database at
the resolved tree of `ref`. The Filesystem is natively read-only:
`readOnly(wrapBackend(makeGitFsBackend(...)))` rejects every mutating
verb with `EACCES`.

Built on top of the upstream `@endo/endo-fs` seam refactor on
`claude/keen-bell-W1acD`: the adapter is a small `FsBackend`
implementation (`packages/daemon/src/git-filesystem.js`, ~150 lines)
plumbed through `wrapBackend`.

## What's in the PR

- **Design doc** — `designs/endo-fs-from-git.md` (In Progress) with a
  `## Status` section that documents the wrap-backend adoption and the
  two design choices dropped vs. the original plan (QID = git OID,
  BlobRef hash = git OID).
- **Backend contract** — `GitBackend` typedef extended with
  `resolveTree`, `lsTree`, `readBlobBytes`, `streamBlobBytes`. Native
  git backend promotes existing internal helpers to expose them.
- **Adapter** — `makeGitFsBackend({ backend, treeOid })` returns an
  `FsBackend`. Reads: `kind`, `list` (async generator), `read` (slice
  over `readBlobBytes`), `getStat`, `statfs`. Writes: throw `EROFS`
  (unreachable behind `readOnly` but contract-complete).
- **Wiring** — `Git.filesystemAt(ref)` resolves the ref to a canonical
  tree OID, memoizes the resulting Filesystem cap per OID (brand
  stability for `compose`), and returns
  `readOnly(wrapBackend(...))`.
- **Tests** — 9 new tests under `Git.filesystemAt:*`: shape, lookup,
  range reads, BlobRef, directory listing, mutation rejection,
  write-open rejection, OID memoization, submodule hiding. Whole
  `git.test.js` is 51/51 green.
- **Endo-fs export** — exposes `./src/backend-types.js` in
  `@endo/endo-fs/package.json` so downstream `FsBackend` authors can
  `@import { FsBackend } from '@endo/endo-fs/src/backend-types.js'`
  cleanly. (One-line companion change.)
- **Test infra** — `provisionGitWorktree` pins `commit.gpgsign=false`
  in repo-local config so the suite is independent of user-global gpg
  config (the env this branch was built in mandated signing).

## Trade-offs vs. original design

Captured in the design doc's Status section. The seam refactor's
shared `synthQid` and `makeBlobRefExo` mean:

1. QID `pathId` is path-based (not the git OID).
2. `BlobRef.algorithm` is `'sha256'` (not `'git-sha1'`); the git OID
   is not surfaced through the BlobRef shape.

Both can be reintroduced as a follow-up if/when `wrapBackend` grows a
backend-supplied QID / hash hook.

## Verification

```
cd packages/daemon
yarn lint    # 0 errors (TS errors in cached-fs/compose are pre-existing on base)
yarn test test/git.test.js   # 51 passed
```

## Test plan

- [ ] CI lints / type-checks daemon + endo-fs cleanly
- [ ] CI runs `packages/daemon/test/git.test.js` to green
- [ ] Manual smoke: `await E(git).filesystemAt('HEAD')` against a real
      worktree, navigate to a file, read bytes

https://claude.ai/code/session_01NnoAr9hbnrXx2RLgr9oECM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnoAr9hbnrXx2RLgr9oECM)_