### PR TITLE
design: Peer App Sharing milestone (deep-link invites, app clone/share, sandboxed UI)

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -390,14 +390,14 @@ P2 app + sandboxed UI → P3 clone).
 |--------|--------|--------|-------|
 | app-sharing-milestone | Proposed | — | Milestone roadmap doc; verified current state + P0–P3 plan |
 | familiar-deep-link-invitations | Proposed | 2 — connect peers | New: `endo://` capture in shell → Chat confirm + naming modal → `host.accept` (daemon `invite`/`accept` already Complete) |
-| endo-app-sharing | Proposed | 3 — make & share apps | New: app handle (source + exec + ui + `cloneable`); cross-daemon clone with hash verification vs remote reference |
+| endo-app-sharing | Proposed | 3 — make & share apps | New: app handle (source + exec + ui + `cloneable`); cross-daemon clone as a single streamed tree-archive into a pluggable durable backing (default zip) vs remote reference — no per-blob hashing |
 | familiar-app-ui-hosting | Proposed | 3 — sandboxed UI | New: app UI manifest + sandbox tiers (`isolated`/`connected`/`trusted`) over the weblet substrate |
 | ~~familiar-electron-shell~~ | **Complete** | 1 — distributable | The shell being distributed (M0) |
 | ~~familiar-daemon-bundling~~ | **Complete** | 1 — distributable | Bundled daemon/Node in the artifact (M0) |
