### PR TITLE
feat(familiar,chat): endo:// deep-link peer invitations

### DIFF
--- a/designs/familiar-deep-link-invitations.md
+++ b/designs/familiar-deep-link-invitations.md
@@ -1,0 +1,193 @@
+# Familiar Deep-Link Peer Invitations
+
+| | |
+|---|---|
+| **Created** | 2026-06-01 |
+| **Updated** | 2026-06-02 |
+| **Author** | Aaron (prompted) |
+| **Status** | In Progress |
+
+## Status
+
+Phases 1–2 are implemented (split out of #383 into a dedicated PR):
+
+- **Shell capture** — `packages/familiar/electron-main.js` registers `endo:`
+  as a privileged default protocol client and captures links via `open-url`
+  (macOS), `second-instance` + single-instance lock (Windows/Linux), and
+  cold-start `process.argv`. Parsing/validation lives in the dependency-free,
+  SES-free `packages/familiar/src/deep-link.js`.
+- **Renderer routing** — `packages/familiar/preload.js` bridges invites to the
+  renderer; `packages/chat/deep-link-invite.js` opens the existing `accept`
+  command form pre-filled (the form is the confirmation + naming screen).
+- **Link generation + accept** — `packages/chat/invite-link.js` plus the chat
+  `invite` / `accept` commands surface and consume the `endo://invite?…` link.
+
+Key deviation from the original sketch: the link is an **intent-path** URL
+(`endo://invite?…`), not the locator string verbatim — see Decision 3.
+
+## What is the Problem Being Solved?
+
+Two people running Familiar should be able to become peers by exchanging a
+single link.
+Today the daemon already has the machinery to mint and accept a peer
+invitation — `host.invite(guestName)` produces a locator string and
+`host.accept(locator, petName)` parses it, registers the remote node's
+addresses via `addPeerInfo`, and binds a local pet name — but there is no
+way to *deliver* that locator through the operating system into a running
+Familiar and turn it into a guided, consent-gated flow.
+
+The missing pieces are entirely in the shell and the Chat UI:
+
+1. **OS deep-link capture.** Familiar does not register a custom URL scheme
+   (e.g. `endo://`), so clicking an invite link in a browser, chat app, or
+   email does nothing.
+2. **A confirmation screen.** Accepting a peer is a trust decision. The user
+   must see *who* they are about to add (a key fingerprint and any
+   self-asserted label) and explicitly approve.
+3. **A naming prompt.** The peer must be bound under a **pet name** chosen by
+   the recipient — the locator cannot dictate the local name, and the user
+   should be asked rather than defaulted silently.
+
+This design adds the deep-link handler and the consent/naming UI on top of
+the existing daemon `invite`/`accept` surface.
+
+## Background: what already exists
+
+| Capability | Location | Status |
+|---|---|---|
+| Locator format `endo://{nodeKey}/?id=…&type=invitation&at=host:port` | `packages/daemon/src/locator.js` | Complete |
+| `host.invite(guestName)` → `Invitation` exo with `locate()` | `packages/daemon/src/host.js` | Complete |
+| `host.accept(invitationLocator, guestName)` → parse, `addPeerInfo`, bind pet name | `packages/daemon/src/host.js` | Complete |
+| OCapN-Noise transport (mutual Ed25519, IK handshake) | `packages/ocapn-noise`, [`ocapn-noise-network`](ocapn-noise-network.md) | Complete (PR #137) |
+| Privileged custom scheme registration in Electron (`localhttp://`) | `packages/familiar/src/protocol-handler.js` | Complete (template) |
+
+The `localhttp://` handler is the working reference for how to register and
+service a custom scheme in the Familiar main process.
+
+## Design
+
+### 1. URL scheme and link shape
+
+Register `endo:` as the application's default protocol client. An invitation
+link is an **intent-path** URL: the authority segment names the action
+(`invite`) and the query carries exactly the fields `host.accept` consumes:
+
+```
+endo://invite?node={nodeKey}&id={invitationNumber}&from={hostHandle}&fromNode={optional}&at=ws:host:port
+```
+
+- `node`, `id`, `from`, `fromNode`, `at` are the daemon-locator fields. The
+  renderer reconstructs the canonical locator
+  (`endo://{node}/?id=…&type=invitation&from=…&at=…`) and forwards that to
+  `host.accept`. `type=invitation` is implied by the `invite` intent, so it is
+  not carried in the link; `from` (the inviter's handle) is required, and
+  `fromNode` appears only when the handle uses a distinct agent key.
+- A future `label` — an **optional, untrusted** self-asserted display string
+  for human recognition on the confirmation screen — is not yet implemented.
+  If added it would never be used as the pet name or granted trust weight.
+
+### 2. Capturing the link in the shell
+
+In `packages/familiar/electron-main.js`:
+
+- `app.setAsDefaultProtocolClient('endo')` (guarded for dev vs packaged
+  paths, matching how `localhttp` is set up).
+- Register `endo` in `protocol.registerSchemesAsPrivileged` before
+  `app.whenReady()`.
+- Handle the three OS delivery paths:
+  - **macOS:** `app.on('open-url', (event, url) => …)`.
+  - **Windows / Linux:** `app.requestSingleInstanceLock()` plus
+    `app.on('second-instance', (event, argv) => …)`, and parse `process.argv`
+    on cold start.
+- Normalise to a single internal event and forward the parsed invite to the
+  renderer over the existing preload IPC bridge (`packages/familiar/preload.js`),
+  never executing `accept` from the main process directly.
+
+### 3. Confirmation + naming screen (Chat)
+
+The renderer receives an `endo:invite` IPC message and opens a modal:
+
+- **Identity block:** key fingerprint (short hash of `nodeKey`), the
+  untrusted `label` clearly marked as self-asserted, and the connection hints
+  (`at` addresses).
+- **Name field:** "What should we call this peer?" — required, validated as a
+  pet name, defaulted to a *suggestion* derived from `label` or the
+  fingerprint that the user must confirm or replace.
+- **Actions:** Accept / Decline. Accept calls
+  `E(host).accept(reconstructedLocator, petName)` over the existing CapTP
+  bridge; Decline discards the invite with no daemon side effects.
+
+The barrier between the host chrome (the modal frame, the Accept button) and
+any peer-supplied content (the `label`) follows the same chrome/guest
+separation principle used for weblet hosting — peer-supplied strings are
+rendered as inert text, never as markup or actionable controls.
+
+## Dependencies
+
+| Design | Relationship |
+|---|---|
+| [ocapn-noise-network](ocapn-noise-network.md) | Provides the secure transport the accepted peer connects over. |
+| [daemon-agent-network-identity](daemon-agent-network-identity.md) | Per-agent keypairs / network registration that make the `nodeKey` in the link meaningful; soft prerequisite. In-flight as per-agent `@transports`: design `ocapn-daemon-integration.md` ([PR #138](https://github.com/endojs/endo-but-for-bots/pull/138) · [raw](https://github.com/endojs/endo-but-for-bots/raw/refs/heads/design/ocapn-daemon-integration/designs/ocapn-daemon-integration.md)), prototype [#262](https://github.com/endojs/endo-but-for-bots/pull/262). |
+| [trust-on-first-bind](trust-on-first-bind.md) | Reference for the prompt-and-pin consent pattern the confirmation screen instantiates. |
+| [familiar-localhttp-protocol](familiar-localhttp-protocol.md) | Working template for privileged custom-scheme registration in Electron. |
+| [app-sharing-milestone](app-sharing-milestone.md) | Parent milestone; this is the "connect peers" pillar. |
+
+**Related in-flight PRs:** locator scheme v2 with `@`-delimited connection hints
+([#178](https://github.com/endojs/endo-but-for-bots/pull/178)) is the basis for
+the `endo://` link's query params; daemon-to-daemon OCapN-Noise connectivity is
+[#340](https://github.com/endojs/endo-but-for-bots/pull/340). No `endo://`
+deep-link / confirmation-screen PR exists yet — this design is net-new.
+
+## Phased Implementation
+
+1. **Scheme registration + capture.** `setAsDefaultProtocolClient`, privileged
+   scheme, `open-url` / `second-instance` / argv parsing, single-instance lock,
+   IPC forward. No UI yet — log the parsed invite.
+2. **Confirmation + naming modal.** Identity block, validated pet-name field,
+   Accept → `host.accept`, Decline path. Untrusted-label rendering discipline.
+3. **Polish.** Invite-link generation affordance in Chat ("Invite a peer" →
+   copy `endo://invite/…`), error states (malformed link, unreachable peer,
+   duplicate pet name), and a smoke test that drives a synthetic `endo://`
+   URL end to end.
+
+## Design Decisions
+
+1. **Accept runs in the renderer over CapTP, not in the Electron main
+   process.** The main process stays a thin transport for the URL; all
+   capability use goes through the same audited preload bridge as the rest of
+   Chat.
+2. **The locator cannot name the peer.** The pet name is always the
+   recipient's choice. The link may *suggest* via `label`, but the suggestion
+   is untrusted and confirmable.
+3. **Intent-path link, locator reconstructed at the boundary.** The link
+   authority names the action (`endo://invite?…`) rather than reusing a locator
+   verbatim, so `endo://` can route future intents (`adopt`, `open-weblet`)
+   without overloading a locator's `type`. The handler validates the link and
+   reconstructs the canonical `endo://{node}/?id=…&type=invitation&from=…`
+   locator that `host.accept` consumes unchanged.
+
+## Outstanding / Follow-ups
+
+- [ ] **Open (multi-use) invitations.** `host.invite` is single-take
+      (consume-once: `accept` overwrites the pre-chosen `guestName`). An *open*
+      invite that accepts N peers — a fresh guest minted per acceptance,
+      revocable, with optional max-uses / expiry — is new daemon work. The
+      `endo://invite?…` link format already accommodates it; only the
+      invitation formula's accept semantics change.
+- [ ] **Deduplicate the link contract.** The parse/format logic (and
+      `NUMBER_PATTERN`) exists twice — `packages/familiar/src/deep-link.js`
+      (SES-free, Electron main) and `packages/chat/invite-link.js` (renderer) —
+      because Chat cannot import the Familiar shell. Extract a shared
+      dependency-free module both import, or a daemon-exported helper.
+- [ ] **Dedicated confirmation modal (Phase 2 polish).** Today an invite
+      pre-fills the existing `accept` command form. A purpose-built identity /
+      consent modal (fingerprint, untrusted label, Accept / Decline) is still
+      future polish.
+- [ ] Naming nit: `ParsedInvite.number` carries the locator's `id` query
+      value; the struct field and the wire key differ in name.
+
+## Prompt
+
+> connect to other peers via a deep linking url format (needs a confirmation
+> screen, should ask you to specify a name). Part of the app-sharing
+> milestone.

--- a/packages/chat/chat-bar-component.js
+++ b/packages/chat/chat-bar-component.js
@@ -1730,6 +1730,9 @@ export const chatBarComponent = (
     getReplyType: sendForm.getReplyType,
     setText: sendForm.setText,
     focus: sendForm.focus,
+    // Open a command form pre-filled with field values; used by deep-link
+    // peer invitations to launch the Accept form with the locator filled in.
+    enterCommandMode,
     dispose: sendForm.dispose,
   };
 };

--- a/packages/chat/chat.js
+++ b/packages/chat/chat.js
@@ -13,6 +13,7 @@ import { createChannelHeader } from './channel-header.js';
 import { inboxComponent } from './inbox-component.js';
 import { inventoryComponent } from './inventory-component.js';
 import { chatBarComponent } from './chat-bar-component.js';
+import { wireDeepLinkInvites } from './deep-link-invite.js';
 import { valueComponent } from './value-component.js';
 import { createSpacesGutter } from './spaces-gutter.js';
 import { inventoryGraphComponent } from './inventory-graph-component.js';
@@ -1742,6 +1743,9 @@ const bodyComponent = (
         },
       );
       chatBarRef = chatBarAPI;
+      // Route endo:// deep-link peer invitations (Familiar shell) into the
+      // Accept command form. No-op outside the Familiar.
+      wireDeepLinkInvites(chatBarAPI);
       const { focusValue, blurValue } = valueComponent(
         $parent,
         /** @type {ERef<EndoHost>} */ (resolvedPowers),

--- a/packages/chat/command-executor.js
+++ b/packages/chat/command-executor.js
@@ -9,6 +9,10 @@ import harden from '@endo/harden';
 import { E } from '@endo/far';
 
 import { makeBrowserTree, checkoutToDirectory } from './browser-tree.js';
+import {
+  locatorToInviteLink,
+  normalizeInvitationInput,
+} from './invite-link.js';
 
 /**
  * @typedef {object} CommandResult
@@ -590,22 +594,33 @@ export const createCommandExecutor = ({
           }
 
           const locator = await E(invitation).locate();
-          console.log(`[Chat] Invitation locator generated`);
-          showMessage(`Invitation locator for "${guestName}":`);
-          showValue(locator, undefined, undefined, undefined);
+          // Prefer the shareable `endo://invite?...` deep link: clicking it
+          // launches the Familiar and pre-fills /accept. Fall back to the raw
+          // locator if the form is unexpectedly not an invitation locator.
+          const inviteLink = locatorToInviteLink(locator) || locator;
+          console.log(`[Chat] Invitation link generated`);
+          showMessage(
+            `Invitation link for "${guestName}" — share it, or paste it into /accept:`,
+          );
+          showValue(inviteLink, undefined, undefined, undefined);
           return {
             success: true,
-            value: locator,
+            value: inviteLink,
             message: `Invitation created for "${guestName}"`,
           };
         }
 
         case 'accept': {
           const { locator, guestName } = params;
+          // Accept either an `endo://invite?...` deep link or a raw locator.
+          const invitationLocator = normalizeInvitationInput(String(locator));
           console.log(
-            `[Chat] Accepting invitation for "${guestName}" from ${String(locator).slice(0, 40)}...`,
+            `[Chat] Accepting invitation for "${guestName}" from ${invitationLocator.slice(0, 40)}...`,
           );
-          const accepted = E(powers).accept(String(locator), String(guestName));
+          const accepted = E(powers).accept(
+            invitationLocator,
+            String(guestName),
+          );
           const timeout = new Promise((_, reject) => {
             setTimeout(
               () =>

--- a/packages/chat/command-registry.js
+++ b/packages/chat/command-registry.js
@@ -633,7 +633,7 @@ export const COMMANDS = {
         label: 'Invitation',
         type: 'locator',
         required: true,
-        placeholder: 'endo://...',
+        placeholder: 'endo://invite?...',
       },
       {
         name: 'guestName',

--- a/packages/chat/deep-link-invite.js
+++ b/packages/chat/deep-link-invite.js
@@ -1,0 +1,87 @@
+// @ts-check
+/**
+ * Route `endo://` deep-link peer invitations into the Accept command form
+ * (designs/familiar-deep-link-invitations.md).
+ *
+ * When the Familiar shell captures an `endo://invite?...` deep link, it
+ * forwards the parsed invite to this renderer over the preload bridge
+ * (`window.familiar`). Rather than invent a bespoke dialog, we open the
+ * existing `accept` command pre-filled with the locator: the command form is
+ * the confirmation screen, and its required `guestName` field is where the
+ * user names the peer before `host.accept` runs.
+ *
+ * Outside the Familiar (no `window.familiar`, e.g. a plain browser tab) this
+ * is a no-op.
+ */
+
+// The Chat bundle imports `ses` but never calls `lockdown()` (Monaco needs
+// mutable intrinsics), so `harden` is not a global here — import the ponyfill
+// like the sibling modules (chime.js, channel-utils.js).
+import harden from '@endo/harden';
+
+/**
+ * @typedef {object} ChatBarApi
+ * @property {(commandName: string, prefill?: Record<string, string>) => void}
+ *   enterCommandMode
+ */
+
+/**
+ * @typedef {object} DeepLinkInvite
+ * @property {string} locator  The invitation locator (an `endo://` URL).
+ */
+
+let wired = false;
+/**
+ * The live chat bar. Chat's `rebuild()` disposes the old bar and makes a new
+ * one on every profile / conversation / reconnect change, so the single IPC
+ * listener registered below must always target the current bar, not the one
+ * captured on first wire.
+ *
+ * @type {ChatBarApi | null}
+ */
+let currentChatBar = null;
+
+/**
+ * Wire deep-link invitations to the chat bar's Accept form. Safe to call on
+ * every rebuild: it updates the live-bar reference each time but registers
+ * the (never-removed) IPC listener only once.
+ *
+ * @param {ChatBarApi} chatBar
+ */
+export const wireDeepLinkInvites = chatBar => {
+  currentChatBar = chatBar;
+  const familiar = /** @type {any} */ (window).familiar;
+  if (!familiar || typeof familiar.onDeepLinkInvite !== 'function') {
+    return;
+  }
+  if (wired) {
+    return;
+  }
+  wired = true;
+
+  /** @param {DeepLinkInvite | null | undefined} invite */
+  const open = invite => {
+    if (currentChatBar && invite && typeof invite.locator === 'string') {
+      // Pre-fill the locator; the user confirms and supplies the pet name.
+      currentChatBar.enterCommandMode('accept', { locator: invite.locator });
+    }
+  };
+
+  // Live invitations that arrive while the app is running.
+  familiar.onDeepLinkInvite(open);
+
+  // Invitations queued before this listener was registered (cold start / OS
+  // launch-by-URL) arrive as an array. Pulling also marks the renderer ready
+  // in the shell.
+  if (typeof familiar.getPendingDeepLinkInvite === 'function') {
+    Promise.resolve(familiar.getPendingDeepLinkInvite()).then(
+      invites => {
+        for (const invite of invites || []) {
+          open(invite);
+        }
+      },
+      () => {},
+    );
+  }
+};
+harden(wireDeepLinkInvites);

--- a/packages/chat/invite-link.js
+++ b/packages/chat/invite-link.js
@@ -1,0 +1,158 @@
+// @ts-check
+/**
+ * Convert between the daemon's canonical invitation locator and the shareable
+ * `endo://invite?...` deep link handled by the Familiar shell's protocol
+ * handler (designs/familiar-deep-link-invitations.md).
+ *
+ * Canonical locator — what `invitation.locate()` emits and `host.accept`
+ * consumes (see daemon `makeInvitation.locate` / host `accept`):
+ *
+ *   endo://{node}/?id={inv}&type=invitation&from={handle}[&fromNode={n}]&at={addr}...
+ *
+ * Deep link — what a person clicks or pastes; the URL *authority* names the
+ * intent so the OS can route `endo://` to the Familiar:
+ *
+ *   endo://invite?node={node}&id={inv}&from={handle}[&fromNode={n}]&at={addr}...
+ *
+ * The two carry the *same fields*. The link moves `node` from the authority
+ * into a `node` query param (freeing the authority to name the `invite`
+ * action) and drops the redundant `type` (the intent implies it). `node` /
+ * `id` / `from` / `fromNode` are 64-char lowercase hex.
+ *
+ * The Familiar's own `packages/familiar/src/deep-link.js` is the SES-free
+ * mirror of this contract for the Electron main process; Chat cannot import it
+ * (Familiar is the shell that loads Chat, not a dependency), so the contract
+ * is duplicated here for the renderer.
+ */
+
+// Chat imports `ses` but does not call `lockdown()` (Monaco needs mutable
+// intrinsics), so `harden` is not a global — use the ponyfill like the
+// sibling renderer modules.
+import harden from '@endo/harden';
+
+/** Ed25519 public key / formula number: 64 lowercase hex characters. */
+const NUMBER_PATTERN = /^[0-9a-f]{64}$/;
+
+/** The deep-link authority segment that denotes a peer-invitation intent. */
+const INVITE_INTENT = 'invite';
+
+/** The locator `type` for a peer invitation. */
+const INVITATION_TYPE = 'invitation';
+
+/**
+ * Convert a canonical invitation locator into a shareable `endo://invite?...`
+ * deep link. Returns `null` when `locator` is not a well-formed invitation
+ * locator (e.g. a directory/channel locator), so callers can fall back to the
+ * raw string.
+ *
+ * @param {string} locator
+ * @returns {string | null}
+ */
+export const locatorToInviteLink = locator => {
+  if (typeof locator !== 'string' || !locator.startsWith('endo://')) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(locator);
+  } catch {
+    return null;
+  }
+  const node = url.hostname;
+  if (!NUMBER_PATTERN.test(node)) {
+    return null;
+  }
+  if (url.searchParams.get('type') !== INVITATION_TYPE) {
+    return null;
+  }
+  const id = url.searchParams.get('id');
+  const from = url.searchParams.get('from');
+  if (id === null || !NUMBER_PATTERN.test(id)) {
+    return null;
+  }
+  // The inviter's handle is intrinsic to an invitation locator.
+  if (from === null || !NUMBER_PATTERN.test(from)) {
+    return null;
+  }
+  const fromNode = url.searchParams.get('fromNode');
+  if (fromNode !== null && !NUMBER_PATTERN.test(fromNode)) {
+    return null;
+  }
+  const link = new URL(`endo://${INVITE_INTENT}`);
+  link.searchParams.set('node', node);
+  link.searchParams.set('id', id);
+  link.searchParams.set('from', from);
+  if (fromNode !== null) {
+    link.searchParams.set('fromNode', fromNode);
+  }
+  for (const address of url.searchParams.getAll('at')) {
+    link.searchParams.append('at', address);
+  }
+  return link.toString();
+};
+harden(locatorToInviteLink);
+
+/**
+ * Convert an `endo://invite?...` deep link into the canonical invitation
+ * locator that `host.accept` consumes. Returns `null` when `text` is not a
+ * well-formed invite link.
+ *
+ * @param {string} text
+ * @returns {string | null}
+ */
+export const inviteLinkToLocator = text => {
+  if (typeof text !== 'string' || !text.startsWith('endo://')) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(text);
+  } catch {
+    return null;
+  }
+  if (url.host !== INVITE_INTENT) {
+    return null;
+  }
+  const node = url.searchParams.get('node');
+  const id = url.searchParams.get('id');
+  const from = url.searchParams.get('from');
+  if (node === null || !NUMBER_PATTERN.test(node)) {
+    return null;
+  }
+  if (id === null || !NUMBER_PATTERN.test(id)) {
+    return null;
+  }
+  if (from === null || !NUMBER_PATTERN.test(from)) {
+    return null;
+  }
+  const fromNode = url.searchParams.get('fromNode');
+  if (fromNode !== null && !NUMBER_PATTERN.test(fromNode)) {
+    return null;
+  }
+  const locator = new URL(`endo://${node}`);
+  locator.pathname = '/';
+  locator.searchParams.set('id', id);
+  locator.searchParams.set('type', INVITATION_TYPE);
+  locator.searchParams.set('from', from);
+  if (fromNode !== null) {
+    locator.searchParams.set('fromNode', fromNode);
+  }
+  for (const address of url.searchParams.getAll('at')) {
+    locator.searchParams.append('at', address);
+  }
+  return locator.toString();
+};
+harden(inviteLinkToLocator);
+
+/**
+ * Normalise `/accept` input: accept either an `endo://invite?...` deep link or
+ * a raw canonical locator. Deep links are converted; anything else (a raw
+ * locator, or input the daemon will reject with a clearer error) is passed
+ * through unchanged.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export const normalizeInvitationInput = text =>
+  inviteLinkToLocator(text) ?? text;
+harden(normalizeInvitationInput);

--- a/packages/chat/test/invite-link.test.js
+++ b/packages/chat/test/invite-link.test.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+import '@endo/init/debug.js';
+
+import test from 'ava';
+
+import {
+  locatorToInviteLink,
+  inviteLinkToLocator,
+  normalizeInvitationInput,
+} from '../invite-link.js';
+
+const NODE = 'a'.repeat(64);
+const ID = 'b'.repeat(64);
+const FROM = 'c'.repeat(64);
+const FROM_NODE = 'd'.repeat(64);
+
+const LOCATOR = `endo://${NODE}/?id=${ID}&type=invitation&from=${FROM}&at=127.0.0.1%3A8920`;
+const LINK = `endo://invite?node=${NODE}&id=${ID}&from=${FROM}&at=127.0.0.1%3A8920`;
+
+test('locatorToInviteLink rewrites a canonical locator into a deep link', t => {
+  const link = locatorToInviteLink(LOCATOR);
+  t.truthy(link);
+  const url = new URL(/** @type {string} */ (link));
+  t.is(url.host, 'invite');
+  t.is(url.searchParams.get('node'), NODE);
+  t.is(url.searchParams.get('id'), ID);
+  t.is(url.searchParams.get('from'), FROM);
+  t.is(url.searchParams.get('type'), null); // intent implies type
+  t.deepEqual(url.searchParams.getAll('at'), ['127.0.0.1:8920']);
+});
+
+test('inviteLinkToLocator reconstructs the canonical locator', t => {
+  const locator = inviteLinkToLocator(LINK);
+  t.truthy(locator);
+  const url = new URL(/** @type {string} */ (locator));
+  t.is(url.hostname, NODE);
+  t.is(url.searchParams.get('id'), ID);
+  t.is(url.searchParams.get('type'), 'invitation');
+  t.is(url.searchParams.get('from'), FROM);
+  t.deepEqual(url.searchParams.getAll('at'), ['127.0.0.1:8920']);
+});
+
+test('locator <-> link round-trips, including fromNode and multiple hints', t => {
+  const locator = `endo://${NODE}/?id=${ID}&type=invitation&from=${FROM}&fromNode=${FROM_NODE}&at=a%3A1&at=b%3A2`;
+  const link = locatorToInviteLink(locator);
+  t.truthy(link);
+  const back = inviteLinkToLocator(/** @type {string} */ (link));
+  t.truthy(back);
+  const url = new URL(/** @type {string} */ (back));
+  t.is(url.searchParams.get('fromNode'), FROM_NODE);
+  t.deepEqual(url.searchParams.getAll('at'), ['a:1', 'b:2']);
+});
+
+test('conversions reject non-invitation input', t => {
+  // A directory/channel locator (no type=invitation, no from).
+  t.is(locatorToInviteLink(`endo://${NODE}/?id=${ID}&type=directory`), null);
+  // Missing required from.
+  t.is(locatorToInviteLink(`endo://${NODE}/?id=${ID}&type=invitation`), null);
+  // Not an invite-intent link.
+  t.is(inviteLinkToLocator(`endo://adopt?node=${NODE}&id=${ID}`), null);
+  // Malformed.
+  t.is(locatorToInviteLink('not-a-url'), null);
+  t.is(inviteLinkToLocator('not-a-url'), null);
+});
+
+test('normalizeInvitationInput converts links and passes locators through', t => {
+  // A deep link is converted to the canonical locator host.accept consumes.
+  t.is(normalizeInvitationInput(LINK), inviteLinkToLocator(LINK));
+  // A raw locator is left untouched (backward compatible).
+  t.is(normalizeInvitationInput(LOCATOR), LOCATOR);
+  // Unrelated input passes through for the daemon to reject with a clear error.
+  t.is(normalizeInvitationInput('garbage'), 'garbage');
+});

--- a/packages/familiar/electron-main.js
+++ b/packages/familiar/electron-main.js
@@ -26,6 +26,7 @@ import { whereEndoState } from '@endo/where';
 import { makeDaemonManager } from './src/daemon-manager.js';
 import { resourcePaths } from './src/resource-paths.js';
 import { makeLogger } from './src/logger.js';
+import { parseInviteUrl, findInviteUrlInArgv } from './src/deep-link.js';
 import {
   registerLocalhttpScheme,
   installLocalhttpHandler,
@@ -60,6 +61,103 @@ registerLocalhttpScheme();
 configureCommandLineFlags();
 
 const vitePort = 5173;
+
+/** @type {Electron.BrowserWindow | null} */
+let mainWindow = null;
+
+// --- Deep-link (endo://) peer invitations ---
+// (designs/familiar-deep-link-invitations.md)
+
+/** @type {import('./src/deep-link.js').ParsedInvite[]} */
+let pendingInvites = [];
+// Set once the renderer has pulled any queued invite via the IPC handler
+// below; until then invites are queued rather than sent, closing the race
+// where a cold-start invite is emitted before the page registers its
+// listener.
+let rendererReady = false;
+
+/**
+ * Deliver a parsed invite to the renderer, or queue it until the renderer is
+ * ready (cold start, pre-`app.whenReady`, or before the window finishes
+ * loading).
+ *
+ * @param {import('./src/deep-link.js').ParsedInvite} parsed
+ */
+const deliverInvite = parsed => {
+  if (rendererReady && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('familiar:deep-link-invite', parsed);
+  } else {
+    // Queue rather than overwrite: several links may arrive before the
+    // renderer pulls (cold start, reload), and none should be dropped.
+    pendingInvites.push(parsed);
+  }
+};
+
+/**
+ * Parse and route an `endo://` URL handed to us by the OS. Unrecognised
+ * links are logged and dropped; authoritative validation happens daemon-side
+ * when the renderer calls `host.accept`.
+ *
+ * @param {string} url
+ */
+const handleInviteUrl = url => {
+  const parsed = parseInviteUrl(url);
+  if (parsed) {
+    logger.log(
+      `[Familiar] Received deep-link invite from ${parsed.fingerprint}`,
+    );
+    deliverInvite(parsed);
+  } else {
+    // Strip query/fragment before logging: an unrecognised link is arbitrary
+    // and its query string could carry secrets. Log only scheme + path.
+    const scrubbed = String(url).split(/[?#]/)[0];
+    logger.warn(
+      `[Familiar] Ignoring unrecognised deep link: ${scrubbed.slice(0, 64)}`,
+    );
+  }
+};
+
+// Register endo:// as this app's protocol client. In dev the app runs from
+// the electron binary, so the entry script must be passed explicitly.
+if (process.defaultApp) {
+  if (process.argv.length >= 2) {
+    app.setAsDefaultProtocolClient('endo', process.execPath, [
+      path.resolve(process.argv[1]),
+    ]);
+  }
+} else {
+  app.setAsDefaultProtocolClient('endo');
+}
+
+// Single-instance: a second launch (e.g. the OS handing us an endo:// URL on
+// Windows/Linux) routes its argv to the already-running instance instead of
+// starting a second daemon-bearing process.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', (_event, argv) => {
+    const url = findInviteUrlInArgv(argv);
+    if (url) {
+      handleInviteUrl(url);
+    }
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
+      mainWindow.focus();
+    }
+  });
+}
+
+// macOS delivers deep links via open-url, which can fire before the app is
+// ready or the window exists; deliverInvite queues until the renderer pulls.
+// preventDefault() suppresses the OS default handling, per Electron's docs
+// for a registered protocol client.
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  handleInviteUrl(url);
+});
 
 /** @type {string | undefined} */
 let gatewayAddress;
