### PR TITLE
feat(endo-fs): streaming tree clone

### DIFF
--- a/designs/endo-app-sharing.md
+++ b/designs/endo-app-sharing.md
@@ -1,0 +1,271 @@
+# Endo App Sharing and Cloning
+
+| | |
+|---|---|
+| **Created** | 2026-06-01 |
+| **Updated** | 2026-06-02 |
+| **Author** | Aaron (prompted) |
+| **Status** | In Progress |
+
+## What is the Problem Being Solved?
+
+A user should be able to build a small runnable "app", hand it to a peer, and
+have the peer **run it** — either as a live reference into the author's daemon
+or, when the app is marked **cloneable**, as their own independent copy that
+keeps working after the author goes offline or garbage-collects the original.
+
+An Endo "app" in this design is the composition the substrate already
+supports:
+
+- an **endo-fs source** — a project tree (a compartment-mapper layout:
+  `compartment-map.json` plus modules) exposed as an `@endo/endo-fs`
+  `Filesystem` capability, and
+- **endo-fs-exec** — the `@endo/endo-fs-exec` `tree-view-module.js` adapter
+  that presents that tree to the daemon's `make-from-tree` formula, whose root
+  program exports `make(powers, context, { env }) => exo`. That `exo` is the
+  running app.
+
+What is missing is everything around *transfer*:
+
+1. **An app handle worth sharing.** A single named thing that bundles
+   `{ source tree, exec/run config, optional UI manifest }`, rather than the
+   user wiring `node-fs-module` → `tree-view-module` → `make-from-tree` by hand
+   each time.
+2. **Share as remote reference.** Hand a peer a capability to the *running*
+   exo (or to the app handle) so they invoke it on the author's machine.
+3. **Clone for independence.** When marked cloneable, materialise the source
+   tree on the recipient's daemon as local `readable-tree` / `readable-blob`
+   formulas so the recipient runs their own instance — no dependency on the
+   author's liveness, and subject to the recipient's own powers.
+
+## Background: what already exists
+
+| Capability | Location | Status |
+|---|---|---|
+| `@endo/endo-fs` `Filesystem` caps (in-memory, node-fs, from-mount; `FsBackend` seam) | `packages/endo-fs`, [`endo-fs-backend-seam`](endo-fs-backend-seam.md) | Complete |
+| `tree-view-module.js` adapting endo-fs → `make-from-tree` | `packages/endo-fs-exec/src/tree-view-module.js` | Complete |
+| `make-from-tree` formula running a compartment-mapped program | `packages/daemon/src/daemon.js` (`makeFromTree`) | Complete |
+| `readable-tree` / `readable-blob` formulas (transitively read-only, content-addressed) | `packages/daemon/src/daemon.js` | Complete |
+| `endo checkin` / `endo checkout` (tree ⇄ filesystem, zip via `-z`) | `packages/cli/src/commands/`, [`daemon-checkin-checkout`](daemon-checkin-checkout.md) | Complete |
+| In-memory zip-as-tree (`@endo/exo-zip`) | [`exo-zip-package`](exo-zip-package.md) | Proposed |
+
+So reading a tree, running it, and serialising it to/from disk and zip all
+exist. What does not exist is a **cross-daemon** "pull this remote tree into my
+own store" operation, the app handle that ties source + exec together, or the
+remote-ref-vs-clone choice exposed at share time.
+
+## Design
+
+### App handle
+
+Introduce an **app** formula (or a thin named record) capturing:
+
+```
+{
+  source:   <readable-tree | endo-fs Filesystem cap>,  // the program tree
+  run:      { workerName, powers, env },               // make-from-tree inputs
+  ui?:      <app UI manifest>,                          // see familiar-app-ui-hosting
+  cloneable: boolean,                                   // may the recipient copy the source?
+}
+```
+
+`cloneable` is the policy bit. It governs which of the two share modes below
+the author is willing to offer.
+
+### Share mode A — remote reference
+
+The author shares a capability to the **app handle** (or directly to the
+running `exo`). The recipient holds a remote reference; every invocation
+crosses to the author's daemon over CapTP / OCapN-Noise. The source tree never
+leaves the author. This is the default and works today for any formula —
+the new work is only naming it as an "app" and surfacing a "share" affordance.
+
+### Share mode B — clone
+
+Available only when `cloneable` is true. The recipient performs a **clone**:
+
+1. The author's side serialises the `source` tree as **one ordered stream of
+   entries** — `(path, kind, content)` in depth-first order — and hands the
+   recipient a single reader.
+2. The recipient drains that one stream into a **fresh durable filesystem**
+   under its own control (the durable backing is pluggable — see below).
+3. Re-run `make-from-tree` against the *local* copy under the recipient's own
+   `run` powers, producing an independent instance.
+
+A new CLI verb (working name `endo clone <remote-app> --name <local-name>`)
+and a Chat "Make my own copy" action drive mode B. The cloned app's powers are
+the recipient's to grant — the clone does not inherit the author's
+capabilities, only the author's *code*.
+
+### Streaming clone: one tree-stream, not a pipelined walk
+
+The clone transport is a **single `@endo/exo-stream` stream** whose items are
+tree entries (path + node kind + file content), emitted depth-first by the
+producer and consumed in order by the recipient. This is deliberately *not* a
+client-driven pipelined walk (`lookup`/`snapshot`/`fetch` per node):
+
+- **One round-trip class, not one-per-file.** The recipient opens the stream
+  once and pulls; the producer pushes the whole tree. Pre-ack `buffer` on the
+  exo-stream keeps the pipe full over a high-latency link. A thousand-file app
+  is one stream, not a thousand request/response pairs.
+- **The producer already holds the tree**, so it serialises locally and emits —
+  no per-node capability hand-off to the recipient.
+- **No content hashing on the path.** We trust the peer to send its own app and
+  the secure transport ([ocapn-noise-network](ocapn-noise-network.md)) to
+  deliver it intact. The clone does not compute or verify per-blob hashes; there
+  is no CAS dedup step and no `BlobRef` round-trip in the clone path. (Integrity
+  and peer-authenticity are the transport's job, established when the peer was
+  added — see [familiar-deep-link-invitations](familiar-deep-link-invitations.md).)
+
+Large files still stream as chunk frames within the single stream so no whole
+file is buffered in memory; this reuses the chunking discipline `Layer.apply`
+already follows (1-MiB ops) rather than method-sized buffers.
+
+A natural realisation makes the **wire format and the durable format the same
+zip**: the producer streams a deflated archive (`@endo/zip` `writer.js` +
+`deflate.js`, both already in-repo), and the recipient writes those bytes
+straight into its durable backing. One codec serves transport, on-disk
+durability, and the runnable backing.
+
+### Durable filesystem on the receiving side (pluggable backing)
+
+The recipient needs the clone to **persist and reincarnate across daemon
+restart**, and we may *not* want to spray loose files onto the host disk. The
+`@endo/endo-fs` `FsBackend` seam (`backend-types.js` + `wrap-backend.js`) is
+built exactly for this: `wrapBackend(backend)` synthesises the full
+`Filesystem` exo surface over a minimal path-keyed backend, so a new backing
+costs ~100 lines. Candidate durable backings for a cloned app:
+
+- **Zip-backed backend** (leading option) — entries land in a `@endo/zip`
+  archive; the archive is the single durable artifact, and the same bytes were
+  the wire format. Projected back as a runnable `ReadableTree` via
+  [exo-zip-package](exo-zip-package.md).
+- **Daemon CAS** — entries become `readable-blob` / `readable-tree` formulas
+  (the existing content-addressed store), the cross-daemon analogue of
+  [`endo checkin`](daemon-checkin-checkout.md) without a host-path round-trip.
+- **node-fs backend** — ordinary files on disk, when that is actually wanted.
+
+The clone verb takes the durable backing as a parameter; the default is the
+zip-backed archive so a cloned app is one self-contained, content-defined file
+rather than scattered state.
+
+### Why cloneability is explicit
+
+Remote-reference sharing and cloning are different trust postures:
+
+- A remote reference keeps the author in the loop (they can revoke, observe,
+  update centrally) and never discloses source.
+- A clone discloses the full source tree and hands control to the recipient.
+
+The author must opt in to disclosure; hence `cloneable` is a deliberate flag,
+not implied by sharing.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [endo-fs-backend-seam](endo-fs-backend-seam.md) | The `FsBackend` seam (`wrapBackend`) that makes a zip-backed (or CAS-backed) durable receiver ~100 lines. **Load-bearing for the receiving side.** |
+| [exo-zip-package](exo-zip-package.md) | Projects the received/durable zip back as a runnable `ReadableTree`; in-flight as exo-zip / exo-unzip ([PR #160](https://github.com/endojs/endo-but-for-bots/pull/160)). |
+| [daemon-checkin-checkout](daemon-checkin-checkout.md) | The local serialisation primitive the cross-daemon clone generalises (CAS-backed receiver option). |
+| [ocapn-noise-network](ocapn-noise-network.md) | The secure transport we trust for clone integrity and peer authenticity in lieu of per-blob hashing. |
+| [familiar-app-ui-hosting](familiar-app-ui-hosting.md) | Hosts the app's `ui` manifest as partially-sandboxed UI. |
+| [daemon-weblet-application](daemon-weblet-application.md) | Prior art for "readable tree + powers → served application". |
+| [app-sharing-milestone](app-sharing-milestone.md) | Parent milestone; this is the "make & share runnable apps" pillar. |
+
+**Related in-flight PRs (reconcile, don't duplicate):** exo-stream
+[#330](https://github.com/endojs/endo-but-for-bots/pull/330) is the streaming
+substrate the single clone tree-stream rides; daemon git-tree `archive` (tar)
+[#367](https://github.com/endojs/endo-but-for-bots/pull/367) is tree-as-archive
+prior art; `familiar-run-apps-vfs.md`
+([#241](https://github.com/endojs/endo-but-for-bots/pull/241) ·
+[raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/familiar-run-vfs-apps/designs/familiar-run-apps-vfs.md))
+is a sibling angle on running apps from a mount/VFS source. The consolidated PR
+index lives in [app-sharing-milestone](app-sharing-milestone.md).
+
+## Phased Implementation
+
+1. **App handle.** Name the `{ source, run, ui?, cloneable }` composition as a
+   first-class shareable thing; "share (reference)" affordance over an existing
+   running formula. (Substrate already runs the app via `make-from-tree`.)
+2. **Streaming clone + durable receiver.** A tree-archive stream helper in
+   `@endo/endo-fs` (producer serialises the tree to one stream; consumer
+   drains it), plus a **zip-backed `FsBackend`** so the recipient gets a
+   durable, self-contained archive that reincarnates across restart. `endo
+   clone` verb wires producer → stream → durable backing → `make-from-tree`.
+3. **Cloneability policy + UX.** Honour the `cloneable` flag end to end; Chat
+   surfaces "Open (remote)" vs "Make my own copy" per the author's policy.
+
+## Design Decisions
+
+1. **An app is `make-from-tree` plus metadata, not a new runtime.** Reuse the
+   existing compartment-mapper / `make` execution path; the app concept is
+   packaging and transfer, not a new way to run code.
+2. **Clone copies code, never capabilities.** The cloned instance binds the
+   recipient's powers. The author shares source, not authority.
+3. **Cloneability is opt-in disclosure.** Defaulting to remote-reference keeps
+   the safe posture; cloning is a deliberate author decision to disclose the
+   source tree.
+4. **One tree-stream, not a pipelined walk.** Cloning ships the whole tree as a
+   single ordered stream of `(path, content)` entries so the cost is one stream
+   regardless of file count — fewer round-trips than per-node
+   `lookup`/`snapshot`/`fetch`.
+5. **Trust the peer and the transport; no content hashing.** The clone does not
+   compute or verify per-blob hashes and does no CAS dedup. Integrity and
+   peer-authenticity come from the secure channel established when the peer was
+   added, not from re-hashing on receipt.
+6. **Durable receiver is pluggable; default zip.** The recipient persists the
+   clone through the `@endo/endo-fs` `FsBackend` seam. The default backing is a
+   self-contained zip archive (same bytes as the wire format) rather than loose
+   files on the host disk.
+
+## Known Gaps and TODOs
+
+- [ ] **Clone of an actively-written source — unresolved.** If the source tree
+      mutates mid-stream the recipient can capture a torn state. Candidate
+      answers: pin the source to an immutable snapshot before streaming
+      (clean, but snapshotting a large live tree has cost), or accept
+      best-effort consistency. Whole-tree atomicity is not yet designed; this
+      is the main open question.
+- [ ] **FS layering for immediate use — deferred.** A copy-on-write
+      `compose(remote-backing, local-writable-layer)` clone would let the
+      recipient use the app before the full copy finishes, materialising
+      entries on demand. Interesting but out of scope for the first cut.
+- [ ] Cross-peer GC interaction for **mode A**: prevent the author GC'ing a
+      source/exo a remote holder still references (relates to
+      [daemon-cross-peer-gc](daemon-cross-peer-gc.md)).
+- [ ] Update/versioning of a cloned app (pull a newer tree) — out of scope for
+      the milestone; clones are point-in-time copies.
+
+### Outstanding from the streaming-clone implementation
+
+- [ ] **Re-clone into a non-empty destination requires `setStat`.** Overwrite
+      correctness (no stale trailing bytes when the new file is shorter) is
+      achieved with `create(name, { truncate: true })`, which needs the
+      backend's `setStat` capability. Backends without it cannot truncate and
+      so cannot correctly clobber a longer pre-existing file.
+- [ ] **`harvestTree` does an extra `lookup` per entry (N+1 round-trips).**
+      `list()` returns `{ name, qid }` but not child caps, so each entry —
+      directories included — costs an `E(dir).lookup(name)` to recurse or open.
+      Over a CapTP boundary this doubles per-node round-trips, partially
+      undercutting the "one stream, few round-trips" goal; reducing it needs a
+      batched walk or a cursor that carries the child cap.
+- [ ] **`writeTreeStream`'s `openFile` is loosely typed (`any`).** It could be
+      tightened to the `OpenFile` cap type once the bytes-writer iterator shape
+      is expressible without widening.
+
+## Prompt (refinement)
+
+> rather than a pipelined approach, I think a stream of filename file content
+> will lead to fewer roundtrips. I don't think we need to check the hashes as
+> we are trusting the peer and the network layer to provide the content. but I
+> haven't thought about a clone over an fs that is being actively written to.
+> the fs layering for immediate use is interesting, but deferrable. we also
+> need to be able to create a durable fs on the receiving side, and we may not
+> want to just write files to disk normally (maybe we want to back it by zip or
+> something else).
+
+## Prompt
+
+> make and share runnable apps (backed by an endo-fs source and endo-fs-exec).
+> apps need to be optionally "cloneable" so you don't just get a remote
+> reference on their machine. Part of the app-sharing milestone.

--- a/packages/endo-fs/src/clone.js
+++ b/packages/endo-fs/src/clone.js
@@ -1,0 +1,265 @@
+// @ts-check
+/* eslint-disable no-await-in-loop -- ordered streaming: directory entries
+   and file chunks are applied sequentially to preserve tree order and
+   bound memory; parallelising would reorder the single frame stream. */
+/**
+ * Streaming clone for `@endo/endo-fs` (designs/endo-app-sharing.md, Pillar 3c).
+ *
+ * A clone ships a whole source tree to a destination as **one ordered
+ * stream of entries** — `(path, kind, content)` in depth-first order —
+ * rather than a client-driven pipelined walk that pays a round-trip per
+ * node. The producer (which already holds the tree) serialises it into a
+ * single `PassableReader<CloneFrame>`; the consumer drains that one reader
+ * and recreates the tree under a destination `Directory`.
+ *
+ * Design decisions realised here:
+ *
+ * - **One stream, not a pipelined walk.** `streamTree` returns a single
+ *   reader regardless of file count; `@endo/exo-stream`'s pre-ack `buffer`
+ *   keeps the pipe full over a high-latency link.
+ * - **No content hashing.** Integrity and peer-authenticity are the
+ *   transport's job (the secure channel established when the peer was
+ *   added). The clone path computes no per-blob hash and does no CAS dedup.
+ * - **Large files stream as chunk frames** within the one stream, so no
+ *   whole file is buffered in memory.
+ * - **Pluggable durable destination.** The consumer writes through an
+ *   ordinary `Directory` cap, so the durable backing is whatever
+ *   `Filesystem` the caller hands in (in-memory, node-fs, a zip-backed
+ *   `FsBackend`, …).
+ *
+ * Bytes ride inside frames as base64 strings because CapTP marshalling
+ * rejects raw mutable typed arrays (see DESIGN.md §5 / §6); this mirrors
+ * how `@endo/exo-stream`'s byte reader/writer haul bytes today.
+ */
+
+import { E } from '@endo/eventual-send';
+import { Fail } from '@endo/errors';
+import { M } from '@endo/patterns';
+import { decodeBase64 } from '@endo/base64/decode.js';
+import { encodeBase64 } from '@endo/base64/encode.js';
+import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
+import { iterateReader } from '@endo/exo-stream/iterate-reader.js';
+import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
+import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
+
+/**
+ * @typedef {object} CloneFrame
+ * A single frame in the depth-first clone stream.
+ * - `{ kind: 'dir', path }` — ensure a directory exists at `path`.
+ * - `{ kind: 'file', path }` — begin a file at `path`.
+ * - `{ kind: 'chunk', base64 }` — append bytes to the file most recently
+ *   opened by a `file` frame.
+ * - `{ kind: 'fileEnd' }` — close the current file.
+ */
+
+/**
+ * Pattern for a single clone frame. Passed to `readerFromIterator` as the
+ * `readPattern` so a malformed frame breaks the stream at the boundary
+ * rather than corrupting the destination tree.
+ */
+export const CloneFrameShape = M.or(
+  harden({ kind: 'dir', path: M.arrayOf(M.string()) }),
+  harden({ kind: 'file', path: M.arrayOf(M.string()) }),
+  harden({ kind: 'chunk', base64: M.string() }),
+  harden({ kind: 'fileEnd' }),
+);
+harden(CloneFrameShape);
+
+/**
+ * Stable, name-sorted directory listing so a clone is reproducible.
+ * Sorts by UTF-16 code point (not `localeCompare`, whose order varies by
+ * environment locale) so the traversal order is deterministic everywhere.
+ *
+ * @param {any} dir  a `Directory` cap (local or remote)
+ * @returns {Promise<Array<{ name: string, qid: { type: string } }>>}
+ */
+const listSorted = async dir => {
+  const cursor = await E(dir).list();
+  const entries = await E(cursor).toArray();
+  return [...entries].sort((a, b) => {
+    const an = String(a.name);
+    const bn = String(b.name);
+    // eslint-disable-next-line no-nested-ternary
+    return an < bn ? -1 : an > bn ? 1 : 0;
+  });
+};
+
+/**
+ * Depth-first generator of clone frames for a directory's contents.
+ * Children are emitted relative to the original source root (the root
+ * directory itself is implied by the destination and gets no frame).
+ *
+ * @param {any} dir  a `Directory` cap
+ * @param {string[]} prefix  path of `dir` relative to the source root
+ * @returns {AsyncGenerator<CloneFrame, void, void>}
+ */
+async function* harvestTree(dir, prefix) {
+  const entries = await listSorted(dir);
+  for (const { name, qid } of entries) {
+    const path = harden([...prefix, name]);
+    const child = await E(dir).lookup(name);
+    if (qid.type === 'directory') {
+      yield harden({ kind: 'dir', path });
+      yield* harvestTree(child, path);
+    } else {
+      yield harden({ kind: 'file', path });
+      const open = await E(child).open({ read: true });
+      try {
+        // `read(0n)` is offset 0, length-to-EOF (DESIGN.md §4.6); the
+        // bytes reader yields transport-sized chunks we re-frame one
+        // for one, so no whole file is buffered.
+        const bytesReader = await E(open).read(0n);
+        for await (const chunk of iterateBytesReader(bytesReader)) {
+          yield harden({ kind: 'chunk', base64: encodeBase64(chunk) });
+        }
+      } finally {
+        await E(open).close();
+      }
+      yield harden({ kind: 'fileEnd' });
+    }
+  }
+}
+
+/**
+ * Serialise a source tree as a single `PassableReader<CloneFrame>`.
+ *
+ * @param {any} sourceRoot  the `Directory` cap at the root of the tree to
+ *   clone (e.g. `await E(filesystem).root()` or any sub-`Directory`)
+ * @param {{ buffer?: number }} [options]  `buffer` is the exo-stream pre-ack
+ *   depth: the producer streams up to this many frames ahead of consumer
+ *   demand, so a drain costs about `frameCount / buffer` synchronization
+ *   round-trips rather than one ack per frame (a large file fans out into
+ *   many `chunk` frames). Defaults to 64; set 0 for strict per-frame
+ *   backpressure, or higher to trade more in-flight frames (memory) for
+ *   fewer round-trips on a high-latency link.
+ * @returns {any}  a `PassableReader` cap over `CloneFrame`s
+ */
+export const streamTree = (sourceRoot, options = {}) => {
+  const { buffer = 64 } = options;
+  return readerFromIterator(harvestTree(sourceRoot, harden([])), {
+    buffer,
+    readPattern: CloneFrameShape,
+  });
+};
+harden(streamTree);
+
+/**
+ * Resolve (creating as needed) the destination `Directory` that should
+ * contain `path`'s leaf, returning `{ parent, name }`.
+ *
+ * @param {any} destRoot  destination `Directory` cap
+ * @param {string[]} path  non-empty path relative to `destRoot`
+ * @returns {Promise<{ parent: any, name: string }>}
+ */
+const resolveParent = async (destRoot, path) => {
+  path.length >= 1 || Fail`clone frame path must be non-empty`;
+  const name = path[path.length - 1];
+  const parentPath = path.slice(0, -1);
+  const parent =
+    parentPath.length === 0
+      ? destRoot
+      : await E(destRoot).materialise(harden(parentPath), {});
+  return { parent, name };
+};
+
+/**
+ * Drain a clone stream into a destination `Directory`, recreating the
+ * source tree. Returns counts for progress reporting.
+ *
+ * @param {any} destRoot  the `Directory` cap to clone into
+ * @param {any} reader  a `PassableReader<CloneFrame>` (from `streamTree`)
+ * @returns {Promise<{ directories: number, files: number, bytes: number }>}
+ */
+export const writeTreeStream = async (destRoot, reader) => {
+  let directories = 0;
+  let files = 0;
+  let bytes = 0;
+
+  /** @type {any} */
+  let openFile;
+  // The exo-stream byte writer (BytesWriterIterator) is iterator-shaped but
+  // not a full AsyncGenerator (no [Symbol.asyncDispose], 0-arg return()), so
+  // it is kept loosely typed.
+  /** @type {any} */
+  let writer;
+
+  try {
+    // Validate frames on the consumer side too. `writeTreeStream` drains an
+    // arbitrary reader (possibly remote/untrusted), so enforce the frame shape
+    // at the stream boundary rather than failing deep in a switch case — or
+    // worse, feeding a non-string into `decodeBase64`.
+    for await (const frame of iterateReader(reader, {
+      readPattern: CloneFrameShape,
+    })) {
+      switch (frame.kind) {
+        case 'dir': {
+          !writer || Fail`clone stream: dir frame while a file is open`;
+          frame.path.length !== 0 || Fail`clone stream: dir frame empty path`;
+          await E(destRoot).materialise(harden(frame.path), {});
+          directories += 1;
+          break;
+        }
+        case 'file': {
+          !writer || Fail`clone stream: nested file frame`;
+          const { parent, name } = await resolveParent(destRoot, frame.path);
+          // Truncate: a clone overwrites the destination wholesale, so an
+          // existing longer file at this path must be shortened. `create`
+          // truncates only with this flag, and `OpenFile.write` is pwrite
+          // (no tail truncate), so without it a re-clone into a non-empty
+          // destination would leave stale trailing bytes.
+          openFile = await E(parent).create(name, { truncate: true });
+          writer = iterateBytesWriter(await E(openFile).write(0n));
+          files += 1;
+          break;
+        }
+        case 'chunk': {
+          writer || Fail`clone stream: chunk frame with no open file`;
+          const data = decodeBase64(frame.base64);
+          bytes += data.length;
+          await writer.next(data);
+          break;
+        }
+        case 'fileEnd': {
+          writer || Fail`clone stream: fileEnd with no open file`;
+          await writer.return();
+          await E(openFile).close();
+          writer = undefined;
+          openFile = undefined;
+          break;
+        }
+        default: {
+          throw Fail`clone stream: unknown frame kind ${frame.kind}`;
+        }
+      }
+    }
+    !writer || Fail`clone stream: ended mid-file`;
+  } finally {
+    // On a mid-stream error (malformed frame, source read failure) close the
+    // partially-written destination file rather than leaking the OpenFile and
+    // its abandoned writer.
+    if (writer) {
+      await writer.return().catch(() => {});
+      await E(openFile)
+        .close()
+        .catch(() => {});
+    }
+  }
+
+  return harden({ directories, files, bytes });
+};
+harden(writeTreeStream);
+
+/**
+ * Clone a source tree into a destination `Directory` as a single
+ * streamed pass. Convenience over `writeTreeStream(dest, streamTree(src))`;
+ * works whether `source` and `dest` are local or across a CapTP boundary,
+ * since everything flows through the one reader cap.
+ *
+ * @param {any} sourceRoot  the `Directory` cap to clone from
+ * @param {any} destRoot  the `Directory` cap to clone into
+ * @param {{ buffer?: number }} [options]
+ * @returns {Promise<{ directories: number, files: number, bytes: number }>}
+ */
+export const cloneTree = (sourceRoot, destRoot, options = {}) =>
+  writeTreeStream(destRoot, streamTree(sourceRoot, options));
+harden(cloneTree);

--- a/packages/endo-fs/src/index.js
+++ b/packages/endo-fs/src/index.js
@@ -29,6 +29,15 @@ export { makeFromMountBackend } from './backends/from-mount-backend.js';
 // Public porcelain helpers (free functions over the typed cap surface).
 export { walk, collectBytes, collectStream } from './helpers.js';
 
+// Streaming clone (designs/endo-app-sharing.md): serialise a source tree
+// as one ordered frame stream and drain it into a destination Directory.
+export {
+  cloneTree,
+  streamTree,
+  writeTreeStream,
+  CloneFrameShape,
+} from './clone.js';
+
 // PosixFs interface sketch — POSIX-shaped attrs / real OS locks /
 // native disk xattrs live in a future companion cap. Only the
 // guard is exported; backing-specific implementations come later.

--- a/packages/endo-fs/test/clone.test.js
+++ b/packages/endo-fs/test/clone.test.js
@@ -1,0 +1,253 @@
+// @ts-nocheck
+/* eslint-disable import/order, no-await-in-loop */
+
+/**
+ * Streaming clone tests (designs/endo-app-sharing.md, Pillar 3c).
+ *
+ * `cloneTree(source, dest)` ships a whole tree as one ordered frame
+ * stream and recreates it under a destination Directory. These tests
+ * build an in-memory source, clone it into a fresh in-memory
+ * destination, and assert the structure and bytes round-trip — including
+ * empty files, empty directories, deep nesting, and multi-chunk content.
+ */
+
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import { E } from '@endo/far';
+import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
+import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
+import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
+
+import { makeInMemoryFilesystem } from '../src/in-memory.js';
+import { cloneTree, streamTree, writeTreeStream } from '../src/clone.js';
+
+/** Wrap an array of frames as a PassableReader for writeTreeStream. */
+const readerOf = frames =>
+  readerFromIterator(
+    (async function* gen() {
+      for (const frame of frames) {
+        yield harden(frame);
+      }
+    })(),
+  );
+
+const utf8 = s => new TextEncoder().encode(s);
+const fromUtf8 = b => new TextDecoder().decode(b);
+
+const collectBytes = async readerRef => {
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of iterateBytesReader(readerRef)) {
+    chunks.push(chunk);
+    total += chunk.length;
+  }
+  const buf = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    buf.set(c, off);
+    off += c.length;
+  }
+  return buf;
+};
+
+const writeBytes = async (writerRef, bytes) => {
+  const writer = iterateBytesWriter(writerRef);
+  await writer.next(bytes);
+  await writer.return();
+};
+
+/** Create a file with `bytes` at `name` under directory `dir`. */
+const putFile = async (dir, name, bytes) => {
+  const open = await E(dir).create(name, {});
+  if (bytes.length) {
+    await writeBytes(await E(open).write(0n), bytes);
+  }
+  await E(open).close();
+};
+
+/** Read the bytes of the file at `path` (string[]) under `root`. */
+const readFileAt = async (root, path) => {
+  let node = root;
+  for (const seg of path) {
+    node = await E(node).lookup(seg);
+  }
+  const open = await E(node).open({ read: true });
+  return collectBytes(await E(open).read(0n));
+};
+
+/** True if a child `name` exists under directory `dir`. */
+const childKinds = async dir => {
+  const cursor = await E(dir).list();
+  const entries = await E(cursor).toArray();
+  const map = new Map();
+  for (const { name, qid } of entries) {
+    map.set(name, qid.type);
+  }
+  return map;
+};
+
+/**
+ * Build a source tree:
+ *   /readme.txt          "top level\n"
+ *   /empty.txt           (zero bytes)
+ *   /emptydir/           (no children)
+ *   /src/index.js        "export const x = 1;\n"
+ *   /src/deep/nested.txt  larger, multi-write content
+ */
+const buildSource = async () => {
+  const fs = makeInMemoryFilesystem();
+  const root = await E(fs).root();
+  await putFile(root, 'readme.txt', utf8('top level\n'));
+  await putFile(root, 'empty.txt', utf8(''));
+  await E(root).makeDirectory('emptydir', {});
+  const src = await E(root).makeDirectory('src', {});
+  await putFile(src, 'index.js', utf8('export const x = 1;\n'));
+  const deep = await E(src).makeDirectory('deep', {});
+  // A larger payload written as several chunks, to exercise multi-chunk
+  // streaming through the single frame stream.
+  const big = 'abcdefghij'.repeat(5000); // 50 KiB
+  const open = await E(deep).create('nested.txt', {});
+  const writer = iterateBytesWriter(await E(open).write(0n));
+  await writer.next(utf8(big.slice(0, 20000)));
+  await writer.next(utf8(big.slice(20000)));
+  await writer.return();
+  await E(open).close();
+  return { fs, root, big };
+};
+
+test('cloneTree reproduces the full tree and its bytes', async t => {
+  const { root: source, big } = await buildSource();
+
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+
+  const stats = await cloneTree(source, dest);
+
+  // Directories: emptydir, src, src/deep → 3. Files: readme.txt,
+  // empty.txt, src/index.js, src/deep/nested.txt → 4.
+  t.is(stats.directories, 3);
+  t.is(stats.files, 4);
+  t.is(stats.bytes, 10 + 0 + 20 + big.length);
+
+  t.is(fromUtf8(await readFileAt(dest, ['readme.txt'])), 'top level\n');
+  t.is(fromUtf8(await readFileAt(dest, ['empty.txt'])), '');
+  t.is(
+    fromUtf8(await readFileAt(dest, ['src', 'index.js'])),
+    'export const x = 1;\n',
+  );
+  t.is(fromUtf8(await readFileAt(dest, ['src', 'deep', 'nested.txt'])), big);
+
+  // Empty directory is materialised even though it has no children.
+  const top = await childKinds(dest);
+  t.is(top.get('emptydir'), 'directory');
+  t.is(top.get('src'), 'directory');
+  t.is(top.get('readme.txt'), 'file');
+  t.is(top.get('empty.txt'), 'file');
+});
+
+test('cloneTree into a non-empty destination overwrites without stale tail bytes', async t => {
+  const { root: source } = await buildSource();
+
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  // Pre-populate the destination with a file that is LONGER than the source's
+  // version. A pwrite-only overwrite would leave the old tail behind.
+  await putFile(
+    dest,
+    'readme.txt',
+    utf8('PRE-EXISTING CONTENT THAT IS LONGER THAN THE SOURCE AND MUST GO\n'),
+  );
+
+  const stats = await cloneTree(source, dest);
+  t.is(stats.files, 4);
+
+  // The clobbered file must equal the source exactly — no leftover tail.
+  t.is(fromUtf8(await readFileAt(dest, ['readme.txt'])), 'top level\n');
+});
+
+test('cloneTree of a sub-directory clones only that subtree', async t => {
+  const { root: source } = await buildSource();
+  const src = await E(source).lookup('src');
+
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+
+  const stats = await cloneTree(src, dest);
+  t.is(stats.files, 2); // index.js + deep/nested.txt
+  t.is(stats.directories, 1); // deep
+
+  t.is(fromUtf8(await readFileAt(dest, ['index.js'])), 'export const x = 1;\n');
+  const top = await childKinds(dest);
+  t.false(top.has('readme.txt')); // outside the cloned subtree
+});
+
+test('streamTree + writeTreeStream compose explicitly', async t => {
+  const { root: source } = await buildSource();
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+
+  // Equivalent to cloneTree, but with the producer/consumer split visible.
+  const reader = streamTree(source, { buffer: 4 });
+  const stats = await writeTreeStream(dest, reader);
+
+  t.is(stats.files, 4);
+  t.is(fromUtf8(await readFileAt(dest, ['readme.txt'])), 'top level\n');
+});
+
+test('cloning an empty tree yields zero counts', async t => {
+  const srcFs = makeInMemoryFilesystem();
+  const source = await E(srcFs).root();
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+
+  const stats = await cloneTree(source, dest);
+  t.deepEqual({ ...stats }, { directories: 0, files: 0, bytes: 0 });
+});
+
+test('writeTreeStream rejects a chunk with no open file', async t => {
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  await t.throwsAsync(
+    writeTreeStream(dest, readerOf([{ kind: 'chunk', base64: 'AA==' }])),
+    { message: /no open file/ },
+  );
+});
+
+test('writeTreeStream rejects a stream ending mid-file and cleans up', async t => {
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  // A file frame with no terminating fileEnd: the drain loop's post-check
+  // throws, and the finally must close the half-open destination file.
+  await t.throwsAsync(
+    writeTreeStream(dest, readerOf([{ kind: 'file', path: ['x.txt'] }])),
+    { message: /mid-file/ },
+  );
+  // The file was created then closed by the cleanup path (no leaked handle).
+  const top = await childKinds(dest);
+  t.is(top.get('x.txt'), 'file');
+});
+
+test('writeTreeStream rejects a dir frame with an empty path', async t => {
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  await t.throwsAsync(
+    writeTreeStream(dest, readerOf([{ kind: 'dir', path: [] }])),
+    { message: /empty path/ },
+  );
+});
+
+test('writeTreeStream rejects a dir frame while a file is open', async t => {
+  const destFs = makeInMemoryFilesystem();
+  const dest = await E(destFs).root();
+  await t.throwsAsync(
+    writeTreeStream(
+      dest,
+      readerOf([
+        { kind: 'file', path: ['a.txt'] },
+        { kind: 'dir', path: ['b'] },
+      ]),
+    ),
+    { message: /file is open/ },
+  );
+});


### PR DESCRIPTION
Split out of #383 (streaming clone half).

## Streaming Tree Clone (`@endo/endo-fs`)

Ships a whole directory tree to a destination as **one ordered, memory-bounded frame stream** rather than a client-driven pipelined walk that pays a round-trip per node. Implements Pillar 3c of `designs/endo-app-sharing.md`.

**API (`packages/endo-fs/src/clone.js`):**
- `streamTree(sourceRoot, options)` — serialise a source tree into a `PassableReader` of depth-first, name-sorted frames. Large files stream as base64 `chunk` frames so no whole file is buffered. Frames are pattern-validated via `CloneFrameShape`.
- `writeTreeStream(destRoot, reader)` — drain the stream into a destination `Directory`. Validates frames on the consumer side too, and creates files with `{ truncate: true }` so a re-clone over a shorter file leaves no stale trailing bytes.
- `cloneTree(sourceRoot, destRoot, options)` — convenience wrapper.

**Design decisions:** one stream (not pipelined walks); no content hashing (integrity is the secure transport's job); large files stream as chunks; pluggable durable destination via an ordinary `Directory` cap; base64 for CapTP marshalling.

**Tests (`packages/endo-fs/test/clone.test.js`):** full round-trip, empty files/dirs, multi-chunk large files, sub-tree clone, explicit `streamTree` + `writeTreeStream` composition, empty-tree edge case, and overwrite-into-a-non-empty-destination.

Outstanding follow-ups are tracked in `designs/endo-app-sharing.md` § Known Gaps (re-clone needs backend `setStat`; `harvestTree` N+1 `lookup`; `openFile` `any`-typing).

https://claude.ai/code/session_0112zLHkZKDDUzUDEwPvScwT

---
_Generated by [Claude Code](https://claude.ai/code/session_0112zLHkZKDDUzUDEwPvScwT)_