### PR TITLE
Add streaming tree clone and deep-link invitation support

### DIFF
--- a/packages/chat/chat-bar-component.js
+++ b/packages/chat/chat-bar-component.js
@@ -1730,6 +1730,9 @@ export const chatBarComponent = (
     getReplyType: sendForm.getReplyType,
     setText: sendForm.setText,
     focus: sendForm.focus,
+    // Open a command form pre-filled with field values; used by deep-link
+    // peer invitations to launch the Accept form with the locator filled in.
+    enterCommandMode,
     dispose: sendForm.dispose,
   };
 };

--- a/packages/chat/chat.js
+++ b/packages/chat/chat.js
@@ -13,6 +13,7 @@ import { createChannelHeader } from './channel-header.js';
 import { inboxComponent } from './inbox-component.js';
 import { inventoryComponent } from './inventory-component.js';
 import { chatBarComponent } from './chat-bar-component.js';
+import { wireDeepLinkInvites } from './deep-link-invite.js';
 import { valueComponent } from './value-component.js';
 import { createSpacesGutter } from './spaces-gutter.js';
 import { inventoryGraphComponent } from './inventory-graph-component.js';
@@ -1742,6 +1743,9 @@ const bodyComponent = (
         },
       );
       chatBarRef = chatBarAPI;
+      // Route endo:// deep-link peer invitations (Familiar shell) into the
+      // Accept command form. No-op outside the Familiar.
+      wireDeepLinkInvites(chatBarAPI);
       const { focusValue, blurValue } = valueComponent(
         $parent,
         /** @type {ERef<EndoHost>} */ (resolvedPowers),

--- a/packages/chat/command-executor.js
+++ b/packages/chat/command-executor.js
@@ -9,6 +9,10 @@ import harden from '@endo/harden';
 import { E } from '@endo/far';
 
 import { makeBrowserTree, checkoutToDirectory } from './browser-tree.js';
+import {
+  locatorToInviteLink,
+  normalizeInvitationInput,
+} from './invite-link.js';
 
 /**
  * @typedef {object} CommandResult
@@ -590,22 +594,33 @@ export const createCommandExecutor = ({
           }
 
           const locator = await E(invitation).locate();
-          console.log(`[Chat] Invitation locator generated`);
-          showMessage(`Invitation locator for "${guestName}":`);
-          showValue(locator, undefined, undefined, undefined);
+          // Prefer the shareable `endo://invite?...` deep link: clicking it
+          // launches the Familiar and pre-fills /accept. Fall back to the raw
+          // locator if the form is unexpectedly not an invitation locator.
+          const inviteLink = locatorToInviteLink(locator) || locator;
+          console.log(`[Chat] Invitation link generated`);
+          showMessage(
+            `Invitation link for "${guestName}" — share it, or paste it into /accept:`,
+          );
+          showValue(inviteLink, undefined, undefined, undefined);
           return {
             success: true,
-            value: locator,
+            value: inviteLink,
             message: `Invitation created for "${guestName}"`,
           };
         }
 
         case 'accept': {
           const { locator, guestName } = params;
+          // Accept either an `endo://invite?...` deep link or a raw locator.
+          const invitationLocator = normalizeInvitationInput(String(locator));
           console.log(
-            `[Chat] Accepting invitation for "${guestName}" from ${String(locator).slice(0, 40)}...`,
+            `[Chat] Accepting invitation for "${guestName}" from ${invitationLocator.slice(0, 40)}...`,
           );
-          const accepted = E(powers).accept(String(locator), String(guestName));
+          const accepted = E(powers).accept(
+            invitationLocator,
+            String(guestName),
+          );
           const timeout = new Promise((_, reject) => {
             setTimeout(
               () =>

--- a/packages/chat/command-registry.js
+++ b/packages/chat/command-registry.js
@@ -633,7 +633,7 @@ export const COMMANDS = {
         label: 'Invitation',
         type: 'locator',
         required: true,
-        placeholder: 'endo://...',
+        placeholder: 'endo://invite?...',
       },
       {
         name: 'guestName',

--- a/packages/chat/deep-link-invite.js
+++ b/packages/chat/deep-link-invite.js
@@ -26,28 +26,39 @@
  */
 
 let wired = false;
+/**
+ * The live chat bar. Chat's `rebuild()` disposes the old bar and makes a new
+ * one on every profile / conversation / reconnect change, so the single IPC
+ * listener registered below must always target the current bar, not the one
+ * captured on first wire.
+ *
+ * @type {ChatBarApi | null}
+ */
+let currentChatBar = null;
 
 /**
- * Wire deep-link invitations to the chat bar's Accept form. Idempotent and
- * safe to call on every (re)connect; only the first call registers.
+ * Wire deep-link invitations to the chat bar's Accept form. Safe to call on
+ * every rebuild: it updates the live-bar reference each time but registers
+ * the (never-removed) IPC listener only once.
  *
  * @param {ChatBarApi} chatBar
  */
 export const wireDeepLinkInvites = chatBar => {
-  if (wired) {
-    return;
-  }
+  currentChatBar = chatBar;
   const familiar = /** @type {any} */ (window).familiar;
   if (!familiar || typeof familiar.onDeepLinkInvite !== 'function') {
+    return;
+  }
+  if (wired) {
     return;
   }
   wired = true;
 
   /** @param {DeepLinkInvite | null | undefined} invite */
   const open = invite => {
-    if (invite && typeof invite.locator === 'string') {
+    if (currentChatBar && invite && typeof invite.locator === 'string') {
       // Pre-fill the locator; the user confirms and supplies the pet name.
-      chatBar.enterCommandMode('accept', { locator: invite.locator });
+      currentChatBar.enterCommandMode('accept', { locator: invite.locator });
     }
   };
 

--- a/packages/chat/deep-link-invite.js
+++ b/packages/chat/deep-link-invite.js
@@ -1,0 +1,63 @@
+// @ts-check
+/**
+ * Route `endo://` deep-link peer invitations into the Accept command form
+ * (designs/familiar-deep-link-invitations.md).
+ *
+ * When the Familiar shell captures an `endo://...&type=invitation` link, it
+ * forwards the parsed invite to this renderer over the preload bridge
+ * (`window.familiar`). Rather than invent a bespoke dialog, we open the
+ * existing `accept` command pre-filled with the locator: the command form is
+ * the confirmation screen, and its required `guestName` field is where the
+ * user names the peer before `host.accept` runs.
+ *
+ * Outside the Familiar (no `window.familiar`, e.g. a plain browser tab) this
+ * is a no-op.
+ */
+
+/**
+ * @typedef {object} ChatBarApi
+ * @property {(commandName: string, prefill?: Record<string, string>) => void}
+ *   enterCommandMode
+ */
+
+/**
+ * @typedef {object} DeepLinkInvite
+ * @property {string} locator  The invitation locator (an `endo://` URL).
+ */
+
+let wired = false;
+
+/**
+ * Wire deep-link invitations to the chat bar's Accept form. Idempotent and
+ * safe to call on every (re)connect; only the first call registers.
+ *
+ * @param {ChatBarApi} chatBar
+ */
+export const wireDeepLinkInvites = chatBar => {
+  if (wired) {
+    return;
+  }
+  const familiar = /** @type {any} */ (window).familiar;
+  if (!familiar || typeof familiar.onDeepLinkInvite !== 'function') {
+    return;
+  }
+  wired = true;
+
+  /** @param {DeepLinkInvite | null | undefined} invite */
+  const open = invite => {
+    if (invite && typeof invite.locator === 'string') {
+      // Pre-fill the locator; the user confirms and supplies the pet name.
+      chatBar.enterCommandMode('accept', { locator: invite.locator });
+    }
+  };
+
+  // Live invitations that arrive while the app is running.
+  familiar.onDeepLinkInvite(open);
+
+  // Any invitation queued before this listener was registered (cold start /
+  // OS launch-by-URL). Pulling it also marks the renderer ready in the shell.
+  if (typeof familiar.getPendingDeepLinkInvite === 'function') {
+    Promise.resolve(familiar.getPendingDeepLinkInvite()).then(open, () => {});
+  }
+};
+harden(wireDeepLinkInvites);

--- a/packages/chat/deep-link-invite.js
+++ b/packages/chat/deep-link-invite.js
@@ -3,7 +3,7 @@
  * Route `endo://` deep-link peer invitations into the Accept command form
  * (designs/familiar-deep-link-invitations.md).
  *
- * When the Familiar shell captures an `endo://...&type=invitation` link, it
+ * When the Familiar shell captures an `endo://invite?...` deep link, it
  * forwards the parsed invite to this renderer over the preload bridge
  * (`window.familiar`). Rather than invent a bespoke dialog, we open the
  * existing `accept` command pre-filled with the locator: the command form is

--- a/packages/chat/deep-link-invite.js
+++ b/packages/chat/deep-link-invite.js
@@ -14,6 +14,11 @@
  * is a no-op.
  */
 
+// The Chat bundle imports `ses` but never calls `lockdown()` (Monaco needs
+// mutable intrinsics), so `harden` is not a global here — import the ponyfill
+// like the sibling modules (chime.js, channel-utils.js).
+import harden from '@endo/harden';
+
 /**
  * @typedef {object} ChatBarApi
  * @property {(commandName: string, prefill?: Record<string, string>) => void}

--- a/packages/chat/deep-link-invite.js
+++ b/packages/chat/deep-link-invite.js
@@ -70,10 +70,18 @@ export const wireDeepLinkInvites = chatBar => {
   // Live invitations that arrive while the app is running.
   familiar.onDeepLinkInvite(open);
 
-  // Any invitation queued before this listener was registered (cold start /
-  // OS launch-by-URL). Pulling it also marks the renderer ready in the shell.
+  // Invitations queued before this listener was registered (cold start / OS
+  // launch-by-URL) arrive as an array. Pulling also marks the renderer ready
+  // in the shell.
   if (typeof familiar.getPendingDeepLinkInvite === 'function') {
-    Promise.resolve(familiar.getPendingDeepLinkInvite()).then(open, () => {});
+    Promise.resolve(familiar.getPendingDeepLinkInvite()).then(
+      invites => {
+        for (const invite of invites || []) {
+          open(invite);
+        }
+      },
+      () => {},
+    );
   }
 };
 harden(wireDeepLinkInvites);

--- a/packages/chat/invite-link.js
+++ b/packages/chat/invite-link.js
@@ -1,0 +1,158 @@
+// @ts-check
+/**
+ * Convert between the daemon's canonical invitation locator and the shareable
+ * `endo://invite?...` deep link handled by the Familiar shell's protocol
+ * handler (designs/familiar-deep-link-invitations.md).
+ *
+ * Canonical locator — what `invitation.locate()` emits and `host.accept`
+ * consumes (see daemon `makeInvitation.locate` / host `accept`):
+ *
+ *   endo://{node}/?id={inv}&type=invitation&from={handle}[&fromNode={n}]&at={addr}...
+ *
+ * Deep link — what a person clicks or pastes; the URL *authority* names the
+ * intent so the OS can route `endo://` to the Familiar:
+ *
+ *   endo://invite?node={node}&id={inv}&from={handle}[&fromNode={n}]&at={addr}...
+ *
+ * The two carry the *same fields*. The link moves `node` from the authority
+ * into a `node` query param (freeing the authority to name the `invite`
+ * action) and drops the redundant `type` (the intent implies it). `node` /
+ * `id` / `from` / `fromNode` are 64-char lowercase hex.
+ *
+ * The Familiar's own `packages/familiar/src/deep-link.js` is the SES-free
+ * mirror of this contract for the Electron main process; Chat cannot import it
+ * (Familiar is the shell that loads Chat, not a dependency), so the contract
+ * is duplicated here for the renderer.
+ */
+
+// Chat imports `ses` but does not call `lockdown()` (Monaco needs mutable
+// intrinsics), so `harden` is not a global — use the ponyfill like the
+// sibling renderer modules.
+import harden from '@endo/harden';
+
+/** Ed25519 public key / formula number: 64 lowercase hex characters. */
+const NUMBER_PATTERN = /^[0-9a-f]{64}$/;
+
+/** The deep-link authority segment that denotes a peer-invitation intent. */
+const INVITE_INTENT = 'invite';
+
+/** The locator `type` for a peer invitation. */
+const INVITATION_TYPE = 'invitation';
+
+/**
+ * Convert a canonical invitation locator into a shareable `endo://invite?...`
+ * deep link. Returns `null` when `locator` is not a well-formed invitation
+ * locator (e.g. a directory/channel locator), so callers can fall back to the
+ * raw string.
+ *
+ * @param {string} locator
+ * @returns {string | null}
+ */
+export const locatorToInviteLink = locator => {
+  if (typeof locator !== 'string' || !locator.startsWith('endo://')) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(locator);
+  } catch {
+    return null;
+  }
+  const node = url.hostname;
+  if (!NUMBER_PATTERN.test(node)) {
+    return null;
+  }
+  if (url.searchParams.get('type') !== INVITATION_TYPE) {
+    return null;
+  }
+  const id = url.searchParams.get('id');
+  const from = url.searchParams.get('from');
+  if (id === null || !NUMBER_PATTERN.test(id)) {
+    return null;
+  }
+  // The inviter's handle is intrinsic to an invitation locator.
+  if (from === null || !NUMBER_PATTERN.test(from)) {
+    return null;
+  }
+  const fromNode = url.searchParams.get('fromNode');
+  if (fromNode !== null && !NUMBER_PATTERN.test(fromNode)) {
+    return null;
+  }
+  const link = new URL(`endo://${INVITE_INTENT}`);
+  link.searchParams.set('node', node);
+  link.searchParams.set('id', id);
+  link.searchParams.set('from', from);
+  if (fromNode !== null) {
+    link.searchParams.set('fromNode', fromNode);
+  }
+  for (const address of url.searchParams.getAll('at')) {
+    link.searchParams.append('at', address);
+  }
+  return link.toString();
+};
+harden(locatorToInviteLink);
+
+/**
+ * Convert an `endo://invite?...` deep link into the canonical invitation
+ * locator that `host.accept` consumes. Returns `null` when `text` is not a
+ * well-formed invite link.
+ *
+ * @param {string} text
+ * @returns {string | null}
+ */
+export const inviteLinkToLocator = text => {
+  if (typeof text !== 'string' || !text.startsWith('endo://')) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(text);
+  } catch {
+    return null;
+  }
+  if (url.host !== INVITE_INTENT) {
+    return null;
+  }
+  const node = url.searchParams.get('node');
+  const id = url.searchParams.get('id');
+  const from = url.searchParams.get('from');
+  if (node === null || !NUMBER_PATTERN.test(node)) {
+    return null;
+  }
+  if (id === null || !NUMBER_PATTERN.test(id)) {
+    return null;
+  }
+  if (from === null || !NUMBER_PATTERN.test(from)) {
+    return null;
+  }
+  const fromNode = url.searchParams.get('fromNode');
+  if (fromNode !== null && !NUMBER_PATTERN.test(fromNode)) {
+    return null;
+  }
+  const locator = new URL(`endo://${node}`);
+  locator.pathname = '/';
+  locator.searchParams.set('id', id);
+  locator.searchParams.set('type', INVITATION_TYPE);
+  locator.searchParams.set('from', from);
+  if (fromNode !== null) {
+    locator.searchParams.set('fromNode', fromNode);
+  }
+  for (const address of url.searchParams.getAll('at')) {
+    locator.searchParams.append('at', address);
+  }
+  return locator.toString();
+};
+harden(inviteLinkToLocator);
+
+/**
+ * Normalise `/accept` input: accept either an `endo://invite?...` deep link or
+ * a raw canonical locator. Deep links are converted; anything else (a raw
+ * locator, or input the daemon will reject with a clearer error) is passed
+ * through unchanged.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export const normalizeInvitationInput = text =>
+  inviteLinkToLocator(text) ?? text;
+harden(normalizeInvitationInput);

--- a/packages/chat/test/invite-link.test.js
+++ b/packages/chat/test/invite-link.test.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+import '@endo/init/debug.js';
+
+import test from 'ava';
+
+import {
+  locatorToInviteLink,
+  inviteLinkToLocator,
+  normalizeInvitationInput,
+} from '../invite-link.js';
+
+const NODE = 'a'.repeat(64);
+const ID = 'b'.repeat(64);
+const FROM = 'c'.repeat(64);
+const FROM_NODE = 'd'.repeat(64);
+
+const LOCATOR = `endo://${NODE}/?id=${ID}&type=invitation&from=${FROM}&at=127.0.0.1%3A8920`;
+const LINK = `endo://invite?node=${NODE}&id=${ID}&from=${FROM}&at=127.0.0.1%3A8920`;
+
+test('locatorToInviteLink rewrites a canonical locator into a deep link', t => {
+  const link = locatorToInviteLink(LOCATOR);
+  t.truthy(link);
+  const url = new URL(/** @type {string} */ (link));
+  t.is(url.host, 'invite');
+  t.is(url.searchParams.get('node'), NODE);
+  t.is(url.searchParams.get('id'), ID);
+  t.is(url.searchParams.get('from'), FROM);
+  t.is(url.searchParams.get('type'), null); // intent implies type
+  t.deepEqual(url.searchParams.getAll('at'), ['127.0.0.1:8920']);
+});
+
+test('inviteLinkToLocator reconstructs the canonical locator', t => {
+  const locator = inviteLinkToLocator(LINK);
+  t.truthy(locator);
+  const url = new URL(/** @type {string} */ (locator));
+  t.is(url.hostname, NODE);
+  t.is(url.searchParams.get('id'), ID);
+  t.is(url.searchParams.get('type'), 'invitation');
+  t.is(url.searchParams.get('from'), FROM);
+  t.deepEqual(url.searchParams.getAll('at'), ['127.0.0.1:8920']);
+});
+
+test('locator <-> link round-trips, including fromNode and multiple hints', t => {
+  const locator = `endo://${NODE}/?id=${ID}&type=invitation&from=${FROM}&fromNode=${FROM_NODE}&at=a%3A1&at=b%3A2`;
+  const link = locatorToInviteLink(locator);
+  t.truthy(link);
+  const back = inviteLinkToLocator(/** @type {string} */ (link));
+  t.truthy(back);
+  const url = new URL(/** @type {string} */ (back));
+  t.is(url.searchParams.get('fromNode'), FROM_NODE);
+  t.deepEqual(url.searchParams.getAll('at'), ['a:1', 'b:2']);
+});
+
+test('conversions reject non-invitation input', t => {
+  // A directory/channel locator (no type=invitation, no from).
+  t.is(locatorToInviteLink(`endo://${NODE}/?id=${ID}&type=directory`), null);
+  // Missing required from.
+  t.is(locatorToInviteLink(`endo://${NODE}/?id=${ID}&type=invitation`), null);
+  // Not an invite-intent link.
+  t.is(inviteLinkToLocator(`endo://adopt?node=${NODE}&id=${ID}`), null);
+  // Malformed.
+  t.is(locatorToInviteLink('not-a-url'), null);
+  t.is(inviteLinkToLocator('not-a-url'), null);
+});
+
+test('normalizeInvitationInput converts links and passes locators through', t => {
+  // A deep link is converted to the canonical locator host.accept consumes.
+  t.is(normalizeInvitationInput(LINK), inviteLinkToLocator(LINK));
+  // A raw locator is left untouched (backward compatible).
+  t.is(normalizeInvitationInput(LOCATOR), LOCATOR);
+  // Unrelated input passes through for the daemon to reject with a clear error.
+  t.is(normalizeInvitationInput('garbage'), 'garbage');
+});