@@ -176,6 +274,13 @@ const createWindow = () => {
   // Install navigation guard
   installNavigationGuard(win, { isDevMode, vitePort });
 
+  // Each (re)load — initial, restart, or purge — starts a fresh renderer that
+  // has not yet pulled queued invites. Drop ready until it pulls again, so an
+  // invite arriving mid-reload is queued rather than sent into a dead page.
+  win.webContents.on('did-start-loading', () => {
+    rendererReady = false;
+  });
+
   return win;
 };
 
@@ -280,22 +385,41 @@ const main = async () => {
   installLocalhttpHandler(gatewayPort);
   installExfiltrationDefenses();
 
-  // Step 4: Create the window
-  /** @type {Electron.BrowserWindow | null} */
-  let mainWindow = createWindow();
-
-  // Step 5: Build menu
-  buildMenu(
-    () => handleRestartDaemon(mainWindow),
-    () => handlePurgeDaemon(mainWindow),
-  );
-
-  // Step 6: Register IPC handlers
+  // Step 4: Register IPC handlers BEFORE creating the window. `createWindow`
+  // starts loading the renderer, which calls `get-pending-invite` on init; if
+  // that invoke reaches main before the handler is registered it rejects, and
+  // the renderer (which swallows the rejection) silently drops a cold-start
+  // invite. Registering first closes that race. The handler closures read
+  // `mainWindow` lazily, so registering before it is assigned is safe.
   ipcMain.handle('familiar:restart-daemon', () =>
     handleRestartDaemon(mainWindow),
   );
   ipcMain.handle('familiar:purge-daemon', () => handlePurgeDaemon(mainWindow));
   ipcMain.handle('familiar:get-version', () => app.getVersion());
+  // The renderer pulls any invite queued before it was listening, and by
+  // doing so marks itself ready for live delivery of subsequent invites.
+  ipcMain.handle('familiar:get-pending-invite', () => {
+    rendererReady = true;
+    const invites = pendingInvites;
+    pendingInvites = [];
+    return invites;
+  });
+
+  // Step 5: Create the window
+  mainWindow = createWindow();
+
+  // A deep link may have arrived on the command line (Windows/Linux cold
+  // start). Queue it; the renderer pulls it via get-pending-invite on init.
+  const coldStartInvite = findInviteUrlInArgv(process.argv);
+  if (coldStartInvite) {
+    handleInviteUrl(coldStartInvite);
+  }
+
+  // Step 6: Build menu
+  buildMenu(
+    () => handleRestartDaemon(mainWindow),
+    () => handlePurgeDaemon(mainWindow),
+  );
 
   // Step 7: Verify exfiltration defenses and notify renderer
   const warnings = await verifyExfiltrationDefenses();
@@ -323,7 +447,12 @@ const main = async () => {
   // Daemon continues running after quit; nothing to clean up.
 };
 
-main().catch(error => {
-  logger.error('[Familiar] Fatal error:', error);
-  process.exit(1);
-});
+// Only the instance that holds the single-instance lock boots the app; a
+// second launch has already forwarded its argv via 'second-instance' above
+// and is quitting.
+if (gotSingleInstanceLock) {
+  main().catch(error => {
+    logger.error('[Familiar] Fatal error:', error);
+    process.exit(1);
+  });
+}

--- a/packages/familiar/package.json
+++ b/packages/familiar/package.json
@@ -32,6 +32,7 @@
     "step:prepare": "node scripts/prepare-package.mjs",
     "step:package": "node scripts/package-app.mjs",
     "step:make": "node scripts/make-distributables.mjs",
+    "test": "node --test",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint --ignore-pattern out '**/*.js'",

--- a/packages/familiar/preload.js
+++ b/packages/familiar/preload.js
@@ -20,5 +20,17 @@ contextBridge.exposeInMainWorld(
       ipcRenderer.on('familiar:security-warnings', (_event, warnings) =>
         callback(warnings),
       ),
+    // endo:// deep-link peer invitations
+    // (designs/familiar-deep-link-invitations.md). The renderer subscribes for
+    // live invites first (`onDeepLinkInvite`), then pulls any queued before it
+    // was listening (`getPendingDeepLinkInvite`); subscribing first closes the
+    // cold-start race where an invite arrives between the pull and the
+    // subscription.
+    getPendingDeepLinkInvite: () =>
+      ipcRenderer.invoke('familiar:get-pending-invite'),
+    onDeepLinkInvite: (/** @type {(invite: object) => void} */ callback) =>
+      ipcRenderer.on('familiar:deep-link-invite', (_event, invite) =>
+        callback(invite),
+      ),
   }),
 );

