### PR TITLE
fix(benchmark): retry + cache esvu installs (llm rebase of #377)

### DIFF
--- a/.changeset/retry-esvu-installs.md
+++ b/.changeset/retry-esvu-installs.md
@@ -1,0 +1,7 @@
+---
+'@endo/benchmark': patch
+---
+
+Retry esvu installs in install-engines.sh to ride out intermittent flakes
+fetching the Moddable XS release on GitHub or the V8 canary build on
+Google's chromium-v8 GCS bucket.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,6 +518,25 @@ jobs:
         working-directory: endo
         run: yarn install --immutable
 
+      # Restore the esvu install directory before invoking install-engines.
+      # On a cache hit, install-engines.sh's are_engines_installed
+      # short-circuit fires and esvu is never invoked, so the upstream
+      # download flakes (endojs/endo#3289) cannot reach this job. On a
+      # miss, the script falls through to esvu and the retry loop in the
+      # script rides out a transient hiccup. The key is bound to the
+      # install-engines.sh hash so a script change (which can change the
+      # engine selection) invalidates the cache; the restore-keys
+      # fallback still seeds the dir from an older script revision when
+      # the engine set is unchanged in practice.
+      - name: Restore esvu engines cache
+        id: restore-esvu
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.esvu
+          key: esvu-${{ runner.os }}-${{ hashFiles('endo/packages/benchmark/install-engines.sh') }}
+          restore-keys: |
+            esvu-${{ runner.os }}-
+
       - name: Install engines
         working-directory: endo
         run: yarn workspace @endo/benchmark run install-engines

--- a/packages/benchmark/install-engines.sh
+++ b/packages/benchmark/install-engines.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e 
+set -e
 
 echo "yarn version: $(yarn --version)"
 
@@ -15,15 +15,42 @@ are_engines_installed() {
     [ -f "$HOME/.esvu/bin/xs" ] && [ -f "$HOME/.esvu/bin/v8" ]
 }
 
+# Retry an esvu install a few times to ride out intermittent flakes
+# fetching the Moddable XS release on GitHub or the V8 canary build on
+# Google's chromium-v8 GCS bucket (endojs/endo#3289). On every attempt
+# we capture the combined output; on the final failure the captured
+# output of the last attempt is what the caller prints before exit 1.
+install_engine_with_retry() {
+    engine=$1
+    attempts=3
+    delay=5
+    i=1
+    while [ "$i" -le "$attempts" ]; do
+        if output=$(yarn dlx esvu install "$engine" 2>&1); then
+            INSTALL_OUTPUT=$output
+            return 0
+        fi
+        INSTALL_OUTPUT=$output
+        if [ "$i" -lt "$attempts" ]; then
+            echo "esvu install $engine attempt $i/$attempts failed; retrying in ${delay}s..."
+            sleep "$delay"
+        fi
+        i=$((i + 1))
+    done
+    return 1
+}
+
 if are_engines_installed; then
     echo "Engines already installed. Skipping installation."
 else
     echo "Installing engines..."
-    INSTALL_OUTPU_XS=$(yarn dlx esvu install xs 2>&1) || INSTALL_STATUS_XS=$?
-    INSTALL_OUTPU_V8=$(yarn dlx esvu install v8 2>&1) || INSTALL_STATUS_V8=$?
+    install_engine_with_retry xs || INSTALL_STATUS_XS=$?
+    INSTALL_OUTPU_XS=$INSTALL_OUTPUT
+    install_engine_with_retry v8 || INSTALL_STATUS_V8=$?
+    INSTALL_OUTPU_V8=$INSTALL_OUTPUT
 fi
 
-if [ -n "$INSTALL_STATUS_XS" ] || [ -n "$INSTALL_STATUS_V8" ]; then 
+if [ -n "$INSTALL_STATUS_XS" ] || [ -n "$INSTALL_STATUS_V8" ]; then
     if are_engines_installed; then
         echo "Engines installed successfully despite esvu error."
     else

--- a/packages/benchmark/install-engines.sh
+++ b/packages/benchmark/install-engines.sh
@@ -15,15 +15,26 @@ are_engines_installed() {
     [ -f "$HOME/.esvu/bin/xs" ] && [ -f "$HOME/.esvu/bin/v8" ]
 }
 
-# Retry an esvu install a few times to ride out intermittent flakes
+# Retry an esvu install a few times to ride out a transient hiccup
 # fetching the Moddable XS release on GitHub or the V8 canary build on
-# Google's chromium-v8 GCS bucket (endojs/endo#3289). On every attempt
-# we capture the combined output; on the final failure the captured
-# output of the last attempt is what the caller prints before exit 1.
+# Google's chromium-v8 GCS bucket (endojs/endo#3289). The job-level
+# actions/cache for ~/.esvu (in ci.yml's test-xs job) is the load-bearing
+# defense against the underlying flake; this retry only covers the
+# cache-miss path where esvu actually has to fetch.
+#
+# Backoff is exponential with a small randomized component so that
+# repeated CI starts on the same upstream blip do not all hammer the
+# release server in lock-step (which a constant-delay retry can do).
+# A persistent outage will still fail after attempts are exhausted;
+# the retry is not a substitute for the cache.
+#
+# On every attempt we capture the combined output; on the final failure
+# the captured output of the last attempt is what the caller prints
+# before exit 1.
 install_engine_with_retry() {
     engine=$1
     attempts=3
-    delay=5
+    base_delay=5
     i=1
     while [ "$i" -le "$attempts" ]; do
         if output=$(yarn dlx esvu install "$engine" 2>&1); then
@@ -32,6 +43,11 @@ install_engine_with_retry() {
         fi
         INSTALL_OUTPUT=$output
         if [ "$i" -lt "$attempts" ]; then
+            # exponential backoff: base_delay * 2^(i-1), plus 0..4s of jitter.
+            # awk's srand() is the most portable random source for /bin/sh.
+            backoff=$((base_delay * (1 << (i - 1))))
+            jitter=$(awk 'BEGIN{srand(); print int(rand() * 5)}')
+            delay=$((backoff + jitter))
             echo "esvu install $engine attempt $i/$attempts failed; retrying in ${delay}s..."
             sleep "$delay"
         fi


### PR DESCRIPTION
Refs: #377

## Description

Rebase of #377's esvu install resilience work onto `llm`. Two changes ride together: `install-engines.sh` gains an exponential-backoff-with-jitter retry around each `esvu install`, and the CI `test-xs` job gains an `actions/cache` step for `~/.esvu` ahead of the install step so a cache hit short-circuits the upstream download entirely.

This branch is opened to probe whether re-running `test-xs` can catch a good network window and populate the esvu engines cache, so subsequent runs hit the cache instead of fetching the Moddable XS release and V8 canary build on every job. It is an experimental cache-bootstrap branch, not yet a merge candidate; net change is against `llm`.

### Security Considerations

No new authorities or trust boundaries. The new CI cache holds prebuilt engine binaries keyed on the install script's hash.

### Scaling Considerations

Reduces, rather than increases, scarce-resource consumption: a cache hit avoids re-downloading engine binaries on every `test-xs` run.

### Documentation Considerations

None. No downstream-visible API or data-format change.

### Testing Considerations

The change is itself CI infrastructure. The retry loop and cache restore are exercised by running `test-xs`.

### Compatibility Considerations

No usage patterns change. The retry and cache are transparent to the benchmark workflow.

### Upgrade Considerations

None.