--- a/packages/endo-fs/src/clone.js
+++ b/packages/endo-fs/src/clone.js
@@ -125,13 +125,17 @@ async function* harvestTree(dir, prefix) {
  *
  * @param {any} sourceRoot  the `Directory` cap at the root of the tree to
  *   clone (e.g. `await E(filesystem).root()` or any sub-`Directory`)
- * @param {{ buffer?: number }} [options]  `buffer` is the exo-stream
- *   pre-ack depth (frames the producer sends ahead of consumer demand);
- *   raise it over a high-latency link.
+ * @param {{ buffer?: number }} [options]  `buffer` is the exo-stream pre-ack
+ *   depth: the producer streams up to this many frames ahead of consumer
+ *   demand, so a drain costs about `frameCount / buffer` synchronization
+ *   round-trips rather than one ack per frame (a large file fans out into
+ *   many `chunk` frames). Defaults to 64; set 0 for strict per-frame
+ *   backpressure, or higher to trade more in-flight frames (memory) for
+ *   fewer round-trips on a high-latency link.
  * @returns {any}  a `PassableReader` cap over `CloneFrame`s
  */
 export const streamTree = (sourceRoot, options = {}) => {
-  const { buffer = 0 } = options;
+  const { buffer = 64 } = options;
   return readerFromIterator(harvestTree(sourceRoot, harden([])), {
     buffer,
     readPattern: CloneFrameShape,

--- a/packages/endo-fs/src/clone.js
+++ b/packages/endo-fs/src/clone.js
@@ -171,42 +171,54 @@ export const writeTreeStream = async (destRoot, reader) => {
   /** @type {AsyncGenerator<any, any, Uint8Array> | undefined} */
   let writer;
 
-  for await (const frame of iterateReader(reader)) {
-    switch (frame.kind) {
-      case 'dir': {
-        await E(destRoot).materialise(harden(frame.path), {});
-        directories += 1;
-        break;
-      }
-      case 'file': {
-        !writer || Fail`clone stream: nested file frame`;
-        const { parent, name } = await resolveParent(destRoot, frame.path);
-        openFile = await E(parent).create(name, {});
-        writer = iterateBytesWriter(await E(openFile).write(0n));
-        files += 1;
-        break;
-      }
-      case 'chunk': {
-        writer || Fail`clone stream: chunk frame with no open file`;
-        const data = decodeBase64(frame.base64);
-        bytes += data.length;
-        await writer.next(data);
-        break;
-      }
-      case 'fileEnd': {
-        writer || Fail`clone stream: fileEnd with no open file`;
-        await writer.return();
-        await E(openFile).close();
-        writer = undefined;
-        openFile = undefined;
-        break;
-      }
-      default: {
-        throw Fail`clone stream: unknown frame kind ${frame.kind}`;
+  try {
+    for await (const frame of iterateReader(reader)) {
+      switch (frame.kind) {
+        case 'dir': {
+          await E(destRoot).materialise(harden(frame.path), {});
+          directories += 1;
+          break;
+        }
+        case 'file': {
+          !writer || Fail`clone stream: nested file frame`;
+          const { parent, name } = await resolveParent(destRoot, frame.path);
+          openFile = await E(parent).create(name, {});
+          writer = iterateBytesWriter(await E(openFile).write(0n));
+          files += 1;
+          break;
+        }
+        case 'chunk': {
+          writer || Fail`clone stream: chunk frame with no open file`;
+          const data = decodeBase64(frame.base64);
+          bytes += data.length;
+          await writer.next(data);
+          break;
+        }
+        case 'fileEnd': {
+          writer || Fail`clone stream: fileEnd with no open file`;
+          await writer.return();
+          await E(openFile).close();
+          writer = undefined;
+          openFile = undefined;
+          break;
+        }
+        default: {
+          throw Fail`clone stream: unknown frame kind ${frame.kind}`;
+        }
       }
     }
+    !writer || Fail`clone stream: ended mid-file`;
+  } finally {
+    // On a mid-stream error (malformed frame, source read failure) close the
+    // partially-written destination file rather than leaking the OpenFile and
+    // its abandoned writer.
+    if (writer) {
+      await writer.return().catch(() => {});
+      await E(openFile)
+        .close()
+        .catch(() => {});
+    }
   }
-  !writer || Fail`clone stream: ended mid-file`;
 
   return harden({ directories, files, bytes });
 };

--- a/packages/endo-fs/src/clone.js
+++ b/packages/endo-fs/src/clone.js
@@ -168,7 +168,10 @@ export const writeTreeStream = async (destRoot, reader) => {
 
   /** @type {any} */
   let openFile;
-  /** @type {AsyncGenerator<any, any, Uint8Array> | undefined} */
+  // The exo-stream byte writer (BytesWriterIterator) is iterator-shaped but
+  // not a full AsyncGenerator (no [Symbol.asyncDispose], 0-arg return()), so
+  // it is kept loosely typed.
+  /** @type {any} */
   let writer;
 
   try {

--- a/packages/endo-fs/src/clone.js
+++ b/packages/endo-fs/src/clone.js
@@ -1,0 +1,228 @@
+// @ts-check
+/* eslint-disable no-await-in-loop -- ordered streaming: directory entries
+   and file chunks are applied sequentially to preserve tree order and
+   bound memory; parallelising would reorder the single frame stream. */
+/**
+ * Streaming clone for `@endo/endo-fs` (designs/endo-app-sharing.md, Pillar 3c).
+ *
+ * A clone ships a whole source tree to a destination as **one ordered
+ * stream of entries** — `(path, kind, content)` in depth-first order —
+ * rather than a client-driven pipelined walk that pays a round-trip per
+ * node. The producer (which already holds the tree) serialises it into a
+ * single `PassableReader<CloneFrame>`; the consumer drains that one reader
+ * and recreates the tree under a destination `Directory`.
+ *
+ * Design decisions realised here:
+ *
+ * - **One stream, not a pipelined walk.** `streamTree` returns a single
+ *   reader regardless of file count; `@endo/exo-stream`'s pre-ack `buffer`
+ *   keeps the pipe full over a high-latency link.
+ * - **No content hashing.** Integrity and peer-authenticity are the
+ *   transport's job (the secure channel established when the peer was
+ *   added). The clone path computes no per-blob hash and does no CAS dedup.
+ * - **Large files stream as chunk frames** within the one stream, so no
+ *   whole file is buffered in memory.
+ * - **Pluggable durable destination.** The consumer writes through an
+ *   ordinary `Directory` cap, so the durable backing is whatever
+ *   `Filesystem` the caller hands in (in-memory, node-fs, a zip-backed
+ *   `FsBackend`, …).
+ *
+ * Bytes ride inside frames as base64 strings because CapTP marshalling
+ * rejects raw mutable typed arrays (see DESIGN.md §5 / §6); this mirrors
+ * how `@endo/exo-stream`'s byte reader/writer haul bytes today.
+ */
+
+import { E } from '@endo/eventual-send';
+import { Fail } from '@endo/errors';
+import { M } from '@endo/patterns';
+import { decodeBase64 } from '@endo/base64/decode.js';
+import { encodeBase64 } from '@endo/base64/encode.js';
+import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
+import { iterateReader } from '@endo/exo-stream/iterate-reader.js';
+import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
+import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
+
+/**
+ * @typedef {object} CloneFrame
+ * A single frame in the depth-first clone stream.
+ * - `{ kind: 'dir', path }` — ensure a directory exists at `path`.
+ * - `{ kind: 'file', path }` — begin a file at `path`.
+ * - `{ kind: 'chunk', base64 }` — append bytes to the file most recently
+ *   opened by a `file` frame.
+ * - `{ kind: 'fileEnd' }` — close the current file.
+ */
+
+/**
+ * Pattern for a single clone frame. Passed to `readerFromIterator` as the
+ * `readPattern` so a malformed frame breaks the stream at the boundary
+ * rather than corrupting the destination tree.
+ */
+export const CloneFrameShape = M.or(
+  harden({ kind: 'dir', path: M.arrayOf(M.string()) }),
+  harden({ kind: 'file', path: M.arrayOf(M.string()) }),
+  harden({ kind: 'chunk', base64: M.string() }),
+  harden({ kind: 'fileEnd' }),
+);
+harden(CloneFrameShape);
+
+/**
+ * Stable, name-sorted directory listing so a clone is reproducible.
+ *
+ * @param {any} dir  a `Directory` cap (local or remote)
+ * @returns {Promise<Array<{ name: string, qid: { type: string } }>>}
+ */
+const listSorted = async dir => {
+  const cursor = await E(dir).list();
+  const entries = await E(cursor).toArray();
+  return [...entries].sort((a, b) =>
+    String(a.name).localeCompare(String(b.name)),
+  );
+};
+
+/**
+ * Depth-first generator of clone frames for a directory's contents.
+ * Children are emitted relative to the original source root (the root
+ * directory itself is implied by the destination and gets no frame).
+ *
+ * @param {any} dir  a `Directory` cap
+ * @param {string[]} prefix  path of `dir` relative to the source root
+ * @returns {AsyncGenerator<CloneFrame, void, void>}
+ */
+async function* harvestTree(dir, prefix) {
+  const entries = await listSorted(dir);
+  for (const { name, qid } of entries) {
+    const path = harden([...prefix, name]);
+    const child = await E(dir).lookup(name);
+    if (qid.type === 'directory') {
+      yield harden({ kind: 'dir', path });
+      yield* harvestTree(child, path);
+    } else {
+      yield harden({ kind: 'file', path });
+      const open = await E(child).open({ read: true });
+      try {
+        // `read(0n)` is offset 0, length-to-EOF (DESIGN.md §4.6); the
+        // bytes reader yields transport-sized chunks we re-frame one
+        // for one, so no whole file is buffered.
+        const bytesReader = await E(open).read(0n);
+        for await (const chunk of iterateBytesReader(bytesReader)) {
+          yield harden({ kind: 'chunk', base64: encodeBase64(chunk) });
+        }
+      } finally {
+        await E(open).close();
+      }
+      yield harden({ kind: 'fileEnd' });
+    }
+  }
+}
+
+/**
+ * Serialise a source tree as a single `PassableReader<CloneFrame>`.
+ *
+ * @param {any} sourceRoot  the `Directory` cap at the root of the tree to
+ *   clone (e.g. `await E(filesystem).root()` or any sub-`Directory`)
+ * @param {{ buffer?: number }} [options]  `buffer` is the exo-stream
+ *   pre-ack depth (frames the producer sends ahead of consumer demand);
+ *   raise it over a high-latency link.
+ * @returns {any}  a `PassableReader` cap over `CloneFrame`s
+ */
+export const streamTree = (sourceRoot, options = {}) => {
+  const { buffer = 0 } = options;
+  return readerFromIterator(harvestTree(sourceRoot, harden([])), {
+    buffer,
+    readPattern: CloneFrameShape,
+  });
+};
+harden(streamTree);
+
+/**
+ * Resolve (creating as needed) the destination `Directory` that should
+ * contain `path`'s leaf, returning `{ parent, name }`.
+ *
+ * @param {any} destRoot  destination `Directory` cap
+ * @param {string[]} path  non-empty path relative to `destRoot`
+ * @returns {Promise<{ parent: any, name: string }>}
+ */
+const resolveParent = async (destRoot, path) => {
+  path.length >= 1 || Fail`clone frame path must be non-empty`;
+  const name = path[path.length - 1];
+  const parentPath = path.slice(0, -1);
+  const parent =
+    parentPath.length === 0
+      ? destRoot
+      : await E(destRoot).materialise(harden(parentPath), {});
+  return { parent, name };
+};
+
+/**
+ * Drain a clone stream into a destination `Directory`, recreating the
+ * source tree. Returns counts for progress reporting.
+ *
+ * @param {any} destRoot  the `Directory` cap to clone into
+ * @param {any} reader  a `PassableReader<CloneFrame>` (from `streamTree`)
+ * @returns {Promise<{ directories: number, files: number, bytes: number }>}
+ */
+export const writeTreeStream = async (destRoot, reader) => {
+  let directories = 0;
+  let files = 0;
+  let bytes = 0;
+
+  /** @type {any} */
+  let openFile;
+  /** @type {AsyncGenerator<any, any, Uint8Array> | undefined} */
+  let writer;
+
+  for await (const frame of iterateReader(reader)) {
+    switch (frame.kind) {
+      case 'dir': {
+        await E(destRoot).materialise(harden(frame.path), {});
+        directories += 1;
+        break;
+      }
+      case 'file': {
+        !writer || Fail`clone stream: nested file frame`;
+        const { parent, name } = await resolveParent(destRoot, frame.path);
+        openFile = await E(parent).create(name, {});
+        writer = iterateBytesWriter(await E(openFile).write(0n));
+        files += 1;
+        break;
+      }
+      case 'chunk': {
+        writer || Fail`clone stream: chunk frame with no open file`;
+        const data = decodeBase64(frame.base64);
+        bytes += data.length;
+        await writer.next(data);
+        break;
+      }
+      case 'fileEnd': {
+        writer || Fail`clone stream: fileEnd with no open file`;
+        await writer.return();
+        await E(openFile).close();
+        writer = undefined;
+        openFile = undefined;
+        break;
+      }
+      default: {
+        throw Fail`clone stream: unknown frame kind ${frame.kind}`;
+      }
+    }
+  }
+  !writer || Fail`clone stream: ended mid-file`;
+
+  return harden({ directories, files, bytes });
+};
+harden(writeTreeStream);
+
+/**
+ * Clone a source tree into a destination `Directory` as a single
+ * streamed pass. Convenience over `writeTreeStream(dest, streamTree(src))`;
+ * works whether `source` and `dest` are local or across a CapTP boundary,
+ * since everything flows through the one reader cap.
+ *
+ * @param {any} sourceRoot  the `Directory` cap to clone from
+ * @param {any} destRoot  the `Directory` cap to clone into
+ * @param {{ buffer?: number }} [options]
+ * @returns {Promise<{ directories: number, files: number, bytes: number }>}
+ */
+export const cloneTree = (sourceRoot, destRoot, options = {}) =>
+  writeTreeStream(destRoot, streamTree(sourceRoot, options));
+harden(cloneTree);

--- a/packages/endo-fs/src/clone.js
+++ b/packages/endo-fs/src/clone.js
@@ -184,7 +184,13 @@ export const writeTreeStream = async (destRoot, reader) => {
   let writer;
 
   try {
-    for await (const frame of iterateReader(reader)) {
+    // Validate frames on the consumer side too. `writeTreeStream` drains an
+    // arbitrary reader (possibly remote/untrusted), so enforce the frame shape
+    // at the stream boundary rather than failing deep in a switch case — or
+    // worse, feeding a non-string into `decodeBase64`.
+    for await (const frame of iterateReader(reader, {
+      readPattern: CloneFrameShape,
+    })) {
       switch (frame.kind) {
         case 'dir': {
           !writer || Fail`clone stream: dir frame while a file is open`;
@@ -196,7 +202,12 @@ export const writeTreeStream = async (destRoot, reader) => {
         case 'file': {
           !writer || Fail`clone stream: nested file frame`;
           const { parent, name } = await resolveParent(destRoot, frame.path);
-          openFile = await E(parent).create(name, {});
+          // Truncate: a clone overwrites the destination wholesale, so an
+          // existing longer file at this path must be shortened. `create`
+          // truncates only with this flag, and `OpenFile.write` is pwrite
+          // (no tail truncate), so without it a re-clone into a non-empty
+          // destination would leave stale trailing bytes.
+          openFile = await E(parent).create(name, { truncate: true });
           writer = iterateBytesWriter(await E(openFile).write(0n));
           files += 1;
           break;

--- a/packages/endo-fs/src/clone.js
+++ b/packages/endo-fs/src/clone.js
@@ -183,6 +183,8 @@ export const writeTreeStream = async (destRoot, reader) => {
     for await (const frame of iterateReader(reader)) {
       switch (frame.kind) {
         case 'dir': {
+          !writer || Fail`clone stream: dir frame while a file is open`;
+          frame.path.length !== 0 || Fail`clone stream: dir frame empty path`;
           await E(destRoot).materialise(harden(frame.path), {});
           directories += 1;
           break;

--- a/packages/endo-fs/src/clone.js
+++ b/packages/endo-fs/src/clone.js
@@ -67,6 +67,8 @@ harden(CloneFrameShape);
 
 /**
  * Stable, name-sorted directory listing so a clone is reproducible.
+ * Sorts by UTF-16 code point (not `localeCompare`, whose order varies by
+ * environment locale) so the traversal order is deterministic everywhere.
  *
  * @param {any} dir  a `Directory` cap (local or remote)
  * @returns {Promise<Array<{ name: string, qid: { type: string } }>>}
@@ -74,9 +76,12 @@ harden(CloneFrameShape);
 const listSorted = async dir => {
   const cursor = await E(dir).list();
   const entries = await E(cursor).toArray();
-  return [...entries].sort((a, b) =>
-    String(a.name).localeCompare(String(b.name)),
-  );
+  return [...entries].sort((a, b) => {
+    const an = String(a.name);
+    const bn = String(b.name);
+    // eslint-disable-next-line no-nested-ternary
+    return an < bn ? -1 : an > bn ? 1 : 0;
+  });
 };
 
 /**

--- a/packages/endo-fs/src/index.js
+++ b/packages/endo-fs/src/index.js
@@ -29,6 +29,15 @@ export { makeFromMountBackend } from './backends/from-mount-backend.js';
 // Public porcelain helpers (free functions over the typed cap surface).
 export { walk, collectBytes, collectStream } from './helpers.js';
 
+// Streaming clone (designs/endo-app-sharing.md): serialise a source tree
+// as one ordered frame stream and drain it into a destination Directory.
+export {
+  cloneTree,
+  streamTree,
+  writeTreeStream,
+  CloneFrameShape,
+} from './clone.js';
+
 // PosixFs interface sketch — POSIX-shaped attrs / real OS locks /
 // native disk xattrs live in a future companion cap. Only the
 // guard is exported; backing-specific implementations come later.

--- a/packages/endo-fs/test/clone.test.js
+++ b/packages/endo-fs/test/clone.test.js
@@ -1,0 +1,178 @@
+// @ts-nocheck
+/* eslint-disable import/order, no-await-in-loop */
+
+/**
+ * Streaming clone tests (designs/endo-app-sharing.md, Pillar 3c).
+ *
+ * `cloneTree(source, dest)` ships a whole tree as one ordered frame
+ * stream and recreates it under a destination Directory. These tests
+ * build an in-memory source, clone it into a fresh in-memory
+ * destination, and assert the structure and bytes round-trip — including
+ * empty files, empty directories, deep nesting, and multi-chunk content.
+ */
+
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import { E } from '@endo/far';
+import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
+import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
+
+import { makeInMemoryFilesystem } from '../src/in-memory.js';
+import { cloneTree, streamTree, writeTreeStream } from '../src/clone.js';
+
+const utf8 = s => new TextEncoder().encode(s);
+const fromUtf8 = b => new TextDecoder().decode(b);
+
+const collectBytes = async readerRef => {
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of iterateBytesReader(readerRef)) {
+    chunks.push(chunk);
+    total += chunk.length;
+  }
+  const buf = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    buf.set(c, off);
+    off += c.length;
+  }
+  return buf;
+};
+
+const writeBytes = async (writerRef, bytes) => {
+  const writer = iterateBytesWriter(writerRef);
+  await writer.next(bytes);
+  await writer.return();
+};
+
+/** Create a file with `bytes` at `name` under directory `dir`. */
+const putFile = async (dir, name, bytes) => {
+  const open = await E(dir).create(name, {});
+  if (bytes.length) {
+    await writeBytes(await E(open).write(0n), bytes);
+  }
+  await E(open).close();
+};
+
+/** Read the bytes of the file at `path` (string[]) under `root`. */
+const readFileAt = async (root, path) => {
+  let node = root;
+  for (const seg of path) {
+    node = await E(node).lookup(seg);
+  }
+  const open = await E(node).open({ read: true });
+  return collectBytes(await E(open).read(0n));
+};
+
+/** True if a child `name` exists under directory `dir`. */
+const childKinds = async dir => {
+  const cursor = await E(dir).list();
+  const entries = await E(cursor).toArray();
+  const map = new Map();
+  for (const { name, qid } of entries) {
+    map.set(name, qid.type);
+  }
+  return map;
+};
+
+/**
+ * Build a source tree:
+ *   /readme.txt          "top level\n"
+ *   /empty.txt           (zero bytes)
+ *   /emptydir/           (no children)
+ *   /src/index.js        "export const x = 1;\n"
+ *   /src/deep/nested.txt  larger, multi-write content
+ */
+const buildSource = async () => {
+  const fs = makeInMemoryFilesystem();
+  const root = await E(fs).root();
+  await putFile(root, 'readme.txt', utf8('top level\n'));
+  await putFile(root, 'empty.txt', utf8(''));
+  await E(root).makeDirectory('emptydir', {});
+  const src = await E(root).makeDirectory('src', {});
+  await putFile(src, 'index.js', utf8('export const x = 1;\n'));
+  const deep = await E(src).makeDirectory('deep', {});
+  // A larger payload written as several chunks, to exercise multi-chunk
+  // streaming through the single frame stream.
+  const big = 'abcdefghij'.repeat(5000); // 50 KiB
+  const open = await E(deep).create('nested.txt', {});
+  const writer = iterateBytesWriter(await E(open).write(0n));
+  await writer.next(utf8(big.slice(0, 20000)));
+  await writer.next(utf8(big.slice(20000)));
+  await writer.return();
+  await E(open).close();
+  return { fs, root, big };
+};
+
+test('cloneTree reproduces the full tree and its bytes', async t => {
+  const { root: source, big } = await buildSource();
+
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+
+  const stats = await cloneTree(source, dest);
+
+  // Directories: emptydir, src, src/deep → 3. Files: readme.txt,
+  // empty.txt, src/index.js, src/deep/nested.txt → 4.
+  t.is(stats.directories, 3);
+  t.is(stats.files, 4);
+  t.is(stats.bytes, 10 + 0 + 20 + big.length);
+
+  t.is(fromUtf8(await readFileAt(dest, ['readme.txt'])), 'top level\n');
+  t.is(fromUtf8(await readFileAt(dest, ['empty.txt'])), '');
+  t.is(
+    fromUtf8(await readFileAt(dest, ['src', 'index.js'])),
+    'export const x = 1;\n',
+  );
+  t.is(fromUtf8(await readFileAt(dest, ['src', 'deep', 'nested.txt'])), big);
+
+  // Empty directory is materialised even though it has no children.
+  const top = await childKinds(dest);
+  t.is(top.get('emptydir'), 'directory');
+  t.is(top.get('src'), 'directory');
+  t.is(top.get('readme.txt'), 'file');
+  t.is(top.get('empty.txt'), 'file');
+});
+
+test('cloneTree of a sub-directory clones only that subtree', async t => {
+  const { root: source } = await buildSource();
+  const src = await E(source).lookup('src');
+
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+
+  const stats = await cloneTree(src, dest);
+  t.is(stats.files, 2); // index.js + deep/nested.txt
+  t.is(stats.directories, 1); // deep
+
+  t.is(
+    fromUtf8(await readFileAt(dest, ['index.js'])),
+    'export const x = 1;\n',
+  );
+  const top = await childKinds(dest);
+  t.false(top.has('readme.txt')); // outside the cloned subtree
+});
+
+test('streamTree + writeTreeStream compose explicitly', async t => {
+  const { root: source } = await buildSource();
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+
+  // Equivalent to cloneTree, but with the producer/consumer split visible.
+  const reader = streamTree(source, { buffer: 4 });
+  const stats = await writeTreeStream(dest, reader);
+
+  t.is(stats.files, 4);
+  t.is(fromUtf8(await readFileAt(dest, ['readme.txt'])), 'top level\n');
+});
+
+test('cloning an empty tree yields zero counts', async t => {
+  const srcFs = makeInMemoryFilesystem();
+  const source = await E(srcFs).root();
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+
+  const stats = await cloneTree(source, dest);
+  t.deepEqual({ ...stats }, { directories: 0, files: 0, bytes: 0 });
+});

--- a/packages/endo-fs/test/clone.test.js
+++ b/packages/endo-fs/test/clone.test.js
@@ -146,6 +146,26 @@ test('cloneTree reproduces the full tree and its bytes', async t => {
   t.is(top.get('empty.txt'), 'file');
 });
 
+test('cloneTree into a non-empty destination overwrites without stale tail bytes', async t => {
+  const { root: source } = await buildSource();
+
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  // Pre-populate the destination with a file that is LONGER than the source's
+  // version. A pwrite-only overwrite would leave the old tail behind.
+  await putFile(
+    dest,
+    'readme.txt',
+    utf8('PRE-EXISTING CONTENT THAT IS LONGER THAN THE SOURCE AND MUST GO\n'),
+  );
+
+  const stats = await cloneTree(source, dest);
+  t.is(stats.files, 4);
+
+  // The clobbered file must equal the source exactly — no leftover tail.
+  t.is(fromUtf8(await readFileAt(dest, ['readme.txt'])), 'top level\n');
+});
+
 test('cloneTree of a sub-directory clones only that subtree', async t => {
   const { root: source } = await buildSource();
   const src = await E(source).lookup('src');

--- a/packages/endo-fs/test/clone.test.js
+++ b/packages/endo-fs/test/clone.test.js
@@ -207,3 +207,27 @@ test('writeTreeStream rejects a stream ending mid-file and cleans up', async t =
   const top = await childKinds(dest);
   t.is(top.get('x.txt'), 'file');
 });
+
+test('writeTreeStream rejects a dir frame with an empty path', async t => {
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  await t.throwsAsync(
+    writeTreeStream(dest, readerOf([{ kind: 'dir', path: [] }])),
+    { message: /empty path/ },
+  );
+});
+
+test('writeTreeStream rejects a dir frame while a file is open', async t => {
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  await t.throwsAsync(
+    writeTreeStream(
+      dest,
+      readerOf([
+        { kind: 'file', path: ['a.txt'] },
+        { kind: 'dir', path: ['b'] },
+      ]),
+    ),
+    { message: /file is open/ },
+  );
+});

--- a/packages/endo-fs/test/clone.test.js
+++ b/packages/endo-fs/test/clone.test.js
@@ -17,9 +17,20 @@ import test from 'ava';
 import { E } from '@endo/far';
 import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
 import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
+import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 
 import { makeInMemoryFilesystem } from '../src/in-memory.js';
 import { cloneTree, streamTree, writeTreeStream } from '../src/clone.js';
+
+/** Wrap an array of frames as a PassableReader for writeTreeStream. */
+const readerOf = frames =>
+  readerFromIterator(
+    (async function* gen() {
+      for (const frame of frames) {
+        yield harden(frame);
+      }
+    })(),
+  );
 
 const utf8 = s => new TextEncoder().encode(s);
 const fromUtf8 = b => new TextDecoder().decode(b);
@@ -172,4 +183,27 @@ test('cloning an empty tree yields zero counts', async t => {
 
   const stats = await cloneTree(source, dest);
   t.deepEqual({ ...stats }, { directories: 0, files: 0, bytes: 0 });
+});
+
+test('writeTreeStream rejects a chunk with no open file', async t => {
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  await t.throwsAsync(
+    writeTreeStream(dest, readerOf([{ kind: 'chunk', base64: 'AA==' }])),
+    { message: /no open file/ },
+  );
+});
+
+test('writeTreeStream rejects a stream ending mid-file and cleans up', async t => {
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  // A file frame with no terminating fileEnd: the drain loop's post-check
+  // throws, and the finally must close the half-open destination file.
+  await t.throwsAsync(
+    writeTreeStream(dest, readerOf([{ kind: 'file', path: ['x.txt'] }])),
+    { message: /mid-file/ },
+  );
+  // The file was created then closed by the cleanup path (no leaked handle).
+  const top = await childKinds(dest);
+  t.is(top.get('x.txt'), 'file');
 });

--- a/packages/endo-fs/test/clone.test.js
+++ b/packages/endo-fs/test/clone.test.js
@@ -146,10 +146,7 @@ test('cloneTree of a sub-directory clones only that subtree', async t => {
   t.is(stats.files, 2); // index.js + deep/nested.txt
   t.is(stats.directories, 1); // deep
 
-  t.is(
-    fromUtf8(await readFileAt(dest, ['index.js'])),
-    'export const x = 1;\n',
-  );
+  t.is(fromUtf8(await readFileAt(dest, ['index.js'])), 'export const x = 1;\n');
   const top = await childKinds(dest);
   t.false(top.has('readme.txt')); // outside the cloned subtree
 });

--- a/packages/familiar/electron-main.js
+++ b/packages/familiar/electron-main.js
@@ -26,6 +26,7 @@ import { whereEndoState } from '@endo/where';
 import { makeDaemonManager } from './src/daemon-manager.js';
 import { resourcePaths } from './src/resource-paths.js';
 import { makeLogger } from './src/logger.js';
+import { parseInviteUrl, findInviteUrlInArgv } from './src/deep-link.js';
 import {
   registerLocalhttpScheme,
   installLocalhttpHandler,
@@ -60,6 +61,95 @@ registerLocalhttpScheme();
 configureCommandLineFlags();
 
 const vitePort = 5173;
+
+/** @type {Electron.BrowserWindow | null} */
+let mainWindow = null;
+
+// --- Deep-link (endo://) peer invitations ---
+// (designs/familiar-deep-link-invitations.md)
+
+/** @type {import('./src/deep-link.js').ParsedInvite | null} */
+let pendingInvite = null;
+// Set once the renderer has pulled any queued invite via the IPC handler
+// below; until then invites are queued rather than sent, closing the race
+// where a cold-start invite is emitted before the page registers its
+// listener.
+let rendererReady = false;
+
+/**
+ * Deliver a parsed invite to the renderer, or queue it until the renderer is
+ * ready (cold start, pre-`app.whenReady`, or before the window finishes
+ * loading).
+ *
+ * @param {import('./src/deep-link.js').ParsedInvite} parsed
+ */
+const deliverInvite = parsed => {
+  if (rendererReady && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('familiar:deep-link-invite', parsed);
+  } else {
+    pendingInvite = parsed;
+  }
+};
+
+/**
+ * Parse and route an `endo://` URL handed to us by the OS. Unrecognised
+ * links are logged and dropped; authoritative validation is the daemon's
+ * when the renderer calls `host.accept`.
+ *
+ * @param {string} url
+ */
+const handleInviteUrl = url => {
+  const parsed = parseInviteUrl(url);
+  if (parsed) {
+    logger.log(
+      `[Familiar] Received deep-link invite from ${parsed.fingerprint}`,
+    );
+    deliverInvite(parsed);
+  } else {
+    logger.warn(
+      `[Familiar] Ignoring unrecognised deep link: ${String(url).slice(0, 32)}`,
+    );
+  }
+};
+
+// Register endo:// as this app's protocol client. In dev the app runs from
+// the electron binary, so the entry script must be passed explicitly.
+if (process.defaultApp) {
+  if (process.argv.length >= 2) {
+    app.setAsDefaultProtocolClient('endo', process.execPath, [
+      path.resolve(process.argv[1]),
+    ]);
+  }
+} else {
+  app.setAsDefaultProtocolClient('endo');
+}
+
+// Single-instance: a second launch (e.g. the OS handing us an endo:// URL on
+// Windows/Linux) routes its argv to the already-running instance instead of
+// starting a second daemon-bearing process.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', (_event, argv) => {
+    const url = findInviteUrlInArgv(argv);
+    if (url) {
+      handleInviteUrl(url);
+    }
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
+      mainWindow.focus();
+    }
+  });
+}
+
+// macOS delivers deep links via open-url, which can fire before the app is
+// ready or the window exists; deliverInvite queues until the renderer pulls.
+app.on('open-url', (_event, url) => {
+  handleInviteUrl(url);
+});
 
 /** @type {string | undefined} */
 let gatewayAddress;
@@ -281,8 +371,14 @@ const main = async () => {
   installExfiltrationDefenses();
 
   // Step 4: Create the window
-  /** @type {Electron.BrowserWindow | null} */
-  let mainWindow = createWindow();
+  mainWindow = createWindow();
+
+  // A deep link may have arrived on the command line (Windows/Linux cold
+  // start). Queue it; the renderer pulls it via get-pending-invite on init.
+  const coldStartInvite = findInviteUrlInArgv(process.argv);
+  if (coldStartInvite) {
+    handleInviteUrl(coldStartInvite);
+  }
 
   // Step 5: Build menu
   buildMenu(
@@ -296,6 +392,14 @@ const main = async () => {
   );
   ipcMain.handle('familiar:purge-daemon', () => handlePurgeDaemon(mainWindow));
   ipcMain.handle('familiar:get-version', () => app.getVersion());
+  // The renderer pulls any invite queued before it was listening, and by
+  // doing so marks itself ready for live delivery of subsequent invites.
+  ipcMain.handle('familiar:get-pending-invite', () => {
+    rendererReady = true;
+    const invite = pendingInvite;
+    pendingInvite = null;
+    return invite;
+  });
 
   // Step 7: Verify exfiltration defenses and notify renderer
   const warnings = await verifyExfiltrationDefenses();
@@ -323,7 +427,12 @@ const main = async () => {
   // Daemon continues running after quit; nothing to clean up.
 };
 
-main().catch(error => {
-  logger.error('[Familiar] Fatal error:', error);
-  process.exit(1);
-});
+// Only the instance that holds the single-instance lock boots the app; a
+// second launch has already forwarded its argv via 'second-instance' above
+// and is quitting.
+if (gotSingleInstanceLock) {
+  main().catch(error => {
+    logger.error('[Familiar] Fatal error:', error);
+    process.exit(1);
+  });
+}

--- a/packages/familiar/electron-main.js
+++ b/packages/familiar/electron-main.js
@@ -108,8 +108,11 @@ const handleInviteUrl = url => {
     );
     deliverInvite(parsed);
   } else {
+    // Strip query/fragment before logging: an unrecognised link is arbitrary
+    // and its query string could carry secrets. Log only scheme + path.
+    const scrubbed = String(url).split(/[?#]/)[0];
     logger.warn(
-      `[Familiar] Ignoring unrecognised deep link: ${String(url).slice(0, 32)}`,
+      `[Familiar] Ignoring unrecognised deep link: ${scrubbed.slice(0, 64)}`,
     );
   }
 };

--- a/packages/familiar/electron-main.js
+++ b/packages/familiar/electron-main.js
@@ -385,23 +385,12 @@ const main = async () => {
   installLocalhttpHandler(gatewayPort);
   installExfiltrationDefenses();
 
-  // Step 4: Create the window
-  mainWindow = createWindow();
-
-  // A deep link may have arrived on the command line (Windows/Linux cold
-  // start). Queue it; the renderer pulls it via get-pending-invite on init.
-  const coldStartInvite = findInviteUrlInArgv(process.argv);
-  if (coldStartInvite) {
-    handleInviteUrl(coldStartInvite);
-  }
-
-  // Step 5: Build menu
-  buildMenu(
-    () => handleRestartDaemon(mainWindow),
-    () => handlePurgeDaemon(mainWindow),
-  );
-
-  // Step 6: Register IPC handlers
+  // Step 4: Register IPC handlers BEFORE creating the window. `createWindow`
+  // starts loading the renderer, which calls `get-pending-invite` on init; if
+  // that invoke reaches main before the handler is registered it rejects, and
+  // the renderer (which swallows the rejection) silently drops a cold-start
+  // invite. Registering first closes that race. The handler closures read
+  // `mainWindow` lazily, so registering before it is assigned is safe.
   ipcMain.handle('familiar:restart-daemon', () =>
     handleRestartDaemon(mainWindow),
   );
@@ -415,6 +404,22 @@ const main = async () => {
     pendingInvites = [];
     return invites;
   });
+
+  // Step 5: Create the window
+  mainWindow = createWindow();
+
+  // A deep link may have arrived on the command line (Windows/Linux cold
+  // start). Queue it; the renderer pulls it via get-pending-invite on init.
+  const coldStartInvite = findInviteUrlInArgv(process.argv);
+  if (coldStartInvite) {
+    handleInviteUrl(coldStartInvite);
+  }
+
+  // Step 6: Build menu
+  buildMenu(
+    () => handleRestartDaemon(mainWindow),
+    () => handlePurgeDaemon(mainWindow),
+  );
 
   // Step 7: Verify exfiltration defenses and notify renderer
   const warnings = await verifyExfiltrationDefenses();

--- a/packages/familiar/electron-main.js
+++ b/packages/familiar/electron-main.js
@@ -68,8 +68,8 @@ let mainWindow = null;
 // --- Deep-link (endo://) peer invitations ---
 // (designs/familiar-deep-link-invitations.md)
 
-/** @type {import('./src/deep-link.js').ParsedInvite | null} */
-let pendingInvite = null;
+/** @type {import('./src/deep-link.js').ParsedInvite[]} */
+let pendingInvites = [];
 // Set once the renderer has pulled any queued invite via the IPC handler
 // below; until then invites are queued rather than sent, closing the race
 // where a cold-start invite is emitted before the page registers its
@@ -87,13 +87,15 @@ const deliverInvite = parsed => {
   if (rendererReady && mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send('familiar:deep-link-invite', parsed);
   } else {
-    pendingInvite = parsed;
+    // Queue rather than overwrite: several links may arrive before the
+    // renderer pulls (cold start, reload), and none should be dropped.
+    pendingInvites.push(parsed);
   }
 };
 
 /**
  * Parse and route an `endo://` URL handed to us by the OS. Unrecognised
- * links are logged and dropped; authoritative validation is the daemon's
+ * links are logged and dropped; authoritative validation happens daemon-side
  * when the renderer calls `host.accept`.
  *
  * @param {string} url
@@ -147,7 +149,10 @@ if (!gotSingleInstanceLock) {
 
 // macOS delivers deep links via open-url, which can fire before the app is
 // ready or the window exists; deliverInvite queues until the renderer pulls.
-app.on('open-url', (_event, url) => {
+// preventDefault() suppresses the OS default handling, per Electron's docs
+// for a registered protocol client.
+app.on('open-url', (event, url) => {
+  event.preventDefault();
   handleInviteUrl(url);
 });
 
@@ -403,9 +408,9 @@ const main = async () => {
   // doing so marks itself ready for live delivery of subsequent invites.
   ipcMain.handle('familiar:get-pending-invite', () => {
     rendererReady = true;
-    const invite = pendingInvite;
-    pendingInvite = null;
-    return invite;
+    const invites = pendingInvites;
+    pendingInvites = [];
+    return invites;
   });
 
   // Step 7: Verify exfiltration defenses and notify renderer

--- a/packages/familiar/electron-main.js
+++ b/packages/familiar/electron-main.js
@@ -266,6 +266,13 @@ const createWindow = () => {
   // Install navigation guard
   installNavigationGuard(win, { isDevMode, vitePort });
 
+  // Each (re)load — initial, restart, or purge — starts a fresh renderer that
+  // has not yet pulled queued invites. Drop ready until it pulls again, so an
+  // invite arriving mid-reload is queued rather than sent into a dead page.
+  win.webContents.on('did-start-loading', () => {
+    rendererReady = false;
+  });
+
   return win;
 };
 

--- a/packages/familiar/package.json
+++ b/packages/familiar/package.json
@@ -32,6 +32,7 @@
     "step:prepare": "node scripts/prepare-package.mjs",
     "step:package": "node scripts/package-app.mjs",
     "step:make": "node scripts/make-distributables.mjs",
+    "test": "node --test",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint --ignore-pattern out '**/*.js'",

--- a/packages/familiar/preload.js
+++ b/packages/familiar/preload.js
@@ -21,8 +21,11 @@ contextBridge.exposeInMainWorld(
         callback(warnings),
       ),
     // endo:// deep-link peer invitations
-    // (designs/familiar-deep-link-invitations.md). The renderer pulls any
-    // invite queued before it was listening, then subscribes for live ones.
+    // (designs/familiar-deep-link-invitations.md). The renderer subscribes for
+    // live invites first (`onDeepLinkInvite`), then pulls any queued before it
+    // was listening (`getPendingDeepLinkInvite`); subscribing first closes the
+    // cold-start race where an invite arrives between the pull and the
+    // subscription.
     getPendingDeepLinkInvite: () =>
       ipcRenderer.invoke('familiar:get-pending-invite'),
     onDeepLinkInvite: (/** @type {(invite: object) => void} */ callback) =>

--- a/packages/familiar/preload.js
+++ b/packages/familiar/preload.js
@@ -20,5 +20,14 @@ contextBridge.exposeInMainWorld(
       ipcRenderer.on('familiar:security-warnings', (_event, warnings) =>
         callback(warnings),
       ),
+    // endo:// deep-link peer invitations
+    // (designs/familiar-deep-link-invitations.md). The renderer pulls any
+    // invite queued before it was listening, then subscribes for live ones.
+    getPendingDeepLinkInvite: () =>
+      ipcRenderer.invoke('familiar:get-pending-invite'),
+    onDeepLinkInvite: (/** @type {(invite: object) => void} */ callback) =>
+      ipcRenderer.on('familiar:deep-link-invite', (_event, invite) =>
+        callback(invite),
+      ),
   }),
 );

--- a/packages/familiar/src/deep-link.js
+++ b/packages/familiar/src/deep-link.js
@@ -7,15 +7,23 @@
  * The deep link is an **intent-path** URL, distinct from the daemon's internal
  * locator string:
  *
- *   endo://invite?node={node}&id={invitationNumber}&at={addr}...
+ *   endo://invite?node={node}&id={invitationNumber}&from={hostHandle}
+ *               [&fromNode={handleNode}]&at={addr}...
  *
  * The authority segment is the *intent* (`invite`), so `endo://` can route
  * other actions later (`endo://adopt`, `endo://open-weblet`, …) without
- * overloading a locator's `type` field. `node` and `id` are 64-char lowercase
- * hex; `at` repeats for connection hints. `parseInviteUrl` validates the link
- * and reconstructs the canonical daemon locator
- * (`endo://{node}/?id=…&type=invitation&at=…`) that `host.accept` consumes —
- * decoupling the clickable link from the internal locator format.
+ * overloading a locator's `type` field, and the clickable link is decoupled
+ * from the internal locator format.
+ *
+ * The fields mirror what `host.accept` consumes from an invitation locator
+ * (see `daemon/src/host.js` `accept` and `daemon/src/daemon.js`
+ * `makeInvitation.locate`): the inviting `node`, the invitation `id`, the
+ * inviter's handle `from` (required — accept throws without it), an optional
+ * `fromNode` when the handle uses a distinct agent key, and `at` connection
+ * hints. `node` / `id` / `from` / `fromNode` are 64-char lowercase hex.
+ * `parseInviteUrl` validates the link and reconstructs the canonical daemon
+ * locator (`endo://{node}/?id=…&type=invitation&from=…&at=…`) that
+ * `host.accept` consumes.
  *
  * This module is pure and dependency-free on purpose. The Electron main
  * process runs WITHOUT SES, so it must not import `@endo/daemon` internals or
@@ -30,34 +38,40 @@ const NUMBER_PATTERN = /^[0-9a-f]{64}$/;
 /** The deep-link authority segment that denotes a peer-invitation intent. */
 const INVITE_INTENT = 'invite';
 
-/** The locator `type` for a peer invitation, used in the reconstructed locator. */
+/** The locator `type` for a peer invitation (set for fidelity with locate()). */
 const INVITATION_TYPE = 'invitation';
 
 /**
  * @typedef {object} ParsedInvite
  * @property {string} locator      The canonical daemon invitation locator
  *   reconstructed from the deep link; pass verbatim to `host.accept`.
- * @property {string} node         The peer node identifier (64-hex).
+ * @property {string} node         The inviting node identifier (64-hex).
  * @property {string} number       The invitation formula number (64-hex).
+ * @property {string} from         The inviter's handle number (64-hex).
+ * @property {string | undefined} fromNode  The handle's node, when it differs
+ *   from `node` (agent-key case); otherwise undefined.
  * @property {string} fingerprint  Short, human-comparable form of `node` for
  *   the confirmation screen.
  * @property {string[]} addresses  Connection hints (the `at` params).
  */
 
 /**
- * Reconstruct the canonical daemon locator from invitation parts. Mirrors the
- * daemon's `formatLocatorForSharing` (`id` / `type` / `at` params).
+ * Reconstruct the canonical daemon invitation locator from its parts, matching
+ * `makeInvitation.locate()` (`id` / `type` / `from` / `fromNode` / `at`).
  *
- * @param {string} node
- * @param {string} number
- * @param {string[]} addresses
+ * @param {{ node: string, number: string, from: string,
+ *   fromNode?: string, addresses: string[] }} parts
  * @returns {string}
  */
-const buildLocator = (node, number, addresses) => {
+const buildLocator = ({ node, number, from, fromNode, addresses }) => {
   const url = new URL(`endo://${node}`);
   url.pathname = '/';
   url.searchParams.set('id', number);
   url.searchParams.set('type', INVITATION_TYPE);
+  url.searchParams.set('from', from);
+  if (fromNode !== undefined) {
+    url.searchParams.set('fromNode', fromNode);
+  }
   for (const address of addresses) {
     url.searchParams.append('at', address);
   }
@@ -86,27 +100,45 @@ export const parseInviteUrl = text => {
   if (url.host !== INVITE_INTENT) {
     return null;
   }
-  // Only node / id / at are meaningful; reject anything else so a malformed
-  // or smuggling link is treated as unrecognised.
+  // Only these keys are meaningful; reject anything else so a malformed or
+  // smuggling link is treated as unrecognised.
   for (const key of url.searchParams.keys()) {
-    if (key !== 'node' && key !== 'id' && key !== 'at') {
+    if (
+      key !== 'node' &&
+      key !== 'id' &&
+      key !== 'from' &&
+      key !== 'fromNode' &&
+      key !== 'at'
+    ) {
       return null;
     }
   }
   const node = url.searchParams.get('node');
+  const number = url.searchParams.get('id');
+  const from = url.searchParams.get('from');
   if (node === null || !NUMBER_PATTERN.test(node)) {
     return null;
   }
-  const number = url.searchParams.get('id');
   if (number === null || !NUMBER_PATTERN.test(number)) {
     return null;
   }
+  // `from` (the inviter's handle) is required: host.accept throws without it.
+  if (from === null || !NUMBER_PATTERN.test(from)) {
+    return null;
+  }
+  const fromNodeParam = url.searchParams.get('fromNode');
+  if (fromNodeParam !== null && !NUMBER_PATTERN.test(fromNodeParam)) {
+    return null;
+  }
+  const fromNode = fromNodeParam === null ? undefined : fromNodeParam;
   const addresses = url.searchParams.getAll('at');
   const fingerprint = `${node.slice(0, 8)}…${node.slice(-8)}`;
   return {
-    locator: buildLocator(node, number, addresses),
+    locator: buildLocator({ node, number, from, fromNode, addresses }),
     node,
     number,
+    from,
+    fromNode,
     fingerprint,
     addresses,
   };
@@ -124,19 +156,38 @@ export const isInviteUrl = text => parseInviteUrl(text) !== null;
  * definition of the link contract. Throws on malformed parts (it is a
  * producer, not a recogniser).
  *
- * @param {{ node: string, number: string, addresses?: string[] }} parts
+ * @param {{ node: string, number: string, from: string,
+ *   fromNode?: string, addresses?: string[] }} parts
  * @returns {string}
  */
-export const formatInviteUrl = ({ node, number, addresses = [] }) => {
+export const formatInviteUrl = ({
+  node,
+  number,
+  from,
+  fromNode,
+  addresses = [],
+}) => {
   if (!NUMBER_PATTERN.test(node)) {
     throw new Error(`formatInviteUrl: invalid node ${JSON.stringify(node)}`);
   }
   if (!NUMBER_PATTERN.test(number)) {
     throw new Error(`formatInviteUrl: invalid id ${JSON.stringify(number)}`);
   }
+  if (!NUMBER_PATTERN.test(from)) {
+    throw new Error(`formatInviteUrl: invalid from ${JSON.stringify(from)}`);
+  }
+  if (fromNode !== undefined && !NUMBER_PATTERN.test(fromNode)) {
+    throw new Error(
+      `formatInviteUrl: invalid fromNode ${JSON.stringify(fromNode)}`,
+    );
+  }
   const url = new URL(`endo://${INVITE_INTENT}`);
   url.searchParams.set('node', node);
   url.searchParams.set('id', number);
+  url.searchParams.set('from', from);
+  if (fromNode !== undefined) {
+    url.searchParams.set('fromNode', fromNode);
+  }
   for (const address of addresses) {
     url.searchParams.append('at', address);
   }

--- a/packages/familiar/src/deep-link.js
+++ b/packages/familiar/src/deep-link.js
@@ -1,0 +1,101 @@
+// @ts-check
+
+/**
+ * `endo://` deep-link invitation parsing for the Familiar shell
+ * (designs/familiar-deep-link-invitations.md).
+ *
+ * An Endo peer invitation locator is itself an `endo://` URL:
+ *
+ *   endo://{node}/?id={invitationNumber}&type=invitation&at={addr}...
+ *
+ * The deep link IS that locator verbatim (design Decision 3): there is no
+ * separate `endo://invite/...` envelope, because the daemon's `parseLocator`
+ * rejects any query param other than `id` / `type` / `at`, and `host.accept`
+ * consumes the locator string directly.
+ *
+ * This module is pure and dependency-free on purpose. The Electron main
+ * process runs WITHOUT SES, so it must not import `@endo/daemon` internals
+ * or rely on a `harden` global. Authoritative validation happens daemon-side
+ * when the renderer calls `E(host).accept(locator, petName)`; these helpers
+ * only recognise a plausible invitation and extract fields for display and
+ * routing.
+ */
+
+/** Ed25519 public key / formula number: 64 lowercase hex characters. */
+const NUMBER_PATTERN = /^[0-9a-f]{64}$/;
+
+/** The locator `type` query value that denotes a peer invitation. */
+const INVITATION_TYPE = 'invitation';
+
+/**
+ * @typedef {object} ParsedInvite
+ * @property {string} locator      The invitation locator (the `endo://` URL),
+ *   normalised — pass verbatim to `host.accept`.
+ * @property {string} node         The peer node identifier (64-hex).
+ * @property {string} number       The invitation formula number (64-hex).
+ * @property {string} fingerprint  Short, human-comparable form of `node` for
+ *   the confirmation screen.
+ * @property {string[]} addresses  Connection hints (the `at` params).
+ */
+
+/**
+ * Parse an `endo://` invitation deep link. Returns `null` when `text` is not
+ * a well-formed invitation locator, so callers can treat it as "not an
+ * invite" without a try/catch.
+ *
+ * @param {string} text
+ * @returns {ParsedInvite | null}
+ */
+export const parseInviteUrl = text => {
+  if (typeof text !== 'string' || !text.startsWith('endo://')) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(text);
+  } catch {
+    return null;
+  }
+  const node = url.host;
+  if (!NUMBER_PATTERN.test(node)) {
+    return null;
+  }
+  // Mirror the daemon's parseLocator allowlist: only id / type / at.
+  for (const key of url.searchParams.keys()) {
+    if (key !== 'id' && key !== 'type' && key !== 'at') {
+      return null;
+    }
+  }
+  if (url.searchParams.get('type') !== INVITATION_TYPE) {
+    return null;
+  }
+  const number = url.searchParams.get('id');
+  if (number === null || !NUMBER_PATTERN.test(number)) {
+    return null;
+  }
+  const addresses = url.searchParams.getAll('at');
+  const fingerprint = `${node.slice(0, 8)}…${node.slice(-8)}`;
+  return { locator: url.toString(), node, number, fingerprint, addresses };
+};
+
+/**
+ * @param {string} text
+ * @returns {boolean}
+ */
+export const isInviteUrl = text => parseInviteUrl(text) !== null;
+
+/**
+ * Find the first `endo://` invitation link in a process `argv` array — the
+ * Windows / Linux cold-start (`process.argv`) and `second-instance`
+ * (relaunch) delivery paths, where the URL arrives as a command-line
+ * argument rather than an `open-url` event.
+ *
+ * @param {string[]} argv
+ * @returns {string | undefined}
+ */
+export const findInviteUrlInArgv = argv => {
+  if (!Array.isArray(argv)) {
+    return undefined;
+  }
+  return argv.find(arg => typeof arg === 'string' && isInviteUrl(arg));
+};

--- a/packages/familiar/src/deep-link.js
+++ b/packages/familiar/src/deep-link.js
@@ -1,36 +1,42 @@
 // @ts-check
 
 /**
- * `endo://` deep-link invitation parsing for the Familiar shell
+ * `endo://` deep-link peer-invitation format for the Familiar shell
  * (designs/familiar-deep-link-invitations.md).
  *
- * An Endo peer invitation locator is itself an `endo://` URL:
+ * The deep link is an **intent-path** URL, distinct from the daemon's internal
+ * locator string:
  *
- *   endo://{node}/?id={invitationNumber}&type=invitation&at={addr}...
+ *   endo://invite?node={node}&id={invitationNumber}&at={addr}...
  *
- * The deep link IS that locator verbatim (design Decision 3): there is no
- * separate `endo://invite/...` envelope, because the daemon's `parseLocator`
- * rejects any query param other than `id` / `type` / `at`, and `host.accept`
- * consumes the locator string directly.
+ * The authority segment is the *intent* (`invite`), so `endo://` can route
+ * other actions later (`endo://adopt`, `endo://open-weblet`, …) without
+ * overloading a locator's `type` field. `node` and `id` are 64-char lowercase
+ * hex; `at` repeats for connection hints. `parseInviteUrl` validates the link
+ * and reconstructs the canonical daemon locator
+ * (`endo://{node}/?id=…&type=invitation&at=…`) that `host.accept` consumes —
+ * decoupling the clickable link from the internal locator format.
  *
  * This module is pure and dependency-free on purpose. The Electron main
- * process runs WITHOUT SES, so it must not import `@endo/daemon` internals
- * or rely on a `harden` global. Authoritative validation happens daemon-side
- * when the renderer calls `E(host).accept(locator, petName)`; these helpers
- * only recognise a plausible invitation and extract fields for display and
- * routing.
+ * process runs WITHOUT SES, so it must not import `@endo/daemon` internals or
+ * rely on a `harden` global. Authoritative validation happens daemon-side when
+ * the renderer calls `E(host).accept(locator, petName)`; these helpers only
+ * recognise a plausible invitation and extract fields for display and routing.
  */
 
 /** Ed25519 public key / formula number: 64 lowercase hex characters. */
 const NUMBER_PATTERN = /^[0-9a-f]{64}$/;
 
-/** The locator `type` query value that denotes a peer invitation. */
+/** The deep-link authority segment that denotes a peer-invitation intent. */
+const INVITE_INTENT = 'invite';
+
+/** The locator `type` for a peer invitation, used in the reconstructed locator. */
 const INVITATION_TYPE = 'invitation';
 
 /**
  * @typedef {object} ParsedInvite
- * @property {string} locator      The invitation locator (the `endo://` URL),
- *   normalised — pass verbatim to `host.accept`.
+ * @property {string} locator      The canonical daemon invitation locator
+ *   reconstructed from the deep link; pass verbatim to `host.accept`.
  * @property {string} node         The peer node identifier (64-hex).
  * @property {string} number       The invitation formula number (64-hex).
  * @property {string} fingerprint  Short, human-comparable form of `node` for
@@ -39,9 +45,29 @@ const INVITATION_TYPE = 'invitation';
  */
 
 /**
- * Parse an `endo://` invitation deep link. Returns `null` when `text` is not
- * a well-formed invitation locator, so callers can treat it as "not an
- * invite" without a try/catch.
+ * Reconstruct the canonical daemon locator from invitation parts. Mirrors the
+ * daemon's `formatLocatorForSharing` (`id` / `type` / `at` params).
+ *
+ * @param {string} node
+ * @param {string} number
+ * @param {string[]} addresses
+ * @returns {string}
+ */
+const buildLocator = (node, number, addresses) => {
+  const url = new URL(`endo://${node}`);
+  url.pathname = '/';
+  url.searchParams.set('id', number);
+  url.searchParams.set('type', INVITATION_TYPE);
+  for (const address of addresses) {
+    url.searchParams.append('at', address);
+  }
+  return url.toString();
+};
+
+/**
+ * Parse an `endo://invite?…` deep link. Returns `null` when `text` is not a
+ * well-formed invitation link, so callers can treat it as "not an invite"
+ * without a try/catch.
  *
  * @param {string} text
  * @returns {ParsedInvite | null}
@@ -56,17 +82,19 @@ export const parseInviteUrl = text => {
   } catch {
     return null;
   }
-  const node = url.host;
-  if (!NUMBER_PATTERN.test(node)) {
+  // Intent-path: the authority segment must be the invite intent.
+  if (url.host !== INVITE_INTENT) {
     return null;
   }
-  // Mirror the daemon's parseLocator allowlist: only id / type / at.
+  // Only node / id / at are meaningful; reject anything else so a malformed
+  // or smuggling link is treated as unrecognised.
   for (const key of url.searchParams.keys()) {
-    if (key !== 'id' && key !== 'type' && key !== 'at') {
+    if (key !== 'node' && key !== 'id' && key !== 'at') {
       return null;
     }
   }
-  if (url.searchParams.get('type') !== INVITATION_TYPE) {
+  const node = url.searchParams.get('node');
+  if (node === null || !NUMBER_PATTERN.test(node)) {
     return null;
   }
   const number = url.searchParams.get('id');
@@ -75,7 +103,13 @@ export const parseInviteUrl = text => {
   }
   const addresses = url.searchParams.getAll('at');
   const fingerprint = `${node.slice(0, 8)}…${node.slice(-8)}`;
-  return { locator: url.toString(), node, number, fingerprint, addresses };
+  return {
+    locator: buildLocator(node, number, addresses),
+    node,
+    number,
+    fingerprint,
+    addresses,
+  };
 };
 
 /**
@@ -85,7 +119,32 @@ export const parseInviteUrl = text => {
 export const isInviteUrl = text => parseInviteUrl(text) !== null;
 
 /**
- * Find the first `endo://` invitation link in a process `argv` array — the
+ * Format an `endo://invite?…` deep link from invitation parts — the inverse
+ * of `parseInviteUrl`, so the inviting side and the receiving side share one
+ * definition of the link contract. Throws on malformed parts (it is a
+ * producer, not a recogniser).
+ *
+ * @param {{ node: string, number: string, addresses?: string[] }} parts
+ * @returns {string}
+ */
+export const formatInviteUrl = ({ node, number, addresses = [] }) => {
+  if (!NUMBER_PATTERN.test(node)) {
+    throw new Error(`formatInviteUrl: invalid node ${JSON.stringify(node)}`);
+  }
+  if (!NUMBER_PATTERN.test(number)) {
+    throw new Error(`formatInviteUrl: invalid id ${JSON.stringify(number)}`);
+  }
+  const url = new URL(`endo://${INVITE_INTENT}`);
+  url.searchParams.set('node', node);
+  url.searchParams.set('id', number);
+  for (const address of addresses) {
+    url.searchParams.append('at', address);
+  }
+  return url.toString();
+};
+
+/**
+ * Find the first `endo://invite?…` link in a process `argv` array — the
  * Windows / Linux cold-start (`process.argv`) and `second-instance`
  * (relaunch) delivery paths, where the URL arrives as a command-line
  * argument rather than an `open-url` event.

--- a/packages/familiar/test/deep-link.test.js
+++ b/packages/familiar/test/deep-link.test.js
@@ -20,21 +20,36 @@ import {
 
 const NODE = 'a'.repeat(64);
 const ID = 'b'.repeat(64);
-const VALID = `endo://invite?node=${NODE}&id=${ID}&at=127.0.0.1%3A8920`;
+const FROM = 'c'.repeat(64);
+const FROM_NODE = 'd'.repeat(64);
+const VALID = `endo://invite?node=${NODE}&id=${ID}&from=${FROM}&at=127.0.0.1%3A8920`;
 
 test('parseInviteUrl accepts a well-formed intent-path invite link', () => {
   const parsed = parseInviteUrl(VALID);
   assert.ok(parsed);
   assert.equal(parsed.node, NODE);
   assert.equal(parsed.number, ID);
+  assert.equal(parsed.from, FROM);
+  assert.equal(parsed.fromNode, undefined);
   assert.deepEqual(parsed.addresses, ['127.0.0.1:8920']);
   assert.equal(parsed.fingerprint, `${'a'.repeat(8)}…${'a'.repeat(8)}`);
-  // The reconstructed locator is the canonical daemon form host.accept wants.
+  // The reconstructed locator is the canonical daemon form host.accept wants:
+  // it must carry id, type, the required `from`, and the hints.
   assert.ok(parsed.locator.startsWith(`endo://${NODE}/`));
   assert.ok(parsed.locator.includes('type=invitation'));
   assert.ok(parsed.locator.includes(`id=${ID}`));
+  assert.ok(parsed.locator.includes(`from=${FROM}`));
   assert.ok(parsed.locator.includes('at=127.0.0.1%3A8920'));
   assert.equal(isInviteUrl(VALID), true);
+});
+
+test('parseInviteUrl carries fromNode when present', () => {
+  const parsed = parseInviteUrl(
+    `endo://invite?node=${NODE}&id=${ID}&from=${FROM}&fromNode=${FROM_NODE}`,
+  );
+  assert.ok(parsed);
+  assert.equal(parsed.fromNode, FROM_NODE);
+  assert.ok(parsed.locator.includes(`fromNode=${FROM_NODE}`));
 });
 
 test('parseInviteUrl rejects non-invitations and malformed input', () => {
@@ -44,21 +59,30 @@ test('parseInviteUrl rejects non-invitations and malformed input', () => {
   assert.equal(parseInviteUrl(`endo://adopt?node=${NODE}&id=${ID}`), null);
   // A bare canonical locator is no longer accepted as a deep link.
   assert.equal(
-    parseInviteUrl(`endo://${NODE}/?id=${ID}&type=invitation`),
+    parseInviteUrl(`endo://${NODE}/?id=${ID}&type=invitation&from=${FROM}`),
     null,
   );
+  // Missing `from` (host.accept requires it).
+  assert.equal(parseInviteUrl(`endo://invite?node=${NODE}&id=${ID}`), null);
   // Node is not 64-hex.
-  assert.equal(parseInviteUrl(`endo://invite?node=nope&id=${ID}`), null);
+  assert.equal(
+    parseInviteUrl(`endo://invite?node=nope&id=${ID}&from=${FROM}`),
+    null,
+  );
   // Disallowed extra query param.
   assert.equal(
-    parseInviteUrl(`endo://invite?node=${NODE}&id=${ID}&label=hi`),
+    parseInviteUrl(`endo://invite?node=${NODE}&id=${ID}&from=${FROM}&x=1`),
     null,
   );
-  // Missing / malformed id.
-  assert.equal(parseInviteUrl(`endo://invite?node=${NODE}`), null);
-  assert.equal(parseInviteUrl(`endo://invite?node=${NODE}&id=short`), null);
-  // Missing node.
-  assert.equal(parseInviteUrl(`endo://invite?id=${ID}`), null);
+  // Malformed id / from.
+  assert.equal(
+    parseInviteUrl(`endo://invite?node=${NODE}&id=short&from=${FROM}`),
+    null,
+  );
+  assert.equal(
+    parseInviteUrl(`endo://invite?node=${NODE}&id=${ID}&from=short`),
+    null,
+  );
   // Non-string input.
   assert.equal(parseInviteUrl(undefined), null);
   assert.equal(isInviteUrl('endo://invite'), false);
@@ -68,6 +92,8 @@ test('formatInviteUrl produces a link parseInviteUrl round-trips', () => {
   const link = formatInviteUrl({
     node: NODE,
     number: ID,
+    from: FROM,
+    fromNode: FROM_NODE,
     addresses: ['127.0.0.1:8920', 'ws://relay.example:443'],
   });
   assert.ok(link.startsWith('endo://invite?'));
@@ -75,6 +101,8 @@ test('formatInviteUrl produces a link parseInviteUrl round-trips', () => {
   assert.ok(parsed);
   assert.equal(parsed.node, NODE);
   assert.equal(parsed.number, ID);
+  assert.equal(parsed.from, FROM);
+  assert.equal(parsed.fromNode, FROM_NODE);
   assert.deepEqual(parsed.addresses, [
     '127.0.0.1:8920',
     'ws://relay.example:443',
@@ -82,8 +110,13 @@ test('formatInviteUrl produces a link parseInviteUrl round-trips', () => {
 });
 
 test('formatInviteUrl throws on malformed parts', () => {
-  assert.throws(() => formatInviteUrl({ node: 'nope', number: ID }));
-  assert.throws(() => formatInviteUrl({ node: NODE, number: 'short' }));
+  assert.throws(() =>
+    formatInviteUrl({ node: 'nope', number: ID, from: FROM }),
+  );
+  assert.throws(() =>
+    formatInviteUrl({ node: NODE, number: 'short', from: FROM }),
+  );
+  assert.throws(() => formatInviteUrl({ node: NODE, number: ID, from: 'x' }));
 });
 
 test('findInviteUrlInArgv finds the first invite argument', () => {

--- a/packages/familiar/test/deep-link.test.js
+++ b/packages/familiar/test/deep-link.test.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
 /**
- * Tests for endo:// deep-link invitation parsing
+ * Tests for endo:// deep-link invitation parsing/formatting
  * (designs/familiar-deep-link-invitations.md).
  *
  * Uses the built-in Node test runner so the Familiar package gains
@@ -14,46 +14,76 @@ import assert from 'node:assert/strict';
 import {
   parseInviteUrl,
   isInviteUrl,
+  formatInviteUrl,
   findInviteUrlInArgv,
 } from '../src/deep-link.js';
 
 const NODE = 'a'.repeat(64);
 const ID = 'b'.repeat(64);
-const VALID = `endo://${NODE}/?id=${ID}&type=invitation&at=127.0.0.1%3A8920`;
+const VALID = `endo://invite?node=${NODE}&id=${ID}&at=127.0.0.1%3A8920`;
 
-test('parseInviteUrl accepts a well-formed invitation locator', () => {
+test('parseInviteUrl accepts a well-formed intent-path invite link', () => {
   const parsed = parseInviteUrl(VALID);
   assert.ok(parsed);
   assert.equal(parsed.node, NODE);
   assert.equal(parsed.number, ID);
   assert.deepEqual(parsed.addresses, ['127.0.0.1:8920']);
   assert.equal(parsed.fingerprint, `${'a'.repeat(8)}…${'a'.repeat(8)}`);
-  // The locator round-trips back to an endo:// URL the daemon can accept.
+  // The reconstructed locator is the canonical daemon form host.accept wants.
   assert.ok(parsed.locator.startsWith(`endo://${NODE}/`));
+  assert.ok(parsed.locator.includes('type=invitation'));
+  assert.ok(parsed.locator.includes(`id=${ID}`));
+  assert.ok(parsed.locator.includes('at=127.0.0.1%3A8920'));
   assert.equal(isInviteUrl(VALID), true);
 });
 
 test('parseInviteUrl rejects non-invitations and malformed input', () => {
   // Not an endo:// URL.
   assert.equal(parseInviteUrl('https://example.com/'), null);
-  // Wrong type.
-  assert.equal(parseInviteUrl(`endo://${NODE}/?id=${ID}&type=remote`), null);
-  // Node is not 64-hex.
-  assert.equal(parseInviteUrl(`endo://nope/?id=${ID}&type=invitation`), null);
-  // Disallowed extra query param (parseLocator allowlist is id/type/at).
+  // Wrong intent (authority must be "invite").
+  assert.equal(parseInviteUrl(`endo://adopt?node=${NODE}&id=${ID}`), null);
+  // A bare canonical locator is no longer accepted as a deep link.
   assert.equal(
-    parseInviteUrl(`endo://${NODE}/?id=${ID}&type=invitation&label=hi`),
+    parseInviteUrl(`endo://${NODE}/?id=${ID}&type=invitation`),
+    null,
+  );
+  // Node is not 64-hex.
+  assert.equal(parseInviteUrl(`endo://invite?node=nope&id=${ID}`), null);
+  // Disallowed extra query param.
+  assert.equal(
+    parseInviteUrl(`endo://invite?node=${NODE}&id=${ID}&label=hi`),
     null,
   );
   // Missing / malformed id.
-  assert.equal(parseInviteUrl(`endo://${NODE}/?type=invitation`), null);
-  assert.equal(
-    parseInviteUrl(`endo://${NODE}/?id=short&type=invitation`),
-    null,
-  );
+  assert.equal(parseInviteUrl(`endo://invite?node=${NODE}`), null);
+  assert.equal(parseInviteUrl(`endo://invite?node=${NODE}&id=short`), null);
+  // Missing node.
+  assert.equal(parseInviteUrl(`endo://invite?id=${ID}`), null);
   // Non-string input.
   assert.equal(parseInviteUrl(undefined), null);
-  assert.equal(isInviteUrl('endo://nope/'), false);
+  assert.equal(isInviteUrl('endo://invite'), false);
+});
+
+test('formatInviteUrl produces a link parseInviteUrl round-trips', () => {
+  const link = formatInviteUrl({
+    node: NODE,
+    number: ID,
+    addresses: ['127.0.0.1:8920', 'ws://relay.example:443'],
+  });
+  assert.ok(link.startsWith('endo://invite?'));
+  const parsed = parseInviteUrl(link);
+  assert.ok(parsed);
+  assert.equal(parsed.node, NODE);
+  assert.equal(parsed.number, ID);
+  assert.deepEqual(parsed.addresses, [
+    '127.0.0.1:8920',
+    'ws://relay.example:443',
+  ]);
+});
+
+test('formatInviteUrl throws on malformed parts', () => {
+  assert.throws(() => formatInviteUrl({ node: 'nope', number: ID }));
+  assert.throws(() => formatInviteUrl({ node: NODE, number: 'short' }));
 });
 
 test('findInviteUrlInArgv finds the first invite argument', () => {

--- a/packages/familiar/test/deep-link.test.js
+++ b/packages/familiar/test/deep-link.test.js
@@ -1,0 +1,63 @@
+// @ts-nocheck
+/**
+ * Tests for endo:// deep-link invitation parsing
+ * (designs/familiar-deep-link-invitations.md).
+ *
+ * Uses the built-in Node test runner so the Familiar package gains
+ * coverage without taking on a test-framework dependency. Run with
+ * `node --test` (the package's `test` script).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseInviteUrl,
+  isInviteUrl,
+  findInviteUrlInArgv,
+} from '../src/deep-link.js';
+
+const NODE = 'a'.repeat(64);
+const ID = 'b'.repeat(64);
+const VALID = `endo://${NODE}/?id=${ID}&type=invitation&at=127.0.0.1%3A8920`;
+
+test('parseInviteUrl accepts a well-formed invitation locator', () => {
+  const parsed = parseInviteUrl(VALID);
+  assert.ok(parsed);
+  assert.equal(parsed.node, NODE);
+  assert.equal(parsed.number, ID);
+  assert.deepEqual(parsed.addresses, ['127.0.0.1:8920']);
+  assert.equal(parsed.fingerprint, `${'a'.repeat(8)}…${'a'.repeat(8)}`);
+  // The locator round-trips back to an endo:// URL the daemon can accept.
+  assert.ok(parsed.locator.startsWith(`endo://${NODE}/`));
+  assert.equal(isInviteUrl(VALID), true);
+});
+
+test('parseInviteUrl rejects non-invitations and malformed input', () => {
+  // Not an endo:// URL.
+  assert.equal(parseInviteUrl('https://example.com/'), null);
+  // Wrong type.
+  assert.equal(parseInviteUrl(`endo://${NODE}/?id=${ID}&type=remote`), null);
+  // Node is not 64-hex.
+  assert.equal(parseInviteUrl(`endo://nope/?id=${ID}&type=invitation`), null);
+  // Disallowed extra query param (parseLocator allowlist is id/type/at).
+  assert.equal(
+    parseInviteUrl(`endo://${NODE}/?id=${ID}&type=invitation&label=hi`),
+    null,
+  );
+  // Missing / malformed id.
+  assert.equal(parseInviteUrl(`endo://${NODE}/?type=invitation`), null);
+  assert.equal(
+    parseInviteUrl(`endo://${NODE}/?id=short&type=invitation`),
+    null,
+  );
+  // Non-string input.
+  assert.equal(parseInviteUrl(undefined), null);
+  assert.equal(isInviteUrl('endo://nope/'), false);
+});
+
+test('findInviteUrlInArgv finds the first invite argument', () => {
+  assert.equal(findInviteUrlInArgv(['electron', '.', VALID]), VALID);
+  assert.equal(findInviteUrlInArgv(['electron', '.', '--dev']), undefined);
+  assert.equal(findInviteUrlInArgv(undefined), undefined);
+});


### PR DESCRIPTION
## Description

This PR implements two major features.

### 1. Streaming Tree Clone (`@endo/endo-fs`)
Adds a high-performance, memory-bounded mechanism to ship entire directory trees as a single ordered frame stream rather than a client-driven pipelined walk. This implements Pillar 3c of `designs/endo-app-sharing.md`.

**Key files:**
- `packages/endo-fs/src/clone.js` — Core streaming clone implementation with:
  - `streamTree(sourceRoot, options)` — Serializes a source tree into a `PassableReader`
  - `writeTreeStream(destRoot, reader)` — Drains the stream into a destination `Directory`
  - `cloneTree(sourceRoot, destRoot, options)` — Convenience wrapper combining both
  - Depth-first traversal with stable name-sorted ordering for reproducibility
  - Large files streamed as base64-encoded chunks within the single frame stream (no whole-file buffering)
  - Pattern-validated frames via `CloneFrameShape` on both the producer (`streamTree`) and consumer (`writeTreeStream`) sides
  - Destination files created with `{ truncate: true }` so re-cloning over a longer pre-existing file leaves no stale trailing bytes

- `packages/endo-fs/test/clone.test.js` — Test suite covering full tree round-trip, empty files/directories, multi-chunk large files, sub-directory cloning, explicit `streamTree` + `writeTreeStream` composition, the empty-tree edge case, and overwrite-into-a-non-empty-destination.

- `packages/endo-fs/src/index.js` — Exports the clone API

**Design decisions realized:**
- One stream, not pipelined walks — eliminates round-trip latency
- No content hashing — integrity is the transport's job (secure channel)
- Large files stream as chunks within the single stream
- Pluggable durable destination via ordinary `Directory` cap
- Base64 encoding for CapTP marshalling compatibility

### 2. Deep-Link Invitation Support (Familiar shell + Chat)
Implements an `endo://` protocol handler for peer invitations, so users can accept (and share) peers by clicking links. This implements `designs/familiar-deep-link-invitations.md`.

**Format.** The deep link is an **intent-path** URL, distinct from the daemon's internal locator:

```
endo://invite?node={node}&id={inv}&from={handle}[&fromNode={n}]&at={addr}...
```

The authority segment names the *intent* (`invite`) so `endo://` can route future actions without overloading a locator's `type`. The link carries exactly the fields `host.accept` consumes — `node`, `id`, the required inviter handle `from`, an optional `fromNode` (agent-key case), and `at` connection hints. The handler validates the link and **reconstructs** the canonical daemon locator (`endo://{node}/?id=…&type=invitation&from=…&at=…`) that `host.accept` takes; the link is not passed verbatim.

**Key files:**
- `packages/familiar/src/deep-link.js` — Pure, dependency-free (SES-free, for the Electron main process):
  - `parseInviteUrl(text)` — validates an `endo://invite?…` link and returns `{ locator, node, number, from, fromNode, fingerprint, addresses }` (locator = reconstructed canonical form)
  - `formatInviteUrl(parts)` — inverse of `parseInviteUrl`, so producer and receiver share one contract
  - `isInviteUrl(text)` / `findInviteUrlInArgv(argv)` — boolean check and Windows/Linux cold-start argv extraction
- `packages/familiar/electron-main.js` — Registers `endo://` as protocol client; single-instance lock; `open-url` (macOS) and `second-instance` (Windows/Linux) handlers; queues invites until the renderer is ready; IPC handlers registered before window creation to avoid a cold-start race.
- `packages/familiar/preload.js` — Bridge: `getPendingDeepLinkInvite()` and `onDeepLinkInvite(callback)` (renderer subscribes first, then pulls queued invites).
- `packages/chat/deep-link-invite.js` — Routes a captured invite into the existing `accept` command form (the form is the confirmation screen).
- `packages/chat/invite-link.js` — Producer/receiver glue in the renderer: `/invite` surfaces the shareable `endo://invite?…` link; `/accept` takes either that link or a raw locator (`normalizeInvitationInput`). Mirrors the `deep-link.js` contract since Chat cannot import the Familiar shell.

**Follow-up (not in this PR):** an *open* (multi-use) invitation. Today `host.invite` is single-take (consume-once); the deep-link format already accommodates a reusable invite, but multi-use acceptance is new daemon work tracked separately.

https://claude.ai/code/session_0112zLHkZKDDUzUDEwPvScwT