--- a/packages/familiar/src/deep-link.js
+++ b/packages/familiar/src/deep-link.js
@@ -1,0 +1,211 @@
+// @ts-check
+
+/**
+ * `endo://` deep-link peer-invitation format for the Familiar shell
+ * (designs/familiar-deep-link-invitations.md).
+ *
+ * The deep link is an **intent-path** URL, distinct from the daemon's internal
+ * locator string:
+ *
+ *   endo://invite?node={node}&id={invitationNumber}&from={hostHandle}
+ *               [&fromNode={handleNode}]&at={addr}...
+ *
+ * The authority segment is the *intent* (`invite`), so `endo://` can route
+ * other actions later (`endo://adopt`, `endo://open-weblet`, …) without
+ * overloading a locator's `type` field, and the clickable link is decoupled
+ * from the internal locator format.
+ *
+ * The fields mirror what `host.accept` consumes from an invitation locator
+ * (see `daemon/src/host.js` `accept` and `daemon/src/daemon.js`
+ * `makeInvitation.locate`): the inviting `node`, the invitation `id`, the
+ * inviter's handle `from` (required — accept throws without it), an optional
+ * `fromNode` when the handle uses a distinct agent key, and `at` connection
+ * hints. `node` / `id` / `from` / `fromNode` are 64-char lowercase hex.
+ * `parseInviteUrl` validates the link and reconstructs the canonical daemon
+ * locator (`endo://{node}/?id=…&type=invitation&from=…&at=…`) that
+ * `host.accept` consumes.
+ *
+ * This module is pure and dependency-free on purpose. The Electron main
+ * process runs WITHOUT SES, so it must not import `@endo/daemon` internals or
+ * rely on a `harden` global. Authoritative validation happens daemon-side when
+ * the renderer calls `E(host).accept(locator, petName)`; these helpers only
+ * recognise a plausible invitation and extract fields for display and routing.
+ */
+
+/** Ed25519 public key / formula number: 64 lowercase hex characters. */
+const NUMBER_PATTERN = /^[0-9a-f]{64}$/;
+
+/** The deep-link authority segment that denotes a peer-invitation intent. */
+const INVITE_INTENT = 'invite';
+
+/** The locator `type` for a peer invitation (set for fidelity with locate()). */
+const INVITATION_TYPE = 'invitation';
+
+/**
+ * @typedef {object} ParsedInvite
+ * @property {string} locator      The canonical daemon invitation locator
+ *   reconstructed from the deep link; pass verbatim to `host.accept`.
+ * @property {string} node         The inviting node identifier (64-hex).
+ * @property {string} number       The invitation formula number (64-hex).
+ * @property {string} from         The inviter's handle number (64-hex).
+ * @property {string | undefined} fromNode  The handle's node, when it differs
+ *   from `node` (agent-key case); otherwise undefined.
+ * @property {string} fingerprint  Short, human-comparable form of `node` for
+ *   the confirmation screen.
+ * @property {string[]} addresses  Connection hints (the `at` params).
+ */
+
+/**
+ * Reconstruct the canonical daemon invitation locator from its parts, matching
+ * `makeInvitation.locate()` (`id` / `type` / `from` / `fromNode` / `at`).
+ *
+ * @param {{ node: string, number: string, from: string,
+ *   fromNode?: string, addresses: string[] }} parts
+ * @returns {string}
+ */
+const buildLocator = ({ node, number, from, fromNode, addresses }) => {
+  const url = new URL(`endo://${node}`);
+  url.pathname = '/';
+  url.searchParams.set('id', number);
+  url.searchParams.set('type', INVITATION_TYPE);
+  url.searchParams.set('from', from);
+  if (fromNode !== undefined) {
+    url.searchParams.set('fromNode', fromNode);
+  }
+  for (const address of addresses) {
+    url.searchParams.append('at', address);
+  }
+  return url.toString();
+};
+
+/**
+ * Parse an `endo://invite?…` deep link. Returns `null` when `text` is not a
+ * well-formed invitation link, so callers can treat it as "not an invite"
+ * without a try/catch.
+ *
+ * @param {string} text
+ * @returns {ParsedInvite | null}
+ */
+export const parseInviteUrl = text => {
+  if (typeof text !== 'string' || !text.startsWith('endo://')) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(text);
+  } catch {
+    return null;
+  }
+  // Intent-path: the authority segment must be the invite intent.
+  if (url.host !== INVITE_INTENT) {
+    return null;
+  }
+  // Only these keys are meaningful; reject anything else so a malformed or
+  // smuggling link is treated as unrecognised.
+  for (const key of url.searchParams.keys()) {
+    if (
+      key !== 'node' &&
+      key !== 'id' &&
+      key !== 'from' &&
+      key !== 'fromNode' &&
+      key !== 'at'
+    ) {
+      return null;
+    }
+  }
+  const node = url.searchParams.get('node');
+  const number = url.searchParams.get('id');
+  const from = url.searchParams.get('from');
+  if (node === null || !NUMBER_PATTERN.test(node)) {
+    return null;
+  }
+  if (number === null || !NUMBER_PATTERN.test(number)) {
+    return null;
+  }
+  // `from` (the inviter's handle) is required: host.accept throws without it.
+  if (from === null || !NUMBER_PATTERN.test(from)) {
+    return null;
+  }
+  const fromNodeParam = url.searchParams.get('fromNode');
+  if (fromNodeParam !== null && !NUMBER_PATTERN.test(fromNodeParam)) {
+    return null;
+  }
+  const fromNode = fromNodeParam === null ? undefined : fromNodeParam;
+  const addresses = url.searchParams.getAll('at');
+  const fingerprint = `${node.slice(0, 8)}…${node.slice(-8)}`;
+  return {
+    locator: buildLocator({ node, number, from, fromNode, addresses }),
+    node,
+    number,
+    from,
+    fromNode,
+    fingerprint,
+    addresses,
+  };
+};
+
+/**
+ * @param {string} text
+ * @returns {boolean}
+ */
+export const isInviteUrl = text => parseInviteUrl(text) !== null;
+
+/**
+ * Format an `endo://invite?…` deep link from invitation parts — the inverse
+ * of `parseInviteUrl`, so the inviting side and the receiving side share one
+ * definition of the link contract. Throws on malformed parts (it is a
+ * producer, not a recogniser).
+ *
+ * @param {{ node: string, number: string, from: string,
+ *   fromNode?: string, addresses?: string[] }} parts
+ * @returns {string}
+ */
+export const formatInviteUrl = ({
+  node,
+  number,
+  from,
+  fromNode,
+  addresses = [],
+}) => {
+  if (!NUMBER_PATTERN.test(node)) {
+    throw new Error(`formatInviteUrl: invalid node ${JSON.stringify(node)}`);
+  }
+  if (!NUMBER_PATTERN.test(number)) {
+    throw new Error(`formatInviteUrl: invalid id ${JSON.stringify(number)}`);
+  }
+  if (!NUMBER_PATTERN.test(from)) {
+    throw new Error(`formatInviteUrl: invalid from ${JSON.stringify(from)}`);
+  }
+  if (fromNode !== undefined && !NUMBER_PATTERN.test(fromNode)) {
+    throw new Error(
+      `formatInviteUrl: invalid fromNode ${JSON.stringify(fromNode)}`,
+    );
+  }
+  const url = new URL(`endo://${INVITE_INTENT}`);
+  url.searchParams.set('node', node);
+  url.searchParams.set('id', number);
+  url.searchParams.set('from', from);
+  if (fromNode !== undefined) {
+    url.searchParams.set('fromNode', fromNode);
+  }
+  for (const address of addresses) {
+    url.searchParams.append('at', address);
+  }
+  return url.toString();
+};
+
+/**
+ * Find the first `endo://invite?…` link in a process `argv` array — the
+ * Windows / Linux cold-start (`process.argv`) and `second-instance`
+ * (relaunch) delivery paths, where the URL arrives as a command-line
+ * argument rather than an `open-url` event.
+ *
+ * @param {string[]} argv
+ * @returns {string | undefined}
+ */
+export const findInviteUrlInArgv = argv => {
+  if (!Array.isArray(argv)) {
+    return undefined;
+  }
+  return argv.find(arg => typeof arg === 'string' && isInviteUrl(arg));
+};