-| Release signing / auto-update / Windows-CI | Not Started | 1 — distributable | *No standalone doc; tracked in app-sharing-milestone P0.* Working **unsigned** build + CI exist (`familiar-release.yml`); gaps: code signing/notarization, Windows CI + installer, AppImage, `electron-updater`, checksums |
-| ~~ocapn-noise-network~~ | **Complete** | 2 — connect peers | Secure transport peers connect over (M2) |
-| daemon-agent-network-identity | Not Started | 2 — connect peers | Per-agent keypairs behind the locator node key; soft prereq (M2) |
-| exo-zip-package | Proposed | 3 — make & share apps | Filesystem-free clone path (M3) |
+| `familiar-release.md` (MVR plan) | Proposed | 1 — distributable | **Owns Pillar 1.** PR [#231](https://github.com/endojs/endo-but-for-bots/pull/231) (issue #229): G1–G16, **macOS-arm64-first**; P0 adopts it rather than running a competing plan. G-item PRs: [#318](https://github.com/endojs/endo-but-for-bots/pull/318) [#321](https://github.com/endojs/endo-but-for-bots/pull/321) [#319](https://github.com/endojs/endo-but-for-bots/pull/319) [#316](https://github.com/endojs/endo-but-for-bots/pull/316) [#320](https://github.com/endojs/endo-but-for-bots/pull/320) [#323](https://github.com/endojs/endo-but-for-bots/pull/323) [#324](https://github.com/endojs/endo-but-for-bots/pull/324) [#322](https://github.com/endojs/endo-but-for-bots/pull/322) [#317](https://github.com/endojs/endo-but-for-bots/pull/317) [#360](https://github.com/endojs/endo-but-for-bots/pull/360) |
+| ~~ocapn-noise-network~~ | **Complete** | 2 — connect peers | Secure transport peers connect over (M2); daemon-to-daemon [#340](https://github.com/endojs/endo-but-for-bots/pull/340) |
+| daemon-agent-network-identity | Not Started | 2 — connect peers | Per-agent keypairs behind the locator node key; soft prereq (M2). In-flight as `ocapn-daemon-integration` [#138](https://github.com/endojs/endo-but-for-bots/pull/138)/[#262](https://github.com/endojs/endo-but-for-bots/pull/262); locator v2 [#178](https://github.com/endojs/endo-but-for-bots/pull/178) |
+| exo-zip-package | Proposed | 3 — make & share apps | Durable zip backing for clones; in-flight as exo-zip/exo-unzip [#160](https://github.com/endojs/endo-but-for-bots/pull/160) |
 | ~~daemon-checkin-checkout~~ | **Complete** | 3 — make & share apps | Local serialisation the clone generalises (M3) |
 | familiar-unified-weblet-server | In Progress | 3 — sandboxed UI | Virtual-host serving for app UIs (M3) |
 | familiar-chat-weblet-hosting | Not Started | 3 — sandboxed UI | In-Chat iframe pane + chrome/guest barrier (M3) |

--- a/designs/README.md
+++ b/designs/README.md
@@ -199,8 +199,12 @@ LLM-agent stack).*
 | [workers-panel](workers-panel.md) | 2026-02-14 | 2026-02-24 | Not Started |
 | [namehub-interface-unification](namehub-interface-unification.md) | 2026-05-07 | 2026-05-07 | Proposed |
 | [forge-gap-analysis](forge-gap-analysis.md) | 2026-05-20 | 2026-05-20 | Reference (exploratory) |
+| [app-sharing-milestone](app-sharing-milestone.md) | 2026-06-01 | 2026-06-01 | Proposed |
+| [familiar-deep-link-invitations](familiar-deep-link-invitations.md) | 2026-06-01 | 2026-06-01 | Proposed |
+| [endo-app-sharing](endo-app-sharing.md) | 2026-06-01 | 2026-06-01 | Proposed |
+| [familiar-app-ui-hosting](familiar-app-ui-hosting.md) | 2026-06-01 | 2026-06-01 | Proposed |
 
-**Totals:** 39 Complete/Implemented, 18 In Progress, 37 Not Started, 20 Proposed, 2 Active, 7 Reference, 2 Deprecated, 1 Superseded (126 designs). Refreshed 2026-05-19 by a status-only sweep (consolidating the 2026-05-18 sweep with the 2026-05-19 batch update for 11 additional designs from closed PR #302) plus the patterns-diagnostic-feedback and ocapn-noise-session-reconnect Proposed entries; the 12-design jump in Complete/Implemented over the 2026-05-08 snapshot reflects shipped work whose Status field had not previously been updated, not new completions in this pass; see the corresponding "## Status" sections in each design file for evidence pointers (commit SHA or PR number). Totals reflect the 16 design files added on `llm` since the sweep's branch point (the endopi raft of `endopi` + 8 `endopi-*` gap-closing designs, `hardened-text-codecs-shim`, `hardened-url-shim`, namehub-interface-unification (Proposed) added by PR #117 on rebase, forge-gap-analysis (Reference) added 2026-05-20, and the daemon mount and git capability trio: `daemon-mount-capabilities` + `daemon-git-capability` + `daemon-git-remotes`), plus the endo-gateway-mcp (Not Started) entry added 2026-05-29.
+**Totals:** 39 Complete/Implemented, 18 In Progress, 37 Not Started, 24 Proposed, 2 Active, 7 Reference, 2 Deprecated, 1 Superseded (130 designs). The 2026-06-01 pass adds the **Peer App Sharing** milestone cut (`app-sharing-milestone`) and its three new Proposed designs (`familiar-deep-link-invitations`, `endo-app-sharing`, `familiar-app-ui-hosting`); see "Milestone A: Peer App Sharing" below. Refreshed 2026-05-19 by a status-only sweep (consolidating the 2026-05-18 sweep with the 2026-05-19 batch update for 11 additional designs from closed PR #302) plus the patterns-diagnostic-feedback and ocapn-noise-session-reconnect Proposed entries; the 12-design jump in Complete/Implemented over the 2026-05-08 snapshot reflects shipped work whose Status field had not previously been updated, not new completions in this pass; see the corresponding "## Status" sections in each design file for evidence pointers (commit SHA or PR number). Totals reflect the 16 design files added on `llm` since the sweep's branch point (the endopi raft of `endopi` + 8 `endopi-*` gap-closing designs, `hardened-text-codecs-shim`, `hardened-url-shim`, namehub-interface-unification (Proposed) added by PR #117 on rebase, forge-gap-analysis (Reference) added 2026-05-20, and the daemon mount and git capability trio: `daemon-mount-capabilities` + `daemon-git-capability` + `daemon-git-remotes`), plus the endo-gateway-mcp (Not Started) entry added 2026-05-29.
 
 ## Roadmap
 
@@ -346,9 +350,71 @@ flowchart TD
         dpers --> dbank
         dbank --> icancel
     end
+
+    subgraph App Sharing Cut
+        aship[app-sharing-milestone<br/><i>PROPOSED</i>]
+        adeep[familiar-deep-link-invitations<br/><i>PROPOSED</i>]
+        ashare[endo-app-sharing<br/><i>PROPOSED</i>]
+        auihost[familiar-app-ui-hosting<br/><i>PROPOSED</i>]
+        onoise --> adeep
+        dnet --> adeep
+        adeep --> aship
+        exozip --> ashare
+        dci --> ashare
+        dapp --> auihost
+        fweb --> auihost
+        fchat --> auihost
+        ashare --> auihost
+        auihost --> aship
+        fbund --> aship
+    end
 ```
 
 ### Milestones
+
+#### Milestone A: Peer App Sharing (cross-cutting cut)
+
+**Goal:** An end-to-end "make a thing, send it to a friend, they run it" cut.
+Two people install Familiar, become peers by clicking an `endo://` link
+(confirmation screen + naming), and share runnable apps (endo-fs source +
+endo-fs-exec) either as a live remote reference or as an independent clone,
+with the app's UI hosted in a partial sandbox.
+
+This is a **cut, not a new bucket**: it sequences slices that already live in
+M1–M3 and adds three new designs for the missing connective tissue. See
+[app-sharing-milestone](app-sharing-milestone.md) for the verified
+current-state analysis and phased plan (P0 installer → P1 deep-link →
+P2 app + sandboxed UI → P3 clone).
+
+| Design | Status | Pillar | Notes |
+|--------|--------|--------|-------|
+| app-sharing-milestone | Proposed | — | Milestone roadmap doc; verified current state + P0–P3 plan |
+| familiar-deep-link-invitations | Proposed | 2 — connect peers | New: `endo://` capture in shell → Chat confirm + naming modal → `host.accept` (daemon `invite`/`accept` already Complete) |
+| endo-app-sharing | Proposed | 3 — make & share apps | New: app handle (source + exec + ui + `cloneable`); cross-daemon clone with hash verification vs remote reference |
+| familiar-app-ui-hosting | Proposed | 3 — sandboxed UI | New: app UI manifest + sandbox tiers (`isolated`/`connected`/`trusted`) over the weblet substrate |
+| ~~familiar-electron-shell~~ | **Complete** | 1 — distributable | The shell being distributed (M0) |
+| ~~familiar-daemon-bundling~~ | **Complete** | 1 — distributable | Bundled daemon/Node in the artifact (M0) |
+| Release signing / auto-update / Windows-CI | Not Started | 1 — distributable | *No standalone doc; tracked in app-sharing-milestone P0.* Working **unsigned** build + CI exist (`familiar-release.yml`); gaps: code signing/notarization, Windows CI + installer, AppImage, `electron-updater`, checksums |
+| ~~ocapn-noise-network~~ | **Complete** | 2 — connect peers | Secure transport peers connect over (M2) |
+| daemon-agent-network-identity | Not Started | 2 — connect peers | Per-agent keypairs behind the locator node key; soft prereq (M2) |
+| exo-zip-package | Proposed | 3 — make & share apps | Filesystem-free clone path (M3) |
+| ~~daemon-checkin-checkout~~ | **Complete** | 3 — make & share apps | Local serialisation the clone generalises (M3) |
+| familiar-unified-weblet-server | In Progress | 3 — sandboxed UI | Virtual-host serving for app UIs (M3) |
+| familiar-chat-weblet-hosting | Not Started | 3 — sandboxed UI | In-Chat iframe pane + chrome/guest barrier (M3) |
+| daemon-weblet-application | Not Started | 3 — sandboxed UI | Serve readable-tree files + powers over CapTP (M3) |
+
+**Exit criterion:** A non-developer installs a signed Familiar build, clicks an
+`endo://` invite from a friend, confirms and names that peer, then receives a
+shared app — opening it either as a live remote reference or, when the author
+marked it cloneable, as their own independent copy — with the app's UI running
+in a partial sandbox.
+
+**Estimated added effort (the three new designs; existing constituents counted
+under their home milestones):** ~2-3 weeks, plus the P0 release-hardening track
+(signing/notarization/auto-update/Windows-CI) which is operational rather than
+a design item.
+
+---
 
 #### Milestone 0: Downloadable AI Agent Experience
 
@@ -870,6 +936,10 @@ Recalibrated on 2026-03-02 using observed velocity from 15 active work days
 | endopi-prompt-templates | S | 1-2 days | 4 | Reusable user-prompt scaffolds with `{{var}}` expansion; shares skills' discovery walker |
 | endopi-stdio-rpc-bridge | M | 4-5 days | 1 | LF-delimited JSONL RPC for embedding the Lal/Fae agent in another process; short-term shape before `endor-bus-tui` |
 | endopi-extension-package-manifest | S-M | 3 days | 5 | `package.json` `endo` keyword bundling guests + skills + prompts + providers in one install |
+| app-sharing-milestone | — | — | A | Roadmap/cut doc; no implementation of its own (reference for the P0–P3 sequencing) |
+| familiar-deep-link-invitations | S-M | 3 days | A | `endo://` capture in shell + Chat confirm/naming modal; daemon `invite`/`accept` already Complete |
+| endo-app-sharing | M | 4-5 days | A | App handle + cross-daemon `endo clone` (hash-verified) vs remote reference (1.2x bump) |
+| familiar-app-ui-hosting | M | 4-5 days | A | App UI manifest + sandbox tiers over the existing weblet substrate (1.2x bump) |
 
 #### Summary by Milestone
 
@@ -891,7 +961,8 @@ date of this pass.
 | M4: UX & Tooling | 12 (`chat-pending-commands`, `chat-slot-slash-commands`, `daemon-commands-as-messages`, `inventory-cancel-and-liveness`, `inventory-grouping-by-type`, `inventory-drag-and-drop`, `formula-inspector`, `workers-panel`, `daemon-retention-paths`, `chat-edit-message-ui`, `lal-transcript-memory-management`, `namehub-interface-unification`) | 8-11 weeks | 10-13 weeks |
 | M5: Confinement & Ecosystem | 6 (`endo-posix-sandbox`, `daemon-capability-persona`, `daemon-capability-bank`, `endoclaw-browser`, `endoclaw-channel-bridges`, `endoclaw-skill-registry`) | 14-20 weeks | 16-22 weeks |
 | M6: Rust Daemon (`endor`) | 2 (`endor-tui`, `endor-bus-tui`) | 12-17 weeks | 14-19 weeks |
-| **Total remaining** | **48** | **~52-71 weeks** | **~63-86 weeks** |
+| Milestone A: Peer App Sharing (cut) | 3 net-new (`familiar-deep-link-invitations`, `endo-app-sharing`, `familiar-app-ui-hosting`); existing constituents counted under M1–M3 | 2-3 weeks | 3-5 weeks |
+| **Total remaining** | **51** | **~54-74 weeks** | **~66-90 weeks** |
 
 The 2026-05-20 reconciliation corrects a counting gap in the prior
 snapshot's narrative: M1, M3, and M4 had absorbed new rows since the

--- a/designs/app-sharing-milestone.md
+++ b/designs/app-sharing-milestone.md
@@ -1,0 +1,176 @@
+# Milestone: Peer App Sharing
+
+| | |
+|---|---|
+| **Created** | 2026-06-01 |
+| **Author** | Aaron (prompted) |
+| **Status** | Proposed |
+
+## What is the Problem Being Solved?
+
+This milestone defines a single coherent, shippable cut: **two people can
+install Familiar, become peers by clicking a link, and share runnable apps —
+either as a live remote reference or as an independent clone — with the app's
+UI hosted in a partial sandbox.**
+
+It is a *cut*, not a new bucket of unrelated work: it pulls forward and
+sequences slices that already live across Milestones 1–3, and adds three new
+design docs for the genuinely-missing connective tissue. The point is to reach
+an end-to-end "make a thing, send it to a friend, they run it" experience
+sooner than the linear M1→M2→M3 march would deliver it.
+
+The cut has three pillars:
+
+1. **Distribute the chat app as a downloadable.** A real installer users can
+   run without developer warnings.
+2. **Connect to peers via a deep-link URL.** Click a link → confirmation
+   screen → name the peer → bound.
+3. **Make and share runnable apps.** Apps backed by an endo-fs source +
+   endo-fs-exec, optionally cloneable, with partially-sandboxed UI.
+
+## Verified Current State (2026-06-01)
+
+The substrate is far along; most pillars are connective tissue and UX over
+shipped primitives.
+
+### Pillar 1 — Distributable: a working unsigned build exists
+
+`packages/familiar` already produces a runnable app and ships a CI release
+pipeline:
+
+- `yarn build:package` → `scripts/build.mjs` → bundle (esbuild) → download
+  Node (v20.18.1) → `@electron/packager` → `out/Familiar-<os>-<arch>/`.
+- `scripts/make-distributables.mjs` emits: macOS **DMG + zip**, Linux **zip**,
+  Windows **zip**.
+- `.github/workflows/familiar-release.yml` (trigger: `familiar-v*` tag or
+  `workflow_dispatch`) builds **macOS arm64 (macos-14), macOS x64 (macos-13),
+  Linux x64 (ubuntu)** and uploads all artifacts to a **draft** GitHub release.
+- Designs [familiar-electron-shell](familiar-electron-shell.md),
+  [familiar-daemon-bundling](familiar-daemon-bundling.md),
+  [familiar-bundled-agents](familiar-bundled-agents.md) are **Complete**.
+
+**Gaps (operational, not architectural):**
+
+- No **code signing / notarization** — `package-app.mjs` passes no
+  `osxSign`/`osxNotarize`; CI holds no signing secrets. Unsigned macOS builds
+  hit Gatekeeper quarantine ("damaged" on Apple Silicon).
+- **Windows is not in the CI matrix** (the script supports `win32`, but no job
+  builds it) and there is **no installer** (NSIS/MSI) — zip only.
+- No **Linux AppImage** (zip only).
+- No **auto-update** — `electron-updater` is absent (the shell design only
+  *recommends* it).
+- No **release checksums**; app `version` is hardcoded `0.1.0`, not synced to
+  the release tag.
+
+### Pillar 2 — Peer deep-link: daemon ready, shell + UI missing
+
+- Locator format and `host.invite(name)` / `host.accept(locator, petName)` are
+  **Complete** (`packages/daemon/src/locator.js`, `host.js`): accept parses the
+  locator, registers addresses via `addPeerInfo`, and binds a pet name.
+- OCapN-Noise transport is **Complete** (PR #137).
+- Familiar already registers a privileged custom scheme (`localhttp://`) — a
+  working template.
+- **Missing:** `endo://` deep-link capture in the shell, a confirmation
+  screen, and a naming prompt. → [familiar-deep-link-invitations](familiar-deep-link-invitations.md).
+
+### Pillar 3 — Runnable apps: run + serialise exist, transfer + UI missing
+
+- `@endo/endo-fs` (Filesystem caps; `FsBackend` seam **Complete**) and
+  `@endo/endo-fs-exec` `tree-view-module.js` adapt a project tree into the
+  daemon's **`make-from-tree`** formula — which runs a compartment-mapped
+  `make(powers, context, { env }) => exo`. **This is the run mechanism, and it
+  is Complete.**
+- `readable-tree` / `readable-blob` formulas and `endo checkin`/`checkout`
+  (tree ⇄ fs, zip via `-z`) are **Complete**. Per-app origin isolation + CSP in
+  Familiar are **Complete**.
+- **Missing:** an app handle bundling source + exec + UI; a **cross-daemon
+  clone** (remote-ref vs independent copy) with hash verification; and the
+  app-facing **partially-sandboxed UI** layer. →
+  [endo-app-sharing](endo-app-sharing.md),
+  [familiar-app-ui-hosting](familiar-app-ui-hosting.md). The hosting substrate
+  ([familiar-unified-weblet-server](familiar-unified-weblet-server.md),
+  [familiar-chat-weblet-hosting](familiar-chat-weblet-hosting.md),
+  [daemon-weblet-application](daemon-weblet-application.md)) is designed but
+  partly unbuilt.
+
+## Constituent Work
+
+### New designs (introduced by this milestone)
+
+| Design | Pillar | Size |
+|---|---|---|
+| [familiar-deep-link-invitations](familiar-deep-link-invitations.md) | 2 — connect peers | S-M |
+| [endo-app-sharing](endo-app-sharing.md) | 3 — make & share apps | M |
+| [familiar-app-ui-hosting](familiar-app-ui-hosting.md) | 3 — sandboxed UI | M |
+
+### Existing designs pulled into the cut
+
+| Design | Pillar | Home milestone | Why needed here |
+|---|---|---|---|
+| [familiar-electron-shell](familiar-electron-shell.md) (Complete) | 1 | M0 | The shell being distributed. |
+| [familiar-daemon-bundling](familiar-daemon-bundling.md) (Complete) | 1 | M0 | Bundled daemon/Node in the artifact. |
+| Release signing / auto-update / Windows-CI hardening (*no doc; tracked here*) | 1 | new | The gap between "build exists" and "real download". |
+| [ocapn-noise-network](ocapn-noise-network.md) (Complete) | 2 | M2 | Secure transport peers connect over. |
+| [daemon-agent-network-identity](daemon-agent-network-identity.md) | 2 | M2 | Per-agent keypairs behind the locator's node key (soft prereq). |
+| [exo-zip-package](exo-zip-package.md) | 3 | M3 | Filesystem-free clone path. |
+| [daemon-checkin-checkout](daemon-checkin-checkout.md) (Complete) | 3 | M3 | Local serialisation the clone generalises. |
+| [familiar-unified-weblet-server](familiar-unified-weblet-server.md) | 3 | M3 | Virtual-host serving for app UIs. |
+| [familiar-chat-weblet-hosting](familiar-chat-weblet-hosting.md) | 3 | M3 | In-Chat iframe pane + chrome/guest barrier. |
+| [daemon-weblet-application](daemon-weblet-application.md) | 3 | M3 | Serve readable-tree files + powers over CapTP. |
+
+## Phased Plan
+
+**P0 — Ship a real installer (Pillar 1).** Code signing + notarization
+(macOS Developer ID; Windows Authenticode), add Windows to the CI matrix with
+an NSIS/MSI installer, Linux AppImage, `electron-updater` auto-update, SHA256
+checksums, and tag-synced version. *Exit:* a non-developer downloads, installs,
+and launches Familiar on macOS/Windows/Linux without security warnings, and
+receives an update.
+
+**P1 — Peer deep-link invites (Pillar 2).** Implement
+[familiar-deep-link-invitations](familiar-deep-link-invitations.md): `endo://`
+capture in the shell → Chat confirmation + naming modal → `host.accept`.
+*Exit:* clicking an `endo://invite/…` link in another app opens Familiar, shows
+who is being added, asks for a pet name, and binds the peer.
+
+**P2 — App handle + sandboxed UI (Pillar 3a/3b).** Name the app handle and
+"share (reference)" affordance ([endo-app-sharing](endo-app-sharing.md) phase
+1); land the app UI manifest + `connected` sandbox tier
+([familiar-app-ui-hosting](familiar-app-ui-hosting.md) phase 1) on top of the
+weblet substrate. *Exit:* a user runs an endo-fs/`make-from-tree` app, opens
+its partially-sandboxed UI in a Chat pane, and shares a remote reference to a
+peer who opens the same UI.
+
+**P3 — Clone & share (Pillar 3c).** Cross-daemon `endo clone` with hash
+verification and the `cloneable` policy end to end
+([endo-app-sharing](endo-app-sharing.md) phases 2–3). *Exit:* a peer receiving
+a cloneable app chooses "Make my own copy", gets an independent local instance
+under their own powers, and it keeps working after the author disconnects.
+
+## Exit Criterion
+
+A non-developer installs a signed Familiar build, clicks an `endo://` invite
+from a friend, confirms and names that peer, then receives a shared app —
+opening it either as a live remote reference or, when the author marked it
+cloneable, as their own independent copy — with the app's UI running in a
+partial sandbox.
+
+## Dependencies
+
+This milestone composes the three new designs above with the existing
+[familiar-*](familiar-electron-shell.md), [ocapn-noise-network](ocapn-noise-network.md),
+[exo-zip-package](exo-zip-package.md), and weblet-hosting designs. It does not
+require all of M1/M2/M3 to complete — only the slices listed under *Constituent
+Work*.
+
+## Prompt
+
+> explore the existing design docs. I want to roadmap out to an MVP. the goals
+> are 1) to be able to distribute the endo daemon chat app as a distributeable.
+> 2) connect to other peers via a deep linking url format (needs a confirmation
+> screen, should ask you to specify a name). 3) make and share runnable apps
+> (backed by an endo-fs source and endo-fs-exec). apps need to be optionally
+> "cloneable" so you don't just get a remote reference on their machine. they
+> need a way of hosting partially sandboxed ui.
+>
+> rather than "MVP doc" call it "app-sharing" milestone or something.

--- a/designs/app-sharing-milestone.md
+++ b/designs/app-sharing-milestone.md
@@ -49,18 +49,42 @@ pipeline:
   [familiar-daemon-bundling](familiar-daemon-bundling.md),
   [familiar-bundled-agents](familiar-bundled-agents.md) are **Complete**.
 
-**Gaps (operational, not architectural):**
+**This pillar is already an active workstream — defer to it, do not restate.**
+The gap analysis and release plan live in `familiar-release.md`
+([PR #231](https://github.com/endojs/endo-but-for-bots/pull/231) ·
+[raw doc](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-release/designs/familiar-release.md),
+closing issue #229), which enumerates **sixteen gaps (G1–G16)** with severity
+and effort and
+— importantly — **scopes the MVR to macOS arm64 only** (the maintainer's
+primary platform), deferring Linux/Windows to followups. Its top-three
+blockers are **G1** (wire the build into per-platform CI artifacts), **G2**
+(macOS Developer ID + notarization), and **G16** (Primer-into-CAS packaged
+smoke). Six maintainer open questions remain (distribution channel, signing
+identity, version policy, OS matrix, bundled-vs-published daemon, auto-update
+posture).
 
-- No **code signing / notarization** — `package-app.mjs` passes no
-  `osxSign`/`osxNotarize`; CI holds no signing secrets. Unsigned macOS builds
-  hit Gatekeeper quarantine ("damaged" on Apple Silicon).
-- **Windows is not in the CI matrix** (the script supports `win32`, but no job
-  builds it) and there is **no installer** (NSIS/MSI) — zip only.
-- No **Linux AppImage** (zip only).
-- No **auto-update** — `electron-updater` is absent (the shell design only
-  *recommends* it).
-- No **release checksums**; app `version` is hardcoded `0.1.0`, not synced to
-  the release tag.
+A swarm of G-item implementation PRs is already open against it: CI build
+pipeline [#318](https://github.com/endojs/endo-but-for-bots/pull/318) (G1),
+macOS arm64+x64 matrix
+[#321](https://github.com/endojs/endo-but-for-bots/pull/321) (G15), icon
+projection [#319](https://github.com/endojs/endo-but-for-bots/pull/319) (G7),
+Node LTS pin [#316](https://github.com/endojs/endo-but-for-bots/pull/316) (G5),
+stop/purge [#320](https://github.com/endojs/endo-but-for-bots/pull/320) (G8),
+LICENSE aggregation [#323](https://github.com/endojs/endo-but-for-bots/pull/323)
+(G14), Primer-CAS smoke
+[#324](https://github.com/endojs/endo-but-for-bots/pull/324) (G16), Flatpak
+[#322](https://github.com/endojs/endo-but-for-bots/pull/322) (G4),
+telemetry/crash [#317](https://github.com/endojs/endo-but-for-bots/pull/317)
+(G13), and packaging lanes + pre-release CI
+[#360](https://github.com/endojs/endo-but-for-bots/pull/360).
+
+The concrete gaps that plan covers (recorded here only so the milestone is
+self-contained): no code signing / notarization (`package-app.mjs` passes no
+`osxSign`/`osxNotarize`; Gatekeeper "damaged" on Apple Silicon); Windows absent
+from the CI matrix and no NSIS/MSI installer; no Linux AppImage; no
+`electron-updater` auto-update; no release checksums; `version` hardcoded
+`0.1.0`. **This milestone adopts `familiar-release.md`'s plan for Pillar 1
+rather than offering a competing one.**
 
 ### Pillar 2 — Peer deep-link: daemon ready, shell + UI missing
 
@@ -84,14 +108,24 @@ pipeline:
   (tree ⇄ fs, zip via `-z`) are **Complete**. Per-app origin isolation + CSP in
   Familiar are **Complete**.
 - **Missing:** an app handle bundling source + exec + UI; a **cross-daemon
-  clone** (remote-ref vs independent copy) with hash verification; and the
-  app-facing **partially-sandboxed UI** layer. →
-  [endo-app-sharing](endo-app-sharing.md),
+  clone** (remote-ref vs independent copy, shipped as one streamed tree-archive
+  into a pluggable durable backing); and the app-facing **partially-sandboxed
+  UI** layer. → [endo-app-sharing](endo-app-sharing.md),
   [familiar-app-ui-hosting](familiar-app-ui-hosting.md). The hosting substrate
   ([familiar-unified-weblet-server](familiar-unified-weblet-server.md),
   [familiar-chat-weblet-hosting](familiar-chat-weblet-hosting.md),
   [daemon-weblet-application](daemon-weblet-application.md)) is designed but
   partly unbuilt.
+- **Related in-flight work (reconcile, don't duplicate):** a different angle on
+  running apps from a VFS — `familiar-run-apps-vfs.md`
+  ([PR #241](https://github.com/endojs/endo-but-for-bots/pull/241) ·
+  [raw doc](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-run-vfs-apps/designs/familiar-run-apps-vfs.md))
+  runs apps under `endor` against `Mount` caps with a sqlite-backed module
+  store. The clone's durable backing leans on the in-flight
+  [exo-zip / exo-unzip](https://github.com/endojs/endo-but-for-bots/pull/160)
+  (PR #160) and [exo-stream](https://github.com/endojs/endo-but-for-bots/pull/330)
+  (PR #330); tree-as-archive prior art is daemon git-tree `archive`
+  ([PR #367](https://github.com/endojs/endo-but-for-bots/pull/367)).
 
 ## Constituent Work
 
@@ -109,10 +143,11 @@ pipeline:
 |---|---|---|---|
 | [familiar-electron-shell](familiar-electron-shell.md) (Complete) | 1 | M0 | The shell being distributed. |
 | [familiar-daemon-bundling](familiar-daemon-bundling.md) (Complete) | 1 | M0 | Bundled daemon/Node in the artifact. |
-| Release signing / auto-update / Windows-CI hardening (*no doc; tracked here*) | 1 | new | The gap between "build exists" and "real download". |
-| [ocapn-noise-network](ocapn-noise-network.md) (Complete) | 2 | M2 | Secure transport peers connect over. |
-| [daemon-agent-network-identity](daemon-agent-network-identity.md) | 2 | M2 | Per-agent keypairs behind the locator's node key (soft prereq). |
-| [exo-zip-package](exo-zip-package.md) | 3 | M3 | Filesystem-free clone path. |
+| `familiar-release.md` — MVR release plan ([PR #231](https://github.com/endojs/endo-but-for-bots/pull/231) · [raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-release/designs/familiar-release.md)) | 1 | issue #229 | **Owns Pillar 1.** G1–G16, macOS-arm64-first MVR. P0 adopts it. |
+| `familiar-run-apps-vfs.md` — run apps over a VFS ([PR #241](https://github.com/endojs/endo-but-for-bots/pull/241) · [raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-run-vfs-apps/designs/familiar-run-apps-vfs.md)) | 3 | M1 | Sibling angle on running apps from a mount/VFS source (`endor` + sqlite module store). |
+| [ocapn-noise-network](ocapn-noise-network.md) (Complete) | 2 | M2 | Secure transport peers connect over. Daemon-to-daemon wiring in [PR #340](https://github.com/endojs/endo-but-for-bots/pull/340). |
+| [daemon-agent-network-identity](daemon-agent-network-identity.md) | 2 | M2 | Per-agent keypairs behind the locator's node key (soft prereq). Per-agent `@transports` design [PR #138](https://github.com/endojs/endo-but-for-bots/pull/138), prototype [#262](https://github.com/endojs/endo-but-for-bots/pull/262); locator v2 [#178](https://github.com/endojs/endo-but-for-bots/pull/178). |
+| [exo-zip-package](exo-zip-package.md) | 3 | M3 | Durable zip backing for clones; in-flight as exo-zip/exo-unzip [PR #160](https://github.com/endojs/endo-but-for-bots/pull/160). |
 | [daemon-checkin-checkout](daemon-checkin-checkout.md) (Complete) | 3 | M3 | Local serialisation the clone generalises. |
 | [familiar-unified-weblet-server](familiar-unified-weblet-server.md) | 3 | M3 | Virtual-host serving for app UIs. |
 | [familiar-chat-weblet-hosting](familiar-chat-weblet-hosting.md) | 3 | M3 | In-Chat iframe pane + chrome/guest barrier. |
@@ -120,12 +155,18 @@ pipeline:
 
 ## Phased Plan
 
-**P0 — Ship a real installer (Pillar 1).** Code signing + notarization
-(macOS Developer ID; Windows Authenticode), add Windows to the CI matrix with
-an NSIS/MSI installer, Linux AppImage, `electron-updater` auto-update, SHA256
-checksums, and tag-synced version. *Exit:* a non-developer downloads, installs,
-and launches Familiar on macOS/Windows/Linux without security warnings, and
-receives an update.
+**P0 — Ship a real installer (Pillar 1) — adopt `familiar-release.md`'s MVR.**
+Do not run a competing plan: execute the MVR in
+[PR #231](https://github.com/endojs/endo-but-for-bots/pull/231), which is
+**macOS-arm64-first** and whose top blockers are G1 (per-platform CI
+artifacts, [PR #318](https://github.com/endojs/endo-but-for-bots/pull/318) /
+[#321](https://github.com/endojs/endo-but-for-bots/pull/321)), G2 (macOS
+Developer ID + notarization), and G16 (Primer-into-CAS packaged smoke,
+[PR #324](https://github.com/endojs/endo-but-for-bots/pull/324)). Linux/Windows
+installers and `electron-updater` auto-update are MVR *followups* in that plan.
+*Exit (this milestone's slice):* a non-developer downloads, installs, and
+launches a signed/notarized Familiar on **macOS arm64** without Gatekeeper
+warnings.
 
 **P1 — Peer deep-link invites (Pillar 2).** Implement
 [familiar-deep-link-invitations](familiar-deep-link-invitations.md): `endo://`
@@ -141,11 +182,13 @@ weblet substrate. *Exit:* a user runs an endo-fs/`make-from-tree` app, opens
 its partially-sandboxed UI in a Chat pane, and shares a remote reference to a
 peer who opens the same UI.
 
-**P3 — Clone & share (Pillar 3c).** Cross-daemon `endo clone` with hash
-verification and the `cloneable` policy end to end
-([endo-app-sharing](endo-app-sharing.md) phases 2–3). *Exit:* a peer receiving
-a cloneable app chooses "Make my own copy", gets an independent local instance
-under their own powers, and it keeps working after the author disconnects.
+**P3 — Clone & share (Pillar 3c).** Cross-daemon `endo clone` as a single
+streamed tree-archive into a pluggable durable backing (default zip), honouring
+the `cloneable` policy end to end ([endo-app-sharing](endo-app-sharing.md)
+phases 2–3) — no per-blob hashing; integrity is the transport's job. *Exit:* a
+peer receiving a cloneable app chooses "Make my own copy", gets an independent
+local instance under their own powers, and it keeps working after the author
+disconnects.
 
 ## Exit Criterion
 
@@ -162,6 +205,43 @@ This milestone composes the three new designs above with the existing
 [exo-zip-package](exo-zip-package.md), and weblet-hosting designs. It does not
 require all of M1/M2/M3 to complete — only the slices listed under *Constituent
 Work*.
+
+## Related in-flight PRs
+
+Snapshot taken 2026-06-01 from open PRs on `endojs/endo-but-for-bots`. The two
+genuinely net-new pieces — `endo://` deep-link invites and the streaming clone
+helper + zip-backed receiver — have **no** open PR; everything else below is
+substrate to reconcile against rather than re-invent. Design-doc PRs include a
+raw-file link so the doc can be read without checking out the branch.
+
+| Pillar | PR | What it is |
+|---|---|---|
+| 1 | [#231](https://github.com/endojs/endo-but-for-bots/pull/231) ([raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-release/designs/familiar-release.md)) | `familiar-release.md` — MVR release plan, G1–G16, macOS-arm64-first. **Owns Pillar 1.** |
+| 1 | [#318](https://github.com/endojs/endo-but-for-bots/pull/318) | CI per-platform build pipeline (G1) |
+| 1 | [#321](https://github.com/endojs/endo-but-for-bots/pull/321) | macOS arm64 + x64 CI matrix (G15) |
+| 1 | [#319](https://github.com/endojs/endo-but-for-bots/pull/319) | cross-platform icon projection (G7) |
+| 1 | [#316](https://github.com/endojs/endo-but-for-bots/pull/316) | bundled Node → v22 LTS pin (G5) |
+| 1 | [#320](https://github.com/endojs/endo-but-for-bots/pull/320) | consolidate daemon stop/purge (G8) |
+| 1 | [#323](https://github.com/endojs/endo-but-for-bots/pull/323) | third-party LICENSE aggregation (G14) |
+| 1 | [#324](https://github.com/endojs/endo-but-for-bots/pull/324) | Primer-into-CAS packaged smoke (G16) |
+| 1 | [#322](https://github.com/endojs/endo-but-for-bots/pull/322) ([raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/feat/familiar-flatpak-pipeline/designs/familiar-flatpak-pipeline.md)) | Flatpak packaging design (G4) |
+| 1 | [#317](https://github.com/endojs/endo-but-for-bots/pull/317) ([raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-telemetry/designs/familiar-telemetry-crash-reporting.md)) | telemetry / crash-reporting design (G13) |
+| 1 | [#360](https://github.com/endojs/endo-but-for-bots/pull/360) | per-platform packaging lanes + pre-release CI |
+| 2 | [#178](https://github.com/endojs/endo-but-for-bots/pull/178) | locator scheme v2 (`@`-delimited connection hints) — the `endo://` link's basis |
+| 2 | [#138](https://github.com/endojs/endo-but-for-bots/pull/138) ([raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/ocapn-daemon-integration/designs/ocapn-daemon-integration.md)) | per-agent `@transports` design (network identity) |
+| 2 | [#262](https://github.com/endojs/endo-but-for-bots/pull/262) | per-agent `@transports` gap-revealing prototype |
+| 2 | [#340](https://github.com/endojs/endo-but-for-bots/pull/340) | OCapN-Noise daemon-to-daemon connectivity |
+| 2 | [#343](https://github.com/endojs/endo-but-for-bots/pull/343) · [#356](https://github.com/endojs/endo-but-for-bots/pull/356) · [#337](https://github.com/endojs/endo-but-for-bots/pull/337) | `@endo/gateway` package / packaging+AWS / host-scope path funcs |
+| 3 | [#241](https://github.com/endojs/endo-but-for-bots/pull/241) ([raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-run-vfs-apps/designs/familiar-run-apps-vfs.md)) | `familiar-run-apps-vfs.md` — run apps over a VFS (`endor` + sqlite module store) |
+| 3 | [#160](https://github.com/endojs/endo-but-for-bots/pull/160) | exo-zip / exo-unzip — durable zip backing for clones |
+| 3 | [#330](https://github.com/endojs/endo-but-for-bots/pull/330) | exo-stream — the streaming substrate the clone tree-stream rides |
+| 3 | [#367](https://github.com/endojs/endo-but-for-bots/pull/367) | daemon git-tree `archive` (tar) — tree-as-archive prior art |
+| 3 | [#135](https://github.com/endojs/endo-but-for-bots/pull/135) · [#127](https://github.com/endojs/endo-but-for-bots/pull/127) · [#277](https://github.com/endojs/endo-but-for-bots/pull/277) · [#358](https://github.com/endojs/endo-but-for-bots/pull/358) | mount / VFS source substrate (Phase 4, extensions, follow-name, importLocation) |
+| 3 | [#238](https://github.com/endojs/endo-but-for-bots/pull/238) | rps-demo — a working shared distributed app |
+
+> **Note on the raw-doc URLs:** they point at the PR head branches as they
+> stand on 2026-06-01; if a branch is rebased or merged the link may move. The
+> PR link is the durable anchor.
 
 ## Prompt
 

--- a/designs/endo-app-sharing.md
+++ b/designs/endo-app-sharing.md
@@ -165,12 +165,22 @@ not implied by sharing.
 | Design | Relationship |
 |---|---|
 | [endo-fs-backend-seam](endo-fs-backend-seam.md) | The `FsBackend` seam (`wrapBackend`) that makes a zip-backed (or CAS-backed) durable receiver ~100 lines. **Load-bearing for the receiving side.** |
-| [exo-zip-package](exo-zip-package.md) | Projects the received/durable zip back as a runnable `ReadableTree`. |
+| [exo-zip-package](exo-zip-package.md) | Projects the received/durable zip back as a runnable `ReadableTree`; in-flight as exo-zip / exo-unzip ([PR #160](https://github.com/endojs/endo-but-for-bots/pull/160)). |
 | [daemon-checkin-checkout](daemon-checkin-checkout.md) | The local serialisation primitive the cross-daemon clone generalises (CAS-backed receiver option). |
 | [ocapn-noise-network](ocapn-noise-network.md) | The secure transport we trust for clone integrity and peer authenticity in lieu of per-blob hashing. |
 | [familiar-app-ui-hosting](familiar-app-ui-hosting.md) | Hosts the app's `ui` manifest as partially-sandboxed UI. |
 | [daemon-weblet-application](daemon-weblet-application.md) | Prior art for "readable tree + powers → served application". |
 | [app-sharing-milestone](app-sharing-milestone.md) | Parent milestone; this is the "make & share runnable apps" pillar. |
+
+**Related in-flight PRs (reconcile, don't duplicate):** exo-stream
+[#330](https://github.com/endojs/endo-but-for-bots/pull/330) is the streaming
+substrate the single clone tree-stream rides; daemon git-tree `archive` (tar)
+[#367](https://github.com/endojs/endo-but-for-bots/pull/367) is tree-as-archive
+prior art; `familiar-run-apps-vfs.md`
+([#241](https://github.com/endojs/endo-but-for-bots/pull/241) ·
+[raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-run-vfs-apps/designs/familiar-run-apps-vfs.md))
+is a sibling angle on running apps from a mount/VFS source. The consolidated PR
+index lives in [app-sharing-milestone](app-sharing-milestone.md).
 
 ## Phased Implementation
 

--- a/designs/endo-app-sharing.md
+++ b/designs/endo-app-sharing.md
@@ -3,6 +3,7 @@
 | | |
 |---|---|
 | **Created** | 2026-06-01 |
+| **Updated** | 2026-06-01 |
 | **Author** | Aaron (prompted) |
 | **Status** | Proposed |
 
@@ -83,22 +84,70 @@ the new work is only naming it as an "app" and surfacing a "share" affordance.
 
 Available only when `cloneable` is true. The recipient performs a **clone**:
 
-1. Resolve the shared app handle's `source` `readable-tree`.
-2. Walk it, streaming each `readable-blob` into the recipient's own
-   content-addressed store as fresh local `readable-blob` / `readable-tree`
-   formulas — the cross-daemon analogue of `endo checkout` immediately
-   followed by `endo checkin`, but without a filesystem round-trip (compose
-   with [`exo-zip-package`](exo-zip-package.md) for the in-memory path).
-3. **Verify content hashes** during the walk so the clone is provably the tree
-   the author offered (trust-on-clone, sibling to
-   [`trust-on-first-bind`](trust-on-first-bind.md)).
-4. Re-run `make-from-tree` against the *local* copy under the recipient's own
+1. The author's side serialises the `source` tree as **one ordered stream of
+   entries** — `(path, kind, content)` in depth-first order — and hands the
+   recipient a single reader.
+2. The recipient drains that one stream into a **fresh durable filesystem**
+   under its own control (the durable backing is pluggable — see below).
+3. Re-run `make-from-tree` against the *local* copy under the recipient's own
    `run` powers, producing an independent instance.
 
 A new CLI verb (working name `endo clone <remote-app> --name <local-name>`)
 and a Chat "Make my own copy" action drive mode B. The cloned app's powers are
 the recipient's to grant — the clone does not inherit the author's
 capabilities, only the author's *code*.
+
+### Streaming clone: one tree-stream, not a pipelined walk
+
+The clone transport is a **single `@endo/exo-stream` stream** whose items are
+tree entries (path + node kind + file content), emitted depth-first by the
+producer and consumed in order by the recipient. This is deliberately *not* a
+client-driven pipelined walk (`lookup`/`snapshot`/`fetch` per node):
+
+- **One round-trip class, not one-per-file.** The recipient opens the stream
+  once and pulls; the producer pushes the whole tree. Pre-ack `buffer` on the
+  exo-stream keeps the pipe full over a high-latency link. A thousand-file app
+  is one stream, not a thousand request/response pairs.
+- **The producer already holds the tree**, so it serialises locally and emits —
+  no per-node capability hand-off to the recipient.
+- **No content hashing on the path.** We trust the peer to send its own app and
+  the secure transport ([ocapn-noise-network](ocapn-noise-network.md)) to
+  deliver it intact. The clone does not compute or verify per-blob hashes; there
+  is no CAS dedup step and no `BlobRef` round-trip in the clone path. (Integrity
+  and peer-authenticity are the transport's job, established when the peer was
+  added — see [familiar-deep-link-invitations](familiar-deep-link-invitations.md).)
+
+Large files still stream as chunk frames within the single stream so no whole
+file is buffered in memory; this reuses the chunking discipline `Layer.apply`
+already follows (1-MiB ops) rather than method-sized buffers.
+
+A natural realisation makes the **wire format and the durable format the same
+zip**: the producer streams a deflated archive (`@endo/zip` `writer.js` +
+`deflate.js`, both already in-repo), and the recipient writes those bytes
+straight into its durable backing. One codec serves transport, on-disk
+durability, and the runnable backing.
+
+### Durable filesystem on the receiving side (pluggable backing)
+
+The recipient needs the clone to **persist and reincarnate across daemon
+restart**, and we may *not* want to spray loose files onto the host disk. The
+`@endo/endo-fs` `FsBackend` seam (`backend-types.js` + `wrap-backend.js`) is
+built exactly for this: `wrapBackend(backend)` synthesises the full
+`Filesystem` exo surface over a minimal path-keyed backend, so a new backing
+costs ~100 lines. Candidate durable backings for a cloned app:
+
+- **Zip-backed backend** (leading option) — entries land in a `@endo/zip`
+  archive; the archive is the single durable artifact, and the same bytes were
+  the wire format. Projected back as a runnable `ReadableTree` via
+  [exo-zip-package](exo-zip-package.md).
+- **Daemon CAS** — entries become `readable-blob` / `readable-tree` formulas
+  (the existing content-addressed store), the cross-daemon analogue of
+  [`endo checkin`](daemon-checkin-checkout.md) without a host-path round-trip.
+- **node-fs backend** — ordinary files on disk, when that is actually wanted.
+
+The clone verb takes the durable backing as a parameter; the default is the
+zip-backed archive so a cloned app is one self-contained, content-defined file
+rather than scattered state.
 
 ### Why cloneability is explicit
 
@@ -115,10 +164,10 @@ not implied by sharing.
 
 | Design | Relationship |
 |---|---|
-| [exo-zip-package](exo-zip-package.md) | In-memory zip ⇄ `ReadableTree` makes the clone path filesystem-free. |
-| [daemon-checkin-checkout](daemon-checkin-checkout.md) | The local serialisation primitive the cross-daemon clone generalises. |
-| [endo-fs-backend-seam](endo-fs-backend-seam.md) | The endo-fs backing the app source is mounted from. |
-| [trust-on-first-bind](trust-on-first-bind.md) | Pattern for hash-verified acceptance of remote content. |
+| [endo-fs-backend-seam](endo-fs-backend-seam.md) | The `FsBackend` seam (`wrapBackend`) that makes a zip-backed (or CAS-backed) durable receiver ~100 lines. **Load-bearing for the receiving side.** |
+| [exo-zip-package](exo-zip-package.md) | Projects the received/durable zip back as a runnable `ReadableTree`. |
+| [daemon-checkin-checkout](daemon-checkin-checkout.md) | The local serialisation primitive the cross-daemon clone generalises (CAS-backed receiver option). |
+| [ocapn-noise-network](ocapn-noise-network.md) | The secure transport we trust for clone integrity and peer authenticity in lieu of per-blob hashing. |
 | [familiar-app-ui-hosting](familiar-app-ui-hosting.md) | Hosts the app's `ui` manifest as partially-sandboxed UI. |
 | [daemon-weblet-application](daemon-weblet-application.md) | Prior art for "readable tree + powers → served application". |
 | [app-sharing-milestone](app-sharing-milestone.md) | Parent milestone; this is the "make & share runnable apps" pillar. |
@@ -128,8 +177,11 @@ not implied by sharing.
 1. **App handle.** Name the `{ source, run, ui?, cloneable }` composition as a
    first-class shareable thing; "share (reference)" affordance over an existing
    running formula. (Substrate already runs the app via `make-from-tree`.)
-2. **Cross-daemon clone.** `endo clone` verb: resolve remote `readable-tree`,
-   stream blobs into the local store with hash verification, re-run locally.
+2. **Streaming clone + durable receiver.** A tree-archive stream helper in
+   `@endo/endo-fs` (producer serialises the tree to one stream; consumer
+   drains it), plus a **zip-backed `FsBackend`** so the recipient gets a
+   durable, self-contained archive that reincarnates across restart. `endo
+   clone` verb wires producer → stream → durable backing → `make-from-tree`.
 3. **Cloneability policy + UX.** Honour the `cloneable` flag end to end; Chat
    surfaces "Open (remote)" vs "Make my own copy" per the author's policy.
 
@@ -143,16 +195,47 @@ not implied by sharing.
 3. **Cloneability is opt-in disclosure.** Defaulting to remote-reference keeps
    the safe posture; cloning is a deliberate author decision to disclose the
    source tree.
-4. **Verify on clone.** Content-addressing already gives us hashes; the clone
-   walk checks them so a cloned app is provably the offered tree.
+4. **One tree-stream, not a pipelined walk.** Cloning ships the whole tree as a
+   single ordered stream of `(path, content)` entries so the cost is one stream
+   regardless of file count — fewer round-trips than per-node
+   `lookup`/`snapshot`/`fetch`.
+5. **Trust the peer and the transport; no content hashing.** The clone does not
+   compute or verify per-blob hashes and does no CAS dedup. Integrity and
+   peer-authenticity come from the secure channel established when the peer was
+   added, not from re-hashing on receipt.
+6. **Durable receiver is pluggable; default zip.** The recipient persists the
+   clone through the `@endo/endo-fs` `FsBackend` seam. The default backing is a
+   self-contained zip archive (same bytes as the wire format) rather than loose
+   files on the host disk.
 
 ## Known Gaps and TODOs
 
+- [ ] **Clone of an actively-written source — unresolved.** If the source tree
+      mutates mid-stream the recipient can capture a torn state. Candidate
+      answers: pin the source to an immutable snapshot before streaming
+      (clean, but snapshotting a large live tree has cost), or accept
+      best-effort consistency. Whole-tree atomicity is not yet designed; this
+      is the main open question.
+- [ ] **FS layering for immediate use — deferred.** A copy-on-write
+      `compose(remote-backing, local-writable-layer)` clone would let the
+      recipient use the app before the full copy finishes, materialising
+      entries on demand. Interesting but out of scope for the first cut.
 - [ ] Cross-peer GC interaction for **mode A**: prevent the author GC'ing a
       source/exo a remote holder still references (relates to
       [daemon-cross-peer-gc](daemon-cross-peer-gc.md)).
 - [ ] Update/versioning of a cloned app (pull a newer tree) — out of scope for
       the milestone; clones are point-in-time copies.
+
+## Prompt (refinement)
+
+> rather than a pipelined approach, I think a stream of filename file content
+> will lead to fewer roundtrips. I don't think we need to check the hashes as
+> we are trusting the peer and the network layer to provide the content. but I
+> haven't thought about a clone over an fs that is being actively written to.
+> the fs layering for immediate use is interesting, but deferrable. we also
+> need to be able to create a durable fs on the receiving side, and we may not
+> want to just write files to disk normally (maybe we want to back it by zip or
+> something else).
 
 ## Prompt
 

--- a/designs/endo-app-sharing.md
+++ b/designs/endo-app-sharing.md
@@ -1,0 +1,161 @@
+# Endo App Sharing and Cloning
+
+| | |
+|---|---|
+| **Created** | 2026-06-01 |
+| **Author** | Aaron (prompted) |
+| **Status** | Proposed |
+
+## What is the Problem Being Solved?
+
+A user should be able to build a small runnable "app", hand it to a peer, and
+have the peer **run it** — either as a live reference into the author's daemon
+or, when the app is marked **cloneable**, as their own independent copy that
+keeps working after the author goes offline or garbage-collects the original.
+
+An Endo "app" in this design is the composition the substrate already
+supports:
+
+- an **endo-fs source** — a project tree (a compartment-mapper layout:
+  `compartment-map.json` plus modules) exposed as an `@endo/endo-fs`
+  `Filesystem` capability, and
+- **endo-fs-exec** — the `@endo/endo-fs-exec` `tree-view-module.js` adapter
+  that presents that tree to the daemon's `make-from-tree` formula, whose root
+  program exports `make(powers, context, { env }) => exo`. That `exo` is the
+  running app.
+
+What is missing is everything around *transfer*:
+
+1. **An app handle worth sharing.** A single named thing that bundles
+   `{ source tree, exec/run config, optional UI manifest }`, rather than the
+   user wiring `node-fs-module` → `tree-view-module` → `make-from-tree` by hand
+   each time.
+2. **Share as remote reference.** Hand a peer a capability to the *running*
+   exo (or to the app handle) so they invoke it on the author's machine.
+3. **Clone for independence.** When marked cloneable, materialise the source
+   tree on the recipient's daemon as local `readable-tree` / `readable-blob`
+   formulas so the recipient runs their own instance — no dependency on the
+   author's liveness, and subject to the recipient's own powers.
+
+## Background: what already exists
+
+| Capability | Location | Status |
+|---|---|---|
+| `@endo/endo-fs` `Filesystem` caps (in-memory, node-fs, from-mount; `FsBackend` seam) | `packages/endo-fs`, [`endo-fs-backend-seam`](endo-fs-backend-seam.md) | Complete |
+| `tree-view-module.js` adapting endo-fs → `make-from-tree` | `packages/endo-fs-exec/src/tree-view-module.js` | Complete |
+| `make-from-tree` formula running a compartment-mapped program | `packages/daemon/src/daemon.js` (`makeFromTree`) | Complete |
+| `readable-tree` / `readable-blob` formulas (transitively read-only, content-addressed) | `packages/daemon/src/daemon.js` | Complete |
+| `endo checkin` / `endo checkout` (tree ⇄ filesystem, zip via `-z`) | `packages/cli/src/commands/`, [`daemon-checkin-checkout`](daemon-checkin-checkout.md) | Complete |
+| In-memory zip-as-tree (`@endo/exo-zip`) | [`exo-zip-package`](exo-zip-package.md) | Proposed |
+
+So reading a tree, running it, and serialising it to/from disk and zip all
+exist. What does not exist is a **cross-daemon** "pull this remote tree into my
+own store" operation, the app handle that ties source + exec together, or the
+remote-ref-vs-clone choice exposed at share time.
+
+## Design
+
+### App handle
+
+Introduce an **app** formula (or a thin named record) capturing:
+
+```
+{
+  source:   <readable-tree | endo-fs Filesystem cap>,  // the program tree
+  run:      { workerName, powers, env },               // make-from-tree inputs
+  ui?:      <app UI manifest>,                          // see familiar-app-ui-hosting
+  cloneable: boolean,                                   // may the recipient copy the source?
+}
+```
+
+`cloneable` is the policy bit. It governs which of the two share modes below
+the author is willing to offer.
+
+### Share mode A — remote reference
+
+The author shares a capability to the **app handle** (or directly to the
+running `exo`). The recipient holds a remote reference; every invocation
+crosses to the author's daemon over CapTP / OCapN-Noise. The source tree never
+leaves the author. This is the default and works today for any formula —
+the new work is only naming it as an "app" and surfacing a "share" affordance.
+
+### Share mode B — clone
+
+Available only when `cloneable` is true. The recipient performs a **clone**:
+
+1. Resolve the shared app handle's `source` `readable-tree`.
+2. Walk it, streaming each `readable-blob` into the recipient's own
+   content-addressed store as fresh local `readable-blob` / `readable-tree`
+   formulas — the cross-daemon analogue of `endo checkout` immediately
+   followed by `endo checkin`, but without a filesystem round-trip (compose
+   with [`exo-zip-package`](exo-zip-package.md) for the in-memory path).
+3. **Verify content hashes** during the walk so the clone is provably the tree
+   the author offered (trust-on-clone, sibling to
+   [`trust-on-first-bind`](trust-on-first-bind.md)).
+4. Re-run `make-from-tree` against the *local* copy under the recipient's own
+   `run` powers, producing an independent instance.
+
+A new CLI verb (working name `endo clone <remote-app> --name <local-name>`)
+and a Chat "Make my own copy" action drive mode B. The cloned app's powers are
+the recipient's to grant — the clone does not inherit the author's
+capabilities, only the author's *code*.
+
+### Why cloneability is explicit
+
+Remote-reference sharing and cloning are different trust postures:
+
+- A remote reference keeps the author in the loop (they can revoke, observe,
+  update centrally) and never discloses source.
+- A clone discloses the full source tree and hands control to the recipient.
+
+The author must opt in to disclosure; hence `cloneable` is a deliberate flag,
+not implied by sharing.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [exo-zip-package](exo-zip-package.md) | In-memory zip ⇄ `ReadableTree` makes the clone path filesystem-free. |
+| [daemon-checkin-checkout](daemon-checkin-checkout.md) | The local serialisation primitive the cross-daemon clone generalises. |
+| [endo-fs-backend-seam](endo-fs-backend-seam.md) | The endo-fs backing the app source is mounted from. |
+| [trust-on-first-bind](trust-on-first-bind.md) | Pattern for hash-verified acceptance of remote content. |
+| [familiar-app-ui-hosting](familiar-app-ui-hosting.md) | Hosts the app's `ui` manifest as partially-sandboxed UI. |
+| [daemon-weblet-application](daemon-weblet-application.md) | Prior art for "readable tree + powers → served application". |
+| [app-sharing-milestone](app-sharing-milestone.md) | Parent milestone; this is the "make & share runnable apps" pillar. |
+
+## Phased Implementation
+
+1. **App handle.** Name the `{ source, run, ui?, cloneable }` composition as a
+   first-class shareable thing; "share (reference)" affordance over an existing
+   running formula. (Substrate already runs the app via `make-from-tree`.)
+2. **Cross-daemon clone.** `endo clone` verb: resolve remote `readable-tree`,
+   stream blobs into the local store with hash verification, re-run locally.
+3. **Cloneability policy + UX.** Honour the `cloneable` flag end to end; Chat
+   surfaces "Open (remote)" vs "Make my own copy" per the author's policy.
+
+## Design Decisions
+
+1. **An app is `make-from-tree` plus metadata, not a new runtime.** Reuse the
+   existing compartment-mapper / `make` execution path; the app concept is
+   packaging and transfer, not a new way to run code.
+2. **Clone copies code, never capabilities.** The cloned instance binds the
+   recipient's powers. The author shares source, not authority.
+3. **Cloneability is opt-in disclosure.** Defaulting to remote-reference keeps
+   the safe posture; cloning is a deliberate author decision to disclose the
+   source tree.
+4. **Verify on clone.** Content-addressing already gives us hashes; the clone
+   walk checks them so a cloned app is provably the offered tree.
+
+## Known Gaps and TODOs
+
+- [ ] Cross-peer GC interaction for **mode A**: prevent the author GC'ing a
+      source/exo a remote holder still references (relates to
+      [daemon-cross-peer-gc](daemon-cross-peer-gc.md)).
+- [ ] Update/versioning of a cloned app (pull a newer tree) — out of scope for
+      the milestone; clones are point-in-time copies.
+
+## Prompt
+
+> make and share runnable apps (backed by an endo-fs source and endo-fs-exec).
+> apps need to be optionally "cloneable" so you don't just get a remote
+> reference on their machine. Part of the app-sharing milestone.

--- a/designs/familiar-app-ui-hosting.md
+++ b/designs/familiar-app-ui-hosting.md
@@ -1,0 +1,146 @@
+# Familiar App UI Hosting (Partial Sandbox)
+
+| | |
+|---|---|
+| **Created** | 2026-06-01 |
+| **Author** | Aaron (prompted) |
+| **Status** | Proposed |
+
+## What is the Problem Being Solved?
+
+A shared, runnable Endo app (see [endo-app-sharing](endo-app-sharing.md)) needs
+a way to present a **user interface** — and because an app may be authored by
+someone else, that UI must be **partially sandboxed**: confined enough that it
+cannot exfiltrate data or escalate, but still able to talk to its own backing
+exo over CapTP to do useful work.
+
+The hosting substrate for this already exists or is designed across three
+documents:
+
+- [familiar-unified-weblet-server](familiar-unified-weblet-server.md) — one
+  HTTP server that routes by virtual host to weblet handlers.
+- [familiar-chat-weblet-hosting](familiar-chat-weblet-hosting.md) — embedding a
+  weblet as an iframe pane inside Chat with a chrome/guest barrier.
+- [daemon-weblet-application](daemon-weblet-application.md) — serving a
+  `readable-tree` of static files plus a powers reference over CapTP.
+
+What those documents do not yet pin down is the **app-specific** layer this
+milestone needs:
+
+1. A **UI manifest** on the app handle saying *what* to serve (entry HTML, the
+   `readable-tree` of assets) and *how much* to sandbox it.
+2. A small **sandbox-level policy** so an author can choose the confinement
+   tier appropriate to their app.
+3. The **CapTP wiring** from the sandboxed UI back to *that app's* exo
+   specifically (not ambient daemon authority), so a cloned or referenced app's
+   UI is bound to the right instance with the right powers.
+
+This design adds that thin app-UI layer; it defers all core hosting mechanics
+to the three documents above.
+
+## Background: what already exists
+
+| Capability | Location | Status |
+|---|---|---|
+| `localhttp://<weblet-id>/` privileged scheme, per-app origin isolation | `packages/familiar/src/protocol-handler.js` | Complete |
+| CSP injection per response (`connect-src 'self'`, `object-src 'none'`, `frame-src 'self'`, …) | `packages/familiar/src/protocol-handler.js` | Complete |
+| Navigation guards / exfiltration defenses | `packages/familiar/electron-main.js`, `src/exfiltration-defense.js` | Complete (partial) |
+| Unified weblet server routing | [familiar-unified-weblet-server](familiar-unified-weblet-server.md) | In Progress |
+| Chat iframe weblet pane | [familiar-chat-weblet-hosting](familiar-chat-weblet-hosting.md) | Not Started |
+| Serve `readable-tree` files + powers over CapTP | [daemon-weblet-application](daemon-weblet-application.md) | Not Started |
+
+Per-app origin isolation and CSP are the strong parts that already ship. The
+gap is the app-facing manifest, the sandbox tiers, and binding the UI's CapTP
+session to a specific app exo.
+
+## Design
+
+### App UI manifest
+
+The `ui` field of an app handle ([endo-app-sharing](endo-app-sharing.md)):
+
+```
+ui: {
+  entry:   'index.html',                 // path within the assets tree
+  assets:  <readable-tree>,              // static files to serve
+  sandbox: 'isolated' | 'connected' | 'trusted',
+  bridge:  'message-port' | 'web-socket',// CapTP transport to the app exo
+}
+```
+
+### Sandbox tiers
+
+| Tier | Origin | CSP `connect-src` | CapTP to app exo | Use |
+|---|---|---|---|---|
+| `isolated` | unique `localhttp://<id>` | `'none'` | no | Pure presentational UI; no back-channel. |
+| `connected` (default) | unique `localhttp://<id>` | `'self'` | yes, **only** to its own exo | The normal case: app UI drives its own backing capability. |
+| `trusted` | unique `localhttp://<id>` | `'self'` + author-declared origins | yes | Author opts into extra reach (e.g. an allowlisted API), surfaced to the user at install. |
+
+Every tier keeps the per-app unique origin and the `object-src 'none'` /
+`form-action 'self'` baseline from the existing protocol handler. Tiers only
+widen `connect-src` and whether a CapTP bootstrap is granted — they never relax
+origin isolation.
+
+### Binding the UI to its app exo
+
+The CapTP bootstrap handed to a `connected`/`trusted` UI resolves to **that
+app instance's exo**, carrying only the powers the app was run with
+(`run.powers` from the app handle). This matters for the two share modes:
+
+- A **referenced** app's UI bridges back to the author's running exo.
+- A **cloned** app's UI bridges to the recipient's *local* exo, under the
+  recipient's powers.
+
+Transport is `MessagePort` for the in-Chat iframe (preferred, no network
+surface) with a `web-socket` fallback for an external browser, matching
+[daemon-weblet-application](daemon-weblet-application.md)'s integration point.
+
+### Chrome / guest barrier
+
+The host chrome (pane frame, close button, app title) lives outside the iframe;
+the app's UI lives inside it. Controls that act on the app's lifecycle are
+never rendered by the guest. This is the same barrier described in
+[familiar-chat-weblet-hosting](familiar-chat-weblet-hosting.md), restated here
+as a hard requirement for app UIs because app authors are potentially
+untrusted third parties.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [familiar-unified-weblet-server](familiar-unified-weblet-server.md) | Provides the virtual-host HTTP routing this serves over. |
+| [familiar-chat-weblet-hosting](familiar-chat-weblet-hosting.md) | Provides the in-Chat iframe pane and chrome/guest barrier. |
+| [daemon-weblet-application](daemon-weblet-application.md) | Provides readable-tree file serving + CapTP-over-MessagePort/WebSocket. |
+| [familiar-localhttp-protocol](familiar-localhttp-protocol.md) | The per-app origin + CSP mechanism the tiers build on. |
+| [endo-app-sharing](endo-app-sharing.md) | Owns the app handle whose `ui` manifest this consumes. |
+| [app-sharing-milestone](app-sharing-milestone.md) | Parent milestone; this is the "partially sandboxed UI" pillar. |
+
+## Phased Implementation
+
+1. **Manifest + `connected` tier.** Serve an app's `assets` tree at a unique
+   origin with the existing CSP, bootstrap CapTP to the app's own exo over
+   `MessagePort` inside a Chat iframe pane. (Depends on the unified server and
+   chat-weblet-hosting integration points landing.)
+2. **Tiers `isolated` and `trusted`.** Add the no-bridge and
+   author-allowlisted-origin tiers; surface `trusted` origins to the user at
+   install/open time.
+3. **External-browser path.** `web-socket` bridge fallback for opening an app
+   UI outside Familiar.
+
+## Design Decisions
+
+1. **Reuse the weblet substrate; add only an app-facing manifest.** This design
+   deliberately owns no HTTP server or iframe mechanics — only the
+   `{ entry, assets, sandbox, bridge }` shape and the exo-binding rule.
+2. **Tiers widen reach, never relax origin isolation.** Per-app unique origin
+   and the plugin/form lockdown are invariant across tiers.
+3. **The UI is bound to a specific app exo, not ambient authority.** Whether
+   referenced or cloned, the UI can only reach the instance and powers the app
+   was run with.
+4. **`connected` is the sensible default.** Most app UIs need exactly one
+   thing: a confined back-channel to their own capability.
+
+## Prompt
+
+> apps … need a way of hosting partially sandboxed ui. Part of the app-sharing
+> milestone.

--- a/designs/familiar-deep-link-invitations.md
+++ b/designs/familiar-deep-link-invitations.md
@@ -104,10 +104,16 @@ rendered as inert text, never as markup or actionable controls.
 | Design | Relationship |
 |---|---|
 | [ocapn-noise-network](ocapn-noise-network.md) | Provides the secure transport the accepted peer connects over. |
-| [daemon-agent-network-identity](daemon-agent-network-identity.md) | Per-agent keypairs / network registration that make the `nodeKey` in the link meaningful; soft prerequisite. |
+| [daemon-agent-network-identity](daemon-agent-network-identity.md) | Per-agent keypairs / network registration that make the `nodeKey` in the link meaningful; soft prerequisite. In-flight as per-agent `@transports`: design `ocapn-daemon-integration.md` ([PR #138](https://github.com/endojs/endo-but-for-bots/pull/138) · [raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/ocapn-daemon-integration/designs/ocapn-daemon-integration.md)), prototype [#262](https://github.com/endojs/endo-but-for-bots/pull/262). |
 | [trust-on-first-bind](trust-on-first-bind.md) | Reference for the prompt-and-pin consent pattern the confirmation screen instantiates. |
 | [familiar-localhttp-protocol](familiar-localhttp-protocol.md) | Working template for privileged custom-scheme registration in Electron. |
 | [app-sharing-milestone](app-sharing-milestone.md) | Parent milestone; this is the "connect peers" pillar. |
+
+**Related in-flight PRs:** locator scheme v2 with `@`-delimited connection hints
+([#178](https://github.com/endojs/endo-but-for-bots/pull/178)) is the basis for
+the `endo://` link's query params; daemon-to-daemon OCapN-Noise connectivity is
+[#340](https://github.com/endojs/endo-but-for-bots/pull/340). No `endo://`
+deep-link / confirmation-screen PR exists yet — this design is net-new.
 
 ## Phased Implementation
 

--- a/designs/familiar-deep-link-invitations.md
+++ b/designs/familiar-deep-link-invitations.md
@@ -1,0 +1,142 @@
+# Familiar Deep-Link Peer Invitations
+
+| | |
+|---|---|
+| **Created** | 2026-06-01 |
+| **Author** | Aaron (prompted) |
+| **Status** | Proposed |
+
+## What is the Problem Being Solved?
+
+Two people running Familiar should be able to become peers by exchanging a
+single link.
+Today the daemon already has the machinery to mint and accept a peer
+invitation — `host.invite(guestName)` produces a locator string and
+`host.accept(locator, petName)` parses it, registers the remote node's
+addresses via `addPeerInfo`, and binds a local pet name — but there is no
+way to *deliver* that locator through the operating system into a running
+Familiar and turn it into a guided, consent-gated flow.
+
+The missing pieces are entirely in the shell and the Chat UI:
+
+1. **OS deep-link capture.** Familiar does not register a custom URL scheme
+   (e.g. `endo://`), so clicking an invite link in a browser, chat app, or
+   email does nothing.
+2. **A confirmation screen.** Accepting a peer is a trust decision. The user
+   must see *who* they are about to add (a key fingerprint and any
+   self-asserted label) and explicitly approve.
+3. **A naming prompt.** The peer must be bound under a **pet name** chosen by
+   the recipient — the locator cannot dictate the local name, and the user
+   should be asked rather than defaulted silently.
+
+This design adds the deep-link handler and the consent/naming UI on top of
+the existing daemon `invite`/`accept` surface.
+
+## Background: what already exists
+
+| Capability | Location | Status |
+|---|---|---|
+| Locator format `endo://{nodeKey}/?id=…&type=invitation&at=host:port` | `packages/daemon/src/locator.js` | Complete |
+| `host.invite(guestName)` → `Invitation` exo with `locate()` | `packages/daemon/src/host.js` | Complete |
+| `host.accept(invitationLocator, guestName)` → parse, `addPeerInfo`, bind pet name | `packages/daemon/src/host.js` | Complete |
+| OCapN-Noise transport (mutual Ed25519, IK handshake) | `packages/ocapn-noise`, [`ocapn-noise-network`](ocapn-noise-network.md) | Complete (PR #137) |
+| Privileged custom scheme registration in Electron (`localhttp://`) | `packages/familiar/src/protocol-handler.js` | Complete (template) |
+
+The `localhttp://` handler is the working reference for how to register and
+service a custom scheme in the Familiar main process.
+
+## Design
+
+### 1. URL scheme and link shape
+
+Register `endo:` as the application's default protocol client. An invitation
+link reuses the existing locator query string under a stable host segment so
+the same string round-trips through `host.accept`:
+
+```
+endo://invite/?node={nodeKey}&id={invitationNumber}&type=invitation&at=ws:host:port&label={optional}
+```
+
+- `node`, `id`, `type`, `at` mirror the daemon locator so the renderer can
+  forward the reconstructed locator straight to `host.accept`.
+- `label` is an **optional, untrusted** self-asserted display string shown on
+  the confirmation screen for human recognition only. It is never used as the
+  pet name and never granted trust weight.
+
+### 2. Capturing the link in the shell
+
+In `packages/familiar/electron-main.js`:
+
+- `app.setAsDefaultProtocolClient('endo')` (guarded for dev vs packaged
+  paths, matching how `localhttp` is set up).
+- Register `endo` in `protocol.registerSchemesAsPrivileged` before
+  `app.whenReady()`.
+- Handle the three OS delivery paths:
+  - **macOS:** `app.on('open-url', (event, url) => …)`.
+  - **Windows / Linux:** `app.requestSingleInstanceLock()` plus
+    `app.on('second-instance', (event, argv) => …)`, and parse `process.argv`
+    on cold start.
+- Normalise to a single internal event and forward the parsed invite to the
+  renderer over the existing preload IPC bridge (`packages/familiar/preload.js`),
+  never executing `accept` from the main process directly.
+
+### 3. Confirmation + naming screen (Chat)
+
+The renderer receives an `endo:invite` IPC message and opens a modal:
+
+- **Identity block:** key fingerprint (short hash of `nodeKey`), the
+  untrusted `label` clearly marked as self-asserted, and the connection hints
+  (`at` addresses).
+- **Name field:** "What should we call this peer?" — required, validated as a
+  pet name, defaulted to a *suggestion* derived from `label` or the
+  fingerprint that the user must confirm or replace.
+- **Actions:** Accept / Decline. Accept calls
+  `E(host).accept(reconstructedLocator, petName)` over the existing CapTP
+  bridge; Decline discards the invite with no daemon side effects.
+
+The barrier between the host chrome (the modal frame, the Accept button) and
+any peer-supplied content (the `label`) follows the same chrome/guest
+separation principle used for weblet hosting — peer-supplied strings are
+rendered as inert text, never as markup or actionable controls.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [ocapn-noise-network](ocapn-noise-network.md) | Provides the secure transport the accepted peer connects over. |
+| [daemon-agent-network-identity](daemon-agent-network-identity.md) | Per-agent keypairs / network registration that make the `nodeKey` in the link meaningful; soft prerequisite. |
+| [trust-on-first-bind](trust-on-first-bind.md) | Reference for the prompt-and-pin consent pattern the confirmation screen instantiates. |
+| [familiar-localhttp-protocol](familiar-localhttp-protocol.md) | Working template for privileged custom-scheme registration in Electron. |
+| [app-sharing-milestone](app-sharing-milestone.md) | Parent milestone; this is the "connect peers" pillar. |
+
+## Phased Implementation
+
+1. **Scheme registration + capture.** `setAsDefaultProtocolClient`, privileged
+   scheme, `open-url` / `second-instance` / argv parsing, single-instance lock,
+   IPC forward. No UI yet — log the parsed invite.
+2. **Confirmation + naming modal.** Identity block, validated pet-name field,
+   Accept → `host.accept`, Decline path. Untrusted-label rendering discipline.
+3. **Polish.** Invite-link generation affordance in Chat ("Invite a peer" →
+   copy `endo://invite/…`), error states (malformed link, unreachable peer,
+   duplicate pet name), and a smoke test that drives a synthetic `endo://`
+   URL end to end.
+
+## Design Decisions
+
+1. **Accept runs in the renderer over CapTP, not in the Electron main
+   process.** The main process stays a thin transport for the URL; all
+   capability use goes through the same audited preload bridge as the rest of
+   Chat.
+2. **The locator cannot name the peer.** The pet name is always the
+   recipient's choice. The link may *suggest* via `label`, but the suggestion
+   is untrusted and confirmable.
+3. **Reuse the existing locator string verbatim.** The link is a thin
+   `endo://` envelope around the daemon's own locator query params so there is
+   one parser of record (`packages/daemon/src/locator.js`) and `host.accept`
+   needs no changes.
+
+## Prompt
+
+> connect to other peers via a deep linking url format (needs a confirmation
+> screen, should ask you to specify a name). Part of the app-sharing
+> milestone.


### PR DESCRIPTION
## Summary

Roadmaps a single shippable cut — **Peer App Sharing** — across the three goals: (1) distribute the Familiar chat app, (2) connect to peers via an `endo://` deep link (confirmation screen + naming), and (3) make/share runnable apps backed by an endo-fs source + endo-fs-exec, optionally **cloneable**, with partially-sandboxed UI.

Framed as an **"app-sharing" milestone** (not an "MVP doc") per maintainer steer.

### New design docs (all Proposed)

- **`designs/app-sharing-milestone.md`** — the milestone roadmap: verified current-state analysis, gaps, P0–P3 phased plan, exit criterion, and a consolidated **Related in-flight PRs** index.
- **`designs/familiar-deep-link-invitations.md`** — `endo://` capture in the Electron shell → Chat confirmation + naming modal → existing `host.accept`. (Net-new; daemon `invite`/`accept` + OCapN-Noise already exist.)
- **`designs/endo-app-sharing.md`** — app handle (`source` + exec + `ui` + `cloneable`); cross-daemon **clone** shipped as a **single streamed tree-archive** into a **pluggable durable backing** (default zip via the endo-fs `FsBackend` seam) vs. a remote reference. Per maintainer refinement: one entry-stream rather than a pipelined walk, **no per-blob hashing** (trust the peer + transport), durable receiver may be zip-backed rather than loose files. Open question recorded: clone over an actively-written source. CoW layering for immediate use deferred.
- **`designs/familiar-app-ui-hosting.md`** — app UI manifest + sandbox tiers (`isolated`/`connected`/`trusted`) over the existing weblet substrate, binding each UI to its own app exo.

### Reconciliation with in-flight work

After surveying open PRs, two pillars already have active workstreams, so this milestone **adopts rather than duplicates** them:

- **Pillar 1 (distributable)** is owned by `familiar-release.md` (#231, issue #229): a **macOS-arm64-first** MVR with gaps G1–G16 and a swarm of implementation PRs (#318, #321, #319, #316, #320, #323, #324, #322, #317, #360). P0 defers to it.
- **Pillar 3** cross-references exo-zip/exo-unzip (#160), exo-stream (#330), daemon git-tree `archive` (#367), and the sibling `familiar-run-apps-vfs.md` (#241).
- **Pillar 2** cross-references locator v2 (#178), per-agent `@transports` / `ocapn-daemon-integration.md` (#138/#262), and daemon-to-daemon Noise (#340).

The two genuinely net-new pieces — `endo://` deep-link invites and the streaming clone helper + zip-backed receiver — have no existing PR.

The milestone's PR index includes **raw-file links** to the PR-only design docs so reviewers can read them without checking out each branch.

### `designs/README.md`

Wired in per the design-doc conventions: summary-table rows, totals (126 → 130), a new "Milestone A: Peer App Sharing" section, dependency-graph subgraph, and per-design estimates.

## Notes

- Docs-only change; no code. Prettier-clean.
- Targets `llm` (the roadmap/design branch), consistent with the other open design PRs.

https://claude.ai/code/session_0112zLHkZKDDUzUDEwPvScwT

---
_Generated by [Claude Code](https://claude.ai/code/session_0112zLHkZKDDUzUDEwPvScwT)_