### PR TITLE
fix(benchmark): install xs/v8 via direct download instead of esvu

### DIFF
--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -6,4 +6,4 @@ This package just provides a minimalistic ava-like interface to run benchmark te
 Run the command `yarn test` in the `packages/benchmark` folder.
 
 ## Pre-reqs of running `yarn test`
-Run the command `yarn install-engines` to ensure installation of V8 and XS engines in $HOME/.esvu for this package's `eshost`.
+Run the command `yarn install-engines` to ensure installation of V8 and XS engines in $HOME/.bench-engines for this package's `eshost`.

--- a/packages/benchmark/install-engines.sh
+++ b/packages/benchmark/install-engines.sh
@@ -1,50 +1,105 @@
 #!/bin/sh
 
-set -e 
+set -e
 
 echo "yarn version: $(yarn --version)"
 
-mkdir -p "$HOME/.esvu/bin"
+mkdir -p "$HOME/.bench-engines/bin"
 
 if [ -f "$GITHUB_WORKSPACE/bin/xst" ]; then
-  ln -s "$GITHUB_WORKSPACE/bin/xst" "$HOME/.esvu/bin"
+  ln -s "$GITHUB_WORKSPACE/bin/xst" "$HOME/.bench-engines/bin"
 fi
 
-## Installing Engines and skiping if already installed ##
+## Installing Engines and skipping if already installed ##
 are_engines_installed() {
-    [ -f "$HOME/.esvu/bin/xs" ] && [ -f "$HOME/.esvu/bin/v8" ]
+    [ -f "$HOME/.bench-engines/bin/xs" ] && [ -f "$HOME/.bench-engines/bin/v8" ]
+}
+
+# Download $1 to $2, retrying genuine transient network failures.
+download() {
+    curl -fSL --retry 3 --retry-all-errors --max-time 300 -o "$2" "$1"
+}
+
+install_xs() {
+    # Install the latest Moddable release. Resolve the tag by following
+    # the releases/latest redirect (avoids the GitHub API rate limit).
+    # Fall back to a known-good pin if resolution is fragile.
+    XS_VERSION=$(curl -fsSL -o /dev/null -w '%{redirect_url}' \
+        https://github.com/Moddable-OpenSource/moddable/releases/latest \
+        | sed -n 's#.*/releases/tag/\(.*\)$#\1#p')
+    if [ -z "$XS_VERSION" ]; then
+        XS_VERSION="8.1.1"
+        echo "Could not resolve latest Moddable release; pinning XS_VERSION=$XS_VERSION"
+    fi
+    echo "Installing XS $XS_VERSION..."
+
+    xs_zip="$tmp/xst-lin64.zip"
+    download \
+        "https://github.com/Moddable-OpenSource/moddable/releases/download/$XS_VERSION/xst-lin64.zip" \
+        "$xs_zip"
+    unzip -t "$xs_zip" >/dev/null || { echo "XS download is corrupt: $xs_zip" >&2; exit 1; }
+
+    mkdir -p "$HOME/.bench-engines/engines/xs"
+    unzip -o "$xs_zip" xst -d "$HOME/.bench-engines/engines/xs"
+    [ -f "$HOME/.bench-engines/engines/xs/xst" ] || { echo "XS extract missing xst binary" >&2; exit 1; }
+    chmod +x "$HOME/.bench-engines/engines/xs/xst"
+
+    ln -sf "$HOME/.bench-engines/engines/xs/xst" "$HOME/.bench-engines/bin/xs"
+}
+
+install_v8() {
+    # Resolve the latest version from the canary latest.json, then
+    # download the matching linux64 release zip.
+    V8_VERSION=$(curl -fsSL --max-time 60 \
+        https://storage.googleapis.com/chromium-v8/official/canary/v8-linux64-rel-latest.json \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')
+    [ -n "$V8_VERSION" ] || { echo "Could not resolve latest V8 version" >&2; exit 1; }
+    echo "Installing V8 $V8_VERSION..."
+
+    v8_zip="$tmp/v8-linux64-rel.zip"
+    download \
+        "https://storage.googleapis.com/chromium-v8/official/canary/v8-linux64-rel-$V8_VERSION.zip" \
+        "$v8_zip"
+    unzip -t "$v8_zip" >/dev/null || { echo "V8 download is corrupt: $v8_zip" >&2; exit 1; }
+
+    mkdir -p "$HOME/.bench-engines/engines/v8"
+    unzip -o "$v8_zip" -d "$HOME/.bench-engines/engines/v8"
+    [ -f "$HOME/.bench-engines/engines/v8/d8" ] || { echo "V8 extract missing d8 binary" >&2; exit 1; }
+    chmod +x "$HOME/.bench-engines/engines/v8/d8"
+
+    # Launcher script: d8 finds icudtl.dat in its own directory; the
+    # snapshot blob is passed explicitly.
+    cat > "$HOME/.bench-engines/bin/v8" <<EOF
+#!/usr/bin/env bash
+"$HOME/.bench-engines/engines/v8/d8" --snapshot_blob="$HOME/.bench-engines/engines/v8/snapshot_blob.bin" "\$@"
+EOF
+    chmod 0755 "$HOME/.bench-engines/bin/v8"
 }
 
 if are_engines_installed; then
     echo "Engines already installed. Skipping installation."
 else
     echo "Installing engines..."
-    INSTALL_OUTPU_XS=$(yarn dlx esvu install xs 2>&1) || INSTALL_STATUS_XS=$?
-    INSTALL_OUTPU_V8=$(yarn dlx esvu install v8 2>&1) || INSTALL_STATUS_V8=$?
-fi
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
 
-if [ -n "$INSTALL_STATUS_XS" ] || [ -n "$INSTALL_STATUS_V8" ]; then 
-    if are_engines_installed; then
-        echo "Engines installed successfully despite esvu error."
-    else
-        echo "Error installing XS or V8:"
-        echo "$INSTALL_OUTPU_XS"
-        echo "$INSTALL_OUTPU_V8"
-        exit 1
-    fi
+    install_xs
+    install_v8
+
+    are_engines_installed || { echo "Engine install finished but binaries are missing" >&2; exit 1; }
 fi
 
 
 ## Making engine binaries executable ##
-chmod +x "$HOME/.esvu/bin/xs" "$HOME/.esvu/bin/v8"
+chmod +x "$HOME/.bench-engines/bin/xs" "$HOME/.bench-engines/bin/v8"
 
 ## Adding engines to eshost (if not already) ##
 if ! yarn eshost --list | grep -q '"xs"'; then
-    yarn eshost --add "xs" xs "$HOME/.esvu/bin/xs"
+    yarn eshost --add "xs" xs "$HOME/.bench-engines/bin/xs"
 fi
 
 if ! yarn eshost --list | grep -q '"v8"'; then
-    yarn eshost --add "v8" d8 "$HOME/.esvu/bin/v8"
+    yarn eshost --add "v8" d8 "$HOME/.bench-engines/bin/v8"
 fi
 
 

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -44,7 +44,6 @@
     "c8": "catalog:dev",
     "eshost-cli": "^9.0.0",
     "eslint": "catalog:dev",
-    "esvu": "^1.2.16",
     "rollup": "^4.34.6",
     "tsd": "catalog:dev",
     "typescript": "catalog:dev"

--- a/packages/benchmark/run-tests.sh
+++ b/packages/benchmark/run-tests.sh
@@ -5,12 +5,12 @@ set -e
 echo "yarn version: $(yarn --version)"
 
 are_engines_installed() {
-    [ -f "$HOME/.esvu/bin/xs" ] && [ -f "$HOME/.esvu/bin/v8" ]
+    [ -f "$HOME/.bench-engines/bin/xs" ] && [ -f "$HOME/.bench-engines/bin/v8" ]
 }
 
 
 if ! are_engines_installed; then
-    echo "xs and/or v8 not found in $HOME/.esvu/bin; please run 'yarn install-engines' to install them."
+    echo "xs and/or v8 not found in $HOME/.bench-engines/bin; please run 'yarn install-engines' to install them."
     exit 127
 fi
 

--- a/packages/hex/test/run-benches.sh
+++ b/packages/hex/test/run-benches.sh
@@ -19,7 +19,7 @@ set -e
 cd "$(dirname "$0")/.."
 
 # Locate eshost and engines from the @endo/benchmark sibling, which is
-# already wired up to esvu-managed xs / v8 binaries.
+# already wired up to its installed xs / v8 binaries.
 BENCHMARK_DIR="$(cd ../benchmark && pwd)"
 ESHOST="${BENCHMARK_DIR}/node_modules/.bin/eshost"
 ROLLUP="${BENCHMARK_DIR}/node_modules/.bin/rollup"
@@ -30,8 +30,8 @@ if [ ! -x "$ESHOST" ] || [ ! -x "$ROLLUP" ]; then
   exit 1
 fi
 
-if [ ! -f "$HOME/.esvu/bin/xs" ] || [ ! -f "$HOME/.esvu/bin/v8" ]; then
-  echo "xs and/or v8 not found in \$HOME/.esvu/bin." >&2
+if [ ! -f "$HOME/.bench-engines/bin/xs" ] || [ ! -f "$HOME/.bench-engines/bin/v8" ]; then
+  echo "xs and/or v8 not found in \$HOME/.bench-engines/bin." >&2
   echo "Run \`yarn workspace @endo/benchmark install-engines\` first." >&2
   exit 127
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,7 +1488,6 @@ __metadata:
     c8: "catalog:dev"
     eshost-cli: "npm:^9.0.0"
     eslint: "catalog:dev"
-    esvu: "npm:^1.2.16"
     rollup: "npm:^4.34.6"
     tsd: "catalog:dev"
     typescript: "catalog:dev"
@@ -3354,96 +3353,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/ansi@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@inquirer/ansi@npm:2.0.5"
-  checksum: 10c0/ad61532e5bb47473e3d987c32d4015499a8ce5f4f86e46467e8e672fc52670beb303905d6b324e453935a61671f59f3b9b1b6a1edbbe1f64085e2bb87735e295
-  languageName: node
-  linkType: hard
-
-"@inquirer/checkbox@npm:^5.1.4":
-  version: 5.1.4
-  resolution: "@inquirer/checkbox@npm:5.1.4"
-  dependencies:
-    "@inquirer/ansi": "npm:^2.0.5"
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/figures": "npm:^2.0.5"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/38d6c8b49c392307c29fbb252d5dd09a819aecc34c83f01a7652efa09d7b8b901c448216496eda3962e319209243297ec575eff4e081a758bb08adb805f7e3d4
-  languageName: node
-  linkType: hard
-
-"@inquirer/confirm@npm:^6.0.12":
-  version: 6.0.12
-  resolution: "@inquirer/confirm@npm:6.0.12"
-  dependencies:
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/36e9b1ef60e08562f07bcbcd78ba0a681b2fa3e5f54fa5e12303fc5982e8ba875ed782c24161e2295028b2b404ba690e841837303d16eeeb28df7aa9eb8aa835
-  languageName: node
-  linkType: hard
-
-"@inquirer/core@npm:^11.1.9":
-  version: 11.1.9
-  resolution: "@inquirer/core@npm:11.1.9"
-  dependencies:
-    "@inquirer/ansi": "npm:^2.0.5"
-    "@inquirer/figures": "npm:^2.0.5"
-    "@inquirer/type": "npm:^4.0.5"
-    cli-width: "npm:^4.1.0"
-    fast-wrap-ansi: "npm:^0.2.0"
-    mute-stream: "npm:^3.0.0"
-    signal-exit: "npm:^4.1.0"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/f7b162ce5f67fb75aab00a3668fdd8c8629aec790087840ea66ee8ead6009ab2066bec9cbf5bcc394ccdf130e6139051d6bace334b3a66c4f05349585213172c
-  languageName: node
-  linkType: hard
-
-"@inquirer/editor@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@inquirer/editor@npm:5.1.1"
-  dependencies:
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/external-editor": "npm:^3.0.0"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/d9506fc4d16362ee060df0c8aa722ee85eae79e0be373253ecc49d0f51569f886bf0d09da9ae9910e3d5f79dca10767a5c1711c799af41c668b2a97866470221
-  languageName: node
-  linkType: hard
-
-"@inquirer/expand@npm:^5.0.13":
-  version: 5.0.13
-  resolution: "@inquirer/expand@npm:5.0.13"
-  dependencies:
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/108055f24dc4348a4981003003ca41fe793c7b3292ff80f583a1e1f1097bee64a0c2e5795cae969bcf77d4f34f03a3feeaa6315363eb01554f1c1eae6769c9f5
-  languageName: node
-  linkType: hard
-
 "@inquirer/external-editor@npm:^1.0.2":
   version: 1.0.3
   resolution: "@inquirer/external-editor@npm:1.0.3"
@@ -3456,157 +3365,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/82951cb7f3762dd78cca2ea291396841e3f4adfe26004b5badfed1cec4b6a04bb567dff94d0e41b35c61bdd7957317c64c22f58074d14b238d44e44d9e420019
-  languageName: node
-  linkType: hard
-
-"@inquirer/external-editor@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@inquirer/external-editor@npm:3.0.0"
-  dependencies:
-    chardet: "npm:^2.1.1"
-    iconv-lite: "npm:^0.7.2"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/120910c954869c73c54aee825abef6f4c4aa8620cafa831d56b218586b1ee02c12ad0a17b8d701784fb9d33fa8fd63ee155d9c718c90533ff4d8086b99986e1d
-  languageName: node
-  linkType: hard
-
-"@inquirer/figures@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@inquirer/figures@npm:2.0.5"
-  checksum: 10c0/139671b88f33f059aec85ed3fdf464999115573350c6dea61141adc1cfd43d14742b6cb68150c2ca9baf5a1bae618f990ed89b4430ae768d415bbd19944c56df
-  languageName: node
-  linkType: hard
-
-"@inquirer/input@npm:^5.0.12":
-  version: 5.0.12
-  resolution: "@inquirer/input@npm:5.0.12"
-  dependencies:
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/bb8273925c774bc5dffd93d6edc9e24391ab03c3ddd0c604987abbb74a7efcf03ca10b3bd0607ccf6613369e004417b14cf3c031327601118cff2cc98c5098e6
-  languageName: node
-  linkType: hard
-
-"@inquirer/number@npm:^4.0.12":
-  version: 4.0.12
-  resolution: "@inquirer/number@npm:4.0.12"
-  dependencies:
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/e933967d9879792775d4ac8f4abcc9c2f263107a1e3c1cdd5ce85dd446a03bed2f6cb01c41ed1a3b45b80f385eb3a991d1442703d9816416c79c0ca6f20e57f3
-  languageName: node
-  linkType: hard
-
-"@inquirer/password@npm:^5.0.12":
-  version: 5.0.12
-  resolution: "@inquirer/password@npm:5.0.12"
-  dependencies:
-    "@inquirer/ansi": "npm:^2.0.5"
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/e1399196f01ff5fadc1d3e1bc6946a4f53a5753ccf8e39b2f11f1dae5c51fdb85e33ef44760d83c5b58dacc442de603f32e9c991b2e5f2f8a2a451ff62e1fe48
-  languageName: node
-  linkType: hard
-
-"@inquirer/prompts@npm:^8.4.2":
-  version: 8.4.2
-  resolution: "@inquirer/prompts@npm:8.4.2"
-  dependencies:
-    "@inquirer/checkbox": "npm:^5.1.4"
-    "@inquirer/confirm": "npm:^6.0.12"
-    "@inquirer/editor": "npm:^5.1.1"
-    "@inquirer/expand": "npm:^5.0.13"
-    "@inquirer/input": "npm:^5.0.12"
-    "@inquirer/number": "npm:^4.0.12"
-    "@inquirer/password": "npm:^5.0.12"
-    "@inquirer/rawlist": "npm:^5.2.8"
-    "@inquirer/search": "npm:^4.1.8"
-    "@inquirer/select": "npm:^5.1.4"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/0519d6a52e195e24b03949afda1ad7fc2ae752c72a7ba554d4bdbbac844fd47dc83d79e67f732c6bf3c56a407e3171b92bd3b0dc334fd35eea446a889d1100f7
-  languageName: node
-  linkType: hard
-
-"@inquirer/rawlist@npm:^5.2.8":
-  version: 5.2.8
-  resolution: "@inquirer/rawlist@npm:5.2.8"
-  dependencies:
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/35b0a9e29972342669365af70ea8feebc4e13ce688ce53c1fae723cbd02a7082294553eeb49ee443f5e993c1a97be31fcbe366f7cb573c075557316717792527
-  languageName: node
-  linkType: hard
-
-"@inquirer/search@npm:^4.1.8":
-  version: 4.1.8
-  resolution: "@inquirer/search@npm:4.1.8"
-  dependencies:
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/figures": "npm:^2.0.5"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/7281c59e8953aa4663c5afe3d6a3b558ec3e97867569f29dcc0a67e89ff05b37f374ac34ebc7356a7137f76a5172d52c60469cadcc323cc733b4d635b5cf3334
-  languageName: node
-  linkType: hard
-
-"@inquirer/select@npm:^5.1.4":
-  version: 5.1.4
-  resolution: "@inquirer/select@npm:5.1.4"
-  dependencies:
-    "@inquirer/ansi": "npm:^2.0.5"
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/figures": "npm:^2.0.5"
-    "@inquirer/type": "npm:^4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/30b6b061acd08f3f4cfde08a626446d308271e32569acec03f8c87a17e04c21aeccbecf354c8b254a2decfbe7d2189d8ae4443bf10d0be4a2aedeb4e850574c2
-  languageName: node
-  linkType: hard
-
-"@inquirer/type@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@inquirer/type@npm:4.0.5"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/390edb0fd1f027f9c8dc26bac28486d38bbde6c19974ef1588ea187f54a2cb58db639ebca31fa81a8fe4a4e84c2f0953ab3f5a6768ba86649368c5e806148a6f
   languageName: node
   linkType: hard
 
@@ -7483,7 +7241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
+"ansi-styles@npm:^3.2.0":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
@@ -8403,27 +8161,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.4.2":
-  version: 2.4.2
-  resolution: "chalk@npm:2.4.2"
-  dependencies:
-    ansi-styles: "npm:^3.2.1"
-    escape-string-regexp: "npm:^1.0.5"
-    supports-color: "npm:^5.3.0"
-  checksum: 10c0/e6543f02ec877732e3a2d1c3c3323ddb4d39fbab687c23f526e25bd4c6a9bf3b83a696e8c769d078e04e5754921648f7821b2a2acfd16c550435fd630026e073
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/ee650b0a065b3d7a6fda258e75d3a86fc8e4effa55871da730a9e42ccb035bf5fd203525e5a1ef45ec2582ecc4f65b47eb11357c526b84dd29a14fb162c414d2
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^5.4.1":
   version: 5.4.1
   resolution: "chalk@npm:5.4.1"
@@ -8552,15 +8289,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-progress@npm:^3.8.2":
-  version: 3.12.0
-  resolution: "cli-progress@npm:3.12.0"
-  dependencies:
-    string-width: "npm:^4.2.3"
-  checksum: 10c0/f464cb19ebde2f3880620a2adfaeeefaec6cb15c8e610c8a659ca1047ee90d69f3bf2fdabbb1fe33ac408678e882e3e0eecdb84ab5df0edf930b269b8a72682d
-  languageName: node
-  linkType: hard
-
 "cli-spinners@npm:2.6.1":
   version: 2.6.1
   resolution: "cli-spinners@npm:2.6.1"
@@ -8568,7 +8296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.2.0, cli-spinners@npm:^2.5.0":
+"cli-spinners@npm:^2.5.0":
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
@@ -8611,13 +8339,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-width@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "cli-width@npm:4.1.0"
-  checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^3.0.3":
   version: 3.2.0
   resolution: "cliui@npm:3.2.0"
@@ -8637,17 +8358,6 @@ __metadata:
     strip-ansi: "npm:^5.2.0"
     wrap-ansi: "npm:^5.1.0"
   checksum: 10c0/76142bf306965850a71efd10c9755bd7f447c7c20dd652e1c1ce27d987f862a3facb3cceb2909cef6f0cb363646ee7a1735e3dfdd49f29ed16d733d33e15e2f8
-  languageName: node
-  linkType: hard
-
-"cliui@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "cliui@npm:6.0.0"
-  dependencies:
-    string-width: "npm:^4.2.0"
-    strip-ansi: "npm:^6.0.0"
-    wrap-ansi: "npm:^6.2.0"
-  checksum: 10c0/35229b1bb48647e882104cac374c9a18e34bbf0bace0e2cf03000326b6ca3050d6b59545d91e17bfe3705f4a0e2988787aa5cde6331bf5cbbf0164732cef6492
   languageName: node
   linkType: hard
 
@@ -10675,28 +10385,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esvu@npm:^1.2.16":
-  version: 1.3.0
-  resolution: "esvu@npm:1.3.0"
-  dependencies:
-    chalk: "npm:^3.0.0"
-    cli-progress: "npm:^3.8.2"
-    execa: "npm:^4.1.0"
-    extract-zip: "npm:^2.0.1"
-    glob: "npm:^7.1.6"
-    inquirer: "npm:^13.4.1"
-    macos-release: "npm:^3.2.0"
-    node-fetch: "npm:^2.6.1"
-    ora: "npm:^4.1.1"
-    rimraf: "npm:^3.0.2"
-    tar: "npm:^7.5.13"
-    yargs: "npm:^15.4.1"
-  bin:
-    esvu: src/bin.js
-  checksum: 10c0/0a98325db081b96e5187673abd5f1f72c5b948be0508d4a4af5af0bd9796ff265efb2774613ad544f7870314f273d47fbc8a0e5dcaca354f8a965715237ff478
-  languageName: node
-  linkType: hard
-
 "event-iterator@npm:^2.0.0":
   version: 2.0.0
   resolution: "event-iterator@npm:2.0.0"
@@ -10761,23 +10449,6 @@ __metadata:
     signal-exit: "npm:^3.0.0"
     strip-eof: "npm:^1.0.0"
   checksum: 10c0/cc71707c9aa4a2552346893ee63198bf70a04b5a1bc4f8a0ef40f1d03c319eae80932c59191f037990d7d102193e83a38ec72115fff814ec2fb3099f3661a590
-  languageName: node
-  linkType: hard
-
-"execa@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "execa@npm:4.1.0"
-  dependencies:
-    cross-spawn: "npm:^7.0.0"
-    get-stream: "npm:^5.0.0"
-    human-signals: "npm:^1.1.1"
-    is-stream: "npm:^2.0.0"
-    merge-stream: "npm:^2.0.0"
-    npm-run-path: "npm:^4.0.0"
-    onetime: "npm:^5.1.0"
-    signal-exit: "npm:^3.0.2"
-    strip-final-newline: "npm:^2.0.0"
-  checksum: 10c0/02211601bb1c52710260edcc68fb84c3c030dc68bafc697c90ada3c52cc31375337de8c24826015b8382a58d63569ffd203b79c94fef217d65503e3e8d2c52ba
   languageName: node
   linkType: hard
 
@@ -10911,31 +10582,6 @@ __metadata:
   version: 1.3.0
   resolution: "fast-sha256@npm:1.3.0"
   checksum: 10c0/87f9e4baa7639576cf60a2b6235c9f436e1a1c52323abbd8a705b5bea8355500acf176f2aed0c14f2ecd6d6007e26151461bab2f27b8953bcca8d9d6b76a86e4
-  languageName: node
-  linkType: hard
-
-"fast-string-truncated-width@npm:^3.0.2":
-  version: 3.0.3
-  resolution: "fast-string-truncated-width@npm:3.0.3"
-  checksum: 10c0/043b8663397d14a3880ce4f3407bcda60b40db9bbeafe62863a35d1f9c69ea17c8da3fcd72de235553e6c9cd053128cde9e24ca0d4a7463208f48db3cd23d981
-  languageName: node
-  linkType: hard
-
-"fast-string-width@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "fast-string-width@npm:3.0.2"
-  dependencies:
-    fast-string-truncated-width: "npm:^3.0.2"
-  checksum: 10c0/c8822d175315bb353ebe782b65214ac53b13e3bf704e03b132ea7bdfa8de6a636375b3ab7a4097545393d109381c37c4f387c72a462c90b61412dbc4632f39a7
-  languageName: node
-  linkType: hard
-
-"fast-wrap-ansi@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "fast-wrap-ansi@npm:0.2.0"
-  dependencies:
-    fast-string-width: "npm:^3.0.2"
-  checksum: 10c0/c0eb6debee565c5dbb9132dddff5c4d4aba5eb02185ae4dab285acd6186018cffca04264e92f373cbf592a9bcd1c33d65dba036030a8f3baeff1169969a1b59b
   languageName: node
   linkType: hard
 
@@ -11583,7 +11229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.0.0, get-stream@npm:^5.1.0":
+"get-stream@npm:^5.1.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
@@ -11755,7 +11401,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -12002,13 +11648,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-flag@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "has-flag@npm:3.0.0"
-  checksum: 10c0/1c6c83b14b8b1b3c25b0727b8ba3e3b647f99e9e6e13eb7322107261de07a4c1be56fc0d45678fc376e09772a3a1642ccdaf8fc69bdf123b6c086598397ce473
-  languageName: node
-  linkType: hard
-
 "has-flag@npm:^4.0.0":
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
@@ -12207,13 +11846,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-signals@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "human-signals@npm:1.1.1"
-  checksum: 10c0/18810ed239a7a5e23fb6c32d0fd4be75d7cd337a07ad59b8dbf0794cb0761e6e628349ee04c409e605fe55344716eab5d0a47a62ba2a2d0d367c89a2b4247b1e
-  languageName: node
-  linkType: hard
-
 "human-signals@npm:^2.1.0":
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
@@ -12255,7 +11887,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.7.0, iconv-lite@npm:^0.7.2":
+"iconv-lite@npm:^0.7.0":
   version: 0.7.2
   resolution: "iconv-lite@npm:0.7.2"
   dependencies:
@@ -12466,26 +12098,6 @@ __metadata:
     react-devtools-core:
       optional: true
   checksum: 10c0/68a75781ea4dc7b92b1808e0df9b9316be3c72c2a609fced325253ba6b8e903a2d3193d361ab2217bd6a083e02b7d917edba7dea9427a99c9205160fa1369a52
-  languageName: node
-  linkType: hard
-
-"inquirer@npm:^13.4.1":
-  version: 13.4.2
-  resolution: "inquirer@npm:13.4.2"
-  dependencies:
-    "@inquirer/ansi": "npm:^2.0.5"
-    "@inquirer/core": "npm:^11.1.9"
-    "@inquirer/prompts": "npm:^8.4.2"
-    "@inquirer/type": "npm:^4.0.5"
-    mute-stream: "npm:^3.0.0"
-    run-async: "npm:^4.0.6"
-    rxjs: "npm:^7.8.2"
-  peerDependencies:
-    "@types/node": ">=18"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 10c0/6e30a9ac935094bf6391c3f20657167f6ca39c76719dd180449026bb4ed0976cc77dd01ad6dfd06b9336655c513bc2949714707f46d32116de760859b4c60131
   languageName: node
   linkType: hard
 
@@ -14129,15 +13741,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "log-symbols@npm:3.0.0"
-  dependencies:
-    chalk: "npm:^2.4.2"
-  checksum: 10c0/d11582a1b499b76aa1415988234ad54d9fb3f888f4cb4186cbc20ee4d314ac4b5f3d9fe9edd828748d2c0d372df2ea9f5dfd89100510988a8ce5ddf483ae015e
-  languageName: node
-  linkType: hard
-
 "log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -14223,13 +13826,6 @@ __metadata:
     node-gyp: "npm:latest"
   checksum: 10c0/2cf2bcd937a79cdfbf97e55afcb9b9f0004fb329e8026e158ad96563aec3a5180f7acba5716e55c8354a5df03b3419ab834af5397906521ce50e01cd0ba4df67
   conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"macos-release@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "macos-release@npm:3.3.0"
-  checksum: 10c0/e95a483ba8751280b8c3a8f466c8f57769e85b22a29ed7159bddee5ef7eaf00569f7940d66eeac253c49239b083af2e4c839ba4bfc73df332874f763e6f166cf
   languageName: node
   linkType: hard
 
@@ -14906,13 +14502,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "mute-stream@npm:3.0.0"
-  checksum: 10c0/12cdb36a101694c7a6b296632e6d93a30b74401873cf7507c88861441a090c71c77a58f213acadad03bc0c8fa186639dec99d68a14497773a8744320c136e701
-  languageName: node
-  linkType: hard
-
 "nan@npm:^2.4.0":
   version: 2.26.2
   resolution: "nan@npm:2.26.2"
@@ -15033,7 +14622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.7":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -15374,7 +14963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^4.0.0, npm-run-path@npm:^4.0.1":
+"npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
   dependencies:
@@ -15679,22 +15268,6 @@ __metadata:
     strip-ansi: "npm:^6.0.0"
     wcwidth: "npm:^1.0.1"
   checksum: 10c0/30d5f3218eb75b0a2028c5fb9aa88e83e38a2f1745ab56839abb06c3ba31bae35f768f4e72c4f9e04e2a66be6a898e9312e8cf85c9333e1e3613eabb8c7cdf57
-  languageName: node
-  linkType: hard
-
-"ora@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "ora@npm:4.1.1"
-  dependencies:
-    chalk: "npm:^3.0.0"
-    cli-cursor: "npm:^3.1.0"
-    cli-spinners: "npm:^2.2.0"
-    is-interactive: "npm:^1.0.0"
-    log-symbols: "npm:^3.0.0"
-    mute-stream: "npm:0.0.8"
-    strip-ansi: "npm:^6.0.0"
-    wcwidth: "npm:^1.0.1"
-  checksum: 10c0/5203b4cc615cbd970244981679471aedb2b935e0659602efb5c872c01b3fcdb10be8fd541ed9d4ca51e2d7b2ebe601c03f33653ef44fd284d0cab44f67775aa1
   languageName: node
   linkType: hard
 
@@ -17499,13 +17072,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"run-async@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "run-async@npm:4.0.6"
-  checksum: 10c0/3e512c689d356238a06a59839deddeb09aec23bc66f780fe970fcf12b64bfc00c6880e9530ea22b8cf88a927145561f5a43343d8be87166e849ec0daaa3d4cf4
-  languageName: node
-  linkType: hard
-
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -17530,15 +17096,6 @@ __metadata:
   dependencies:
     tslib: "npm:^2.1.0"
   checksum: 10c0/c48833638ae5d339332f8b792e716c3c662950ba95ba04e9e97a8cfd4628d8f009129672793c6c067c872a4dab5757231d41d7256a2114a5fabbf30d8a5b9d67
-  languageName: node
-  linkType: hard
-
-"rxjs@npm:^7.8.2":
-  version: 7.8.2
-  resolution: "rxjs@npm:7.8.2"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/1fcd33d2066ada98ba8f21fcbbcaee9f0b271de1d38dc7f4e256bfbc6ffcdde68c8bfb69093de7eeb46f24b1fb820620bf0223706cff26b4ab99a7ff7b2e2c45
   languageName: node
   linkType: hard
 
@@ -18514,15 +18071,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0":
-  version: 5.5.0
-  resolution: "supports-color@npm:5.5.0"
-  dependencies:
-    has-flag: "npm:^3.0.0"
-  checksum: 10c0/6ae5ff319bfbb021f8a86da8ea1f8db52fac8bd4d499492e30ec17095b58af11f0c55f8577390a749b1c4dde691b6a0315dab78f5f54c9b3d83f8fb5905c1c05
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
@@ -18618,7 +18166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.13, tar@npm:^7.5.4":
+"tar@npm:^7.5.4":
   version: 7.5.13
   resolution: "tar@npm:7.5.13"
   dependencies:
@@ -19993,17 +19541,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "wrap-ansi@npm:6.2.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
-  languageName: node
-  linkType: hard
-
 "wrap-ansi@npm:^8.1.0":
   version: 8.1.0
   resolution: "wrap-ansi@npm:8.1.0"
@@ -20217,16 +19754,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^18.1.2":
-  version: 18.1.3
-  resolution: "yargs-parser@npm:18.1.3"
-  dependencies:
-    camelcase: "npm:^5.0.0"
-    decamelize: "npm:^1.2.0"
-  checksum: 10c0/25df918833592a83f52e7e4f91ba7d7bfaa2b891ebf7fe901923c2ee797534f23a176913ff6ff7ebbc1cc1725a044cc6a6539fed8bfd4e13b5b16376875f9499
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3, yargs-parser@npm:^20.2.9":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
@@ -20283,25 +19810,6 @@ __metadata:
     y18n: "npm:^4.0.0"
     yargs-parser: "npm:^13.1.2"
   checksum: 10c0/6612f9f0ffeee07fff4c85f153d10eba4072bf5c11e1acba96153169f9d771409dfb63253dbb0841ace719264b663cd7b18c75c0eba91af7740e76094239d386
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^15.4.1":
-  version: 15.4.1
-  resolution: "yargs@npm:15.4.1"
-  dependencies:
-    cliui: "npm:^6.0.0"
-    decamelize: "npm:^1.2.0"
-    find-up: "npm:^4.1.0"
-    get-caller-file: "npm:^2.0.1"
-    require-directory: "npm:^2.1.1"
-    require-main-filename: "npm:^2.0.0"
-    set-blocking: "npm:^2.0.0"
-    string-width: "npm:^4.2.0"
-    which-module: "npm:^2.0.0"
-    y18n: "npm:^4.0.0"
-    yargs-parser: "npm:^18.1.2"
-  checksum: 10c0/f1ca680c974333a5822732825cca7e95306c5a1e7750eb7b973ce6dc4f97a6b0a8837203c8b194f461969bfe1fb1176d1d423036635285f6010b392fa498ab2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

The benchmark's `test-xs` job began running on Node 24 when `ci: read Node version from .node-version` (01bbaccc) landed on `llm` on 2026-05-20, replacing the workflow's explicit Node pins with `.node-version` (`lts/*` = Node 24). On Node 24 `yarn dlx esvu` hangs while extracting its engine downloads: esvu unzips with yauzl 2.10.0 through fd-slicer, which stalls on that runtime.

This drops esvu and installs xs and v8 by direct download with `curl` and the system `unzip`, reproducing the `bin/` + `engines/` layout the `eshost` tail of `install-engines.sh` expects (now under `~/.bench-engines`):

- **XS** from the latest Moddable release (resolved by following the `releases/latest` redirect, falling back to a pinned `8.1.1`): `xst-lin64.zip` extracts to `~/.bench-engines/engines/xs/xst` and is symlinked at `~/.bench-engines/bin/xs`.
- **V8** from the canary build named by `v8-linux64-rel-latest.json`: the zip extracts to `~/.bench-engines/engines/v8/`, and a launcher at `~/.bench-engines/bin/v8` runs `d8` with the snapshot blob.

The `are_engines_installed` short-circuit and the `yarn eshost --add`/`--list` tail are unchanged. The `esvu` devDependency is removed from `packages/benchmark/package.json` and the lockfile. `packages/hex/test/run-benches.sh` reads the same `~/.bench-engines` path. Downloads use `curl -fSL --retry 3 --retry-all-errors` and verify each archive with `unzip -t` plus a binary-presence check.

### Security Considerations

Scoped to CI/dev tooling (the benchmark `test-xs` job) — no shipped package or runtime is affected. Within that scope it reduces the supply-chain surface: the job no longer `yarn dlx`-executes esvu and its transitive npm tree (an unpinned package execution) on every run. The xs/v8 binaries are still fetched over HTTPS from the same upstreams (Moddable releases, the V8 canary bucket) resolved to "latest" without checksum pinning, so trust in those sources is unchanged.

### Scaling Considerations

N/A.

### Documentation Considerations

`packages/benchmark/README.md` points at `~/.bench-engines`.

### Testing Considerations

The `test-xs` CI job is the verification: it now completes on Node 24 where esvu hung.

### Compatibility Considerations

The engine path moves from `~/.esvu` to `~/.bench-engines`; a local checkout reruns `yarn install-engines` to repopulate it.

### Upgrade Considerations

N/A.