--- a/packages/familiar/test/deep-link.test.js
+++ b/packages/familiar/test/deep-link.test.js
@@ -1,0 +1,126 @@
+// @ts-nocheck
+/**
+ * Tests for endo:// deep-link invitation parsing/formatting
+ * (designs/familiar-deep-link-invitations.md).
+ *
+ * Uses the built-in Node test runner so the Familiar package gains
+ * coverage without taking on a test-framework dependency. Run with
+ * `node --test` (the package's `test` script).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseInviteUrl,
+  isInviteUrl,
+  formatInviteUrl,
+  findInviteUrlInArgv,
+} from '../src/deep-link.js';
+
+const NODE = 'a'.repeat(64);
+const ID = 'b'.repeat(64);
+const FROM = 'c'.repeat(64);
+const FROM_NODE = 'd'.repeat(64);
+const VALID = `endo://invite?node=${NODE}&id=${ID}&from=${FROM}&at=127.0.0.1%3A8920`;
+
+test('parseInviteUrl accepts a well-formed intent-path invite link', () => {
+  const parsed = parseInviteUrl(VALID);
+  assert.ok(parsed);
+  assert.equal(parsed.node, NODE);
+  assert.equal(parsed.number, ID);
+  assert.equal(parsed.from, FROM);
+  assert.equal(parsed.fromNode, undefined);
+  assert.deepEqual(parsed.addresses, ['127.0.0.1:8920']);
+  assert.equal(parsed.fingerprint, `${'a'.repeat(8)}…${'a'.repeat(8)}`);
+  // The reconstructed locator is the canonical daemon form host.accept wants:
+  // it must carry id, type, the required `from`, and the hints.
+  assert.ok(parsed.locator.startsWith(`endo://${NODE}/`));
+  assert.ok(parsed.locator.includes('type=invitation'));
+  assert.ok(parsed.locator.includes(`id=${ID}`));
+  assert.ok(parsed.locator.includes(`from=${FROM}`));
+  assert.ok(parsed.locator.includes('at=127.0.0.1%3A8920'));
+  assert.equal(isInviteUrl(VALID), true);
+});
+
+test('parseInviteUrl carries fromNode when present', () => {
+  const parsed = parseInviteUrl(
+    `endo://invite?node=${NODE}&id=${ID}&from=${FROM}&fromNode=${FROM_NODE}`,
+  );
+  assert.ok(parsed);
+  assert.equal(parsed.fromNode, FROM_NODE);
+  assert.ok(parsed.locator.includes(`fromNode=${FROM_NODE}`));
+});
+
+test('parseInviteUrl rejects non-invitations and malformed input', () => {
+  // Not an endo:// URL.
+  assert.equal(parseInviteUrl('https://example.com/'), null);
+  // Wrong intent (authority must be "invite").
+  assert.equal(parseInviteUrl(`endo://adopt?node=${NODE}&id=${ID}`), null);
+  // A bare canonical locator is no longer accepted as a deep link.
+  assert.equal(
+    parseInviteUrl(`endo://${NODE}/?id=${ID}&type=invitation&from=${FROM}`),
+    null,
+  );
+  // Missing `from` (host.accept requires it).
+  assert.equal(parseInviteUrl(`endo://invite?node=${NODE}&id=${ID}`), null);
+  // Node is not 64-hex.
+  assert.equal(
+    parseInviteUrl(`endo://invite?node=nope&id=${ID}&from=${FROM}`),
+    null,
+  );
+  // Disallowed extra query param.
+  assert.equal(
+    parseInviteUrl(`endo://invite?node=${NODE}&id=${ID}&from=${FROM}&x=1`),
+    null,
+  );
+  // Malformed id / from.
+  assert.equal(
+    parseInviteUrl(`endo://invite?node=${NODE}&id=short&from=${FROM}`),
+    null,
+  );
+  assert.equal(
+    parseInviteUrl(`endo://invite?node=${NODE}&id=${ID}&from=short`),
+    null,
+  );
+  // Non-string input.
+  assert.equal(parseInviteUrl(undefined), null);
+  assert.equal(isInviteUrl('endo://invite'), false);
+});
+
+test('formatInviteUrl produces a link parseInviteUrl round-trips', () => {
+  const link = formatInviteUrl({
+    node: NODE,
+    number: ID,
+    from: FROM,
+    fromNode: FROM_NODE,
+    addresses: ['127.0.0.1:8920', 'ws://relay.example:443'],
+  });
+  assert.ok(link.startsWith('endo://invite?'));
+  const parsed = parseInviteUrl(link);
+  assert.ok(parsed);
+  assert.equal(parsed.node, NODE);
+  assert.equal(parsed.number, ID);
+  assert.equal(parsed.from, FROM);
+  assert.equal(parsed.fromNode, FROM_NODE);
+  assert.deepEqual(parsed.addresses, [
+    '127.0.0.1:8920',
+    'ws://relay.example:443',
+  ]);
+});
+
+test('formatInviteUrl throws on malformed parts', () => {
+  assert.throws(() =>
+    formatInviteUrl({ node: 'nope', number: ID, from: FROM }),
+  );
+  assert.throws(() =>
+    formatInviteUrl({ node: NODE, number: 'short', from: FROM }),
+  );
+  assert.throws(() => formatInviteUrl({ node: NODE, number: ID, from: 'x' }));
+});
+
+test('findInviteUrlInArgv finds the first invite argument', () => {
+  assert.equal(findInviteUrlInArgv(['electron', '.', VALID]), VALID);
+  assert.equal(findInviteUrlInArgv(['electron', '.', '--dev']), undefined);
+  assert.equal(findInviteUrlInArgv(undefined), undefined);
+});


### PR DESCRIPTION
Split out of #383 (deep-link half).

## Deep-Link Peer Invitations (Familiar shell + Chat)

Accept and share peers by clicking an `endo://` link. Implements `designs/familiar-deep-link-invitations.md`.

**Format — intent-path URL:**
```
endo://invite?node={node}&id={inv}&from={handle}[&fromNode={n}]&at={addr}...
```
The authority segment names the *intent* (`invite`) so `endo://` can route future actions without overloading a locator's `type`. The link carries exactly the fields `host.accept` consumes; the handler validates it and **reconstructs** the canonical daemon locator (`endo://{node}/?id=…&type=invitation&from=…&at=…`) — the link is not passed verbatim. `from` (inviter handle) is required.

**Key files:**
- `packages/familiar/src/deep-link.js` — pure, dependency-free, SES-free `parseInviteUrl` / `formatInviteUrl` / `findInviteUrlInArgv`.
- `packages/familiar/electron-main.js` — `endo://` privileged protocol client; `open-url` (macOS), `second-instance` + single-instance lock (Windows/Linux), cold-start argv; IPC handlers registered before window creation to avoid a cold-start race; invites queued until the renderer is ready.
- `packages/familiar/preload.js` — `getPendingDeepLinkInvite` / `onDeepLinkInvite` bridge (subscribe first, then pull).
- `packages/chat/deep-link-invite.js` — routes a captured invite into the existing `accept` command form (the form is the confirmation + naming screen).
- `packages/chat/invite-link.js` + the chat `invite` / `accept` commands — `/invite` surfaces the shareable `endo://invite?…` link; `/accept` takes that link or a raw locator.

**Tests:** `packages/familiar/test/deep-link.test.js` (parse/format/argv, reject cases, round-trip) and `packages/chat/test/invite-link.test.js` (locator↔link conversion, normalize).

Outstanding follow-ups are tracked in the design doc § Outstanding / Follow-ups: open (multi-use) invitations, deduplicating the link contract (`deep-link.js` vs `invite-link.js`, since Chat can't import the shell), and a dedicated confirmation modal.

https://claude.ai/code/session_0112zLHkZKDDUzUDEwPvScwT

---
_Generated by [Claude Code](https://claude.ai/code/session_0112zLHkZKDDUzUDEwPvScwT)_