### PR TITLE
feat(agent-tools): makeTool + confined git/FS tools + schema⟷guard divergence gate

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -233,6 +233,7 @@ LLM-agent stack).*
 | [endo-bytes](endo-bytes.md) | 2026-05-08 | 2026-05-10 | Implemented |
 | [endo-gateway](endo-gateway.md) | 2026-05-10 | 2026-05-10 | Proposed |
 | [endo-gateway-mcp](endo-gateway-mcp.md) | 2026-05-29 | 2026-05-29 | Not Started |
+| [agent-tools-mount-fs-tools](agent-tools-mount-fs-tools.md) | 2026-06-01 | 2026-06-01 | Not Started |
 | [unhandled-rejection-display](unhandled-rejection-display.md) | 2026-05-10 | 2026-05-18 | **Complete** |
 | [weblet-next](weblet-next.md) | 2026-03-24 | 2026-03-24 | Reference |
 | [workers-panel](workers-panel.md) | 2026-02-14 | 2026-02-24 | Not Started |

--- a/designs/agent-tools-mount-fs-tools.md
+++ b/designs/agent-tools-mount-fs-tools.md
@@ -1,0 +1,448 @@
+# Agent Tools: `@endo/endo-fs` `Filesystem`-backed Tool Group
+
+| | |
+|---|---|
+| **Created** | 2026-06-01 |
+| **Author** | 0xPatrick (prompted) |
+| **Status** | Not Started |
+
+## What is the Problem Being Solved?
+
+[endo-gateway-mcp](endo-gateway-mcp.md) proposes `@endo/agent-tools`, a
+provider-independent package that lifts Lal's tool catalog out of
+`packages/lal/agent.js` into `makeAgentTools(powers, { extra } = {})`
+returning `{ tools, executeTool, processToolCalls }`.
+It leaves an explicit seam — the `extra` option — where capability-scoped
+filesystem, shell, and git tools plug in "as `Dir` / `Shell` / `Git` come
+online".
+[daemon-agent-tools](daemon-agent-tools.md) is the conceptual parent for
+that capability-tool model; its 2026-05-18 revision routes local
+filesystem and git authority through a confined filesystem capability.
+
+Neither design says *how* a capability-filesystem tool group is
+constructed, what its `schema` / `execute` records look like, how it
+slots into the `extra` array, or what happens when the underlying
+filesystem capability is revoked mid-session.
+This design fills that gap.
+It does **not** re-spec `@endo/agent-tools`; it builds on the package's
+`extra` seam and on the `@endo/endo-fs` `Filesystem` capability
+(`packages/endo-fs/`), the structural, confined, ocap-shaped filesystem
+surface the daemon's local-filesystem authority is converging on.
+
+The mount-backed tool group is designed around least authority. It closes
+over a `Filesystem` capability for a single subtree, walks it by
+`lookup`, cannot name a path outside that capability, and observes
+revocation as a rejected tool call.
+
+## Background
+
+Three pieces of landed and in-flight code frame the design.
+
+**`@endo/endo-fs` `Filesystem` (landed).**
+`packages/endo-fs/` exposes a structural, confined filesystem capability.
+A `Filesystem` is not a flat path-keyed surface: it has no `readText`.
+`E(fs).root()` returns a `Directory`; `E(dir).lookup(name)` returns a
+child `Directory` or `File` eref; `E(file).open({ read: true })` returns
+an `OpenFile`, whose `read(offset, length)` yields a
+`PassableBytesReader` over the requested slice (Uint8Array can't cross
+CapTP directly, so bytes arrive base64-streamed). A read therefore *walks*
+the tree segment-by-segment rather than naming a whole path in one call.
+The package ships porcelain helpers for exactly this: `walk(root, segments)`
+chains the per-segment `lookup`s into one pipelined CapTP batch, and
+`collectBytes(reader)` drains a `PassableBytesReader` into one `Uint8Array`.
+Confinement is structural and enforced at two layers: `Directory.lookup`
+rejects the reserved names `.` and `..` (a `..` segment is *not* a parent
+traversal — it is an invalid name), and the disk backend's `realpath`
+containment check rejects any path — including one reached through a
+symlink — whose physical target escapes the filesystem root.
+`readOnly(fs)` returns a `Filesystem` whose mutating methods (`create`,
+`mkdir`, `unlink`, `setAttrs`, write-mode `open`, …) reject with `EACCES`
+while the read path passes through; `chroot(fs, subPath)` presents a
+subtree as the new root, so a tool over it cannot name anything above the
+subtree. Both attenuations return a `Filesystem` indistinguishable from a
+primitive one — a subtree or read-only handle is itself an attenuated
+capability.
+
+A daemon-hosted `Filesystem` is constructed over a disk root by
+`makeNodeFilesystem({ rootPath })` (or `mountAsFilesystem` over an
+`EndoMount`, for callers bridging the legacy mount surface); the daemon
+mints and revokes it as a formula like any other capability.
+
+**`@endo/agent-tools` (proposed, not yet landed).**
+Per [endo-gateway-mcp](endo-gateway-mcp.md) §"Package shape", the
+package exports `makeAgentTools(powers, { extra } = {})`.
+`tools` is an array of OpenAI-format tool schemas (`{ type: 'function',
+function: { name, description, parameters } }`), `executeTool(name,
+args)` is the dispatcher, and `extra` is an array of additional tool
+contributions composed in alongside the built-ins.
+
+## Design
+
+### What a mount-backed tool group is
+
+A *tool group* is a function that takes a capability and returns one or
+more tool contributions shaped to drop into `makeAgentTools`' `extra`
+array.
+A single contribution is the same record shape `@endo/agent-tools`
+already uses internally and that the existing tool makers use today
+(`schema()` returning an OpenAI-format schema, `execute(args)` returning
+a result), so no new wire contract is introduced.
+
+```mermaid
+flowchart LR
+    host["EndoHost"] -- "makeNodeFilesystem({rootPath}) + readOnly(fs)" --> fs["@endo/endo-fs<br/>Filesystem<br/>(read-only)"]
+    fs -- "makeMountReadTool(fs)" --> tool["tool contribution<br/>{ schema, execute }"]
+    tool -- "extra: [tool]" --> at["makeAgentTools(powers, {extra})"]
+    at --> tools["tools[] + executeTool"]
+    tools --> harness["Lal / Gateway MCP adapter"]
+```
+
+The group's `execute` closes over the `Filesystem` capability, not a path
+string.
+Every read is a walk of eventual-sends — `E(fs).root()`, then a `lookup`
+per path segment, then `open` / `read` — assembled by the `@endo/endo-fs`
+`walk` / `collectBytes` helpers.
+The tool never holds `fs` (the Node module), never resolves an absolute
+path, and cannot construct a reference to anything the `Filesystem` does
+not already reach.
+
+### Composition into the `extra` seam
+
+`makeAgentTools` composes built-in tools with the `extra` array.
+A mount-backed group is one entry (or a small flat set of entries) in
+that array:
+
+```js
+import { makeMountReadTool } from '@endo/agent-tools/mount-fs.js';
+import { readOnly } from '@endo/endo-fs';
+
+const projectFs = await E(powers).lookup('project'); // a Filesystem
+const { tools, executeTool } = makeAgentTools(powers, {
+  extra: [makeMountReadTool(readOnly(projectFs))],
+});
+```
+
+The contribution participates in `tools` (its `schema()` is projected
+into the catalog) and in `executeTool` (a call with its tool name routes
+to its `execute`).
+The capability-scoped tools and the built-in namespace / mail tools are
+peers in the same flat catalog; the LLM sees one tool list.
+
+Two seam questions [endo-gateway-mcp](endo-gateway-mcp.md) §Open
+Questions §1 explicitly left open are answered narrowly here for the
+filesystem group and surfaced for the maintainer in Open Questions:
+
+- **Name collisions.** The mount-read tool is named `mountReadText`
+  (not `readText`) so it does not collide with Lal's built-in `readText`
+  (which reads from the *petname* namespace, a different surface). The
+  built-in keeps its name; the capability tool takes a distinct one.
+- **Absent capability.** A filesystem-backed group is only added to
+  `extra` when the caller already holds the `Filesystem`. There is no
+  "always-fail hidden tool" — if no `Filesystem` is granted, the group is
+  not in `extra` and the tool does not appear in the catalog (the
+  same conditional-registration shape `daemon-agent-tools` §"Agent tool
+  discovery" describes).
+
+### The thinnest first slice: `makeMountReadTool`
+
+The first contribution is read-only and single-method: a text-file read
+tool with the same top-level contribution shape as the rest of the tool
+catalog.
+
+```js
+// packages/agent-tools/mount-fs.js
+// @ts-check
+import { E } from '@endo/far';
+import { walk, collectBytes } from '@endo/endo-fs';
+
+const MAX_TEXT_CHARS = 50_000;
+
+/**
+ * A read-only filesystem tool bound to an `@endo/endo-fs` `Filesystem`.
+ * Reads a single text file by root-relative path. Confinement,
+ * symlink-escape rejection, and revocation are the Filesystem's job, not
+ * this tool's.
+ *
+ * @param {import('@endo/far').ERef<{ root: () => Promise<object> }>} fs
+ * @returns {{
+ *   schema: () => object,
+ *   execute: (args: Record<string, unknown>) => Promise<string>,
+ *   help: () => string,
+ * }}
+ */
+export const makeMountReadTool = fs => {
+  const schema = harden({
+    type: 'function',
+    function: {
+      name: 'mountReadText',
+      description:
+        'Read a UTF-8 text file from the mounted project directory. ' +
+        'Path is relative to the mount root; "../" escapes are rejected.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Mount-relative path to the file to read.',
+          },
+        },
+        required: ['path'],
+      },
+    },
+  });
+  return harden({
+    schema: () => schema,
+    async execute(args) {
+      const { path } = /** @type {{ path: string }} */ (args);
+      if (!path) {
+        throw new Error('path is required');
+      }
+      // One lookup per path segment; '.' steps are dropped, and a '..'
+      // segment is rejected by Directory.lookup (reserved name).
+      const segments = path
+        .split('/')
+        .map(segment => segment || '.')
+        .filter(segment => segment !== '.');
+      const root = await E(fs).root();
+      const file = await walk(root, segments);
+      const openFile = await E(file).open({ read: true });
+      const bytes = await collectBytes(await E(openFile).read(0n));
+      const content = new TextDecoder().decode(bytes);
+      if (content.length > MAX_TEXT_CHARS) {
+        return `${content.slice(0, MAX_TEXT_CHARS)}\n\n... (truncated, ${content.length} chars total)`;
+      }
+      return content;
+    },
+    help: () =>
+      'Read a text file from the mounted project directory (read-only).',
+  });
+};
+harden(makeMountReadTool);
+```
+
+What it needs that **already ships**: the `@endo/endo-fs` `Filesystem`
+surface (`root` / `lookup` / `open` / `read`) and the `walk` /
+`collectBytes` porcelain, plus the `readOnly` / `chroot` attenuators, all
+live in `packages/endo-fs/`. The confinement (the backend's `realpath`
+containment check, following symlinks) and the `..`-segment rejection
+(`Directory.lookup`'s reserved-name validator) are enforced inside the
+`Filesystem` exos, so the tool carries *no* path-safety logic of its
+own.
+What it needs that does **not** yet ship: `@endo/agent-tools` itself
+(its Phase-1 extraction) and the post-#290 tool seam (below).
+
+The truncation cap keeps large reads bounded at 50 000 chars.
+
+### Attenuation model
+
+Authority on a filesystem tool is shaped by attenuating the *`Filesystem`*
+handed to the maker, never by the tool gating itself:
+
+- **Read-only.** Pass `readOnly(fs)`. The returned `Filesystem` passes
+  reads through but rejects every mutating method (`create`, `mkdir`,
+  `unlink`, `setAttrs`, write-mode `open`, …) with `EACCES`. The tool's
+  read walk (`root` → `lookup` → `open({ read: true })` → `read`) is
+  entirely on the read path, so it works unchanged over the read-only
+  view; a write attempted through the same handle fails closed.
+- **Subtree scoping.** Pass `chroot(fs, subPath)` to hand the tool a
+  `Filesystem` whose root *is* the named subtree. A tool over it resolves
+  every path relative to the subtree and cannot name anything above it —
+  a path that walks off the top is an `ENOENT`, not an escape.
+- **Destructive-op gating.** Write / move / remove tools are deferred
+  past the first slice. When they land they are *separate* makers
+  (`makeMountWriteTool`, etc.) added to `extra` only when a writable
+  `Filesystem` is granted; a read-only deployment does not include
+  them. Gating is by which makers the caller composes, not by a runtime
+  flag inside a single omnibus tool. This keeps the authority of the tool
+  set legible from the `extra` array alone.
+
+### Revocation: fail closed, no restart
+
+A `Filesystem` is a daemon formula. When the formula is cancelled
+(`E(host).cancel(petName)`) or garbage-collected (the `Filesystem`
+becomes unreachable from any retained formula), the daemon tears down the
+exo. The tool holds an `ERef` to that exo, so the *next* `E(fs).root()`
+(or any deeper send in the walk) after revocation rejects — the
+eventual-send resolves to a rejection because the target no longer
+resolves.
+
+Three operational properties follow:
+
+1. **No process filesystem fallback.** The tool does not retain the
+   Node `fs` module or a host-path string. A revoked filesystem tool
+   cannot perform a read through another path; the call rejects.
+2. **No restart needed.** Revocation is observed at call time as a
+   rejected promise; the agent loop sees a failed tool call and reports
+   it like any other error. The harness does not need to be restarted to
+   drop the authority.
+3. **Stale handles do not re-acquire authority.** Because the tool
+   closes over the capability reference (not a path), a re-minted
+   `Filesystem` at the same path under a new formula id is a *different*
+   capability; the old tool's reference does not silently start working
+   again. Re-granting is an explicit re-composition of `extra` with the
+   new `Filesystem`.
+
+The tool maker itself does nothing special for revocation — it neither
+catches nor retries. Failing closed is the default behavior of an
+eventual-send to a revoked target; the maker does not cache reads or
+hold a host-path string alongside the capability.
+
+### Package placement
+
+The mount-fs group lives in `@endo/agent-tools` as a sibling module to
+the built-in catalog, since it is the canonical first `extra`
+contribution and the package is the agreed home for the tool-catalog
+shape:
+
+```
+packages/agent-tools/
+  mount-fs.js        # makeMountReadTool (this design); write/list/stat siblings later
+  test/
+    mount-fs.test.js
+```
+
+It depends on `@endo/far` (`E`) and `@endo/endo-fs` (the `walk` /
+`collectBytes` porcelain and, for callers, the `readOnly` / `chroot`
+attenuators); it is handed a `Filesystem` capability reference at call
+time and does not import `packages/daemon`, keeping `@endo/agent-tools`
+free of a daemon dependency, consistent with the package's
+provider-independent intent.
+
+## Test plan
+
+`packages/agent-tools/test/mount-fs.test.js`. The `Filesystem` under test
+is a real `makeNodeFilesystem({ rootPath })` over a `mkdtemp` directory
+(teardown registered per the project AVA conventions), attenuated with
+`readOnly` (and `chroot` for the subtree analog), so the tests exercise
+the actual confinement and revocation behavior, not a stub.
+
+1. **Happy path.** Build a temp-dir `Filesystem` containing `a.txt`;
+   assert `execute({ path: 'a.txt' })` returns its contents, a
+   subdirectory file by relative path, an empty file as the empty string,
+   and the >50 000-char truncation branch on a large file. A `chroot`
+   case asserts a subtree-scoped read works and that a path above the
+   subtree is `ENOENT`.
+2. **Structural out-of-root access failure.** Assert
+   `t.throwsAsync(() => execute({ path: '../secret' }), { message:
+   /reserved|EINVAL|ENOENT/ })` — the `..` segment is rejected by
+   `Directory.lookup` (reserved name), not by the tool. Add a symlink
+   inside the root pointing outside it and assert reading through it
+   rejects (`/escapes filesystem root|EACCES|ENOENT/`), proving the guard
+   is the backend's `realpath` containment check rather than tool-local
+   path string handling.
+3. **Revoke-then-call fails closed.** Construct the tool over a
+   `Filesystem`, confirm one successful read, then revoke it (cancel its
+   formula in a daemon-backed test, or in a unit test wrap it in a
+   forwarder whose `root()` rejects once revoked) and assert the next
+   `execute` rejects rather than returning stale content. Assert the
+   rejection is not satisfied through cached content or a process
+   filesystem fallback.
+4. **`extra`-seam integration.** Once `@endo/agent-tools` Phase 1 is
+   landed: assert `makeAgentTools(powers, { extra: [makeMountReadTool(
+   mount)] })` surfaces `mountReadText` in `tools` and that
+   `executeTool('mountReadText', { path })` routes to the group's
+   `execute`. This test is gated on Phase 1 and may land with the
+   integration, not the first slice.
+
+## Sequencing and dependencies
+
+This work has two hard predecessors, stated plainly:
+
+1. **#290 must merge first.** PR #290 (`feat/lal-pi-harness`) swaps Lal's
+   harness for `@endo/genie`'s pi-based one while preserving the tool
+   surface by name and cleanly separating the LLM loop from the tools.
+   Until it lands, Lal's tool catalog and `executeTool` switch are still
+   entangled with the pre-pi harness in `packages/lal/agent.js`. Building
+   the `extra`-seam consumer against the pre-#290 file would mean writing
+   against a tool seam that #290 reshapes. The mount-fs maker itself does
+   not import Lal, so it can be *written* independently, but its
+   integration test (test 4) and the Lal-side composition example assume
+   the post-#290 separated seam.
+
+2. **`@endo/agent-tools` Phase 1 must land.** Per
+   [endo-gateway-mcp](endo-gateway-mcp.md) §"Phase 1: extract
+   `@endo/agent-tools`", the tool catalog, SmallCaps decoder,
+   `executeTool`, and `processToolCalls` move out of `packages/lal/agent.js`
+   into the new package, and `makeAgentTools(powers, { extra })` becomes
+   the construction point. The `extra` array is the slot this group
+   plugs into; without it there is no seam to target. Phase 1 is the
+   refactor; this design is the first thing that uses the seam Phase 1
+   opens.
+
+Ordering: **#290 → `@endo/agent-tools` Phase 1 → this design's
+`makeMountReadTool`**. The maker module and its unit tests (tests 1–3)
+can be drafted in parallel with Phase 1 because they depend only on the
+landed `@endo/endo-fs` `Filesystem`; the integration test (test 4) and
+the catalog wiring wait for Phase 1.
+
+The capability itself (`@endo/endo-fs`, `makeNodeFilesystem`,
+`readOnly` / `chroot`) is **already landed** and is not a blocker.
+
+## Dependencies
+
+| Design | Relationship |
+|--------|--------------|
+| [endo-gateway-mcp](endo-gateway-mcp.md) | Defines `@endo/agent-tools` and the `extra` seam this group plugs into. This design does not re-spec the package; it fills the "compose via `extra`" gap that design's Open Questions §1 leaves open for filesystem tools. |
+| [daemon-agent-tools](daemon-agent-tools.md) | Conceptual parent: the `Dir` / `Shell` / `Git` capability-tool model. Its 2026-05-18 revision routes fs authority through a confined filesystem capability; this design is the concrete first realization (Phase 1, filesystem, read slice) of that revised model over the `@endo/endo-fs` `Filesystem`. |
+| [daemon-mount-capabilities](daemon-mount-capabilities.md) | The legacy `EndoMount` capability and the `Filesystem` it bridges to via `mountAsFilesystem`. This group binds the `@endo/endo-fs` `Filesystem` surface directly; it deliberately uses no host-path accessor — the tool holds the capability, not a path. |
+
+## Design Decisions
+
+1. **The tool holds a capability, not a path.** `execute` closes over a
+   `Filesystem` `ERef` and does every read as a walk of `E(...)`
+   eventual-sends (`root` → per-segment `lookup` → `open` → `read`). This
+   delegates confinement, symlink-escape rejection, and revocation
+   behavior to the filesystem capability.
+
+2. **Attenuate the `Filesystem`, not the tool.** Read-only and subtree
+   scoping are expressed by handing the maker an already-attenuated
+   `Filesystem` (`readOnly(fs)`, `chroot(fs, subPath)`), and destructive
+   operations are separate makers added to `extra` conditionally. The
+   authority of a tool set is legible from its `extra` array; there is no
+   per-tool runtime flag to audit.
+
+3. **Distinct tool name to avoid collision.** `mountReadText` does not
+   shadow Lal's built-in `readText` (which reads the petname namespace).
+   This is the narrow, filesystem-group answer to the name-collision
+   open question [endo-gateway-mcp](endo-gateway-mcp.md) §Open Questions
+   §1 deferred.
+
+4. **Read-only first slice.** The first contribution is one read method
+   that exercises the `extra` seam and the filesystem capability's
+   confinement/revocation behavior before any destructive operation is
+   exposed. Considered and rejected: shipping a full `Dir` tool group
+   (read + write + list + stat + glob) in one slice. Reason: the
+   read-only slice is enough to review text-read composition end to end,
+   and write/move/remove each carry
+   their own destructive-op gating decisions better made once the read
+   slice is in review.
+
+5. **No daemon dependency in `@endo/agent-tools`.** The maker imports
+   only `@endo/far` and the `@endo/endo-fs` porcelain (`walk` /
+   `collectBytes`) and is handed the `Filesystem` capability at call
+   time, so the package stays provider- and daemon-independent, matching
+   the package's stated intent.
+
+## Open Questions
+
+1. **Does the read walk go through `OpenFile.read` or `File.snapshot`?**
+   The slice binds to the `@endo/endo-fs` `Filesystem`, walking
+   `root` → `lookup` → `open({ read: true })` → `read(0n)` and draining
+   the reader with `collectBytes`. An alternative one-call read is
+   `File.snapshot()`, which returns a `BlobRef` over the whole file's
+   bytes — fewer sends for a small file, but it materializes the entire
+   file server-side before fetch and carries blob semantics this read
+   tool does not need. The design uses the `open` / `read` walk (the same
+   path the `@endo/endo-fs` read tests exercise); the maintainer can
+   route the slice to `snapshot` if the blob path proves cheaper for the
+   expected file sizes.
+
+2. **Where does the granted `Filesystem` come from in the Lal
+   integration — a fixed petname (e.g. `project`) the host grants, or the
+   form-based provisioning of
+   [daemon-agent-tools](daemon-agent-tools.md) §"Form-based capability
+   provisioning"?** This design assumes the caller already holds the
+   `Filesystem` and is concerned only with turning it into a tool; the
+   grant mechanism (petname lookup vs. provisioning form) is a separate
+   integration decision the maintainer can route to the agent-tools
+   integration PR.

--- a/packages/agent-tools/LICENSE
+++ b/packages/agent-tools/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Endo Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -1,0 +1,130 @@
+# `@endo/agent-tools`
+
+Provider-independent agent tool records for Endo capabilities.
+
+The package helps adapters expose Endo capabilities to LLM or MCP-style tool
+callers without giving those callers ambient authority. Each tool record pairs
+a JSON Schema with an `invoke(args)` function that validates the named
+arguments before dispatching to a capability.
+
+## Exports
+
+```js
+import {
+  makeTool,
+  makeGitTool,
+  makeMountReadTool,
+} from '@endo/agent-tools';
+```
+
+```ts
+import type { ToolRecord, ToolSpec } from '@endo/agent-tools';
+```
+
+Subpath exports are also available:
+
+```js
+import { makeTool } from '@endo/agent-tools/tool.js';
+import { makeGitTool } from '@endo/agent-tools/git-tool.js';
+import { makeMountReadTool } from '@endo/agent-tools/mount-fs.js';
+```
+
+## Tool Records
+
+A tool record has the shape:
+
+```ts
+interface ToolRecord {
+  name: string;
+  description: string;
+  parameters: object;
+  inputSchema: object;
+  invoke(args: Record<string, unknown>): Promise<unknown>;
+}
+```
+
+`parameters` and `inputSchema` are the same JSON Schema object. Adapters can
+use `parameters` for LLM tool definitions and `inputSchema` for MCP tool
+definitions.
+
+## Named Arguments
+
+`makeTool` accepts optional positional guards, but callers pass a JSON object.
+The positional arguments are encoded as `arg0`, `arg1`, and so on:
+
+```js
+const tool = makeTool({
+  name: 'commit',
+  description: 'Record staged changes as a new commit.',
+  parameters: harden({
+    type: 'object',
+    properties: {
+      arg0: { type: 'string', description: 'The commit message.' },
+    },
+    required: ['arg0'],
+    additionalProperties: false,
+  }),
+  argGuards: harden([M.string()]),
+  execute: async ({ arg0 }) => E(git).commit(arg0),
+});
+
+await tool.invoke({ arg0: 'Update docs' });
+```
+
+This is the current MCP-facing wire shape: MCP tool calls use named JSON
+object properties, so the adapter gives positional APIs stable `argN` names.
+A future adapter can expose separate variants that accept `{ args: [...] }` or
+another positional shape when the caller supports it.
+
+When guards are present, `invoke` rejects unknown `argN` keys, rejects missing
+required arguments declared by the schema, copy-hardens incoming parsed JSON
+objects, and validates supplied positional arguments with `mustMatch` before
+calling `execute`.
+
+## Git Tools
+
+`makeGitTool(gitCap)` builds tool records over a live `@endo/exo-git` `Git`
+capability:
+
+```js
+const tools = makeGitTool(git);
+```
+
+The current slice exposes:
+
+- `log`
+- `diff`
+- `show`
+- `commit`
+- `branches`
+- `createBranch`
+- `switchBranch`
+- `currentBranch`
+
+Methods that require remotable arguments or can return live capabilities, such
+as `status`, `add`, `restore`, and `filesystemAt`, are not included in this
+first slice.
+
+## Filesystem Tool
+
+`makeMountReadTool(fs)` builds one read-only `mountReadText` tool over an
+`@endo/endo-fs` `Filesystem` capability:
+
+```js
+import { readOnly } from '@endo/endo-fs';
+import { makeMountReadTool } from '@endo/agent-tools/mount-fs.js';
+
+const readTool = makeMountReadTool(readOnly(projectFs));
+const content = await readTool.execute({ path: 'README.md' });
+```
+
+The tool reads UTF-8 text by walking the filesystem tree, opening the final
+file, and reading a bounded byte range. The supplied `Filesystem` capability
+enforces containment, symlink handling, attenuation, subtree scoping, and
+revocation. The tool retains the same 50k character text cap as the existing
+file reader.
+
+## Schema Conformance
+
+JSON Schemas are hand-authored. The package tests compare those schemas with
+the runtime `@endo/patterns` guards so schema drift is caught in CI.

--- a/packages/agent-tools/SECURITY.md
+++ b/packages/agent-tools/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+The SES package and associated Endo packages are still undergoing development and security review, and all
+users are encouraged to use the latest version available. Security fixes will
+be made for the most recent branch only.
+
+## Coordinated Vulnerability Disclosure of Security Bugs
+
+SES stands for fearless cooperation, and strong security requires strong collaboration with security researchers. If you believe that you have found a security sensitive bug that should not be disclosed until a fix has been made available, we encourage you to report it. To report a bug in HardenedJS, you have several options that include:
+
+* Reporting the issue to the [Agoric HackerOne vulnerability rewards program](https://hackerone.com/agoric).
+
+* Sending an email to security at (@) agoric.com., encrypted or unencrypted. To encrypt, please use  @Warner’s personal GPG key  [A476E2E6 11880C98 5B3C3A39 0386E81B 11CAA07A](http://www.lothar.com/warner-gpg.html)  .
+
+* Sending a message on Keybase to `@agoric_security`, or sharing code and other log files via Keybase’s encrypted file system. ((_keybase_private/agoric_security,$YOURNAME).
+
+* It is important to be able to provide steps that reproduce the issue and demonstrate its impact with a Proof of Concept example in an initial bug report. Before reporting a bug, a reporter may want to have another trusted individual reproduce the issue.
+
+* A bug reporter can expect acknowledgment of a potential vulnerability reported through  [security@agoric.com](mailto:security@agoric.com)  within one business day of submitting a report. If an acknowledgement of an issue is not received within this time frame, especially during a weekend or holiday period, please reach out again. Any issues reported to the HackerOne program will be acknowledged within the time frames posted on the program page.
+	* The bug triage team and Agoric code maintainers are primarily located in the San Francisco Bay Area with business hours in  [Pacific Time](https://www.timeanddate.com/worldclock/usa/san-francisco) .
+
+* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public GitHub issues during the coordination process.
+
+* Once a vulnerability report has been received and triaged:
+	* Agoric code maintainers will confirm whether it is valid, and will provide updates to the reporter on validity of the report.
+	* It may take up to 72 hours for an issue to be validated, especially if reported during holidays or on weekends.
+
+* When the Agoric team has verified an issue, remediation steps and patch release timeline information will be shared with the reporter.
+	* Complexity, severity, impact, and likelihood of exploitation are all vital factors that determine the amount of time required to remediate an issue and distribute a software patch.
+	* If an issue is Critical or High Severity, Agoric code maintainers will release a security advisory to notify impacted parties to prepare for an emergency patch.
+	* While the current industry standard for vulnerability coordination resolution is 90 days, Agoric code maintainers will strive to release a patch as quickly as possible.
+
+When a bug patch is included in a software release, the Agoric code maintainers will:
+	* Confirm the version and date of the software release with the reporter.
+	* Provide information about the security issue that the software release resolves.
+	* Credit the bug reporter for discovery by adding thanks in release notes, securing a CVE designation, or adding the researcher’s name to a Hall of Fame.

--- a/packages/agent-tools/git-tool.d.ts
+++ b/packages/agent-tools/git-tool.d.ts
@@ -1,0 +1,1 @@
+export { makeGitTool } from './src/git-tool.js';

--- a/packages/agent-tools/mount-fs.d.ts
+++ b/packages/agent-tools/mount-fs.d.ts
@@ -1,0 +1,1 @@
+export { makeMountReadTool } from './src/mount-fs.js';

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -1,0 +1,93 @@
+{
+  "name": "@endo/agent-tools",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Provider-independent agent tool catalog for Endo, including capability-scoped filesystem tools backed by an @endo/endo-fs Filesystem",
+  "keywords": [],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/agent-tools"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "types": "./types-index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types-index.d.ts",
+      "default": "./types-index.js"
+    },
+    "./tool.js": {
+      "types": "./tool.d.ts",
+      "default": "./src/tool.js"
+    },
+    "./git-tool.js": {
+      "types": "./git-tool.d.ts",
+      "default": "./src/git-tool.js"
+    },
+    "./mount-fs.js": {
+      "types": "./mount-fs.d.ts",
+      "default": "./src/mount-fs.js"
+    },
+    "./src/index.js": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./src/tool.js": {
+      "types": "./src/tool.d.ts",
+      "default": "./src/tool.js"
+    },
+    "./src/git-tool.js": {
+      "types": "./src/git-tool.d.ts",
+      "default": "./src/git-tool.js"
+    },
+    "./src/mount-fs.js": {
+      "types": "./src/mount-fs.d.ts",
+      "default": "./src/mount-fs.js"
+    },
+    "./types-index.js": {
+      "types": "./types-index.d.ts",
+      "default": "./types-index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "test": "ava",
+    "test:c8": "c8 ${C8_OPTIONS:-} ava",
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint-fix": "yarn lint:eslint --fix",
+    "lint:eslint": "eslint '**/*.js'",
+    "lint:types": "tsc"
+  },
+  "ava": {
+    "files": [
+      "test/**/*.test.*"
+    ],
+    "timeout": "2m"
+  },
+  "dependencies": {
+    "@endo/endo-fs": "workspace:^",
+    "@endo/exo-git": "workspace:^",
+    "@endo/far": "workspace:^",
+    "@endo/patterns": "workspace:^"
+  },
+  "devDependencies": {
+    "@endo/daemon": "workspace:^",
+    "@endo/init": "workspace:^",
+    "ajv": "^8.17.1",
+    "ava": "catalog:dev",
+    "c8": "catalog:dev",
+    "eslint": "catalog:dev",
+    "typescript": "catalog:dev"
+  },
+  "eslintConfig": {
+    "extends": [
+      "plugin:@endo/internal"
+    ]
+  }
+}

--- a/packages/agent-tools/src/git-tool.d.ts
+++ b/packages/agent-tools/src/git-tool.d.ts
@@ -1,0 +1,6 @@
+import type { ERef } from '@endo/far';
+import type { GitToolCapability, ToolRecord } from './types.js';
+
+export declare const makeGitTool: (
+  gitCap: ERef<GitToolCapability>,
+) => ToolRecord[];

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -1,0 +1,189 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { ERef } from '@endo/far' */
+/** @import { InterfaceGuard, Pattern } from '@endo/patterns' */
+/** @import { GitToolCapability, ToolRecord } from './types.js' */
+
+/** @typedef {Record<keyof GitToolCapability, (...args: unknown[]) => Promise<unknown>>} GitToolDispatch */
+
+import { E } from '@endo/far';
+import {
+  getInterfaceGuardPayload,
+  getMethodGuardPayload,
+} from '@endo/patterns';
+import { GitInterface } from '@endo/exo-git';
+
+import { makeTool } from './tool.js';
+
+/**
+ * JSON Schemas for the Git methods exposed as agent tools. Methods that need
+ * remotable arguments or return live capabilities are excluded; runtime arg
+ * guards come from `GitInterface`.
+ */
+
+const NO_ARGS = harden({
+  type: 'object',
+  properties: {},
+  required: [],
+  additionalProperties: false,
+});
+
+// `M.recordOf(M.string(), M.any())` → an open object.
+const OPTIONS_PROP = harden({
+  type: 'object',
+  description: 'Options record passed through to the underlying git command.',
+});
+
+// `RefArgShape = M.or(M.string(), M.recordOf(M.string(), M.any()))`.
+const REF_PROP = harden({
+  anyOf: [{ type: 'string' }, { type: 'object' }],
+  description:
+    'A git ref: either a ref string (branch/tag/commit/"HEAD") or a ' +
+    'structured ref record.',
+});
+
+/**
+ * This package intentionally exposes only a curated JSON-safe `EndoGit` slice
+ * for now. Methods that remotely accept capabilities or can return
+ * capabilities, including non-empty `status()` rows, need capref/result
+ * serialization and are deferred future work.
+ *
+ * @type {Record<keyof GitToolCapability, { description: string, parameters: object }>}
+ */
+const gitToolSchemas = harden({
+  log: {
+    description: 'List commit history, most recent first.',
+    parameters: {
+      type: 'object',
+      properties: { arg0: OPTIONS_PROP },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  diff: {
+    description: 'Show changes between commits, the index, and the worktree.',
+    parameters: {
+      type: 'object',
+      properties: { arg0: OPTIONS_PROP },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  show: {
+    description: 'Show the contents of a git object (commit, tag, blob).',
+    parameters: {
+      type: 'object',
+      properties: { arg0: REF_PROP },
+      required: ['arg0'],
+      additionalProperties: false,
+    },
+  },
+  commit: {
+    description: 'Record the staged changes as a new commit.',
+    parameters: {
+      type: 'object',
+      properties: {
+        arg0: { type: 'string', description: 'The commit message.' },
+      },
+      required: ['arg0'],
+      additionalProperties: false,
+    },
+  },
+  branches: {
+    description: 'List the repository branches.',
+    parameters: NO_ARGS,
+  },
+  createBranch: {
+    description: 'Create a new branch.',
+    parameters: {
+      type: 'object',
+      properties: {
+        arg0: { type: 'string', description: 'The new branch name.' },
+        arg1: OPTIONS_PROP,
+      },
+      required: ['arg0'],
+      additionalProperties: false,
+    },
+  },
+  switchBranch: {
+    description: 'Switch the working tree to an existing branch.',
+    parameters: {
+      type: 'object',
+      properties: {
+        arg0: { type: 'string', description: 'The branch to switch to.' },
+      },
+      required: ['arg0'],
+      additionalProperties: false,
+    },
+  },
+  currentBranch: {
+    description:
+      'Report the currently checked-out branch (or nothing when detached).',
+    parameters: NO_ARGS,
+  },
+});
+
+/**
+ * @type {(keyof GitToolCapability)[]}
+ */
+const gitToolMethods = harden(
+  /** @type {(keyof GitToolCapability)[]} */ (Object.keys(gitToolSchemas)),
+);
+
+/**
+ * Positional arg guards for a method, required first and then optional.
+ * `getMethodGuardPayload` unwraps the `M.callWhen` await-arg wrappers.
+ *
+ * @param {string} method
+ * @returns {Pattern[]}
+ */
+const positionalArgGuards = method => {
+  const { methodGuards } = getInterfaceGuardPayload(
+    /** @type {InterfaceGuard} */ (GitInterface),
+  );
+  const { argGuards, optionalArgGuards } = getMethodGuardPayload(
+    methodGuards[method],
+  );
+  return harden([...argGuards, ...(optionalArgGuards || [])]);
+};
+
+/**
+ * Build agent-tool records for a live `Git` capability.
+ *
+ * @param {ERef<GitToolCapability>} gitCap
+ *   A live `Git` capability. The exo `Git` cap is reached by dynamic method
+ *   name through `E`, so this records only the invocation shape this maker
+ *   needs.
+ * @returns {ToolRecord[]}
+ */
+export const makeGitTool = gitCap => {
+  const records = gitToolMethods.map(method => {
+    const schema = gitToolSchemas[method];
+    const argGuards = positionalArgGuards(method);
+    return makeTool({
+      name: method,
+      description: schema.description,
+      parameters: schema.parameters,
+      argGuards,
+      execute: async argsRecord => {
+        // Marshal named args back to positional order.
+        const positional = [];
+        for (let i = 0; i < argGuards.length; i += 1) {
+          positional.push(argsRecord[`arg${i}`]);
+        }
+        while (
+          positional.length > 0 &&
+          positional[positional.length - 1] === undefined
+        ) {
+          positional.pop();
+        }
+        const gitMethod = /** @type {keyof GitToolCapability} */ (method);
+        const git = /** @type {GitToolDispatch} */ (E(gitCap));
+        return git[gitMethod](...positional);
+      },
+    });
+  });
+  return harden(records);
+};
+harden(makeGitTool);

--- a/packages/agent-tools/src/index.d.ts
+++ b/packages/agent-tools/src/index.d.ts
@@ -1,0 +1,3 @@
+export { makeTool } from './tool.js';
+export { makeGitTool } from './git-tool.js';
+export { makeMountReadTool } from './mount-fs.js';

--- a/packages/agent-tools/src/index.js
+++ b/packages/agent-tools/src/index.js
@@ -1,3 +1,4 @@
 // @ts-check
 
 export { makeTool } from './tool.js';
+export { makeGitTool } from './git-tool.js';

--- a/packages/agent-tools/src/index.js
+++ b/packages/agent-tools/src/index.js
@@ -1,0 +1,3 @@
+// @ts-check
+
+export { makeTool } from './tool.js';

--- a/packages/agent-tools/src/index.js
+++ b/packages/agent-tools/src/index.js
@@ -2,3 +2,4 @@
 
 export { makeTool } from './tool.js';
 export { makeGitTool } from './git-tool.js';
+export { makeMountReadTool } from './mount-fs.js';

--- a/packages/agent-tools/src/mount-fs.d.ts
+++ b/packages/agent-tools/src/mount-fs.d.ts
@@ -1,0 +1,7 @@
+import type { ERef } from '@endo/far';
+import type { Filesystem } from '@endo/endo-fs';
+import type { MountReadToolRecord } from './types.js';
+
+export declare const makeMountReadTool: (
+  fs: ERef<Filesystem>,
+) => MountReadToolRecord;

--- a/packages/agent-tools/src/mount-fs.d.ts
+++ b/packages/agent-tools/src/mount-fs.d.ts
@@ -1,7 +1,8 @@
 import type { ERef } from '@endo/far';
 import type { Filesystem } from '@endo/endo-fs';
-import type { MountReadToolRecord } from './types.js';
+import type { MountReadToolRecord, MountReadToolOptions } from './types.js';
 
 export declare const makeMountReadTool: (
   fs: ERef<Filesystem>,
+  opts?: MountReadToolOptions,
 ) => MountReadToolRecord;

--- a/packages/agent-tools/src/mount-fs.js
+++ b/packages/agent-tools/src/mount-fs.js
@@ -1,0 +1,87 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { ERef } from '@endo/far' */
+/** @import { File, Filesystem } from '@endo/endo-fs' */
+/** @import { MountReadToolRecord, ToolSchema } from './types.js' */
+
+import { E } from '@endo/far';
+import { walk, collectBytes } from '@endo/endo-fs';
+
+/**
+ * Existing text-read truncation cap.
+ */
+const MAX_TEXT_CHARS = 50_000;
+const MAX_TEXT_BYTES = BigInt(MAX_TEXT_CHARS + 1);
+
+/**
+ * A read-only filesystem tool bound to an `@endo/endo-fs` `Filesystem`
+ * capability. Reads a single text file by root-relative path and returns
+ * its UTF-8 contents.
+ *
+ * The path is split into `Filesystem` segments and resolved by `walk`.
+ * Confinement, symlink containment, and revocation are enforced by the
+ * `Filesystem` capability this tool receives.
+ *
+ * @param {ERef<Filesystem>} fs An `@endo/endo-fs` `Filesystem` ERef. Callers
+ *   can attenuate authority with `readOnly` or `chroot`.
+ * @returns {MountReadToolRecord}
+ */
+export const makeMountReadTool = fs => {
+  /** @type {ToolSchema} */
+  const schema = harden({
+    type: 'function',
+    function: {
+      name: 'mountReadText',
+      description:
+        'Read a UTF-8 text file from the mounted project directory. ' +
+        'Path is relative to the mount root; "../" escapes are rejected.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Mount-relative path to the file to read.',
+          },
+        },
+        required: ['path'],
+        additionalProperties: false,
+      },
+    },
+  });
+
+  return harden({
+    schema: () => schema,
+    async execute(args) {
+      for (const key of Object.keys(args)) {
+        if (key !== 'path') {
+          throw new Error(`unexpected mountReadText argument key "${key}"`);
+        }
+      }
+      const { path } = /** @type {{ path?: unknown }} */ (args);
+      if (typeof path !== 'string' || path === '') {
+        throw new Error('mountReadText requires a non-empty string path');
+      }
+      // `walk` expects one `Directory.lookup` segment at a time. Empty path
+      // components become `.` no-op steps, so `/a`, `a//b`, and `a/` work.
+      const segments = path
+        .split('/')
+        .map(segment => segment || '.')
+        .filter(segment => segment !== '.');
+      const file = /** @type {File} */ (
+        /** @type {unknown} */ (walk(E(fs).root(), segments))
+      );
+      const openFile = E(file).open({ read: true });
+      const reader = await E(openFile).read(0n, MAX_TEXT_BYTES);
+      const bytes = await collectBytes(/** @type {object} */ (reader));
+      const content = new TextDecoder().decode(bytes);
+      if (content.length > MAX_TEXT_CHARS) {
+        return `${content.slice(0, MAX_TEXT_CHARS)}\n\n... (truncated at ${MAX_TEXT_CHARS} chars)`;
+      }
+      return content;
+    },
+    help: () =>
+      'Read a text file from the mounted project directory (read-only).',
+  });
+};
+harden(makeMountReadTool);

--- a/packages/agent-tools/src/mount-fs.js
+++ b/packages/agent-tools/src/mount-fs.js
@@ -9,10 +9,10 @@ import { E } from '@endo/far';
 import { walk, collectBytes } from '@endo/endo-fs';
 
 /**
- * Existing text-read truncation cap.
+ * Default text-read truncation cap, in characters. A `maxChars` option of `0`
+ * disables truncation entirely.
  */
-const MAX_TEXT_CHARS = 50_000;
-const MAX_TEXT_BYTES = BigInt(MAX_TEXT_CHARS + 1);
+const DEFAULT_MAX_TEXT_CHARS = 50_000;
 
 /**
  * A read-only filesystem tool bound to an `@endo/endo-fs` `Filesystem`
@@ -25,9 +25,20 @@ const MAX_TEXT_BYTES = BigInt(MAX_TEXT_CHARS + 1);
  *
  * @param {ERef<Filesystem>} fs An `@endo/endo-fs` `Filesystem` ERef. Callers
  *   can attenuate authority with `readOnly` or `chroot`.
+ * @param {object} [opts] Configuration options.
+ * @param {number} [opts.maxChars] Maximum number of UTF-8 characters returned
+ *   before the result is truncated. Defaults to `DEFAULT_MAX_TEXT_CHARS`
+ *   (50,000). A value of `0` disables the limit; the full file contents are
+ *   returned untruncated.
  * @returns {MountReadToolRecord}
  */
-export const makeMountReadTool = fs => {
+export const makeMountReadTool = (fs, opts = {}) => {
+  const { maxChars = DEFAULT_MAX_TEXT_CHARS } = opts;
+  const limitDisabled = maxChars === 0;
+  // `open().read(0n, length)` is exclusive of `length`, so request one extra
+  // byte to detect overflow past the cap. With the limit disabled, read the
+  // whole file in one unbounded request.
+  const readLength = limitDisabled ? undefined : BigInt(maxChars + 1);
   /** @type {ToolSchema} */
   const schema = harden({
     type: 'function',
@@ -72,11 +83,13 @@ export const makeMountReadTool = fs => {
         /** @type {unknown} */ (walk(E(fs).root(), segments))
       );
       const openFile = E(file).open({ read: true });
-      const reader = await E(openFile).read(0n, MAX_TEXT_BYTES);
+      // `read(offset)` with the length omitted reads to EOF, which is what we
+      // want when the limit is disabled (`maxChars === 0`).
+      const reader = await E(openFile).read(0n, readLength);
       const bytes = await collectBytes(/** @type {object} */ (reader));
       const content = new TextDecoder().decode(bytes);
-      if (content.length > MAX_TEXT_CHARS) {
-        return `${content.slice(0, MAX_TEXT_CHARS)}\n\n... (truncated at ${MAX_TEXT_CHARS} chars)`;
+      if (!limitDisabled && content.length > maxChars) {
+        return `${content.slice(0, maxChars)}\n\n... (truncated at ${maxChars} chars)`;
       }
       return content;
     },

--- a/packages/agent-tools/src/tool.d.ts
+++ b/packages/agent-tools/src/tool.d.ts
@@ -1,0 +1,3 @@
+import type { ToolRecord, ToolSpec } from './types.js';
+
+export declare const makeTool: (spec: ToolSpec) => ToolRecord;

--- a/packages/agent-tools/src/tool.js
+++ b/packages/agent-tools/src/tool.js
@@ -1,0 +1,132 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { ToolSpec, ToolRecord } from './types.js' */
+
+import { mustMatch } from '@endo/patterns';
+
+/**
+ * Marshal a named-args record `{arg0, arg1, …}` into a positional array in
+ * ordinal order. Optional trailing `undefined` values are dropped; required
+ * positions are retained for guard validation.
+ *
+ * @param {Record<string, unknown>} argsRecord
+ * @param {number} arity Number of positional slots (`argGuards.length`).
+ * @param {number} requiredCount Number of required positional slots.
+ * @returns {unknown[]}
+ */
+const namedToPositional = (argsRecord, arity, requiredCount) => {
+  const positional = [];
+  for (let i = 0; i < arity; i += 1) {
+    positional.push(argsRecord[`arg${i}`]);
+  }
+  // Drop trailing `undefined` (optional/absent args).
+  while (
+    positional.length > requiredCount &&
+    positional[positional.length - 1] === undefined
+  ) {
+    positional.pop();
+  }
+  return positional;
+};
+
+const ARG_KEY_PATTERN = /^arg(?:0|[1-9]\d*)$/;
+
+/**
+ * @param {object} parameters
+ * @returns {string[]}
+ */
+const getRequiredArgKeys = parameters => {
+  const { required } = /** @type {{ required?: unknown }} */ (parameters);
+  if (!Array.isArray(required)) {
+    return harden([]);
+  }
+  return harden(
+    required.filter(
+      key => typeof key === 'string' && ARG_KEY_PATTERN.test(key),
+    ),
+  );
+};
+
+/**
+ * @param {string[]} requiredArgKeys
+ * @returns {number}
+ */
+const getRequiredArgCount = requiredArgKeys => {
+  let requiredCount = 0;
+  for (const key of requiredArgKeys) {
+    requiredCount = Math.max(requiredCount, Number(key.slice(3)) + 1);
+  }
+  return requiredCount;
+};
+
+/**
+ * @param {Record<string, unknown>} argsRecord
+ * @returns {Record<string, unknown>}
+ */
+const copyHardenArgsRecord = argsRecord => {
+  if (
+    argsRecord === null ||
+    typeof argsRecord !== 'object' ||
+    Array.isArray(argsRecord)
+  ) {
+    throw new Error('tool arguments must be a record');
+  }
+  return harden({ ...argsRecord });
+};
+
+/**
+ * Build a tool record from its JSON Schema, optional positional guards, and
+ * dispatch function. The schema is advertised to callers; the guards enforce
+ * the same positional argument contract at runtime.
+ *
+ * @param {ToolSpec} spec
+ * @returns {ToolRecord}
+ */
+export const makeTool = spec => {
+  const { name, description, parameters, argGuards, execute } = spec;
+  // Avoid retaining a mutable caller-owned schema object.
+  const hardenedParameters = harden(parameters);
+  const requiredArgKeys = getRequiredArgKeys(hardenedParameters);
+  const requiredArgCount = getRequiredArgCount(requiredArgKeys);
+  return harden({
+    name,
+    description,
+    parameters: hardenedParameters,
+    inputSchema: hardenedParameters,
+    /**
+     * @param {Record<string, unknown>} argsRecord
+     */
+    invoke: async argsRecord => {
+      const hardenedArgsRecord = copyHardenArgsRecord(argsRecord);
+      if (argGuards !== undefined) {
+        // Reject keys outside the positional guard list.
+        const allowed = new Set(argGuards.map((_g, i) => `arg${i}`));
+        for (const key of Object.keys(hardenedArgsRecord)) {
+          if (!allowed.has(key)) {
+            throw new Error(`unexpected tool argument key "${key}"`);
+          }
+        }
+        for (const key of requiredArgKeys) {
+          if (
+            !Object.prototype.hasOwnProperty.call(hardenedArgsRecord, key) ||
+            hardenedArgsRecord[key] === undefined
+          ) {
+            throw new Error(`missing required tool argument "${key}"`);
+          }
+        }
+        const positional = namedToPositional(
+          hardenedArgsRecord,
+          argGuards.length,
+          requiredArgCount,
+        );
+        // `namedToPositional` drops omitted optional tail args.
+        for (let i = 0; i < positional.length; i += 1) {
+          mustMatch(positional[i], argGuards[i], `${name} arg${i}`);
+        }
+      }
+      return execute(hardenedArgsRecord);
+    },
+  });
+};
+harden(makeTool);

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -3,6 +3,20 @@ import type { Filesystem } from '@endo/endo-fs';
 import type { EndoGit } from '@endo/exo-git';
 import type { Pattern } from '@endo/patterns';
 
+/**
+ * The read- and branch-navigation slice of `EndoGit` the git tool catalog
+ * exposes to an LLM.
+ *
+ * Deliberately omits the destructive and history-rewriting methods of `EndoGit`
+ * — `merge`, `rebase`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
+ * family, and the working-tree/detach mutators (`add`, `switch`, `detach`,
+ * `worktree`). Those carry authority a tool surface handed to a model should not
+ * advertise: they can discard uncommitted work or rewrite shared history.
+ * `commit`, `createBranch`, and `switchBranch` are included as the additive,
+ * non-destructive write surface. Widening this `Pick` is a deliberate authority
+ * decision, not a convenience — add a method only when the tool surface is meant
+ * to grant it.
+ */
 export type GitToolCapability = Pick<
   EndoGit,
   | 'log'

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -1,3 +1,5 @@
+import type { ERef } from '@endo/far';
+import type { Filesystem } from '@endo/endo-fs';
 import type { Pattern } from '@endo/patterns';
 
 export interface ToolSpec {
@@ -33,3 +35,29 @@ export interface ToolRecord {
    */
   invoke: (args: Record<string, unknown>) => Promise<unknown>;
 }
+
+export interface ToolSchema {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: {
+      type: 'object';
+      properties: Record<string, unknown>;
+      required?: readonly string[];
+      additionalProperties?: boolean;
+    };
+  };
+}
+
+export interface MountReadToolRecord {
+  schema: () => ToolSchema;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+  help: () => string;
+}
+
+export declare function makeTool(spec: ToolSpec): ToolRecord;
+
+export declare function makeMountReadTool(
+  fs: ERef<Filesystem>,
+): MountReadToolRecord;

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -1,6 +1,19 @@
 import type { ERef } from '@endo/far';
 import type { Filesystem } from '@endo/endo-fs';
+import type { EndoGit } from '@endo/exo-git';
 import type { Pattern } from '@endo/patterns';
+
+export type GitToolCapability = Pick<
+  EndoGit,
+  | 'log'
+  | 'diff'
+  | 'show'
+  | 'commit'
+  | 'branches'
+  | 'createBranch'
+  | 'switchBranch'
+  | 'currentBranch'
+>;
 
 export interface ToolSpec {
   /** Tool name advertised to callers. */
@@ -57,6 +70,10 @@ export interface MountReadToolRecord {
 }
 
 export declare function makeTool(spec: ToolSpec): ToolRecord;
+
+export declare function makeGitTool(
+  gitCap: ERef<GitToolCapability>,
+): ToolRecord[];
 
 export declare function makeMountReadTool(
   fs: ERef<Filesystem>,

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -89,6 +89,15 @@ export declare function makeGitTool(
   gitCap: ERef<GitToolCapability>,
 ): ToolRecord[];
 
+export interface MountReadToolOptions {
+  /**
+   * Maximum number of UTF-8 characters returned before truncation. Defaults to
+   * 50,000. A value of `0` disables the limit and returns the full contents.
+   */
+  maxChars?: number;
+}
+
 export declare function makeMountReadTool(
   fs: ERef<Filesystem>,
+  opts?: MountReadToolOptions,
 ): MountReadToolRecord;

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -1,0 +1,35 @@
+import type { Pattern } from '@endo/patterns';
+
+export interface ToolSpec {
+  /** Tool name advertised to callers. */
+  name: string;
+  /** One-line capability description. */
+  description: string;
+  /**
+   * Hand-authored JSON Schema object. It is used verbatim as both the LLM tool
+   * `parameters` and the MCP `inputSchema`.
+   */
+  parameters: object;
+  /**
+   * Optional array of `@endo/patterns` Patterns, one per positional argument,
+   * used for a runtime `mustMatch` of each supplied argument before `execute`
+   * runs.
+   */
+  argGuards?: Pattern[];
+  /** Dispatch target. Receives the named-args record `{arg0, arg1, ...}`. */
+  execute: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface ToolRecord {
+  name: string;
+  description: string;
+  /** The JSON Schema used as LLM `parameters`. */
+  parameters: object;
+  /** The same JSON Schema used as MCP `inputSchema`. */
+  inputSchema: object;
+  /**
+   * Validates the supplied args against `argGuards` when present, then calls
+   * `execute(args)`.
+   */
+  invoke: (args: Record<string, unknown>) => Promise<unknown>;
+}

--- a/packages/agent-tools/test/divergence.test.js
+++ b/packages/agent-tools/test/divergence.test.js
@@ -6,7 +6,7 @@ import '@endo/init/debug.js';
 
 /** @import { ERef } from '@endo/far' */
 /** @import { InterfaceGuard, Pattern } from '@endo/patterns' */
-/** @import { GitToolCapability } from '../src/types.js' */
+/** @import { GitToolCapability, ToolRecord } from '../src/types.js' */
 
 import test from 'ava';
 import { Ajv } from 'ajv';
@@ -116,8 +116,12 @@ const gitTools = makeGitTool(
   ),
 );
 
-for (const tool of gitTools) {
-  test(`schema ⟷ guard agree for git.${tool.name}`, t => {
+/**
+ * For one git tool, assert its hand-authored JSON Schema and its runtime guard
+ * agree on every candidate args record.
+ */
+const schemaGuardAgree = test.macro({
+  exec(t, /** @type {ToolRecord} */ tool) {
     const shape = guardShapeFor(tool.name);
     const validate = ajv.compile(tool.parameters);
     let checked = 0;
@@ -135,7 +139,14 @@ for (const tool of gitTools) {
       checked += 1;
     }
     t.true(checked > 0);
-  });
+  },
+  title(_providedTitle, /** @type {ToolRecord} */ tool) {
+    return `schema ⟷ guard agree for git.${tool.name}`;
+  },
+});
+
+for (const tool of gitTools) {
+  test(schemaGuardAgree, tool);
 }
 
 // --- bigint synthetic case ----------------------------------------------
@@ -159,7 +170,10 @@ test('bigint guard and string-pattern schema agree', t => {
     [5n, '+5'],
     [-3n, '-3'],
     [0n, '0'],
-    [123456789012345678901234567890n, '123456789012345678901234567890'],
+    [
+      123_456_789_012_345_678_901_234_567_890n,
+      '123456789012345678901234567890',
+    ],
     ['x', 'x'],
     [5.5, '5.5'],
     [{}, '{}'],

--- a/packages/agent-tools/test/divergence.test.js
+++ b/packages/agent-tools/test/divergence.test.js
@@ -1,0 +1,216 @@
+// @ts-check
+
+// Establish a SES perimeter (provides the `harden` global).
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+/** @import { ERef } from '@endo/far' */
+/** @import { InterfaceGuard, Pattern } from '@endo/patterns' */
+/** @import { GitToolCapability } from '../src/types.js' */
+
+import test from 'ava';
+import { Ajv } from 'ajv';
+import {
+  M,
+  matches,
+  getInterfaceGuardPayload,
+  getMethodGuardPayload,
+} from '@endo/patterns';
+import { Far } from '@endo/far';
+import { GitInterface } from '@endo/exo-git';
+
+import { makeGitTool } from '../src/git-tool.js';
+
+/**
+ * Conformance checks for hand-authored JSON Schemas and runtime guards.
+ */
+
+const ajv = new Ajv({ strict: false });
+
+/**
+ * Positional guard structure from `GitInterface`.
+ *
+ * @param {string} method
+ */
+const guardShapeFor = method => {
+  const { methodGuards } = getInterfaceGuardPayload(
+    /** @type {InterfaceGuard} */ (GitInterface),
+  );
+  const { argGuards, optionalArgGuards } = getMethodGuardPayload(
+    methodGuards[method],
+  );
+  const optional = optionalArgGuards || [];
+  return {
+    requiredCount: argGuards.length,
+    guards: harden([...argGuards, ...optional]),
+  };
+};
+
+/**
+ * Decide whether the runtime guards accept a named-args record.
+ *
+ * @param {{requiredCount:number, guards:Pattern[]}} shape
+ * @param {Record<string, unknown>} record
+ */
+const guardAccepts = (shape, record) => {
+  const { requiredCount, guards } = shape;
+  const allowed = new Set(guards.map((_g, i) => `arg${i}`));
+  for (const key of Object.keys(record)) {
+    if (!allowed.has(key)) return false;
+  }
+  for (let i = 0; i < guards.length; i += 1) {
+    const key = `arg${i}`;
+    // JSON has no `undefined`, so a known `argN: undefined` is treated as absent.
+    const present =
+      Object.prototype.hasOwnProperty.call(record, key) &&
+      record[key] !== undefined;
+    if (present) {
+      if (!matches(record[key], guards[i])) return false;
+    } else if (i < requiredCount) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Candidate named-args records covering valid and invalid shapes.
+ */
+const candidateRecords = harden([
+  {},
+  { arg0: 'a-string' },
+  { arg0: '' },
+  { arg0: 42 },
+  { arg0: 42n },
+  { arg0: true },
+  { arg0: null },
+  { arg0: undefined },
+  { arg0: {} },
+  { arg0: { k: 'v' } },
+  { arg0: [] },
+  { arg1: 'only-second' },
+  { arg0: 'a', arg1: {} },
+  { arg0: 'a', arg1: { opt: 1 } },
+  { arg0: 'a', arg1: 'not-a-record' },
+  { arg0: 'a', arg1: 5 },
+  { arg0: {}, arg1: {} },
+  { arg0: 'a', arg2: 'extra' },
+  { arg0: 'a', extra: 'x' },
+  { extra: 'x' },
+  { extra: undefined },
+  { arg0: undefined, arg1: undefined },
+  { arg0: 'a', arg1: {}, arg2: 'too-many' },
+  // Open-object option records.
+  { arg0: { a: 1, b: 2 } },
+  { arg0: { nested: { x: 1 } } },
+  { arg0: harden({ author: 'alice', oneline: true, maxCount: 10 }) },
+  { arg0: 'a', arg1: { a: 1, b: 2 } },
+  { arg0: 'a', arg1: { nested: { x: 1 } } },
+  { arg0: 'a', arg1: harden({ track: true, startPoint: 'main' }) },
+]);
+
+const gitTools = makeGitTool(
+  // This test inspects schemas and guards; it never invokes the capability.
+  /** @type {ERef<GitToolCapability>} */ (
+    /** @type {unknown} */ (Far('InertGit', {}))
+  ),
+);
+
+for (const tool of gitTools) {
+  test(`schema ⟷ guard agree for git.${tool.name}`, t => {
+    const shape = guardShapeFor(tool.name);
+    const validate = ajv.compile(tool.parameters);
+    let checked = 0;
+    for (const record of candidateRecords) {
+      const guardOk = guardAccepts(shape, record);
+      const schemaOk = validate({ ...record });
+      t.is(
+        schemaOk,
+        guardOk,
+        `${tool.name}: schema=${schemaOk} guard=${guardOk} for ${JSON.stringify(
+          record,
+          (_k, v) => (typeof v === 'bigint' ? `${v}n` : v),
+        )}`,
+      );
+      checked += 1;
+    }
+    t.true(checked > 0);
+  });
+}
+
+// --- bigint synthetic case ----------------------------------------------
+//
+// The current Git slice has no bigint args, so this covers the bigint
+// guard-to-schema mapping directly.
+
+const BIGINT_GUARD = M.bigint();
+const BIGINT_SCHEMA = harden({
+  type: 'string',
+  pattern: '^[+-]?\\d+$',
+});
+const BIGINT_SCHEMA_WRONG = harden({ type: 'integer' });
+
+test('bigint guard and string-pattern schema agree', t => {
+  const validateStr = ajv.compile(BIGINT_SCHEMA);
+
+  /** @type {Array<[unknown, unknown]>} */
+  const pairs = harden([
+    [5n, '5'],
+    [5n, '+5'],
+    [-3n, '-3'],
+    [0n, '0'],
+    [123456789012345678901234567890n, '123456789012345678901234567890'],
+    ['x', 'x'],
+    [5.5, '5.5'],
+    [{}, '{}'],
+    [true, 'true'],
+    ['', ''],
+  ]);
+
+  for (const [guardValue, wireValue] of pairs) {
+    const guardOk = matches(guardValue, BIGINT_GUARD);
+    const schemaOk = validateStr(wireValue);
+    t.is(
+      schemaOk,
+      guardOk,
+      `bigint: guard(${String(guardValue)})=${guardOk} schema(${JSON.stringify(
+        wireValue,
+      )})=${schemaOk}`,
+    );
+  }
+
+  t.true(matches(5n, BIGINT_GUARD));
+  t.true(validateStr('5'));
+  t.true(validateStr('+5'));
+  t.true(validateStr('-3'));
+  t.false(validateStr('x'));
+  t.false(validateStr('5.5'));
+  t.false(validateStr('{}'));
+});
+
+test('{type:integer} schema diverges from a bigint guard', t => {
+  const validateInt = ajv.compile(BIGINT_SCHEMA_WRONG);
+
+  let divergences = 0;
+
+  {
+    const schemaOk = validateInt(5);
+    const guardOk = matches(5, BIGINT_GUARD);
+    t.true(schemaOk, 'integer-schema accepts the JSON number 5');
+    t.false(guardOk, 'bigint-guard rejects the JS number 5');
+    if (schemaOk !== guardOk) divergences += 1;
+  }
+
+  {
+    const schemaOk = validateInt('5');
+    const guardOk = matches(5n, BIGINT_GUARD);
+    t.false(schemaOk, 'integer-schema rejects the string "5"');
+    t.true(guardOk, 'bigint-guard accepts 5n');
+    if (schemaOk !== guardOk) divergences += 1;
+  }
+
+  t.true(
+    divergences >= 1,
+    'an {type:integer} schema diverges from a bigint guard',
+  );
+});

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -1,0 +1,122 @@
+// @ts-check
+
+// Establish a SES perimeter (provides the `harden` global).
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import { Far } from '@endo/far';
+
+import { makeGitTool } from '../src/git-tool.js';
+
+/** @import { ERef } from '@endo/far' */
+/** @import { GitToolCapability } from '../src/types.js' */
+
+const SLICE = [
+  'log',
+  'diff',
+  'show',
+  'commit',
+  'branches',
+  'createBranch',
+  'switchBranch',
+  'currentBranch',
+];
+
+/**
+ * Stub Git capability that records the method name and positional args.
+ *
+ * @param {unknown[][]} calls An array each call appends its `[name, ...args]` to.
+ * @returns {ERef<GitToolCapability>}
+ */
+const makeStubGit = calls => {
+  /** @type {GitToolCapability} */
+  const stubGit = {
+    log: async (...a) => {
+      calls.push(['log', ...a]);
+      return [];
+    },
+    diff: async (...a) => {
+      calls.push(['diff', ...a]);
+      return '';
+    },
+    show: async (...a) => {
+      calls.push(['show', ...a]);
+      return '';
+    },
+    commit: async (...a) => {
+      calls.push(['commit', ...a]);
+      return { oid: 'x', summary: a[0] };
+    },
+    branches: async (...a) => {
+      calls.push(['branches', ...a]);
+      return [];
+    },
+    createBranch: async (...a) => {
+      calls.push(['createBranch', ...a]);
+      return { name: a[0], kind: 'branch' };
+    },
+    switchBranch: async (...a) => {
+      calls.push(['switchBranch', ...a]);
+    },
+    currentBranch: async (...a) => {
+      calls.push(['currentBranch', ...a]);
+      return undefined;
+    },
+  };
+  return Far('StubGit', stubGit);
+};
+
+test('makeGitTool builds one record per non-remotable-slice method', t => {
+  const tools = makeGitTool(makeStubGit([]));
+  t.is(tools.length, SLICE.length);
+  const names = tools.map(tool => tool.name).sort();
+  t.deepEqual(names, [...SLICE].sort());
+  for (const tool of tools) {
+    t.is(typeof tool.description, 'string');
+    t.truthy(tool.parameters);
+    t.is(tool.inputSchema, tool.parameters);
+    t.is(typeof tool.invoke, 'function');
+  }
+});
+
+test('makeGitTool omits cap-heavy methods', t => {
+  const tools = makeGitTool(makeStubGit([]));
+  const names = new Set(tools.map(tool => tool.name));
+  t.false(names.has('status'));
+  t.false(names.has('add'));
+  t.false(names.has('restore'));
+  t.false(names.has('filesystemAt'));
+});
+
+test('invoke marshals named args to positional and calls the capability', async t => {
+  const calls = [];
+  const tools = makeGitTool(makeStubGit(calls));
+  const byName = name => {
+    const found = tools.find(tool => tool.name === name);
+    if (!found) throw new Error(`no tool named ${name}`);
+    return found;
+  };
+
+  await null;
+
+  await byName('commit').invoke({ arg0: 'a message' });
+  await byName('createBranch').invoke({ arg0: 'feature' });
+  await byName('createBranch').invoke({ arg0: 'feature', arg1: harden({}) });
+  await byName('log').invoke({});
+
+  t.deepEqual(calls, [
+    ['commit', 'a message'],
+    ['createBranch', 'feature'],
+    ['createBranch', 'feature', {}],
+    ['log'],
+  ]);
+});
+
+test('invoke rejects an arg that violates the runtime guard', async t => {
+  const tools = makeGitTool(makeStubGit([]));
+  const commit = tools.find(tool => tool.name === 'commit');
+  if (!commit) throw new Error('no commit tool');
+  await null;
+  await t.throwsAsync(() => commit.invoke({ arg0: 123 }));
+});

--- a/packages/agent-tools/test/mount-fs.test.js
+++ b/packages/agent-tools/test/mount-fs.test.js
@@ -113,6 +113,31 @@ test('truncates content beyond the 50k-char cap', async t => {
   t.is(result.indexOf('\n\n... (truncated'), 50_000);
 });
 
+test('truncates at a caller-supplied maxChars', async t => {
+  const rootPath = makeTempRoot(t);
+  const big = 'x'.repeat(20);
+  fs.writeFileSync(path.join(rootPath, 'big.txt'), big);
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem, { maxChars: 8 });
+  const result = await tool.execute({ path: 'big.txt' });
+  t.true(result.startsWith('x'.repeat(8)));
+  t.true(result.includes('truncated at 8 chars'));
+  t.is(result.indexOf('\n\n... (truncated'), 8);
+});
+
+test('maxChars: 0 disables the limit and returns full contents', async t => {
+  const rootPath = makeTempRoot(t);
+  const big = 'x'.repeat(60_000);
+  fs.writeFileSync(path.join(rootPath, 'big.txt'), big);
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem, { maxChars: 0 });
+  const result = await tool.execute({ path: 'big.txt' });
+  t.is(result, big);
+  t.false(result.includes('truncated'));
+});
+
 test('normalizes leading, trailing, and doubled slashes to "." no-op steps', async t => {
   const rootPath = makeTempRoot(t);
   fs.mkdirSync(path.join(rootPath, 'sub'));

--- a/packages/agent-tools/test/mount-fs.test.js
+++ b/packages/agent-tools/test/mount-fs.test.js
@@ -1,0 +1,280 @@
+// @ts-check
+
+// Establish a SES perimeter (provides the `harden` global).
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+/** @import { ExecutionContext } from 'ava' */
+/** @import { ERef } from '@endo/far' */
+/** @import { Filesystem } from '@endo/endo-fs' */
+
+import test from 'ava';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { Buffer } from 'buffer';
+import { E, Far } from '@endo/far';
+
+import { makeNodeFilesystem, readOnly, chroot } from '@endo/endo-fs';
+
+import { makeMountReadTool } from '../src/mount-fs.js';
+
+/**
+ * @typedef {object} TestFilesystemLike
+ * @property {() => unknown} root
+ */
+
+/**
+ * @typedef {object} TestDirectoryLike
+ * @property {(name: string, opts: object) => unknown} create
+ */
+
+/**
+ * @param {ExecutionContext} t
+ * @returns {string}
+ */
+const makeTempRoot = t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tools-mount-'));
+  t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+};
+
+/**
+ * @param {Uint8Array} bytes
+ */
+const makeFakeBytesReader = bytes =>
+  Far('FakeBytesReader', {
+    streamBase64() {
+      return harden({
+        value: Buffer.from(bytes).toString('base64'),
+        promise: Promise.resolve(harden({ value: undefined, promise: null })),
+      });
+    },
+  });
+
+test('reads a text file inside the filesystem', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'hello mount');
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem);
+  await null;
+  t.is(await tool.execute({ path: 'a.txt' }), 'hello mount');
+});
+
+test('reads a file in a subdirectory by relative path', async t => {
+  await null;
+  const rootPath = makeTempRoot(t);
+  fs.mkdirSync(path.join(rootPath, 'sub'));
+  fs.writeFileSync(path.join(rootPath, 'sub', 'b.txt'), 'nested');
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem);
+  t.is(await tool.execute({ path: 'sub/b.txt' }), 'nested');
+});
+
+test('reads through a chroot subtree view as the new root', async t => {
+  await null;
+  const rootPath = makeTempRoot(t);
+  fs.mkdirSync(path.join(rootPath, 'sub'));
+  fs.writeFileSync(path.join(rootPath, 'sub', 'c.txt'), 'in subtree');
+  fs.writeFileSync(path.join(rootPath, 'top.txt'), 'above subtree');
+  const filesystem = chroot(readOnly(makeNodeFilesystem({ rootPath })), [
+    'sub',
+  ]);
+
+  const tool = makeMountReadTool(filesystem);
+  t.is(await tool.execute({ path: 'c.txt' }), 'in subtree');
+  await t.throwsAsync(() => tool.execute({ path: 'top.txt' }), {
+    message: /ENOENT/,
+  });
+});
+
+test('reads an empty file as the empty string', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'empty.txt'), '');
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem);
+  await null;
+  t.is(await tool.execute({ path: 'empty.txt' }), '');
+});
+
+test('truncates content beyond the 50k-char cap', async t => {
+  const rootPath = makeTempRoot(t);
+  const big = 'x'.repeat(50_001);
+  fs.writeFileSync(path.join(rootPath, 'big.txt'), big);
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem);
+  const result = await tool.execute({ path: 'big.txt' });
+  t.true(result.startsWith('x'.repeat(50_000)));
+  t.true(result.includes('truncated at 50000 chars'));
+  t.is(result.indexOf('\n\n... (truncated'), 50_000);
+});
+
+test('normalizes leading, trailing, and doubled slashes to "." no-op steps', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.mkdirSync(path.join(rootPath, 'sub'));
+  fs.writeFileSync(path.join(rootPath, 'sub', 'd.txt'), 'normalized');
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem);
+  await null;
+  t.is(await tool.execute({ path: '/sub/d.txt' }), 'normalized');
+  t.is(await tool.execute({ path: 'sub//d.txt' }), 'normalized');
+  t.is(await tool.execute({ path: 'sub/d.txt/' }), 'normalized');
+});
+
+test('bounds the underlying file read before draining bytes', async t => {
+  await null;
+  const filesystem = Far('BoundedReadFilesystem', {
+    root() {
+      return Far('BoundedReadRoot', {
+        lookup(name) {
+          t.is(name, 'big.txt');
+          return Far('BoundedReadFile', {
+            open(opts) {
+              t.deepEqual(opts, { read: true });
+              return Far('BoundedReadOpenFile', {
+                read(offset, length) {
+                  t.is(offset, 0n);
+                  t.is(length, 50_001n);
+                  return makeFakeBytesReader(
+                    new TextEncoder().encode('x'.repeat(50_001)),
+                  );
+                },
+              });
+            },
+          });
+        },
+      });
+    },
+  });
+
+  const tool = makeMountReadTool(
+    /** @type {ERef<Filesystem>} */ (/** @type {unknown} */ (filesystem)),
+  );
+  const result = await tool.execute({ path: 'big.txt' });
+  t.is(result.indexOf('\n\n... (truncated'), 50_000);
+});
+
+test('help() returns a one-line capability description', t => {
+  const rootPath = makeTempRoot(t);
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+  const tool = makeMountReadTool(filesystem);
+
+  const help = tool.help();
+  t.is(typeof help, 'string');
+  t.true(help.length > 0);
+  t.false(help.includes('\n'));
+});
+
+test('schema advertises the mountReadText tool name and a required path', t => {
+  const rootPath = makeTempRoot(t);
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+  const tool = makeMountReadTool(filesystem);
+
+  const schema = tool.schema();
+  t.is(schema.type, 'function');
+  t.is(schema.function.name, 'mountReadText');
+  t.deepEqual(schema.function.parameters.required, ['path']);
+  t.false(schema.function.parameters.additionalProperties);
+});
+
+test('rejects extra arguments before any filesystem send', async t => {
+  let touched = false;
+  const filesystem = Far('UntouchedFilesystem', {
+    root() {
+      touched = true;
+      throw new Error('filesystem should not be touched');
+    },
+  });
+  const tool = makeMountReadTool(filesystem);
+
+  const err = await t.throwsAsync(() =>
+    tool.execute({ path: 'a.txt', extra: 'ignored' }),
+  );
+  t.true(
+    err !== undefined && err.message.includes('extra'),
+    `error message should name the offending key; got: ${err?.message}`,
+  );
+  t.false(touched);
+});
+
+test('rejects a missing or empty path before any send', async t => {
+  const rootPath = makeTempRoot(t);
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+  const tool = makeMountReadTool(filesystem);
+
+  await t.throwsAsync(() => tool.execute({}), {
+    message: /non-empty string path/,
+  });
+  await t.throwsAsync(() => tool.execute({ path: '' }), {
+    message: /non-empty string path/,
+  });
+});
+
+test('rejects a "../" escape via the Filesystem, not a string check', async t => {
+  const outsideRoot = makeTempRoot(t);
+  fs.writeFileSync(path.join(outsideRoot, 'secret'), 'TOP SECRET');
+  const rootPath = path.join(outsideRoot, 'mounted');
+  fs.mkdirSync(rootPath);
+  fs.writeFileSync(path.join(rootPath, 'inside.txt'), 'ok');
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem);
+  t.is(
+    fs.readFileSync(path.join(outsideRoot, 'secret'), 'utf-8'),
+    'TOP SECRET',
+  );
+  await t.throwsAsync(() => tool.execute({ path: '../secret' }), {
+    message: /reserved|EINVAL|ENOENT/,
+  });
+  t.is(await tool.execute({ path: 'inside.txt' }), 'ok');
+});
+
+test('rejects reading through a symlink that escapes the root', async t => {
+  const outsideRoot = makeTempRoot(t);
+  const outsideFile = path.join(outsideRoot, 'secret.txt');
+  fs.writeFileSync(outsideFile, 'TOP SECRET');
+  const rootPath = path.join(outsideRoot, 'mounted');
+  fs.mkdirSync(rootPath);
+  fs.symlinkSync(outsideFile, path.join(rootPath, 'link-out'));
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem);
+  await t.throwsAsync(() => tool.execute({ path: 'link-out' }), {
+    message: /escapes filesystem root|EACCES|ENOENT/,
+  });
+});
+
+test('fails closed after the Filesystem is revoked, with no ambient fallback', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'live content');
+  const realFs = readOnly(makeNodeFilesystem({ rootPath }));
+
+  let revoked = false;
+  const revocableFs = Far('RevocableFilesystem', {
+    async root() {
+      if (revoked) {
+        throw new Error('Filesystem has been revoked');
+      }
+      return E(/** @type {TestFilesystemLike} */ (realFs)).root();
+    },
+  });
+
+  const tool = makeMountReadTool(
+    /** @type {ERef<Filesystem>} */ (/** @type {unknown} */ (revocableFs)),
+  );
+
+  await null;
+  t.is(await tool.execute({ path: 'a.txt' }), 'live content');
+
+  revoked = true;
+  await t.throwsAsync(() => tool.execute({ path: 'a.txt' }), {
+    message: /revoked/,
+  });
+
+  t.is(fs.readFileSync(path.join(rootPath, 'a.txt'), 'utf-8'), 'live content');
+});

--- a/packages/agent-tools/test/tool.test.js
+++ b/packages/agent-tools/test/tool.test.js
@@ -1,0 +1,149 @@
+// @ts-check
+
+// Establish a SES perimeter (provides the `harden` global).
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import { M } from '@endo/patterns';
+
+import { makeTool } from '../src/tool.js';
+
+test('makeTool produces the advertised record shape', t => {
+  const parameters = {
+    type: 'object',
+    properties: { arg0: { type: 'string' } },
+    required: ['arg0'],
+    additionalProperties: false,
+  };
+  const tool = makeTool({
+    name: 'echo',
+    description: 'Echo its argument back.',
+    parameters,
+    execute: async ({ arg0 }) => arg0,
+  });
+
+  t.is(tool.name, 'echo');
+  t.is(tool.description, 'Echo its argument back.');
+  t.is(tool.inputSchema, tool.parameters);
+  t.is(typeof tool.invoke, 'function');
+  t.truthy(Object.isFrozen(tool));
+  t.truthy(Object.isFrozen(parameters));
+  t.truthy(Object.isFrozen(parameters.properties));
+});
+
+test('invoke runs execute when no argGuards are supplied', async t => {
+  const tool = makeTool({
+    name: 'echo',
+    description: 'Echo.',
+    parameters: { type: 'object', properties: {}, required: [] },
+    execute: async ({ arg0 }) => `got:${arg0}`,
+  });
+  await null;
+  t.is(await tool.invoke({ arg0: 'hi' }), 'got:hi');
+});
+
+test('invoke enforces argGuards before execute', async t => {
+  let ran = false;
+  const tool = makeTool({
+    name: 'strlen',
+    description: 'Length of a string.',
+    parameters: {
+      type: 'object',
+      properties: { arg0: { type: 'string' } },
+      required: ['arg0'],
+      additionalProperties: false,
+    },
+    argGuards: [M.string()],
+    execute: async ({ arg0 }) => {
+      ran = true;
+      return /** @type {string} */ (arg0).length;
+    },
+  });
+
+  await null;
+  t.is(await tool.invoke({ arg0: 'abcd' }), 4);
+  t.true(ran);
+
+  ran = false;
+  await t.throwsAsync(() => tool.invoke({ arg0: 42 }));
+  t.false(ran);
+});
+
+test('invoke rejects missing required guarded args before execute', async t => {
+  let ran = false;
+  const tool = makeTool({
+    name: 'commit',
+    description: 'Commit.',
+    parameters: {
+      type: 'object',
+      properties: { arg0: { type: 'string' } },
+      required: ['arg0'],
+      additionalProperties: false,
+    },
+    argGuards: [M.string()],
+    execute: async ({ arg0 }) => {
+      ran = true;
+      return arg0;
+    },
+  });
+
+  await null;
+  const err = await t.throwsAsync(() => tool.invoke({}));
+  t.true(
+    err !== undefined && err.message.includes('arg0'),
+    `error message should name the missing key; got: ${err?.message}`,
+  );
+  t.false(ran);
+});
+
+test('invoke rejects unknown argN keys', async t => {
+  const tool = makeTool({
+    name: 'strlen',
+    description: 'Length of a string.',
+    parameters: {
+      type: 'object',
+      properties: { arg0: { type: 'string' } },
+      required: ['arg0'],
+      additionalProperties: false,
+    },
+    argGuards: [M.string()],
+    execute: async ({ arg0 }) => /** @type {string} */ (arg0).length,
+  });
+
+  await null;
+  const err = await t.throwsAsync(() =>
+    tool.invoke({ arg0: 'hello', argZZ: 'extra' }),
+  );
+  t.true(
+    err !== undefined && err.message.includes('argZZ'),
+    `error message should name the offending key; got: ${err?.message}`,
+  );
+
+  t.is(await tool.invoke({ arg0: 'hello' }), 5);
+});
+
+test('invoke marshals named args to positional and validates each', async t => {
+  const tool = makeTool({
+    name: 'pair',
+    description: 'Two args.',
+    parameters: {
+      type: 'object',
+      properties: { arg0: { type: 'string' }, arg1: { type: 'object' } },
+      required: ['arg0'],
+      additionalProperties: false,
+    },
+    argGuards: [M.string(), M.recordOf(M.string(), M.any())],
+    execute: async ({ arg0, arg1 }) => ({ arg0, arg1 }),
+  });
+
+  await null;
+  t.deepEqual(await tool.invoke({ arg0: 'x' }), { arg0: 'x', arg1: undefined });
+
+  t.deepEqual(await tool.invoke({ arg0: 'x', arg1: { k: 1 } }), {
+    arg0: 'x',
+    arg1: { k: 1 },
+  });
+
+  await t.throwsAsync(() => tool.invoke({ arg0: 'x', arg1: 'not-a-record' }));
+});

--- a/packages/agent-tools/tool.d.ts
+++ b/packages/agent-tools/tool.d.ts
@@ -1,0 +1,1 @@
+export { makeTool } from './src/tool.js';

--- a/packages/agent-tools/tsconfig.json
+++ b/packages/agent-tools/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.eslint-base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/agent-tools/typedoc.json
+++ b/packages/agent-tools/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["types-index.js", "src/types.ts"],
+  "tsconfig": "../../tsconfig.json"
+}

--- a/packages/agent-tools/types-index.d.ts
+++ b/packages/agent-tools/types-index.d.ts
@@ -1,0 +1,4 @@
+export type * from './src/types.js';
+export { makeTool } from './src/tool.js';
+export { makeGitTool } from './src/git-tool.js';
+export { makeMountReadTool } from './src/mount-fs.js';

--- a/packages/agent-tools/types-index.js
+++ b/packages/agent-tools/types-index.js
@@ -1,0 +1,3 @@
+export { makeTool } from './src/tool.js';
+export { makeGitTool } from './src/git-tool.js';
+export { makeMountReadTool } from './src/mount-fs.js';

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -32,6 +32,8 @@
     "./locator.js": "./locator.js",
     "./pet-name.js": "./src/pet-name.js",
     "./src/interfaces.js": "./src/interfaces.js",
+    "./src/mount.js": "./src/mount.js",
+    "./src/daemon-node-powers.js": "./src/daemon-node-powers.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/endo-fs/types.d.ts
+++ b/packages/endo-fs/types.d.ts
@@ -25,6 +25,29 @@
 // here so downstream consumers don't need to depend on that package
 // transitively just for the shape.
 declare module '@endo/endo-fs' {
+  export type ERef<T> = T | PromiseLike<T>;
+
+  export interface Filesystem {
+    root(): ERef<Directory>;
+  }
+
+  export interface Directory {
+    lookup(name: string): ERef<Directory | File>;
+  }
+
+  export interface File {
+    open(opts: OpenFileOptions): ERef<OpenFile>;
+  }
+
+  export interface OpenFile {
+    read(offset: bigint, length?: bigint): ERef<unknown>;
+  }
+
+  export interface OpenFileOptions {
+    read?: boolean;
+    write?: boolean;
+  }
+
   /**
    * Build a `Filesystem` exo over an `FsBackend`.  Optional
    * `opts.description` populates `statfs().type`; `opts.namedDirs`
@@ -36,25 +59,25 @@ declare module '@endo/endo-fs' {
       description?: string;
       namedDirs?: Record<string, string[]>;
     },
-  ) => object;
+  ) => Filesystem;
 
   /**
    * Recursively wrap a `Filesystem` so every mutating verb rejects
    * with EACCES at the cap boundary.
    */
-  export const readOnly: (fs: object) => object;
+  export const readOnly: (fs: Filesystem) => Filesystem;
 
   /** Build an in-memory `Filesystem`. */
-  export const makeInMemoryFilesystem: () => object;
+  export const makeInMemoryFilesystem: () => Filesystem;
 
   /** Build a node:fs/promises-backed `Filesystem`. */
   export const makeNodeFilesystem: (opts: {
     rootPath: string;
     [key: string]: unknown;
-  }) => object;
+  }) => Filesystem;
 
   /** Adapt a daemon `Mount` to a `Filesystem`. */
-  export const mountAsFilesystem: (mount: object, opts?: object) => object;
+  export const mountAsFilesystem: (mount: object, opts?: object) => Filesystem;
 
   /** Build an in-memory `FsBackend`. */
   export const makeInMemoryBackend: (opts?: object) => object;
@@ -68,23 +91,26 @@ declare module '@endo/endo-fs' {
   /** Adapt a daemon `Mount` to an `FsBackend`. */
   export const makeFromMountBackend: (mount: object) => object;
 
-  export const emptyFilesystem: () => object;
-  export const chroot: (fs: object, subPath: string[]) => object;
+  export const emptyFilesystem: () => Filesystem;
+  export const chroot: (
+    fs: Filesystem,
+    subPath: readonly string[],
+  ) => Filesystem;
   export const bind: (
-    host: object,
-    mountPath: string[],
-    guest: object,
-  ) => object;
-  export const namespace: (mounts: Record<string, object>) => object;
+    host: Filesystem,
+    mountPath: readonly string[],
+    guest: Filesystem,
+  ) => Filesystem;
+  export const namespace: (mounts: Record<string, Filesystem>) => Filesystem;
   /**
    * CoW union: writes target `layer`, reads merge layer-over-backing.
    * `opts` is reserved for future composer flags; pass `{}` if needed.
    */
   export const compose: (
-    layer: object,
-    backing: object,
+    layer: Filesystem,
+    backing: Filesystem,
     opts?: object,
-  ) => object;
+  ) => Filesystem;
 
   export const makeLayer: (opts?: object) => object;
   export const LayerInterface: object;
@@ -94,9 +120,9 @@ declare module '@endo/endo-fs' {
   export const withCachedReads: (fs: object, cas: object) => object;
 
   export const walk: (
-    fs: object,
-    path: string[],
-  ) => AsyncIterable<{ path: string[]; kind: 'file' | 'directory' }>;
+    root: ERef<Directory>,
+    path: readonly string[],
+  ) => ERef<Directory | File>;
   export const collectBytes: (readerRef: object) => Promise<Uint8Array>;
   export const collectStream: (readerRef: object) => Promise<unknown[]>;
 

--- a/packages/exo-git/types.d.ts
+++ b/packages/exo-git/types.d.ts
@@ -9,6 +9,116 @@
  */
 
 declare module '@endo/exo-git' {
+  export type GitRef = { name: string; kind: string; oid?: string };
+  export type GitCommit = {
+    oid: string;
+    summary: string;
+    author?: string;
+    committedAt?: number;
+  };
+  export type GitIndexStatus =
+    | 'clean'
+    | 'added'
+    | 'modified'
+    | 'deleted'
+    | 'renamed'
+    | 'copied'
+    | 'conflicted';
+  export type GitWorktreeStatus =
+    | 'clean'
+    | 'modified'
+    | 'deleted'
+    | 'untracked'
+    | 'ignored'
+    | 'conflicted';
+  export type GitStatusEntry = {
+    entry: unknown;
+    path: string;
+    index: GitIndexStatus;
+    worktree: GitWorktreeStatus;
+    node?: unknown;
+    renamedFrom?: string;
+  };
+  export type GitDiffOptions = {
+    cached?: boolean;
+    base?: GitRef | string;
+    head?: GitRef | string;
+    entries?: unknown[];
+    paths?: string[];
+  };
+  export type GitLogOptions = {
+    maxCount?: number;
+    ref?: GitRef | string;
+    since?: string;
+    until?: string;
+  };
+  export type GitRestoreOptions = {
+    staged?: boolean;
+  };
+  export type GitCreateBranchOptions = {
+    startPoint?: string;
+    switchAfterCreate?: boolean;
+  };
+  export type GitDeleteBranchOptions = {
+    force?: boolean;
+  };
+  export type GitMergeOptions = {
+    fastForwardOnly?: boolean;
+    noFastForward?: boolean;
+  };
+  export type GitRebaseInput = {
+    mode?: 'start' | 'continue' | 'abort' | 'skip';
+    upstream?: string;
+  };
+  export type GitStashPushOptions = {
+    message?: string;
+    entries?: unknown[];
+    paths?: string[];
+    includeUntracked?: boolean;
+  };
+  export type EndoMount = unknown;
+  export type EndoMountEntry = unknown;
+  export type ReadableTreeView = unknown;
+  export type EndoGit = {
+    worktree: () => EndoMount;
+    status: () => Promise<GitStatusEntry[]>;
+    diff: (options?: GitDiffOptions) => Promise<string>;
+    log: (options?: GitLogOptions) => Promise<GitCommit[]>;
+    show: (ref: GitRef | string) => Promise<string>;
+    revParse: (ref: GitRef | string) => Promise<GitRef>;
+    add: (entries: EndoMountEntry[]) => Promise<void>;
+    restore: (
+      entries: EndoMountEntry[],
+      options?: GitRestoreOptions,
+    ) => Promise<void>;
+    commit: (message: string) => Promise<GitCommit>;
+    currentBranch: () => Promise<GitRef | undefined>;
+    branches: () => Promise<GitRef[]>;
+    createBranch: (
+      name: string,
+      options?: GitCreateBranchOptions,
+    ) => Promise<GitRef>;
+    deleteBranch: (
+      name: string,
+      options?: GitDeleteBranchOptions,
+    ) => Promise<void>;
+    renameBranch: (from: string, to: string) => Promise<void>;
+    switchBranch: (name: string) => Promise<void>;
+    detach: (ref: GitRef | string) => Promise<void>;
+    switch: (ref: GitRef | string) => Promise<void>;
+    merge: (ref: GitRef | string, options?: GitMergeOptions) => Promise<string>;
+    rebase: (input: GitRebaseInput) => Promise<string>;
+    stashPush: (options?: GitStashPushOptions) => Promise<string>;
+    stashList: () => Promise<string[]>;
+    stashShow: (index?: number) => Promise<string>;
+    stashApply: (index?: number) => Promise<void>;
+    stashPop: (index?: number) => Promise<void>;
+    stashDrop: (index?: number) => Promise<void>;
+    tree: (ref: GitRef | string) => Promise<ReadableTreeView>;
+    filesystemAt: (ref: GitRef | string) => Promise<unknown>;
+    readOnly: () => EndoGit;
+  };
+
   /** Build the `EndoGit` exo over a `Mount` and a `GitBackend`. */
   export const makeGit: (powers: {
     mount: object;

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:0.91.1":
+"@anthropic-ai/sdk@npm:^0.91.1":
   version: 0.91.1
   resolution: "@anthropic-ai/sdk@npm:0.91.1"
   dependencies:
@@ -112,262 +112,421 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-bedrock-runtime@npm:3.1048.0":
-  version: 3.1048.0
-  resolution: "@aws-sdk/client-bedrock-runtime@npm:3.1048.0"
+"@aws-sdk/client-bedrock-runtime@npm:^3.1030.0":
+  version: 3.1041.0
+  resolution: "@aws-sdk/client-bedrock-runtime@npm:3.1041.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:^3.974.11"
-    "@aws-sdk/credential-provider-node": "npm:^3.972.42"
-    "@aws-sdk/eventstream-handler-node": "npm:^3.972.16"
-    "@aws-sdk/middleware-eventstream": "npm:^3.972.12"
-    "@aws-sdk/middleware-websocket": "npm:^3.972.19"
-    "@aws-sdk/token-providers": "npm:3.1048.0"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.39"
+    "@aws-sdk/eventstream-handler-node": "npm:^3.972.14"
+    "@aws-sdk/middleware-eventstream": "npm:^3.972.10"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.10"
+    "@aws-sdk/middleware-logger": "npm:^3.972.10"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.11"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
+    "@aws-sdk/middleware-websocket": "npm:^3.972.16"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.13"
+    "@aws-sdk/token-providers": "npm:3.1041.0"
     "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/core": "npm:^3.24.2"
-    "@smithy/fetch-http-handler": "npm:^5.4.2"
-    "@smithy/node-http-handler": "npm:^4.7.2"
+    "@aws-sdk/util-endpoints": "npm:^3.996.8"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.10"
+    "@aws-sdk/util-user-agent-node": "npm:^3.973.24"
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.14"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.14"
+    "@smithy/eventstream-serde-node": "npm:^4.2.14"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/hash-node": "npm:^4.2.14"
+    "@smithy/invalid-dependency": "npm:^4.2.14"
+    "@smithy/middleware-content-length": "npm:^4.2.14"
+    "@smithy/middleware-endpoint": "npm:^4.4.32"
+    "@smithy/middleware-retry": "npm:^4.5.7"
+    "@smithy/middleware-serde": "npm:^4.2.20"
+    "@smithy/middleware-stack": "npm:^4.2.14"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
     "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-body-length-browser": "npm:^4.2.2"
+    "@smithy/util-body-length-node": "npm:^4.2.3"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.49"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.54"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/util-stream": "npm:^4.5.25"
+    "@smithy/util-utf8": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8172a964cf580631e02906bc1312f1b44ad862a367417600e45f65f79a6f35318a713393ba565af6b73292071ee52751d405696a864820b12c70ffdb75dc06c1
+  checksum: 10c0/ea42e319b5f5ff86c0082a88b073f0320438bc2bdc62f25c4ea3782d04977f81240532a61ab75269e56284bd7b8835280e5ed4890033a97eba43b6bfe9429ec9
   languageName: node
   linkType: hard
 
-"@aws-sdk/core@npm:^3.974.11, @aws-sdk/core@npm:^3.974.17":
-  version: 3.974.17
-  resolution: "@aws-sdk/core@npm:3.974.17"
+"@aws-sdk/core@npm:^3.974.8":
+  version: 3.974.8
+  resolution: "@aws-sdk/core@npm:3.974.8"
   dependencies:
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@aws-sdk/xml-builder": "npm:^3.972.27"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/xml-builder": "npm:^3.972.22"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7b7e01e01e8b5f28b5d1b3d6f263bcf1b395600c2401009ad2b398a39b43ade33eacd59371c1e960c969f8164bfa9aff3ce950a5ba527a73c82eedc21456850f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:^3.972.34":
+  version: 3.972.34
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.34"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2f75940784b92ff71292b6dc5e660982f80bcfb4c3fcd0f0a04b0ff7de0a5b91000505b947434813b1104647d05678c3504560a7937aa82639e0042cb4597705
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:^3.972.36":
+  version: 3.972.36
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.36"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-stream": "npm:^4.5.25"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b3dd17e4403b3ef026a65da15cc3d08fdfddd42449f6d10edc6a4b016ed05306f7d4fe1fe286abd00bcf6cf3817ed19556fd97db9b2449deb0182569980dcd01
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.34"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.36"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.38"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.34"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.38"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.38"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/credential-provider-imds": "npm:^4.2.14"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/198c7e3f88f525f814f599f6a1bc3a63c84ed046140017786f23de255adcb5c90f0bbcf9ec167c8c6771d63270f7ed9ac061713884ecddebc01da74be88ee6ea
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-login@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f84ab04b8fec3355dce3d2a0f9bd63e79ef04915f019f2b6731a267e853f7cfb066baf67a22c955e58aa86f5b6eded6acdfdfd67532cc923edeefb8e88f46d63
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:^3.972.39":
+  version: 3.972.39
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.39"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.34"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.36"
+    "@aws-sdk/credential-provider-ini": "npm:^3.972.38"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.34"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.38"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.38"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/credential-provider-imds": "npm:^4.2.14"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e21808419372f95c842ed6f893d15599565a1fa9dffed81256a374f98ef3a3c276ab4be30fbaac963e5c4761b676fe10482f5a6b1fb2b03273b18e9ecd30c12d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.34":
+  version: 3.972.34
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.34"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f65dbaaa40a81ba8e84d314e8ac0528f6d807b63b98820102ffccb38f47b1aa52f0c6dd4d7e4e8df186cef9cd57041e1d2d929c0e692804a8af0d06497f38a6a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/token-providers": "npm:3.1041.0"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4919362e1b8f6b73b8ec8ed0e0cc8f7a33db9b0d3ef63346a03047a024910d1acc6d80428a51444f6f15d58534dd535bc461b8505dd8f1cd6dc4fd8f863f956d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7a235d693dae5578c15448c8484d68ca7749ffd327b4e3784e3a1c6784a14535b398cc09c6be26e97042779acc261adedc7064681b930d93ebcda26da17c1f72
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-handler-node@npm:^3.972.14":
+  version: 3.972.14
+  resolution: "@aws-sdk/eventstream-handler-node@npm:3.972.14"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/eventstream-codec": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9e91aeddfbc23d41b8628c8ed93582857941c3caabe94aeccc28bfe0156270d392c90d214ed24bf8367d16266b274b4cd01a96069ed0d6ab64adfd7b369ab0b3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-eventstream@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-eventstream@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/425a0cf0d1c3c079f63fb4a2017350867e4f62082bf261375387a64f1b41d3bf2392a7b38590306ebf440c211083e83c6089c5dfb624b81c41bea9a8a7f98dd4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-host-header@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e631b48f8d8fd40f8977da8d1fc012208f953000dd5645dc0a700c7283af8fafb996c9c1c50e40b8392c402ad98d11e0ddddb949896db5163a7f06e2385e619a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-logger@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a24e0c98b3cf6c9b7960bf8979d2ab8f839fb89294ba8943136d99dbe7370cc45b010460ed7f5bf14ab6ad8e113ccec6387cf1bda655bcbdb58722df21d9b713
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:^3.972.11":
+  version: 3.972.11
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.972.11"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
     "@aws/lambda-invoke-store": "npm:^0.2.2"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/signature-v4": "npm:^5.4.6"
-    "@smithy/types": "npm:^4.14.3"
-    bowser: "npm:^2.11.0"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/beec8841b27a88c8c54df66ba2593668eb400ab7df0507ee6de03999077d01de79d2a0454005ec85953f2c90fa735060c99465a618f11e5b443c236880597512
+  checksum: 10c0/e52501b00e79e714218897ddec9edd40ecf33fdb43c19b00195c8ed71c8295d0d148f07465465d464f103a23aa535dc1daf60bbb5b95303e330767a5eba78f54
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:^3.972.43":
-  version: 3.972.43
-  resolution: "@aws-sdk/credential-provider-env@npm:3.972.43"
+"@aws-sdk/middleware-sdk-s3@npm:^3.972.37":
+  version: 3.972.37
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.37"
   dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-arn-parser": "npm:^3.972.3"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-config-provider": "npm:^4.2.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-stream": "npm:^4.5.25"
+    "@smithy/util-utf8": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8f75167eb52d156b9fe5107a3e9920e985b61a28b23f0926842c8348f56628a9e3cd79350069aef272968ebc6794d1e22714184fd20471cfe00a7cacc585c9c7
+  checksum: 10c0/c8d4ad6aa908eca70ef085ac2c55362229071caa9518ed538574cc4d317d9f1f4e2173d6b01259dd83f77356ad4b68656b5720a31b3effe01f7fe10aec265aed
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-http@npm:^3.972.45":
-  version: 3.972.45
-  resolution: "@aws-sdk/credential-provider-http@npm:3.972.45"
+"@aws-sdk/middleware-user-agent@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.972.38"
   dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/fetch-http-handler": "npm:^5.4.6"
-    "@smithy/node-http-handler": "npm:^4.7.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-endpoints": "npm:^3.996.8"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-retry": "npm:^4.3.6"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/904a5bc2e961354404226b1da8503de2d4b7b540d0308bb674bd793f48eda1cb710b83becc585abb52361d353f06d85e39937f3d2a56b8b39d2ee3be781ad799
+  checksum: 10c0/b9cf9416bc276b4abf42513515de5ee45ee419255b5953c9e53b44010500fcc486de988351683ecae52bf00c6bb5819c67375261afe1375b8a2a44196a8b9884
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:^3.972.48":
-  version: 3.972.48
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.48"
+"@aws-sdk/middleware-websocket@npm:^3.972.16":
+  version: 3.972.16
+  resolution: "@aws-sdk/middleware-websocket@npm:3.972.16"
   dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/credential-provider-env": "npm:^3.972.43"
-    "@aws-sdk/credential-provider-http": "npm:^3.972.45"
-    "@aws-sdk/credential-provider-login": "npm:^3.972.47"
-    "@aws-sdk/credential-provider-process": "npm:^3.972.43"
-    "@aws-sdk/credential-provider-sso": "npm:^3.972.47"
-    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.47"
-    "@aws-sdk/nested-clients": "npm:^3.997.15"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/credential-provider-imds": "npm:^4.3.7"
-    "@smithy/types": "npm:^4.14.3"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-format-url": "npm:^3.972.10"
+    "@smithy/eventstream-codec": "npm:^4.2.14"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.14"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-hex-encoding": "npm:^4.2.2"
+    "@smithy/util-utf8": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d3b4b869a2eb9c8a6b0b076f9ecbf0d9036a10e2a7af5d34a7be856e92bd3a7ddec00f04234e023a3ab3a1e3edfe6b7b52b7c7589a3817be6eaf505eca48d4c8
+  checksum: 10c0/2eb40a402be07af99a5b11e63d1ef408c8d0e90fd6692665cb3e8f5d827841f1dedf7c84a5b233b76141dcd9c0d8210194286779808a639149eff6cadf2ba458
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-login@npm:^3.972.47":
-  version: 3.972.47
-  resolution: "@aws-sdk/credential-provider-login@npm:3.972.47"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/nested-clients": "npm:^3.997.15"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/3fd44948542ed2393de13a68f0e38f77a39146ad27d70fb9cfdb20eea8085d84c3c5b4ee3ef2bcf109e765d1dbf80c0dcdf336f3ebcb494fc252b54ed5dd1e0c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:^3.972.42":
-  version: 3.972.50
-  resolution: "@aws-sdk/credential-provider-node@npm:3.972.50"
-  dependencies:
-    "@aws-sdk/credential-provider-env": "npm:^3.972.43"
-    "@aws-sdk/credential-provider-http": "npm:^3.972.45"
-    "@aws-sdk/credential-provider-ini": "npm:^3.972.48"
-    "@aws-sdk/credential-provider-process": "npm:^3.972.43"
-    "@aws-sdk/credential-provider-sso": "npm:^3.972.47"
-    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.47"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/credential-provider-imds": "npm:^4.3.7"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/b823c0c730ae94ac62cef0de7b4f765457b4074e3ca665daacd033efb252025358efd7e65a3e99e27c719fe6fa968cd91e6035116f9fb76fcad1edae95c24f23
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:^3.972.43":
-  version: 3.972.43
-  resolution: "@aws-sdk/credential-provider-process@npm:3.972.43"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/76ef1711c592bbe5f56d1c163663ac847fc971a60ae00280214367ca4b528838030f0efb2ecc25fc231488626b5fd03e19283ed8410bfba3dc8f0ab61079e397
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-sso@npm:^3.972.47":
-  version: 3.972.47
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.47"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/nested-clients": "npm:^3.997.15"
-    "@aws-sdk/token-providers": "npm:3.1060.0"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/1d90103f45dc8f83507545b702c577afb90569df060e9bd10e94180ef02a5e85e3f7b492d24f065dd40f1c8e5ee68eca812e6a398f42d59438295d902fcc8966
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:^3.972.47":
-  version: 3.972.47
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.47"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/nested-clients": "npm:^3.997.15"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/0f9bd22250bc9d20d2a80c45b24b2ddc5ea2d695c5f63e517461588d16b43df8c733b50e518697416eac287580112a2cce4278efe8f3b4e7042d0ab6f19a99db
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-handler-node@npm:^3.972.16":
-  version: 3.972.19
-  resolution: "@aws-sdk/eventstream-handler-node@npm:3.972.19"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/a77c33b1545ba441e1a485990abd0e8120a49f78e08b6ea3b6ec465ec77eecec1670436ca5699e0cf80def434617d8145d570772d0d7e2fb96f94edd658bb8ea
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-eventstream@npm:^3.972.12":
-  version: 3.972.15
-  resolution: "@aws-sdk/middleware-eventstream@npm:3.972.15"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/3d2bed9cff37779e2ce7910bcf2fa5b21e8e791bc24a7509f556ec15c1431cc42a79134a4a5e54df192bf64164975bb0ae93fd322ac1cd06b129d2ce62cf34fa
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-websocket@npm:^3.972.19":
-  version: 3.972.25
-  resolution: "@aws-sdk/middleware-websocket@npm:3.972.25"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/fetch-http-handler": "npm:^5.4.6"
-    "@smithy/signature-v4": "npm:^5.4.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/58f3ab23721a8adfdfd3a97f929a89b0840d50f270f15020e2d3296f1c130407f5f50c73663e1a2de00c42ff411537b6c2e852396342bfe65d8d3f47d7ec8855
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/nested-clients@npm:^3.997.15, @aws-sdk/nested-clients@npm:^3.997.9":
-  version: 3.997.15
-  resolution: "@aws-sdk/nested-clients@npm:3.997.15"
+"@aws-sdk/nested-clients@npm:^3.997.6":
+  version: 3.997.6
+  resolution: "@aws-sdk/nested-clients@npm:3.997.6"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.31"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/fetch-http-handler": "npm:^5.4.6"
-    "@smithy/node-http-handler": "npm:^4.7.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/f6f426f96be80779433894f759d0454bd87d32e12dde9e70c320de99d18e778368b669fa71aa439d1acdf304421612c0f7617591cf6fa84c1886330776ab60fe
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4-multi-region@npm:^3.996.31":
-  version: 3.996.31
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.31"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/signature-v4": "npm:^5.4.6"
-    "@smithy/types": "npm:^4.14.3"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/f319bf8f30005ea1771d7d3e82faa8ec9354539b179ec0a0676aec1aee758bbc2d7a57a3956d361d015e999db962c79ccbd5a1a4f7f0196efe9647095236c134
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/token-providers@npm:3.1048.0":
-  version: 3.1048.0
-  resolution: "@aws-sdk/token-providers@npm:3.1048.0"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.11"
-    "@aws-sdk/nested-clients": "npm:^3.997.9"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.10"
+    "@aws-sdk/middleware-logger": "npm:^3.972.10"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.11"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.13"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.25"
     "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/core": "npm:^3.24.2"
+    "@aws-sdk/util-endpoints": "npm:^3.996.8"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.10"
+    "@aws-sdk/util-user-agent-node": "npm:^3.973.24"
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/hash-node": "npm:^4.2.14"
+    "@smithy/invalid-dependency": "npm:^4.2.14"
+    "@smithy/middleware-content-length": "npm:^4.2.14"
+    "@smithy/middleware-endpoint": "npm:^4.4.32"
+    "@smithy/middleware-retry": "npm:^4.5.7"
+    "@smithy/middleware-serde": "npm:^4.2.20"
+    "@smithy/middleware-stack": "npm:^4.2.14"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-body-length-browser": "npm:^4.2.2"
+    "@smithy/util-body-length-node": "npm:^4.2.3"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.49"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.54"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/05c74c7362be74c723b64667763bd1e635c8d566456f70b64fa26546e7c605a49bf1bede7c2f5c293a0677b737093bbdc9b957a26124b9e1de5acf715dc57bb4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/region-config-resolver@npm:^3.972.13":
+  version: 3.972.13
+  resolution: "@aws-sdk/region-config-resolver@npm:3.972.13"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/node-config-provider": "npm:^4.3.14"
     "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4dbca618047f9a051999031e0f027098fbd880fe7732bcd38cd0fd48461c41d7f28797bbf4292aa573815d7a2cdd44a0dad1fafd1922f52792f70c54bfd165b2
+  checksum: 10c0/8cc3e5433ccf9ec4efb6d12ccd924701cfd6fb018124c9e5106486da10402ea1b83b0855353dae5e0f31ad2c7b6d962ac832350a5cdbeda59a30231525fd1118
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.1060.0":
-  version: 3.1060.0
-  resolution: "@aws-sdk/token-providers@npm:3.1060.0"
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.25":
+  version: 3.996.25
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.25"
   dependencies:
-    "@aws-sdk/core": "npm:^3.974.17"
-    "@aws-sdk/nested-clients": "npm:^3.997.15"
-    "@aws-sdk/types": "npm:^3.973.10"
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.37"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/630be421583ac3f779d1229805784385aac52193cdada290529835ec768a86762a2928083801fa581bf70c0e96b9fd1e50307ceecfbfe2783f006bb445974821
+  checksum: 10c0/05196c85d265e5e59df621c7844235a449a940ebc8264578c0f87d76b6fbb741650a5634433589b9223a05003198be214068eef7d6e50596196de0f1d1954b5d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.1041.0":
+  version: 3.1041.0
+  resolution: "@aws-sdk/token-providers@npm:3.1041.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/af70f8e23a98a750dcb661b43bbd896e4a2425f553336c491b118a058e46691689ac4fa980f69d2dae42d1488f3b859adbd2f347d73ac1261f44b421d2041101
   languageName: node
   linkType: hard
 
@@ -381,13 +540,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:^3.973.10":
-  version: 3.973.10
-  resolution: "@aws-sdk/types@npm:3.973.10"
+"@aws-sdk/util-arn-parser@npm:^3.972.3":
+  version: 3.972.3
+  resolution: "@aws-sdk/util-arn-parser@npm:3.972.3"
   dependencies:
-    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/39925f52641effda9722093bb204818552c0504190e920945a4dd5da2dd1c7245d805a50595ae5a01353e0274e999566a9ad0f50af07db245ff2e3d7bcfd66a2
+  checksum: 10c0/75c94dcd5d99a60375ce3474b0ee4f1ca17abdcd46ffbf34ce9d2e15238d77903c8993dddd46f1f328a7989c5aaec0c7dfef8b3eaa3e1125bea777399cfc46f2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-endpoints@npm:^3.996.8":
+  version: 3.996.8
+  resolution: "@aws-sdk/util-endpoints@npm:3.996.8"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/66f17e85357ab8e265ab7d1c9a69a064ad3bea99420c786be9ef1f92bc71dca22d328bbceeaf6c64b4a3c37161b78318a3e4a424bf247dcb211d7ae29344db2f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-format-url@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/util-format-url@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/querystring-builder": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d97445228f8ae9f8b7b53659e57d68c28f406d025d2902c6d1ba9bbb386d990011951d77f5a3d82360dc7bc5fd39a12c5e8bc27975ede72e586466597857cd19
   languageName: node
   linkType: hard
 
@@ -400,14 +583,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/xml-builder@npm:^3.972.27":
-  version: 3.972.27
-  resolution: "@aws-sdk/xml-builder@npm:3.972.27"
+"@aws-sdk/util-user-agent-browser@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.972.10"
   dependencies:
-    "@smithy/types": "npm:^4.14.3"
-    fast-xml-parser: "npm:5.7.3"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/types": "npm:^4.14.1"
+    bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/6544aee8bd653252da337dd83482309a5fd46159a8e50280795708c7cf9194c19bf63a75e086ad764ec52fbc239857a03e7ae238a213f5dfa4aa496cbf938f1d
+  checksum: 10c0/e139dda2cb51a0a3553c80ec6f89c39cb1292876c116f8449f21a7fdbe39bd7b545ef8ea69a447dd9fa2aa43c99f625ee6a55cbf6d8e6cf2094d0ef00ceb1e36
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:^3.973.24":
+  version: 3.973.24
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.973.24"
+  dependencies:
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-config-provider": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 10c0/859c6441d1d24594d73a125c2a335faeb412a5cc3ab318005ce2e4904c3f9a0c6781437ae0fb2e3a1eb2343146dafbb9ac037ea88fbd8e78d50f7153732c5bb4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.22":
+  version: 3.972.22
+  resolution: "@aws-sdk/xml-builder@npm:3.972.22"
+  dependencies:
+    "@nodable/entities": "npm:2.1.0"
+    "@smithy/types": "npm:^4.14.1"
+    fast-xml-parser: "npm:5.7.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4d9a7056a8ce6af639a9fa354f70a5a895b2e23c06c027776849d32ba18aa0d7f174133f1bc15756b79ac2bfdb9d990f092fb76a3891a7d1f6b03a424a8a6735
   languageName: node
   linkType: hard
 
@@ -537,13 +752,6 @@ __metadata:
   version: 7.27.1
   resolution: "@babel/helper-string-parser@npm:7.27.1"
   checksum: 10c0/8bda3448e07b5583727c103560bcf9c4c24b3c1051a4c516d4050ef69df37bb9a4734a585fe12725b8c2763de0a265aa1e909b485a4e3270b7cfd3e4dbe4b602
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.24.7":
-  version: 7.29.7
-  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
-  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
   languageName: node
   linkType: hard
 
@@ -1057,38 +1265,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@earendil-works/pi-agent-core@npm:^0.79.0":
-  version: 0.79.0
-  resolution: "@earendil-works/pi-agent-core@npm:0.79.0"
-  dependencies:
-    "@earendil-works/pi-ai": "npm:^0.79.0"
-    ignore: "npm:7.0.5"
-    typebox: "npm:1.1.38"
-    yaml: "npm:2.9.0"
-  checksum: 10c0/88e2623637ed854446164afe47e63617434696312d93405308dacfb78f7014196e62c1fb99ff67710d7e34c1fbe0e390ac82788a3b5eda6a0cbdf1a5d8ef0efc
-  languageName: node
-  linkType: hard
-
-"@earendil-works/pi-ai@npm:^0.79.0":
-  version: 0.79.0
-  resolution: "@earendil-works/pi-ai@npm:0.79.0"
-  dependencies:
-    "@anthropic-ai/sdk": "npm:0.91.1"
-    "@aws-sdk/client-bedrock-runtime": "npm:3.1048.0"
-    "@google/genai": "npm:1.52.0"
-    "@mistralai/mistralai": "npm:2.2.1"
-    "@smithy/node-http-handler": "npm:4.7.3"
-    http-proxy-agent: "npm:7.0.2"
-    https-proxy-agent: "npm:7.0.6"
-    openai: "npm:6.26.0"
-    partial-json: "npm:0.1.7"
-    typebox: "npm:1.1.38"
-  bin:
-    pi-ai: dist/cli.js
-  checksum: 10c0/db32adba4af2f5911e36fa0709648138db994fd7ef75fd2aac06d8109829cf4f3050075cae7f937ab73c19ca1f3fa977c040463cd22d15a182797c44dd2d05c5
-  languageName: node
-  linkType: hard
-
 "@electron/asar@npm:^4.0.0, @electron/asar@npm:^4.0.1":
   version: 4.2.0
   resolution: "@electron/asar@npm:4.2.0"
@@ -1290,6 +1466,24 @@ __metadata:
     "@endo/patterns": "workspace:^"
     ava: "catalog:dev"
     eslint: "catalog:dev"
+  languageName: unknown
+  linkType: soft
+
+"@endo/agent-tools@workspace:packages/agent-tools":
+  version: 0.0.0-use.local
+  resolution: "@endo/agent-tools@workspace:packages/agent-tools"
+  dependencies:
+    "@endo/daemon": "workspace:^"
+    "@endo/endo-fs": "workspace:^"
+    "@endo/exo-git": "workspace:^"
+    "@endo/far": "workspace:^"
+    "@endo/init": "workspace:^"
+    "@endo/patterns": "workspace:^"
+    ajv: "npm:^8.17.1"
+    ava: "catalog:dev"
+    c8: "catalog:dev"
+    eslint: "catalog:dev"
+    typescript: "catalog:dev"
   languageName: unknown
   linkType: soft
 
@@ -1755,8 +1949,6 @@ __metadata:
     tsutils: "npm:~3.21.0"
     typescript: "catalog:dev"
     typescript-eslint: "npm:8.59.2"
-  peerDependencies:
-    eslint-plugin-unicorn: ^56.0.1
   languageName: unknown
   linkType: soft
 
@@ -1937,8 +2129,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/genie@workspace:packages/genie"
   dependencies:
-    "@earendil-works/pi-agent-core": "npm:^0.79.0"
-    "@earendil-works/pi-ai": "npm:^0.79.0"
     "@endo/cli": "workspace:^"
     "@endo/daemon": "workspace:^"
     "@endo/errors": "workspace:^"
@@ -1953,6 +2143,8 @@ __metadata:
     "@endo/sandbox": "workspace:^"
     "@endo/ses-ava": "workspace:^"
     "@fast-check/ava": "catalog:dev"
+    "@mariozechner/pi-agent-core": "npm:^0.73.1"
+    "@mariozechner/pi-ai": "npm:^0.73.1"
     ava: "catalog:dev"
     better-sqlite3: "npm:^11.0.0"
     eslint: "catalog:dev"
@@ -3057,7 +3249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0, @eslint-community/eslint-utils@npm:^4.7.0, @eslint-community/eslint-utils@npm:^4.9.1":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.7.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -3154,9 +3346,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google/genai@npm:1.52.0":
-  version: 1.52.0
-  resolution: "@google/genai@npm:1.52.0"
+"@google/genai@npm:^1.40.0":
+  version: 1.51.0
+  resolution: "@google/genai@npm:1.51.0"
   dependencies:
     google-auth-library: "npm:^10.3.0"
     p-retry: "npm:^4.6.2"
@@ -3167,7 +3359,7 @@ __metadata:
   peerDependenciesMeta:
     "@modelcontextprotocol/sdk":
       optional: true
-  checksum: 10c0/2d22f6bd4baa915a402289dae4797410acbd5c5add1ed0c8d1bedef3ac7871fe1f04640d0612aa793fe7055f086719487491f55474a5b21597addfdea8631fa6
+  checksum: 10c0/e82e938f43f833f8d424532cb02a4fbbf266fe9740ca20bf02795f22e5adf708b5e5d21aa6e9b9dc31bc322c9f2dd1c33c773adf95ce0b9decae633ab28811c9
   languageName: node
   linkType: hard
 
@@ -4068,7 +4260,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mistralai/mistralai@npm:2.2.1":
+"@mariozechner/pi-agent-core@npm:^0.73.1":
+  version: 0.73.1
+  resolution: "@mariozechner/pi-agent-core@npm:0.73.1"
+  dependencies:
+    "@mariozechner/pi-ai": "npm:^0.73.1"
+    typebox: "npm:^1.1.24"
+  checksum: 10c0/30d88a57c821d11ae93e49c47b22038348be0ac6b23293a13530ee406cef460464484c661045fcbc83eb9fab7a8d35381d8ae65fa19de62b2c5f99463479efac
+  languageName: node
+  linkType: hard
+
+"@mariozechner/pi-ai@npm:^0.73.1":
+  version: 0.73.1
+  resolution: "@mariozechner/pi-ai@npm:0.73.1"
+  dependencies:
+    "@anthropic-ai/sdk": "npm:^0.91.1"
+    "@aws-sdk/client-bedrock-runtime": "npm:^3.1030.0"
+    "@google/genai": "npm:^1.40.0"
+    "@mistralai/mistralai": "npm:^2.2.0"
+    chalk: "npm:^5.6.2"
+    openai: "npm:6.26.0"
+    partial-json: "npm:^0.1.7"
+    proxy-agent: "npm:^6.5.0"
+    typebox: "npm:^1.1.24"
+    undici: "npm:^7.19.1"
+    zod-to-json-schema: "npm:^3.24.6"
+  bin:
+    pi-ai: dist/cli.js
+  checksum: 10c0/0afc3ee124b191ab69d8e897f0e02a5615b3013b556cd49c069ea023963920759d1e20441ad688b411e2ceeac3f2b2dae8142c7ad8c9237830e782343716e520
+  languageName: node
+  linkType: hard
+
+"@mistralai/mistralai@npm:^2.2.0":
   version: 2.2.1
   resolution: "@mistralai/mistralai@npm:2.2.1"
   dependencies:
@@ -4227,7 +4450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodable/entities@npm:^2.1.0":
+"@nodable/entities@npm:2.1.0, @nodable/entities@npm:^2.1.0":
   version: 2.1.0
   resolution: "@nodable/entities@npm:2.1.0"
   checksum: 10c0/5a4cba2b61a5b6c726328b18b1de6d033cae4a658a118644bf31e0bcbda126ea7b69385043dc556cf1ed859b9ca220e82b81b5e5c48ef1b519fb8ec104575dee
@@ -5487,36 +5710,138 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^3.24.2, @smithy/core@npm:^3.24.3, @smithy/core@npm:^3.24.6":
-  version: 3.24.6
-  resolution: "@smithy/core@npm:3.24.6"
+"@smithy/config-resolver@npm:^4.4.17":
+  version: 4.4.17
+  resolution: "@smithy/config-resolver@npm:4.4.17"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-config-provider": "npm:^4.2.2"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/44e653e2ed31bf765f0b30ca404dc3e02f30ad800971f812a6363b71da8d37de5d7d8901d9db4d86d2493f25037904f35c01bbb1a83a2a72e7e7b201ce5c411a
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^3.23.17":
+  version: 3.23.17
+  resolution: "@smithy/core@npm:3.23.17"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-body-length-browser": "npm:^4.2.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-stream": "npm:^4.5.25"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    "@smithy/uuid": "npm:^1.1.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/223631835e93c314a8fa394db724673c0940d3ba9e5ffbd73bd7c09854d7e003d19de950b44ce408e099c72ed3c22eb5e41370abea4ac656f7037e6da07be3c1
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/credential-provider-imds@npm:4.2.14"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/62ced0249cb1ba64c6dd98a90b35b93dd9e3f1469d020752c46b5a83ecef38280f4b29c2f63e3b0c414a2fa2ec7631a19370415c80ed4d6ea18a9be040803126
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-codec@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/eventstream-codec@npm:4.2.14"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-hex-encoding": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4d3db2296a99a4bcb17007b8276a243930f63c3169b9b86b973a2d1422e8dee7e95e3b98eea115e2759b989b23db1ff89ca505bddbacb7391ca3fe4e222b84ff
+  checksum: 10c0/c2f9139004b3f75d3621b21e0ef80f850baf4955cce230e6d18faef171c2b4dc62694b1d86d4000a7ec1babb482afeca666520f69cf31455ed63259da6b2a3ee
   languageName: node
   linkType: hard
 
-"@smithy/credential-provider-imds@npm:^4.3.7":
-  version: 4.3.7
-  resolution: "@smithy/credential-provider-imds@npm:4.3.7"
+"@smithy/eventstream-serde-browser@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/eventstream-serde-browser@npm:4.2.14"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/eventstream-serde-universal": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9a2f44c8bdc7f7770163fa26bc83f8adbb9e02c6ffa98751af3cbfc8107652d0a8e2a7bffc9761de20b776957eff33a865ec24523644b131003286bd2def9a4e
+  checksum: 10c0/b624cf962ec84bbc61c419938de07548cbff3b1049fe5fb0c88097bdb516e6f3af22f6856ab3a5212cf352e7f1c69b0c5d03370cb4fe7f91a29dff975c385da5
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^5.4.2, @smithy/fetch-http-handler@npm:^5.4.6":
-  version: 5.4.6
-  resolution: "@smithy/fetch-http-handler@npm:5.4.6"
+"@smithy/eventstream-serde-config-resolver@npm:^4.3.14":
+  version: 4.3.14
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.3.14"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/06fd6f9a819766d1071ad0eca774ecd936b0b130057076a5e42f1bcc9c751deeddfa279adc4bcddd71ac7699744a2ed06a0405a239a379d98670855d18a6586b
+  checksum: 10c0/d889a6e12797928c9507e99193f86ba0b7807441b67305643ec6b8b953c54237aa0ae7a4baaf00eb72ff07e3c71e88d6225de3db3d2b33729af38adb81b593f8
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-node@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/eventstream-serde-node@npm:4.2.14"
+  dependencies:
+    "@smithy/eventstream-serde-universal": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c9dda5011ef3e6565dfa483811567b942fd822dfefb41768213fc9322b5298075c4a9228f8aa745af5bcebb23a2a61e24f091ce2be263da1ca3713aafa89c243
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-universal@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/eventstream-serde-universal@npm:4.2.14"
+  dependencies:
+    "@smithy/eventstream-codec": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/82cf563ff67b6543f0981dc3b1ef7fc3b507d5322e611a4f7fde4ae90d1d0eae172298c5bdda3837c5dd5c4d8839d59b72189797e178709be7b1996b3ea71a64
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^5.3.17":
+  version: 5.3.17
+  resolution: "@smithy/fetch-http-handler@npm:5.3.17"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/querystring-builder": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-base64": "npm:^4.3.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/8adac6bf9d5735f8ddbe9e59dd268f985881b64b03cba7e83401471b3094139189476324fe640bbd19d75f5cd8e098d9a2a7f4925bc9fadecd1ccbe937773c12
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-node@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/hash-node@npm:4.2.14"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-buffer-from": "npm:^4.2.2"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c2cfc5dac4f2b996c4c5c503d3c26e52fcd0a647e71541182b24a48925801659828c9d378dad6857444b9d997c1655bdb23f6db5994ad8b7c814b2d0a09655b7
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/invalid-dependency@npm:4.2.14"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/deba2c21232050de87e7893b86a27a8f080ace391a3cccf22d7aee183bc3b392247f3bb1a0e4f0b6ea6f928c18ba035fd2ed3af257178ba84f3564d47c635d16
   languageName: node
   linkType: hard
 
@@ -5529,36 +5854,194 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:4.7.3":
-  version: 4.7.3
-  resolution: "@smithy/node-http-handler@npm:4.7.3"
+"@smithy/is-array-buffer@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/is-array-buffer@npm:4.2.2"
   dependencies:
-    "@smithy/core": "npm:^3.24.3"
-    "@smithy/types": "npm:^4.14.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/805002fc7e55f48f61d15de738dcd79f7bf8fbd372157b2967a9ac7616d76b744a410cc58efd672fa9c8f1592f5a8410aff35e3bd77ea5dfc47ff7c08fe42373
+  checksum: 10c0/ab5bf2cad0f3bc6c1d882e15de436b80fa1504739ab9facc3d7006003870855480a6b15367e516fd803b3859c298b1fcc9212c854374b7e756cda01180bab0a6
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^4.7.2, @smithy/node-http-handler@npm:^4.7.6":
-  version: 4.7.6
-  resolution: "@smithy/node-http-handler@npm:4.7.6"
+"@smithy/middleware-content-length@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/middleware-content-length@npm:4.2.14"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e926567ffda09c55c992f83449e185208a0fe87b0037254f8621dc13c495c2a8e6a24e0fe19211bb23f9c12d85e034e611dc2d1547494f8ef648844bddf62c56
+  checksum: 10c0/c26cc36504ad9a720e42f009bcc185b16e35ff64644bbec710a998c071d3366face29bb6fa68744adc7312356803666922459e416f3a7ae5c804841957832c3d
   languageName: node
   linkType: hard
 
-"@smithy/signature-v4@npm:^5.4.6":
-  version: 5.4.6
-  resolution: "@smithy/signature-v4@npm:5.4.6"
+"@smithy/middleware-endpoint@npm:^4.4.32":
+  version: 4.4.32
+  resolution: "@smithy/middleware-endpoint@npm:4.4.32"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/middleware-serde": "npm:^4.2.20"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-middleware": "npm:^4.2.14"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7d7db13f4ddb09cca0a902dd760d83ff9770c085657e577153e4a93c0cd0314a36cbafaaae58c7be1aa1162e81ecab8b1395b0b0e488b20c22eb0dd9714b2b25
+  checksum: 10c0/a77ba3f56956b872a533754c71f75d2a9d6df9af8d58a059d07caedd1af3ffdcae5b667a0b96b6d067555a777510f6fc5847f699a2dd705e9b5837d21510daa4
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-retry@npm:^4.5.7":
+  version: 4.5.7
+  resolution: "@smithy/middleware-retry@npm:4.5.7"
+  dependencies:
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/service-error-classification": "npm:^4.3.1"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/uuid": "npm:^1.1.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/44ba622d961f83935aa13210fc92edfbf017f655ad4f4fb2024f7e880a70867d547b358be2089966689ed92c5deedcdf4723177c015babaf332ba3b55a40fe9b
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-serde@npm:^4.2.20":
+  version: 4.2.20
+  resolution: "@smithy/middleware-serde@npm:4.2.20"
+  dependencies:
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2db736d58c0d628a33febad86259eedd6d025135fc403458e4469a077a6adbb909587408acb62c982fa1b2d8b1376507da90661a4315a544c7d73a62179a3453
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-stack@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/middleware-stack@npm:4.2.14"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5a0323c50b399c4a2ff0d91b219c7c285b006f905f66b291b6013a4e94f14c036ff5a74c565989afc3c6f0fafc6c266bca6746b79e242403713b7d18dc266a92
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^4.3.14":
+  version: 4.3.14
+  resolution: "@smithy/node-config-provider@npm:4.3.14"
+  dependencies:
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/59033a2fde5327d9ae1a0304a0eb2c3145141024cb4dcb58c5cd3c48371cd3a55d7228a3d2f33a5785b2d6a0a35475cbd0d1b2435d964c824683ac89a664e926
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "@smithy/node-http-handler@npm:4.6.1"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/querystring-builder": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/6c07fbfd8326cd5369283bd19c1af923ee49b7dcf42fdd199bb7132e4c25eaa6db8573e3b669fb60be0d8f9757a3f2482cd0cf6d6631494255f08239d3036ed2
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/property-provider@npm:4.2.14"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/8d3da90e228b53885d1e82f28b33c095b72f3b1cb5dcd7f7edcd96292d90848e9cdfed85cef00040e198343e850acef61540e4de24bd10b07fbc8e1e8f4a1fdd
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^5.3.14":
+  version: 5.3.14
+  resolution: "@smithy/protocol-http@npm:5.3.14"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ed7306e7e4b919fdacf60d1928f003ac4c4679cffd7472b078547fbed7b6cb9ba524f105b1871c2cd79222871169d3183257fd0a1a81c172fa7cf0a9abaf35f9
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-builder@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/querystring-builder@npm:4.2.14"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-uri-escape": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ae2ceec55b4f32b73fe2eca710563b9dbe65c81157ed58c12c282bad6445998f1fe99d723591f9bac4ae6106d84213b57e960176865fb2dec78fc3bdf024b14b
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-parser@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/querystring-parser@npm:4.2.14"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/245923618197bbae5eb38b72807368f397fafccee8e98cd98ee7d8961a34acb57b5176fa5fe8083b796229043f135ea775060f17e14aa12080a5d7cdfbf56333
+  languageName: node
+  linkType: hard
+
+"@smithy/service-error-classification@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@smithy/service-error-classification@npm:4.3.1"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+  checksum: 10c0/1bc927f53693035165f4b15232c644be579cdd432cf2d3e026faa746d26693e6b1e0f35bcd5d812dd89445695fd1eb7188e415e2523d6d8991e8db900cecdf36
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^4.4.9":
+  version: 4.4.9
+  resolution: "@smithy/shared-ini-file-loader@npm:4.4.9"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9bf96ea80cedff027373c5547ffa53b35d272292b7d142a86211726343061953a34610f3dbd02153bb285c7c0f3802c5a25b4e27870e8068d777abdcaa9c1748
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.3.14":
+  version: 5.3.14
+  resolution: "@smithy/signature-v4@npm:5.3.14"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^4.2.2"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-hex-encoding": "npm:^4.2.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-uri-escape": "npm:^4.2.2"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ccc788992e281a681984e079b7194a219af40cf4f7087988eba69c4947264b9a83ac00a806164b9074c7e2f0697e492fa2b377b56b783316d247be02aaccbdb3
+  languageName: node
+  linkType: hard
+
+"@smithy/smithy-client@npm:^4.12.13":
+  version: 4.12.13
+  resolution: "@smithy/smithy-client@npm:4.12.13"
+  dependencies:
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/middleware-endpoint": "npm:^4.4.32"
+    "@smithy/middleware-stack": "npm:^4.2.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-stream": "npm:^4.5.25"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/0680d4d0720d110a637fabb8bdc85175e1471191925f5c55f08636f5327de1bc29c8db75318aac1396491fa83c8a319dd4cd26c5e9fff619207c9a96b9dbd9fe
   languageName: node
   linkType: hard
 
@@ -5571,12 +6054,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^4.14.2, @smithy/types@npm:^4.14.3":
-  version: 4.14.3
-  resolution: "@smithy/types@npm:4.14.3"
+"@smithy/url-parser@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/url-parser@npm:4.2.14"
+  dependencies:
+    "@smithy/querystring-parser": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/360463fe1fb51b8a1c5b80f4a16df993ee4e87221e60ce51c428b0737d6f1325434ec572bb7afca7d65bb9a09c750f307822a23e42be675706ee71fedd7c6c06
+  languageName: node
+  linkType: hard
+
+"@smithy/util-base64@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@smithy/util-base64@npm:4.3.2"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^4.2.2"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/acc08ff0b482ef4473289be655e0adc21c33555a837bbbc1cc7121d70e3ad595807bcaaec7456d92e93d83c2e8773729d42f78d716ac7d91552845b50cd87d89
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-browser@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-body-length-browser@npm:4.2.2"
   dependencies:
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c80244d5ca88992e5609e372eaf2441497d36063688af44e9f0e81ab0ee8d5a4cbdb644822243e4cdfad2dd6484c6274e618dc2a9e91b3b9befe7c7b55e09ddc
+  checksum: 10c0/4444039b995068eeda3dd0b143eb22cf86c7ef7632a590559dad12b0e681a728a7d82f8ed4f4019cdc09a72e4b5f14281262b64db75514dbcc08d170d9e8f1db
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-node@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/util-body-length-node@npm:4.2.3"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5345d75e8c3e0a726ed6e2fe604dfe97b0bcc37e940b30b045e3e116fced9555d8a9fa684d9f898111773eeef548bcb5f0bb03ee67c206ee498064842d6173b5
   languageName: node
   linkType: hard
 
@@ -5590,6 +6104,118 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-buffer-from@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-buffer-from@npm:4.2.2"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d9acea42ee035e494da0373de43a25fa14f81d11e3605a2c6c5f56efef9a4f901289ec2ba343ebb3ad32ae4e0cfe517e8b6b3449a4297d1c060889c83cd1c94f
+  languageName: node
+  linkType: hard
+
+"@smithy/util-config-provider@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-config-provider@npm:4.2.2"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/cfd3350607ec00b6294724033aa3e469f8d9d258a7a70772e67d80c301f2eae62b17850ea0c8d8a20208b3f4f1ea5aa0019f45545a6c0577a94a47a05c81d8e8
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-browser@npm:^4.3.49":
+  version: 4.3.49
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.49"
+  dependencies:
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/0979b09f1108aa41f5bf623e32fa138e129fbffe3adc23c46308afa310b925635428f9d7e36e3e2a312cafe9af325cb5f01667791ee672418d4f302c1961623b
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-node@npm:^4.2.54":
+  version: 4.2.54
+  resolution: "@smithy/util-defaults-mode-node@npm:4.2.54"
+  dependencies:
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/credential-provider-imds": "npm:^4.2.14"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7146087fa1d7758b37da456719d589f63300843ff5610891de02a0434c5abbd49fd257712c2d9e0bede904f4ec62c9d3c9eddcd6ec0372134f998e4f9c0bce09
+  languageName: node
+  linkType: hard
+
+"@smithy/util-endpoints@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "@smithy/util-endpoints@npm:3.4.2"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/602e05c8dc43d8902604bac74b717d09da5b4f1994dcdd5025bffeced6002eaa0612ae1ccbe7a0e636a3d92a60747715e22cbacf8feeb672394d15b6ae211b13
+  languageName: node
+  linkType: hard
+
+"@smithy/util-hex-encoding@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-hex-encoding@npm:4.2.2"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b2f2bca85475cd599b998e169b7026db40edc2a0a338ad7988b9c94d9f313c5f7e08451aced4f8e62dbeaa54e15d1300d76c572b83ffa36f9f8ca22b6fc84bd7
+  languageName: node
+  linkType: hard
+
+"@smithy/util-middleware@npm:^4.2.14":
+  version: 4.2.14
+  resolution: "@smithy/util-middleware@npm:4.2.14"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/6ba5026b70ad7b58fac89d7428c0b1679be2a97a8fb47811a39e0183901a3c6ca8732ee225ddfda28e7b86223d49983ff709421905da571bc00b82c660e4fc27
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^4.3.6":
+  version: 4.3.6
+  resolution: "@smithy/util-retry@npm:4.3.6"
+  dependencies:
+    "@smithy/service-error-classification": "npm:^4.3.1"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a2d3b34ca48edd4f58885c91de28f7ccbe48d0e4a8f005eb569197cf37640b5c04043fd556b0e1ecf6d8623b6c384b52b1c34c898acf77260e517f7d00641811
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.5.25":
+  version: 4.5.25
+  resolution: "@smithy/util-stream@npm:4.5.25"
+  dependencies:
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-buffer-from": "npm:^4.2.2"
+    "@smithy/util-hex-encoding": "npm:^4.2.2"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4b222c975eca2018831f1ab4067f122f4ef5e68f3abb71776003309f1a27f67d509a2d86f5f1f81a91656236db0e29c38314c005b17dbf63f053de4d97be7b59
+  languageName: node
+  linkType: hard
+
+"@smithy/util-uri-escape@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-uri-escape@npm:4.2.2"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/33b6546086c975278d16b5029e6555df551b4bd1e3a84042544d1ef956a287fe033b317954b1737b2773e82b6f27ebde542956ff79ef0e8a813dc0dbf9d34a58
+  languageName: node
+  linkType: hard
+
 "@smithy/util-utf8@npm:^2.0.0":
   version: 2.3.0
   resolution: "@smithy/util-utf8@npm:2.3.0"
@@ -5597,6 +6223,25 @@ __metadata:
     "@smithy/util-buffer-from": "npm:^2.2.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e18840c58cc507ca57fdd624302aefd13337ee982754c9aa688463ffcae598c08461e8620e9852a424d662ffa948fc64919e852508028d09e89ced459bd506ab
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-utf8@npm:4.2.2"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/55b5119873237519a9175491c74fd0a14acd4f9c54c7eec9ae547de6c554098912d46572edb12d5b52a0b9675c0577e2e63d1f7cb8e022ca342f5bf80b56a466
+  languageName: node
+  linkType: hard
+
+"@smithy/uuid@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@smithy/uuid@npm:1.1.2"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/cbedfe5e2c1ec5ee05ae0cd6cc3c9f6f5e600207362d62470278827488794e19148a05a61ee9b6a2359bb460985af1a528c48d54f365891fe1c4913504250667
   languageName: node
   linkType: hard
 
@@ -5613,6 +6258,13 @@ __metadata:
   dependencies:
     defer-to-connect: "npm:^2.0.0"
   checksum: 10c0/73946918c025339db68b09abd91fa3001e87fc749c619d2e9c2003a663039d4c3cb89836c98a96598b3d47dec2481284ba85355392644911f5ecd2336536697f
+  languageName: node
+  linkType: hard
+
+"@tootallnate/quickjs-emscripten@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "@tootallnate/quickjs-emscripten@npm:0.23.0"
+  checksum: 10c0/2a939b781826fb5fd3edd0f2ec3b321d259d760464cf20611c9877205aaca3ccc0b7304dea68416baa0d568e82cd86b17d29548d1e5139fa3155a4a86a2b4b49
   languageName: node
   linkType: hard
 
@@ -6550,6 +7202,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:^8.17.1":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
+  languageName: node
+  linkType: hard
+
 "amaro@npm:^0.3.2":
   version: 0.3.2
   resolution: "amaro@npm:0.3.2"
@@ -6893,6 +7557,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ast-types@npm:^0.13.4":
+  version: 0.13.4
+  resolution: "ast-types@npm:0.13.4"
+  dependencies:
+    tslib: "npm:^2.0.1"
+  checksum: 10c0/3a1a409764faa1471601a0ad01b3aa699292991aa9c8a30c7717002cabdf5d98008e7b53ae61f6e058f757fc6ba965e147967a93c13e62692c907d79cfb245f8
+  languageName: node
+  linkType: hard
+
 "async-sema@npm:^3.1.1":
   version: 3.1.1
   resolution: "async-sema@npm:3.1.1"
@@ -7086,6 +7759,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"basic-ftp@npm:^5.0.2":
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: 10c0/03511b488cd292abfa82a8c0ea3b9573b40d12d2f1518d6f41a9461b012b3376d3e6d50679b38d9b2b4f48fd6e8e0418ac196312ee7e2da13cb801169940d1c3
+  languageName: node
+  linkType: hard
+
 "before-after-hook@npm:^2.2.0":
   version: 2.2.2
   resolution: "before-after-hook@npm:2.2.2"
@@ -7250,7 +7930,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
+"browserslist@npm:^4.24.0":
   version: 4.28.2
   resolution: "browserslist@npm:4.28.2"
   dependencies:
@@ -7293,13 +7973,6 @@ __metadata:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.1.13"
   checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
-  languageName: node
-  linkType: hard
-
-"builtin-modules@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "builtin-modules@npm:3.3.0"
-  checksum: 10c0/2cb3448b4f7306dc853632a4fcddc95e8d4e4b9868c139400027b71938fc6806d4ff44007deffb362ac85724bd40c2c6452fb6a0aa4531650eeddb98d8e5ee8a
   languageName: node
   linkType: hard
 
@@ -7632,15 +8305,6 @@ __metadata:
   version: 1.0.1
   resolution: "ci-parallel-vars@npm:1.0.1"
   checksum: 10c0/80952f699cbbc146092b077b4f3e28d085620eb4e6be37f069b4dbb3db0ee70e8eec3beef4ebe70ff60631e9fc743b9d0869678489f167442cac08b260e5ac08
-  languageName: node
-  linkType: hard
-
-"clean-regexp@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "clean-regexp@npm:1.0.0"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.5"
-  checksum: 10c0/fd9c7446551b8fc536f95e8a286d431017cd4ba1ec2e53997ec9159385e9c317672f6dfc4d49fdb97449fdb53b0bacd0a8bab9343b8fdd2e46c7ddf6173d0db7
   languageName: node
   linkType: hard
 
@@ -8184,15 +8848,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.38.1":
-  version: 3.49.0
-  resolution: "core-js-compat@npm:3.49.0"
-  dependencies:
-    browserslist: "npm:^4.28.1"
-  checksum: 10c0/546e64b7ce45f724825bc13c1347f35c0459a6e71c0dcccff3ec21fbff463f5b0b97fc1220e6d90302153863489301793276fe2bf96f46001ff555ead4140308
-  languageName: node
-  linkType: hard
-
 "core-js@npm:^3.31.0":
   version: 3.49.0
   resolution: "core-js@npm:3.49.0"
@@ -8284,6 +8939,13 @@ __metadata:
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
   checksum: 10c0/20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
+  languageName: node
+  linkType: hard
+
+"data-uri-to-buffer@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "data-uri-to-buffer@npm:6.0.2"
+  checksum: 10c0/f76922bf895b3d7d443059ff278c9cc5efc89d70b8b80cd9de0aa79b3adc6d7a17948eefb8692e30398c43635f70ece1673d6085cc9eba2878dbc6c6da5292ac
   languageName: node
   linkType: hard
 
@@ -8541,6 +9203,17 @@ __metadata:
     has-property-descriptors: "npm:^1.0.0"
     object-keys: "npm:^1.1.1"
   checksum: 10c0/88a152319ffe1396ccc6ded510a3896e77efac7a1bfbaa174a7b00414a1747377e0bb525d303794a47cf30e805c2ec84e575758512c6e44a993076d29fd4e6c3
+  languageName: node
+  linkType: hard
+
+"degenerator@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "degenerator@npm:5.0.1"
+  dependencies:
+    ast-types: "npm:^0.13.4"
+    escodegen: "npm:^2.1.0"
+    esprima: "npm:^4.0.1"
+  checksum: 10c0/e48d8a651edeb512a648711a09afec269aac6de97d442a4bb9cf121a66877e0eec11b9727100a10252335c0666ae1c84a8bc1e3a3f47788742c975064d2c7b1c
   languageName: node
   linkType: hard
 
@@ -9324,6 +9997,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escodegen@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "escodegen@npm:2.1.0"
+  dependencies:
+    esprima: "npm:^4.0.1"
+    estraverse: "npm:^5.2.0"
+    esutils: "npm:^2.0.2"
+    source-map: "npm:~0.6.1"
+  dependenciesMeta:
+    source-map:
+      optional: true
+  bin:
+    escodegen: bin/escodegen.js
+    esgenerate: bin/esgenerate.js
+  checksum: 10c0/e1450a1f75f67d35c061bf0d60888b15f62ab63aef9df1901cffc81cffbbb9e8b3de237c5502cf8613a017c1df3a3003881307c78835a1ab54d8c8d2206e01d3
+  languageName: node
+  linkType: hard
+
 "eshost-cli@npm:^9.0.0":
   version: 9.0.0
   resolution: "eshost-cli@npm:9.0.0"
@@ -9562,32 +10253,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-unicorn@npm:^56.0.1":
-  version: 56.0.1
-  resolution: "eslint-plugin-unicorn@npm:56.0.1"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.24.7"
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-    ci-info: "npm:^4.0.0"
-    clean-regexp: "npm:^1.0.0"
-    core-js-compat: "npm:^3.38.1"
-    esquery: "npm:^1.6.0"
-    globals: "npm:^15.9.0"
-    indent-string: "npm:^4.0.0"
-    is-builtin-module: "npm:^3.2.1"
-    jsesc: "npm:^3.0.2"
-    pluralize: "npm:^8.0.0"
-    read-pkg-up: "npm:^7.0.1"
-    regexp-tree: "npm:^0.1.27"
-    regjsparser: "npm:^0.10.0"
-    semver: "npm:^7.6.3"
-    strip-indent: "npm:^3.0.0"
-  peerDependencies:
-    eslint: ">=8.56.0"
-  checksum: 10c0/3b853ecde6ab597b12e28b962ba6ad7d3594f7f066d90135db2d3366ac13361c72500119163e13e1c38ca6fbdd331b1cc31dce9e8673880bff050fe51d6c64db
-  languageName: node
-  linkType: hard
-
 "eslint-rule-docs@npm:^1.1.5":
   version: 1.1.235
   resolution: "eslint-rule-docs@npm:1.1.235"
@@ -9714,7 +10379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0, esprima@npm:~4.0.0":
+"esprima@npm:^4.0.0, esprima@npm:^4.0.1, esprima@npm:~4.0.0":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -9733,7 +10398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.6.0, esquery@npm:^1.7.0":
+"esquery@npm:^1.7.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
   dependencies:
@@ -9972,27 +10637,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.7":
-  version: 1.2.0
-  resolution: "fast-xml-builder@npm:1.2.0"
-  dependencies:
-    path-expression-matcher: "npm:^1.5.0"
-    xml-naming: "npm:^0.1.0"
-  checksum: 10c0/84bb105cd04e91d6dcb746c4dbaeb12903b510e7ab9a06ffde55b5a582e005559a87d84467f18a655c6c4baf098f696fd74cee3cbe1aea9d01385907768ba32d
+"fast-uri@npm:^3.0.1":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.7.3":
-  version: 5.7.3
-  resolution: "fast-xml-parser@npm:5.7.3"
+"fast-xml-builder@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "fast-xml-builder@npm:1.1.5"
+  dependencies:
+    path-expression-matcher: "npm:^1.1.3"
+  checksum: 10c0/b814ba5559cb3140de46d2846045607ab4d4c0bfc312a49d22c91efb9f7cd7004971314841e5823eeb467a5bf403e3ade8371b7912200e111df027d42ae51715
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:5.7.2":
+  version: 5.7.2
+  resolution: "fast-xml-parser@npm:5.7.2"
   dependencies:
     "@nodable/entities": "npm:^2.1.0"
-    fast-xml-builder: "npm:^1.1.7"
+    fast-xml-builder: "npm:^1.1.5"
     path-expression-matcher: "npm:^1.5.0"
     strnum: "npm:^2.2.3"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/eeb802855e852ce16121396297f04131c6dbc74f863be94f19e26e386656bdb31677af469ddc6627983a48b99d8842888460ac5413063cb648fde547bb579978
+  checksum: 10c0/d48439ce0700add82f5e7c6ccc5a1f06483beb7cd8e88caa83c6406843e52f14988e60d05cbb3a86ffe07e073807674c807e0764d94a280e1c96d7e2011dae8e
   languageName: node
   linkType: hard
 
@@ -10663,6 +11334,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-uri@npm:^6.0.1":
+  version: 6.0.5
+  resolution: "get-uri@npm:6.0.5"
+  dependencies:
+    basic-ftp: "npm:^5.0.2"
+    data-uri-to-buffer: "npm:^6.0.2"
+    debug: "npm:^4.3.4"
+  checksum: 10c0/c7ff5d5d55de53d23ecce7c5108cc3ed0db1174db43c9aa15506d640283d36ee0956fd8ba1fc50b06a718466cc85794ae9d8860193f91318afe846e3e7010f3a
+  languageName: node
+  linkType: hard
+
 "git-raw-commits@npm:^3.0.0":
   version: 3.0.0
   resolution: "git-raw-commits@npm:3.0.0"
@@ -10844,13 +11526,6 @@ __metadata:
   version: 14.0.0
   resolution: "globals@npm:14.0.0"
   checksum: 10c0/b96ff42620c9231ad468d4c58ff42afee7777ee1c963013ff8aabe095a451d0ceeb8dcd8ef4cbd64d2538cef45f787a78ba3a9574f4a634438963e334471302d
-  languageName: node
-  linkType: hard
-
-"globals@npm:^15.9.0":
-  version: 15.15.0
-  resolution: "globals@npm:15.15.0"
-  checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
   languageName: node
   linkType: hard
 
@@ -11181,7 +11856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:7.0.2, http-proxy-agent@npm:^7.0.0":
+"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.1":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -11211,7 +11886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:7.0.6, https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5, https-proxy-agent@npm:^7.0.6":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -11312,17 +11987,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:7.0.5, ignore@npm:^7.0.5":
-  version: 7.0.5
-  resolution: "ignore@npm:7.0.5"
-  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^5.0.4, ignore@npm:^5.0.5, ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "ignore@npm:7.0.5"
+  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
   languageName: node
   linkType: hard
 
@@ -11569,6 +12244,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -11645,15 +12327,6 @@ __metadata:
     call-bound: "npm:^1.0.2"
     has-tostringtag: "npm:^1.0.2"
   checksum: 10c0/2ef601d255a39fdbde79cfe6be80c27b47430ed6712407f29b17d002e20f64c1e3d6692f1d842ba16bf1e9d8ddf1c4f13cac3ed7d9a4a21290f44879ebb4e8f5
-  languageName: node
-  linkType: hard
-
-"is-builtin-module@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "is-builtin-module@npm:3.2.1"
-  dependencies:
-    builtin-modules: "npm:^3.3.0"
-  checksum: 10c0/5a66937a03f3b18803381518f0ef679752ac18cdb7dd53b5e23ee8df8d440558737bd8dcc04d2aae555909d2ecb4a81b5c0d334d119402584b61e6a003e31af1
   languageName: node
   linkType: hard
 
@@ -12619,15 +13292,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsesc@npm:~0.5.0":
-  version: 0.5.0
-  resolution: "jsesc@npm:0.5.0"
-  bin:
-    jsesc: bin/jsesc
-  checksum: 10c0/f93792440ae1d80f091b65f8ceddf8e55c4bb7f1a09dee5dcbdb0db5612c55c0f6045625aa6b7e8edb2e0a4feabd80ee48616dbe2d37055573a84db3d24f96d9
-  languageName: node
-  linkType: hard
-
 "json-bigint@npm:^1.0.0":
   version: 1.0.0
   resolution: "json-bigint@npm:1.0.0"
@@ -12686,6 +13350,13 @@ __metadata:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
   languageName: node
   linkType: hard
 
@@ -13223,6 +13894,13 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^7.14.1":
+  version: 7.18.3
+  resolution: "lru-cache@npm:7.18.3"
+  checksum: 10c0/b3a452b491433db885beed95041eb104c157ef7794b9c9b4d647be503be91769d11206bb573849a16b4cc0d03cbd15ffd22df7960997788b74c1d399ac7a4fed
   languageName: node
   linkType: hard
 
@@ -15022,6 +15700,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pac-proxy-agent@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "pac-proxy-agent@npm:7.2.0"
+  dependencies:
+    "@tootallnate/quickjs-emscripten": "npm:^0.23.0"
+    agent-base: "npm:^7.1.2"
+    debug: "npm:^4.3.4"
+    get-uri: "npm:^6.0.1"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.6"
+    pac-resolver: "npm:^7.0.1"
+    socks-proxy-agent: "npm:^8.0.5"
+  checksum: 10c0/0265c17c9401c2ea735697931a6553a0c6d8b20c4d7d4e3b3a0506080ba69a8d5ad656e2a6be875411212e2b6ed7a4d9526dd3997e08581fdfb1cbcad454c296
+  languageName: node
+  linkType: hard
+
+"pac-resolver@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "pac-resolver@npm:7.0.1"
+  dependencies:
+    degenerator: "npm:^5.0.0"
+    netmask: "npm:^2.0.2"
+  checksum: 10c0/5f3edd1dd10fded31e7d1f95776442c3ee51aa098c28b74ede4927d9677ebe7cebb2636750c24e945f5b84445e41ae39093d3a1014a994e5ceb9f0b1b88ebff5
+  languageName: node
+  linkType: hard
+
 "package-config@npm:^5.0.0":
   version: 5.0.0
   resolution: "package-config@npm:5.0.0"
@@ -15197,7 +15901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"partial-json@npm:0.1.7":
+"partial-json@npm:^0.1.7":
   version: 0.1.7
   resolution: "partial-json@npm:0.1.7"
   checksum: 10c0/cd5f994c3a5ca903918c028a6947ebc1d46459234c1c57c7ab98e234d8dca49cb46b05a71889ee422b39d1f66b95c59a5ce3a6ae06966aca95a8960ad20c12d2
@@ -15225,7 +15929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-expression-matcher@npm:^1.5.0":
+"path-expression-matcher@npm:^1.1.3, path-expression-matcher@npm:^1.5.0":
   version: 1.5.0
   resolution: "path-expression-matcher@npm:1.5.0"
   checksum: 10c0/646cb5bc66cd7d809a52288336f3ac1e6223f156fd8e912936e490e590f7f93e8056d4fd25fcbcc7da61bb698fa520112cb050372a3f65e7b79bd4afa0f77610
@@ -15439,13 +16143,6 @@ __metadata:
   dependencies:
     irregular-plurals: "npm:^4.2.0"
   checksum: 10c0/5c54badee70debea38e7153b197c1235847edc10952c3dd959c9610005f75013c2053be1cba87acde4531498d7a9e8b16c6b358f3940f05aa6e1aeedbc991b7a
-  languageName: node
-  linkType: hard
-
-"pluralize@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "pluralize@npm:8.0.0"
-  checksum: 10c0/2044cfc34b2e8c88b73379ea4a36fc577db04f651c2909041b054c981cd863dd5373ebd030123ab058d194ae615d3a97cfdac653991e499d10caf592e8b3dc33
   languageName: node
   linkType: hard
 
@@ -15706,6 +16403,22 @@ __metadata:
     uint8arraylist: "npm:^2.4.8"
     uint8arrays: "npm:^5.1.0"
   checksum: 10c0/95e47c06e14559b4eafa64f837a664e8c5b2e36f30e9c7f1daf44e2556e7a97f4df55dd62a546e7e0636da6206471a124fe4fa2409a56a9e99b7b6357fdbb004
+  languageName: node
+  linkType: hard
+
+"proxy-agent@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "proxy-agent@npm:6.5.0"
+  dependencies:
+    agent-base: "npm:^7.1.2"
+    debug: "npm:^4.3.4"
+    http-proxy-agent: "npm:^7.0.1"
+    https-proxy-agent: "npm:^7.0.6"
+    lru-cache: "npm:^7.14.1"
+    pac-proxy-agent: "npm:^7.1.0"
+    proxy-from-env: "npm:^1.1.0"
+    socks-proxy-agent: "npm:^8.0.5"
+  checksum: 10c0/7fd4e6f36bf17098a686d4aee3b8394abfc0b0537c2174ce96b0a4223198b9fafb16576c90108a3fcfc2af0168bd7747152bfa1f58e8fee91d3780e79aab7fd8
   languageName: node
   linkType: hard
 
@@ -16072,15 +16785,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp-tree@npm:^0.1.27":
-  version: 0.1.27
-  resolution: "regexp-tree@npm:0.1.27"
-  bin:
-    regexp-tree: bin/regexp-tree
-  checksum: 10c0/f636f44b4a0d93d7d6926585ecd81f63e4ce2ac895bc417b2ead0874cd36b337dcc3d0fedc63f69bf5aaeaa4340f36ca7e750c9687cceaf8087374e5284e843c
-  languageName: node
-  linkType: hard
-
 "regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
@@ -16095,17 +16799,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regjsparser@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "regjsparser@npm:0.10.0"
-  dependencies:
-    jsesc: "npm:~0.5.0"
-  bin:
-    regjsparser: bin/parser
-  checksum: 10c0/0f0508c142eddbceae55dab9715e714305c19e1e130db53168e8fa5f9f7ff9a4901f674cf6f71e04a0973b2f883882ba05808c80778b2d52b053d925050010f4
-  languageName: node
-  linkType: hard
-
 "repeat-string@npm:^1.5.4":
   version: 1.6.1
   resolution: "repeat-string@npm:1.6.1"
@@ -16117,6 +16810,13 @@ __metadata:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
+  languageName: node
+  linkType: hard
+
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
   languageName: node
   linkType: hard
 
@@ -16456,7 +17156,6 @@ __metadata:
     eslint-import-resolver-exports: "npm:^1.0.0-beta.5"
     eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-jsdoc: "npm:^62.5.5"
-    eslint-plugin-unicorn: "npm:^56.0.1"
     lerna: "npm:^8.2.4"
     prettier: "npm:^3.5.3"
     ses: "workspace:^"
@@ -17009,6 +17708,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"socks-proxy-agent@npm:^8.0.5":
+  version: 8.0.5
+  resolution: "socks-proxy-agent@npm:8.0.5"
+  dependencies:
+    agent-base: "npm:^7.1.2"
+    debug: "npm:^4.3.4"
+    socks: "npm:^2.8.3"
+  checksum: 10c0/5d2c6cecba6821389aabf18728325730504bf9bb1d9e342e7987a5d13badd7a98838cc9a55b8ed3cb866ad37cc23e1086f09c4d72d93105ce9dfe76330e9d2a6
+  languageName: node
+  linkType: hard
+
 "socks@npm:^2.7.1":
   version: 2.8.3
   resolution: "socks@npm:2.8.3"
@@ -17016,6 +17726,16 @@ __metadata:
     ip-address: "npm:^9.0.5"
     smart-buffer: "npm:^4.2.0"
   checksum: 10c0/d54a52bf9325165770b674a67241143a3d8b4e4c8884560c4e0e078aace2a728dffc7f70150660f51b85797c4e1a3b82f9b7aa25e0a0ceae1a243365da5c51a7
+  languageName: node
+  linkType: hard
+
+"socks@npm:^2.8.3":
+  version: 2.8.8
+  resolution: "socks@npm:2.8.8"
+  dependencies:
+    ip-address: "npm:^10.1.1"
+    smart-buffer: "npm:^4.2.0"
+  checksum: 10c0/4777edf8b554182ddf472524a1855c0fc684c7a3778466851dca687ae81cfa19ea9261856765789e51f7cec12e575e2652d5bd69d98fdbbbc947eabd12e9891d
   languageName: node
   linkType: hard
 
@@ -17890,7 +18610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.8.1":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -18068,10 +18788,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typebox@npm:1.1.38":
-  version: 1.1.38
-  resolution: "typebox@npm:1.1.38"
-  checksum: 10c0/b4a5996a25b9265e88335a75697630be82822fae5e7b1993d5eb52ac6b71e80fec924ffa1976269a05524a0954b3f9e6e52f380348ea6836f76920e556fa3ca1
+"typebox@npm:^1.1.24":
+  version: 1.1.37
+  resolution: "typebox@npm:1.1.37"
+  checksum: 10c0/da63b444904d439cbec5fb347039c71c7075c8cd2223a8ef8c4d0fee2e299362785bc4a410f4427a8d45b51e2547b4f896ca09cf3796fac90e147d382152b840
   languageName: node
   linkType: hard
 
@@ -18313,6 +19033,13 @@ __metadata:
   version: 6.25.0
   resolution: "undici@npm:6.25.0"
   checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+  languageName: node
+  linkType: hard
+
+"undici@npm:^7.19.1":
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
   languageName: node
   linkType: hard
 
@@ -19064,13 +19791,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xml-naming@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "xml-naming@npm:0.1.0"
-  checksum: 10c0/8c7614865361bcb7e53e3e091dac21c567e2b92d447919b2f072775aa9dcfc94a5255bd52fbaa0fd53c93513e53a23a6a835218ad2af512451dbc678392f85fe
-  languageName: node
-  linkType: hard
-
 "xmlbuilder@npm:^15.1.1":
   version: 15.1.1
   resolution: "xmlbuilder@npm:15.1.1"
@@ -19131,15 +19851,6 @@ __metadata:
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
   checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
-  languageName: node
-  linkType: hard
-
-"yaml@npm:2.9.0":
-  version: 2.9.0
-  resolution: "yaml@npm:2.9.0"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 
@@ -19310,7 +20021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.25.0":
+"zod-to-json-schema@npm:^3.24.6, zod-to-json-schema@npm:^3.25.0":
   version: 3.25.2
   resolution: "zod-to-json-schema@npm:3.25.2"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:^0.91.1":
+"@anthropic-ai/sdk@npm:0.91.1":
   version: 0.91.1
   resolution: "@anthropic-ai/sdk@npm:0.91.1"
   dependencies:
@@ -112,421 +112,262 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-bedrock-runtime@npm:^3.1030.0":
-  version: 3.1041.0
-  resolution: "@aws-sdk/client-bedrock-runtime@npm:3.1041.0"
+"@aws-sdk/client-bedrock-runtime@npm:3.1048.0":
+  version: 3.1048.0
+  resolution: "@aws-sdk/client-bedrock-runtime@npm:3.1048.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/credential-provider-node": "npm:^3.972.39"
-    "@aws-sdk/eventstream-handler-node": "npm:^3.972.14"
-    "@aws-sdk/middleware-eventstream": "npm:^3.972.10"
-    "@aws-sdk/middleware-host-header": "npm:^3.972.10"
-    "@aws-sdk/middleware-logger": "npm:^3.972.10"
-    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.11"
-    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
-    "@aws-sdk/middleware-websocket": "npm:^3.972.16"
-    "@aws-sdk/region-config-resolver": "npm:^3.972.13"
-    "@aws-sdk/token-providers": "npm:3.1041.0"
+    "@aws-sdk/core": "npm:^3.974.11"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.42"
+    "@aws-sdk/eventstream-handler-node": "npm:^3.972.16"
+    "@aws-sdk/middleware-eventstream": "npm:^3.972.12"
+    "@aws-sdk/middleware-websocket": "npm:^3.972.19"
+    "@aws-sdk/token-providers": "npm:3.1048.0"
     "@aws-sdk/types": "npm:^3.973.8"
-    "@aws-sdk/util-endpoints": "npm:^3.996.8"
-    "@aws-sdk/util-user-agent-browser": "npm:^3.972.10"
-    "@aws-sdk/util-user-agent-node": "npm:^3.973.24"
-    "@smithy/config-resolver": "npm:^4.4.17"
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/eventstream-serde-browser": "npm:^4.2.14"
-    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.14"
-    "@smithy/eventstream-serde-node": "npm:^4.2.14"
-    "@smithy/fetch-http-handler": "npm:^5.3.17"
-    "@smithy/hash-node": "npm:^4.2.14"
-    "@smithy/invalid-dependency": "npm:^4.2.14"
-    "@smithy/middleware-content-length": "npm:^4.2.14"
-    "@smithy/middleware-endpoint": "npm:^4.4.32"
-    "@smithy/middleware-retry": "npm:^4.5.7"
-    "@smithy/middleware-serde": "npm:^4.2.20"
-    "@smithy/middleware-stack": "npm:^4.2.14"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/node-http-handler": "npm:^4.6.1"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/core": "npm:^3.24.2"
+    "@smithy/fetch-http-handler": "npm:^5.4.2"
+    "@smithy/node-http-handler": "npm:^4.7.2"
     "@smithy/types": "npm:^4.14.1"
-    "@smithy/url-parser": "npm:^4.2.14"
-    "@smithy/util-base64": "npm:^4.3.2"
-    "@smithy/util-body-length-browser": "npm:^4.2.2"
-    "@smithy/util-body-length-node": "npm:^4.2.3"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.49"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.54"
-    "@smithy/util-endpoints": "npm:^3.4.2"
-    "@smithy/util-middleware": "npm:^4.2.14"
-    "@smithy/util-retry": "npm:^4.3.6"
-    "@smithy/util-stream": "npm:^4.5.25"
-    "@smithy/util-utf8": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ea42e319b5f5ff86c0082a88b073f0320438bc2bdc62f25c4ea3782d04977f81240532a61ab75269e56284bd7b8835280e5ed4890033a97eba43b6bfe9429ec9
+  checksum: 10c0/8172a964cf580631e02906bc1312f1b44ad862a367417600e45f65f79a6f35318a713393ba565af6b73292071ee52751d405696a864820b12c70ffdb75dc06c1
   languageName: node
   linkType: hard
 
-"@aws-sdk/core@npm:^3.974.8":
-  version: 3.974.8
-  resolution: "@aws-sdk/core@npm:3.974.8"
+"@aws-sdk/core@npm:^3.974.11, @aws-sdk/core@npm:^3.974.17":
+  version: 3.974.17
+  resolution: "@aws-sdk/core@npm:3.974.17"
   dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@aws-sdk/xml-builder": "npm:^3.972.22"
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/signature-v4": "npm:^5.3.14"
-    "@smithy/smithy-client": "npm:^4.12.13"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-base64": "npm:^4.3.2"
-    "@smithy/util-middleware": "npm:^4.2.14"
-    "@smithy/util-retry": "npm:^4.3.6"
-    "@smithy/util-utf8": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/7b7e01e01e8b5f28b5d1b3d6f263bcf1b395600c2401009ad2b398a39b43ade33eacd59371c1e960c969f8164bfa9aff3ce950a5ba527a73c82eedc21456850f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-env@npm:^3.972.34":
-  version: 3.972.34
-  resolution: "@aws-sdk/credential-provider-env@npm:3.972.34"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/2f75940784b92ff71292b6dc5e660982f80bcfb4c3fcd0f0a04b0ff7de0a5b91000505b947434813b1104647d05678c3504560a7937aa82639e0042cb4597705
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-http@npm:^3.972.36":
-  version: 3.972.36
-  resolution: "@aws-sdk/credential-provider-http@npm:3.972.36"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/fetch-http-handler": "npm:^5.3.17"
-    "@smithy/node-http-handler": "npm:^4.6.1"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/smithy-client": "npm:^4.12.13"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-stream": "npm:^4.5.25"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/b3dd17e4403b3ef026a65da15cc3d08fdfddd42449f6d10edc6a4b016ed05306f7d4fe1fe286abd00bcf6cf3817ed19556fd97db9b2449deb0182569980dcd01
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:^3.972.38":
-  version: 3.972.38
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.38"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/credential-provider-env": "npm:^3.972.34"
-    "@aws-sdk/credential-provider-http": "npm:^3.972.36"
-    "@aws-sdk/credential-provider-login": "npm:^3.972.38"
-    "@aws-sdk/credential-provider-process": "npm:^3.972.34"
-    "@aws-sdk/credential-provider-sso": "npm:^3.972.38"
-    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.38"
-    "@aws-sdk/nested-clients": "npm:^3.997.6"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/credential-provider-imds": "npm:^4.2.14"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/198c7e3f88f525f814f599f6a1bc3a63c84ed046140017786f23de255adcb5c90f0bbcf9ec167c8c6771d63270f7ed9ac061713884ecddebc01da74be88ee6ea
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-login@npm:^3.972.38":
-  version: 3.972.38
-  resolution: "@aws-sdk/credential-provider-login@npm:3.972.38"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/nested-clients": "npm:^3.997.6"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/f84ab04b8fec3355dce3d2a0f9bd63e79ef04915f019f2b6731a267e853f7cfb066baf67a22c955e58aa86f5b6eded6acdfdfd67532cc923edeefb8e88f46d63
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:^3.972.39":
-  version: 3.972.39
-  resolution: "@aws-sdk/credential-provider-node@npm:3.972.39"
-  dependencies:
-    "@aws-sdk/credential-provider-env": "npm:^3.972.34"
-    "@aws-sdk/credential-provider-http": "npm:^3.972.36"
-    "@aws-sdk/credential-provider-ini": "npm:^3.972.38"
-    "@aws-sdk/credential-provider-process": "npm:^3.972.34"
-    "@aws-sdk/credential-provider-sso": "npm:^3.972.38"
-    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.38"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/credential-provider-imds": "npm:^4.2.14"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/e21808419372f95c842ed6f893d15599565a1fa9dffed81256a374f98ef3a3c276ab4be30fbaac963e5c4761b676fe10482f5a6b1fb2b03273b18e9ecd30c12d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:^3.972.34":
-  version: 3.972.34
-  resolution: "@aws-sdk/credential-provider-process@npm:3.972.34"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/f65dbaaa40a81ba8e84d314e8ac0528f6d807b63b98820102ffccb38f47b1aa52f0c6dd4d7e4e8df186cef9cd57041e1d2d929c0e692804a8af0d06497f38a6a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-sso@npm:^3.972.38":
-  version: 3.972.38
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.38"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/nested-clients": "npm:^3.997.6"
-    "@aws-sdk/token-providers": "npm:3.1041.0"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/4919362e1b8f6b73b8ec8ed0e0cc8f7a33db9b0d3ef63346a03047a024910d1acc6d80428a51444f6f15d58534dd535bc461b8505dd8f1cd6dc4fd8f863f956d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:^3.972.38":
-  version: 3.972.38
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.38"
-  dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/nested-clients": "npm:^3.997.6"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/7a235d693dae5578c15448c8484d68ca7749ffd327b4e3784e3a1c6784a14535b398cc09c6be26e97042779acc261adedc7064681b930d93ebcda26da17c1f72
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-handler-node@npm:^3.972.14":
-  version: 3.972.14
-  resolution: "@aws-sdk/eventstream-handler-node@npm:3.972.14"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/eventstream-codec": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/9e91aeddfbc23d41b8628c8ed93582857941c3caabe94aeccc28bfe0156270d392c90d214ed24bf8367d16266b274b4cd01a96069ed0d6ab64adfd7b369ab0b3
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-eventstream@npm:^3.972.10":
-  version: 3.972.10
-  resolution: "@aws-sdk/middleware-eventstream@npm:3.972.10"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/425a0cf0d1c3c079f63fb4a2017350867e4f62082bf261375387a64f1b41d3bf2392a7b38590306ebf440c211083e83c6089c5dfb624b81c41bea9a8a7f98dd4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-host-header@npm:^3.972.10":
-  version: 3.972.10
-  resolution: "@aws-sdk/middleware-host-header@npm:3.972.10"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/e631b48f8d8fd40f8977da8d1fc012208f953000dd5645dc0a700c7283af8fafb996c9c1c50e40b8392c402ad98d11e0ddddb949896db5163a7f06e2385e619a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:^3.972.10":
-  version: 3.972.10
-  resolution: "@aws-sdk/middleware-logger@npm:3.972.10"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/a24e0c98b3cf6c9b7960bf8979d2ab8f839fb89294ba8943136d99dbe7370cc45b010460ed7f5bf14ab6ad8e113ccec6387cf1bda655bcbdb58722df21d9b713
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-recursion-detection@npm:^3.972.11":
-  version: 3.972.11
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.972.11"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@aws-sdk/xml-builder": "npm:^3.972.27"
     "@aws/lambda-invoke-store": "npm:^0.2.2"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/signature-v4": "npm:^5.4.6"
+    "@smithy/types": "npm:^4.14.3"
+    bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e52501b00e79e714218897ddec9edd40ecf33fdb43c19b00195c8ed71c8295d0d148f07465465d464f103a23aa535dc1daf60bbb5b95303e330767a5eba78f54
+  checksum: 10c0/beec8841b27a88c8c54df66ba2593668eb400ab7df0507ee6de03999077d01de79d2a0454005ec85953f2c90fa735060c99465a618f11e5b443c236880597512
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:^3.972.37":
-  version: 3.972.37
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.37"
+"@aws-sdk/credential-provider-env@npm:^3.972.43":
+  version: 3.972.43
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.43"
   dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@aws-sdk/util-arn-parser": "npm:^3.972.3"
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/signature-v4": "npm:^5.3.14"
-    "@smithy/smithy-client": "npm:^4.12.13"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-config-provider": "npm:^4.2.2"
-    "@smithy/util-middleware": "npm:^4.2.14"
-    "@smithy/util-stream": "npm:^4.5.25"
-    "@smithy/util-utf8": "npm:^4.2.2"
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c8d4ad6aa908eca70ef085ac2c55362229071caa9518ed538574cc4d317d9f1f4e2173d6b01259dd83f77356ad4b68656b5720a31b3effe01f7fe10aec265aed
+  checksum: 10c0/8f75167eb52d156b9fe5107a3e9920e985b61a28b23f0926842c8348f56628a9e3cd79350069aef272968ebc6794d1e22714184fd20471cfe00a7cacc585c9c7
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:^3.972.38":
-  version: 3.972.38
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.972.38"
+"@aws-sdk/credential-provider-http@npm:^3.972.45":
+  version: 3.972.45
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.45"
   dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@aws-sdk/util-endpoints": "npm:^3.996.8"
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-retry": "npm:^4.3.6"
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/b9cf9416bc276b4abf42513515de5ee45ee419255b5953c9e53b44010500fcc486de988351683ecae52bf00c6bb5819c67375261afe1375b8a2a44196a8b9884
+  checksum: 10c0/904a5bc2e961354404226b1da8503de2d4b7b540d0308bb674bd793f48eda1cb710b83becc585abb52361d353f06d85e39937f3d2a56b8b39d2ee3be781ad799
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-websocket@npm:^3.972.16":
-  version: 3.972.16
-  resolution: "@aws-sdk/middleware-websocket@npm:3.972.16"
+"@aws-sdk/credential-provider-ini@npm:^3.972.48":
+  version: 3.972.48
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.48"
   dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@aws-sdk/util-format-url": "npm:^3.972.10"
-    "@smithy/eventstream-codec": "npm:^4.2.14"
-    "@smithy/eventstream-serde-browser": "npm:^4.2.14"
-    "@smithy/fetch-http-handler": "npm:^5.3.17"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/signature-v4": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-base64": "npm:^4.3.2"
-    "@smithy/util-hex-encoding": "npm:^4.2.2"
-    "@smithy/util-utf8": "npm:^4.2.2"
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.43"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.45"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.47"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.43"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.47"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.47"
+    "@aws-sdk/nested-clients": "npm:^3.997.15"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/credential-provider-imds": "npm:^4.3.7"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/2eb40a402be07af99a5b11e63d1ef408c8d0e90fd6692665cb3e8f5d827841f1dedf7c84a5b233b76141dcd9c0d8210194286779808a639149eff6cadf2ba458
+  checksum: 10c0/d3b4b869a2eb9c8a6b0b076f9ecbf0d9036a10e2a7af5d34a7be856e92bd3a7ddec00f04234e023a3ab3a1e3edfe6b7b52b7c7589a3817be6eaf505eca48d4c8
   languageName: node
   linkType: hard
 
-"@aws-sdk/nested-clients@npm:^3.997.6":
-  version: 3.997.6
-  resolution: "@aws-sdk/nested-clients@npm:3.997.6"
+"@aws-sdk/credential-provider-login@npm:^3.972.47":
+  version: 3.972.47
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.47"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/nested-clients": "npm:^3.997.15"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3fd44948542ed2393de13a68f0e38f77a39146ad27d70fb9cfdb20eea8085d84c3c5b4ee3ef2bcf109e765d1dbf80c0dcdf336f3ebcb494fc252b54ed5dd1e0c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:^3.972.42":
+  version: 3.972.50
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.50"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.43"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.45"
+    "@aws-sdk/credential-provider-ini": "npm:^3.972.48"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.43"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.47"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.47"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/credential-provider-imds": "npm:^4.3.7"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b823c0c730ae94ac62cef0de7b4f765457b4074e3ca665daacd033efb252025358efd7e65a3e99e27c719fe6fa968cd91e6035116f9fb76fcad1edae95c24f23
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.43":
+  version: 3.972.43
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.43"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/76ef1711c592bbe5f56d1c163663ac847fc971a60ae00280214367ca4b528838030f0efb2ecc25fc231488626b5fd03e19283ed8410bfba3dc8f0ab61079e397
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:^3.972.47":
+  version: 3.972.47
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.47"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/nested-clients": "npm:^3.997.15"
+    "@aws-sdk/token-providers": "npm:3.1060.0"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/1d90103f45dc8f83507545b702c577afb90569df060e9bd10e94180ef02a5e85e3f7b492d24f065dd40f1c8e5ee68eca812e6a398f42d59438295d902fcc8966
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.47":
+  version: 3.972.47
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.47"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/nested-clients": "npm:^3.997.15"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/0f9bd22250bc9d20d2a80c45b24b2ddc5ea2d695c5f63e517461588d16b43df8c733b50e518697416eac287580112a2cce4278efe8f3b4e7042d0ab6f19a99db
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-handler-node@npm:^3.972.16":
+  version: 3.972.19
+  resolution: "@aws-sdk/eventstream-handler-node@npm:3.972.19"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a77c33b1545ba441e1a485990abd0e8120a49f78e08b6ea3b6ec465ec77eecec1670436ca5699e0cf80def434617d8145d570772d0d7e2fb96f94edd658bb8ea
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-eventstream@npm:^3.972.12":
+  version: 3.972.15
+  resolution: "@aws-sdk/middleware-eventstream@npm:3.972.15"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3d2bed9cff37779e2ce7910bcf2fa5b21e8e791bc24a7509f556ec15c1431cc42a79134a4a5e54df192bf64164975bb0ae93fd322ac1cd06b129d2ce62cf34fa
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-websocket@npm:^3.972.19":
+  version: 3.972.25
+  resolution: "@aws-sdk/middleware-websocket@npm:3.972.25"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/signature-v4": "npm:^5.4.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/58f3ab23721a8adfdfd3a97f929a89b0840d50f270f15020e2d3296f1c130407f5f50c73663e1a2de00c42ff411537b6c2e852396342bfe65d8d3f47d7ec8855
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:^3.997.15, @aws-sdk/nested-clients@npm:^3.997.9":
+  version: 3.997.15
+  resolution: "@aws-sdk/nested-clients@npm:3.997.15"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/middleware-host-header": "npm:^3.972.10"
-    "@aws-sdk/middleware-logger": "npm:^3.972.10"
-    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.11"
-    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
-    "@aws-sdk/region-config-resolver": "npm:^3.972.13"
-    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.25"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@aws-sdk/util-endpoints": "npm:^3.996.8"
-    "@aws-sdk/util-user-agent-browser": "npm:^3.972.10"
-    "@aws-sdk/util-user-agent-node": "npm:^3.973.24"
-    "@smithy/config-resolver": "npm:^4.4.17"
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/fetch-http-handler": "npm:^5.3.17"
-    "@smithy/hash-node": "npm:^4.2.14"
-    "@smithy/invalid-dependency": "npm:^4.2.14"
-    "@smithy/middleware-content-length": "npm:^4.2.14"
-    "@smithy/middleware-endpoint": "npm:^4.4.32"
-    "@smithy/middleware-retry": "npm:^4.5.7"
-    "@smithy/middleware-serde": "npm:^4.2.20"
-    "@smithy/middleware-stack": "npm:^4.2.14"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/node-http-handler": "npm:^4.6.1"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/smithy-client": "npm:^4.12.13"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/url-parser": "npm:^4.2.14"
-    "@smithy/util-base64": "npm:^4.3.2"
-    "@smithy/util-body-length-browser": "npm:^4.2.2"
-    "@smithy/util-body-length-node": "npm:^4.2.3"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.49"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.54"
-    "@smithy/util-endpoints": "npm:^3.4.2"
-    "@smithy/util-middleware": "npm:^4.2.14"
-    "@smithy/util-retry": "npm:^4.3.6"
-    "@smithy/util-utf8": "npm:^4.2.2"
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.31"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/05c74c7362be74c723b64667763bd1e635c8d566456f70b64fa26546e7c605a49bf1bede7c2f5c293a0677b737093bbdc9b957a26124b9e1de5acf715dc57bb4
+  checksum: 10c0/f6f426f96be80779433894f759d0454bd87d32e12dde9e70c320de99d18e778368b669fa71aa439d1acdf304421612c0f7617591cf6fa84c1886330776ab60fe
   languageName: node
   linkType: hard
 
-"@aws-sdk/region-config-resolver@npm:^3.972.13":
-  version: 3.972.13
-  resolution: "@aws-sdk/region-config-resolver@npm:3.972.13"
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.31":
+  version: 3.996.31
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.31"
   dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/config-resolver": "npm:^4.4.17"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/types": "npm:^4.14.1"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/signature-v4": "npm:^5.4.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8cc3e5433ccf9ec4efb6d12ccd924701cfd6fb018124c9e5106486da10402ea1b83b0855353dae5e0f31ad2c7b6d962ac832350a5cdbeda59a30231525fd1118
+  checksum: 10c0/f319bf8f30005ea1771d7d3e82faa8ec9354539b179ec0a0676aec1aee758bbc2d7a57a3956d361d015e999db962c79ccbd5a1a4f7f0196efe9647095236c134
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:^3.996.25":
-  version: 3.996.25
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.25"
+"@aws-sdk/token-providers@npm:3.1048.0":
+  version: 3.1048.0
+  resolution: "@aws-sdk/token-providers@npm:3.1048.0"
   dependencies:
-    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.37"
+    "@aws-sdk/core": "npm:^3.974.11"
+    "@aws-sdk/nested-clients": "npm:^3.997.9"
     "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/core": "npm:^3.24.2"
     "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/05196c85d265e5e59df621c7844235a449a940ebc8264578c0f87d76b6fbb741650a5634433589b9223a05003198be214068eef7d6e50596196de0f1d1954b5d
+  checksum: 10c0/4dbca618047f9a051999031e0f027098fbd880fe7732bcd38cd0fd48461c41d7f28797bbf4292aa573815d7a2cdd44a0dad1fafd1922f52792f70c54bfd165b2
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.1041.0":
-  version: 3.1041.0
-  resolution: "@aws-sdk/token-providers@npm:3.1041.0"
+"@aws-sdk/token-providers@npm:3.1060.0":
+  version: 3.1060.0
+  resolution: "@aws-sdk/token-providers@npm:3.1060.0"
   dependencies:
-    "@aws-sdk/core": "npm:^3.974.8"
-    "@aws-sdk/nested-clients": "npm:^3.997.6"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
+    "@aws-sdk/core": "npm:^3.974.17"
+    "@aws-sdk/nested-clients": "npm:^3.997.15"
+    "@aws-sdk/types": "npm:^3.973.10"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/af70f8e23a98a750dcb661b43bbd896e4a2425f553336c491b118a058e46691689ac4fa980f69d2dae42d1488f3b859adbd2f347d73ac1261f44b421d2041101
+  checksum: 10c0/630be421583ac3f779d1229805784385aac52193cdada290529835ec768a86762a2928083801fa581bf70c0e96b9fd1e50307ceecfbfe2783f006bb445974821
   languageName: node
   linkType: hard
 
@@ -540,37 +381,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-arn-parser@npm:^3.972.3":
-  version: 3.972.3
-  resolution: "@aws-sdk/util-arn-parser@npm:3.972.3"
+"@aws-sdk/types@npm:^3.973.10":
+  version: 3.973.10
+  resolution: "@aws-sdk/types@npm:3.973.10"
   dependencies:
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/75c94dcd5d99a60375ce3474b0ee4f1ca17abdcd46ffbf34ce9d2e15238d77903c8993dddd46f1f328a7989c5aaec0c7dfef8b3eaa3e1125bea777399cfc46f2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-endpoints@npm:^3.996.8":
-  version: 3.996.8
-  resolution: "@aws-sdk/util-endpoints@npm:3.996.8"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/url-parser": "npm:^4.2.14"
-    "@smithy/util-endpoints": "npm:^3.4.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/66f17e85357ab8e265ab7d1c9a69a064ad3bea99420c786be9ef1f92bc71dca22d328bbceeaf6c64b4a3c37161b78318a3e4a424bf247dcb211d7ae29344db2f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-format-url@npm:^3.972.10":
-  version: 3.972.10
-  resolution: "@aws-sdk/util-format-url@npm:3.972.10"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/querystring-builder": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/d97445228f8ae9f8b7b53659e57d68c28f406d025d2902c6d1ba9bbb386d990011951d77f5a3d82360dc7bc5fd39a12c5e8bc27975ede72e586466597857cd19
+  checksum: 10c0/39925f52641effda9722093bb204818552c0504190e920945a4dd5da2dd1c7245d805a50595ae5a01353e0274e999566a9ad0f50af07db245ff2e3d7bcfd66a2
   languageName: node
   linkType: hard
 
@@ -583,46 +400,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:^3.972.10":
-  version: 3.972.10
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.972.10"
+"@aws-sdk/xml-builder@npm:^3.972.27":
+  version: 3.972.27
+  resolution: "@aws-sdk/xml-builder@npm:3.972.27"
   dependencies:
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/types": "npm:^4.14.1"
-    bowser: "npm:^2.11.0"
+    "@smithy/types": "npm:^4.14.3"
+    fast-xml-parser: "npm:5.7.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e139dda2cb51a0a3553c80ec6f89c39cb1292876c116f8449f21a7fdbe39bd7b545ef8ea69a447dd9fa2aa43c99f625ee6a55cbf6d8e6cf2094d0ef00ceb1e36
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:^3.973.24":
-  version: 3.973.24
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.973.24"
-  dependencies:
-    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
-    "@aws-sdk/types": "npm:^3.973.8"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-config-provider": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  peerDependencies:
-    aws-crt: ">=1.0.0"
-  peerDependenciesMeta:
-    aws-crt:
-      optional: true
-  checksum: 10c0/859c6441d1d24594d73a125c2a335faeb412a5cc3ab318005ce2e4904c3f9a0c6781437ae0fb2e3a1eb2343146dafbb9ac037ea88fbd8e78d50f7153732c5bb4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/xml-builder@npm:^3.972.22":
-  version: 3.972.22
-  resolution: "@aws-sdk/xml-builder@npm:3.972.22"
-  dependencies:
-    "@nodable/entities": "npm:2.1.0"
-    "@smithy/types": "npm:^4.14.1"
-    fast-xml-parser: "npm:5.7.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/4d9a7056a8ce6af639a9fa354f70a5a895b2e23c06c027776849d32ba18aa0d7f174133f1bc15756b79ac2bfdb9d990f092fb76a3891a7d1f6b03a424a8a6735
+  checksum: 10c0/6544aee8bd653252da337dd83482309a5fd46159a8e50280795708c7cf9194c19bf63a75e086ad764ec52fbc239857a03e7ae238a213f5dfa4aa496cbf938f1d
   languageName: node
   linkType: hard
 
@@ -752,6 +537,13 @@ __metadata:
   version: 7.27.1
   resolution: "@babel/helper-string-parser@npm:7.27.1"
   checksum: 10c0/8bda3448e07b5583727c103560bcf9c4c24b3c1051a4c516d4050ef69df37bb9a4734a585fe12725b8c2763de0a265aa1e909b485a4e3270b7cfd3e4dbe4b602
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.24.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
   languageName: node
   linkType: hard
 
@@ -1262,6 +1054,38 @@ __metadata:
     "@leichtgewicht/ip-codec": "npm:^2.0.4"
     utf8-codec: "npm:^1.0.0"
   checksum: 10c0/6df09a06e148ad5869b9b3ca49746f8bda886f70e3959421bc4850a7c27fb856f0f3f7cbe315652a3c5d78060a49748263a49eb64816f524434e1296bf6166fb
+  languageName: node
+  linkType: hard
+
+"@earendil-works/pi-agent-core@npm:^0.79.0":
+  version: 0.79.0
+  resolution: "@earendil-works/pi-agent-core@npm:0.79.0"
+  dependencies:
+    "@earendil-works/pi-ai": "npm:^0.79.0"
+    ignore: "npm:7.0.5"
+    typebox: "npm:1.1.38"
+    yaml: "npm:2.9.0"
+  checksum: 10c0/88e2623637ed854446164afe47e63617434696312d93405308dacfb78f7014196e62c1fb99ff67710d7e34c1fbe0e390ac82788a3b5eda6a0cbdf1a5d8ef0efc
+  languageName: node
+  linkType: hard
+
+"@earendil-works/pi-ai@npm:^0.79.0":
+  version: 0.79.0
+  resolution: "@earendil-works/pi-ai@npm:0.79.0"
+  dependencies:
+    "@anthropic-ai/sdk": "npm:0.91.1"
+    "@aws-sdk/client-bedrock-runtime": "npm:3.1048.0"
+    "@google/genai": "npm:1.52.0"
+    "@mistralai/mistralai": "npm:2.2.1"
+    "@smithy/node-http-handler": "npm:4.7.3"
+    http-proxy-agent: "npm:7.0.2"
+    https-proxy-agent: "npm:7.0.6"
+    openai: "npm:6.26.0"
+    partial-json: "npm:0.1.7"
+    typebox: "npm:1.1.38"
+  bin:
+    pi-ai: dist/cli.js
+  checksum: 10c0/db32adba4af2f5911e36fa0709648138db994fd7ef75fd2aac06d8109829cf4f3050075cae7f937ab73c19ca1f3fa977c040463cd22d15a182797c44dd2d05c5
   languageName: node
   linkType: hard
 
@@ -1949,6 +1773,8 @@ __metadata:
     tsutils: "npm:~3.21.0"
     typescript: "catalog:dev"
     typescript-eslint: "npm:8.59.2"
+  peerDependencies:
+    eslint-plugin-unicorn: ^56.0.1
   languageName: unknown
   linkType: soft
 
@@ -2129,6 +1955,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/genie@workspace:packages/genie"
   dependencies:
+    "@earendil-works/pi-agent-core": "npm:^0.79.0"
+    "@earendil-works/pi-ai": "npm:^0.79.0"
     "@endo/cli": "workspace:^"
     "@endo/daemon": "workspace:^"
     "@endo/errors": "workspace:^"
@@ -2143,8 +1971,6 @@ __metadata:
     "@endo/sandbox": "workspace:^"
     "@endo/ses-ava": "workspace:^"
     "@fast-check/ava": "catalog:dev"
-    "@mariozechner/pi-agent-core": "npm:^0.73.1"
-    "@mariozechner/pi-ai": "npm:^0.73.1"
     ava: "catalog:dev"
     better-sqlite3: "npm:^11.0.0"
     eslint: "catalog:dev"
@@ -3249,7 +3075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.7.0, @eslint-community/eslint-utils@npm:^4.9.1":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0, @eslint-community/eslint-utils@npm:^4.7.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -3346,9 +3172,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google/genai@npm:^1.40.0":
-  version: 1.51.0
-  resolution: "@google/genai@npm:1.51.0"
+"@google/genai@npm:1.52.0":
+  version: 1.52.0
+  resolution: "@google/genai@npm:1.52.0"
   dependencies:
     google-auth-library: "npm:^10.3.0"
     p-retry: "npm:^4.6.2"
@@ -3359,7 +3185,7 @@ __metadata:
   peerDependenciesMeta:
     "@modelcontextprotocol/sdk":
       optional: true
-  checksum: 10c0/e82e938f43f833f8d424532cb02a4fbbf266fe9740ca20bf02795f22e5adf708b5e5d21aa6e9b9dc31bc322c9f2dd1c33c773adf95ce0b9decae633ab28811c9
+  checksum: 10c0/2d22f6bd4baa915a402289dae4797410acbd5c5add1ed0c8d1bedef3ac7871fe1f04640d0612aa793fe7055f086719487491f55474a5b21597addfdea8631fa6
   languageName: node
   linkType: hard
 
@@ -4260,38 +4086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mariozechner/pi-agent-core@npm:^0.73.1":
-  version: 0.73.1
-  resolution: "@mariozechner/pi-agent-core@npm:0.73.1"
-  dependencies:
-    "@mariozechner/pi-ai": "npm:^0.73.1"
-    typebox: "npm:^1.1.24"
-  checksum: 10c0/30d88a57c821d11ae93e49c47b22038348be0ac6b23293a13530ee406cef460464484c661045fcbc83eb9fab7a8d35381d8ae65fa19de62b2c5f99463479efac
-  languageName: node
-  linkType: hard
-
-"@mariozechner/pi-ai@npm:^0.73.1":
-  version: 0.73.1
-  resolution: "@mariozechner/pi-ai@npm:0.73.1"
-  dependencies:
-    "@anthropic-ai/sdk": "npm:^0.91.1"
-    "@aws-sdk/client-bedrock-runtime": "npm:^3.1030.0"
-    "@google/genai": "npm:^1.40.0"
-    "@mistralai/mistralai": "npm:^2.2.0"
-    chalk: "npm:^5.6.2"
-    openai: "npm:6.26.0"
-    partial-json: "npm:^0.1.7"
-    proxy-agent: "npm:^6.5.0"
-    typebox: "npm:^1.1.24"
-    undici: "npm:^7.19.1"
-    zod-to-json-schema: "npm:^3.24.6"
-  bin:
-    pi-ai: dist/cli.js
-  checksum: 10c0/0afc3ee124b191ab69d8e897f0e02a5615b3013b556cd49c069ea023963920759d1e20441ad688b411e2ceeac3f2b2dae8142c7ad8c9237830e782343716e520
-  languageName: node
-  linkType: hard
-
-"@mistralai/mistralai@npm:^2.2.0":
+"@mistralai/mistralai@npm:2.2.1":
   version: 2.2.1
   resolution: "@mistralai/mistralai@npm:2.2.1"
   dependencies:
@@ -4450,7 +4245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodable/entities@npm:2.1.0, @nodable/entities@npm:^2.1.0":
+"@nodable/entities@npm:^2.1.0":
   version: 2.1.0
   resolution: "@nodable/entities@npm:2.1.0"
   checksum: 10c0/5a4cba2b61a5b6c726328b18b1de6d033cae4a658a118644bf31e0bcbda126ea7b69385043dc556cf1ed859b9ca220e82b81b5e5c48ef1b519fb8ec104575dee
@@ -5710,138 +5505,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^4.4.17":
-  version: 4.4.17
-  resolution: "@smithy/config-resolver@npm:4.4.17"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-config-provider": "npm:^4.2.2"
-    "@smithy/util-endpoints": "npm:^3.4.2"
-    "@smithy/util-middleware": "npm:^4.2.14"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/44e653e2ed31bf765f0b30ca404dc3e02f30ad800971f812a6363b71da8d37de5d7d8901d9db4d86d2493f25037904f35c01bbb1a83a2a72e7e7b201ce5c411a
-  languageName: node
-  linkType: hard
-
-"@smithy/core@npm:^3.23.17":
-  version: 3.23.17
-  resolution: "@smithy/core@npm:3.23.17"
-  dependencies:
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/url-parser": "npm:^4.2.14"
-    "@smithy/util-base64": "npm:^4.3.2"
-    "@smithy/util-body-length-browser": "npm:^4.2.2"
-    "@smithy/util-middleware": "npm:^4.2.14"
-    "@smithy/util-stream": "npm:^4.5.25"
-    "@smithy/util-utf8": "npm:^4.2.2"
-    "@smithy/uuid": "npm:^1.1.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/223631835e93c314a8fa394db724673c0940d3ba9e5ffbd73bd7c09854d7e003d19de950b44ce408e099c72ed3c22eb5e41370abea4ac656f7037e6da07be3c1
-  languageName: node
-  linkType: hard
-
-"@smithy/credential-provider-imds@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/credential-provider-imds@npm:4.2.14"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/url-parser": "npm:^4.2.14"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/62ced0249cb1ba64c6dd98a90b35b93dd9e3f1469d020752c46b5a83ecef38280f4b29c2f63e3b0c414a2fa2ec7631a19370415c80ed4d6ea18a9be040803126
-  languageName: node
-  linkType: hard
-
-"@smithy/eventstream-codec@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/eventstream-codec@npm:4.2.14"
+"@smithy/core@npm:^3.24.2, @smithy/core@npm:^3.24.3, @smithy/core@npm:^3.24.6":
+  version: 3.24.6
+  resolution: "@smithy/core@npm:3.24.6"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-hex-encoding": "npm:^4.2.2"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c2f9139004b3f75d3621b21e0ef80f850baf4955cce230e6d18faef171c2b4dc62694b1d86d4000a7ec1babb482afeca666520f69cf31455ed63259da6b2a3ee
+  checksum: 10c0/4d3db2296a99a4bcb17007b8276a243930f63c3169b9b86b973a2d1422e8dee7e95e3b98eea115e2759b989b23db1ff89ca505bddbacb7391ca3fe4e222b84ff
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/eventstream-serde-browser@npm:4.2.14"
+"@smithy/credential-provider-imds@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "@smithy/credential-provider-imds@npm:4.3.7"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/b624cf962ec84bbc61c419938de07548cbff3b1049fe5fb0c88097bdb516e6f3af22f6856ab3a5212cf352e7f1c69b0c5d03370cb4fe7f91a29dff975c385da5
+  checksum: 10c0/9a2f44c8bdc7f7770163fa26bc83f8adbb9e02c6ffa98751af3cbfc8107652d0a8e2a7bffc9761de20b776957eff33a865ec24523644b131003286bd2def9a4e
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^4.3.14":
-  version: 4.3.14
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.3.14"
+"@smithy/fetch-http-handler@npm:^5.4.2, @smithy/fetch-http-handler@npm:^5.4.6":
+  version: 5.4.6
+  resolution: "@smithy/fetch-http-handler@npm:5.4.6"
   dependencies:
-    "@smithy/types": "npm:^4.14.1"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d889a6e12797928c9507e99193f86ba0b7807441b67305643ec6b8b953c54237aa0ae7a4baaf00eb72ff07e3c71e88d6225de3db3d2b33729af38adb81b593f8
-  languageName: node
-  linkType: hard
-
-"@smithy/eventstream-serde-node@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/eventstream-serde-node@npm:4.2.14"
-  dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/c9dda5011ef3e6565dfa483811567b942fd822dfefb41768213fc9322b5298075c4a9228f8aa745af5bcebb23a2a61e24f091ce2be263da1ca3713aafa89c243
-  languageName: node
-  linkType: hard
-
-"@smithy/eventstream-serde-universal@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/eventstream-serde-universal@npm:4.2.14"
-  dependencies:
-    "@smithy/eventstream-codec": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/82cf563ff67b6543f0981dc3b1ef7fc3b507d5322e611a4f7fde4ae90d1d0eae172298c5bdda3837c5dd5c4d8839d59b72189797e178709be7b1996b3ea71a64
-  languageName: node
-  linkType: hard
-
-"@smithy/fetch-http-handler@npm:^5.3.17":
-  version: 5.3.17
-  resolution: "@smithy/fetch-http-handler@npm:5.3.17"
-  dependencies:
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/querystring-builder": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-base64": "npm:^4.3.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/8adac6bf9d5735f8ddbe9e59dd268f985881b64b03cba7e83401471b3094139189476324fe640bbd19d75f5cd8e098d9a2a7f4925bc9fadecd1ccbe937773c12
-  languageName: node
-  linkType: hard
-
-"@smithy/hash-node@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/hash-node@npm:4.2.14"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-buffer-from": "npm:^4.2.2"
-    "@smithy/util-utf8": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/c2cfc5dac4f2b996c4c5c503d3c26e52fcd0a647e71541182b24a48925801659828c9d378dad6857444b9d997c1655bdb23f6db5994ad8b7c814b2d0a09655b7
-  languageName: node
-  linkType: hard
-
-"@smithy/invalid-dependency@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/invalid-dependency@npm:4.2.14"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/deba2c21232050de87e7893b86a27a8f080ace391a3cccf22d7aee183bc3b392247f3bb1a0e4f0b6ea6f928c18ba035fd2ed3af257178ba84f3564d47c635d16
+  checksum: 10c0/06fd6f9a819766d1071ad0eca774ecd936b0b130057076a5e42f1bcc9c751deeddfa279adc4bcddd71ac7699744a2ed06a0405a239a379d98670855d18a6586b
   languageName: node
   linkType: hard
 
@@ -5854,194 +5547,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/is-array-buffer@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/is-array-buffer@npm:4.2.2"
+"@smithy/node-http-handler@npm:4.7.3":
+  version: 4.7.3
+  resolution: "@smithy/node-http-handler@npm:4.7.3"
   dependencies:
+    "@smithy/core": "npm:^3.24.3"
+    "@smithy/types": "npm:^4.14.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ab5bf2cad0f3bc6c1d882e15de436b80fa1504739ab9facc3d7006003870855480a6b15367e516fd803b3859c298b1fcc9212c854374b7e756cda01180bab0a6
+  checksum: 10c0/805002fc7e55f48f61d15de738dcd79f7bf8fbd372157b2967a9ac7616d76b744a410cc58efd672fa9c8f1592f5a8410aff35e3bd77ea5dfc47ff7c08fe42373
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/middleware-content-length@npm:4.2.14"
+"@smithy/node-http-handler@npm:^4.7.2, @smithy/node-http-handler@npm:^4.7.6":
+  version: 4.7.6
+  resolution: "@smithy/node-http-handler@npm:4.7.6"
   dependencies:
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c26cc36504ad9a720e42f009bcc185b16e35ff64644bbec710a998c071d3366face29bb6fa68744adc7312356803666922459e416f3a7ae5c804841957832c3d
+  checksum: 10c0/e926567ffda09c55c992f83449e185208a0fe87b0037254f8621dc13c495c2a8e6a24e0fe19211bb23f9c12d85e034e611dc2d1547494f8ef648844bddf62c56
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^4.4.32":
-  version: 4.4.32
-  resolution: "@smithy/middleware-endpoint@npm:4.4.32"
+"@smithy/signature-v4@npm:^5.4.6":
+  version: 5.4.6
+  resolution: "@smithy/signature-v4@npm:5.4.6"
   dependencies:
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/middleware-serde": "npm:^4.2.20"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/url-parser": "npm:^4.2.14"
-    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a77ba3f56956b872a533754c71f75d2a9d6df9af8d58a059d07caedd1af3ffdcae5b667a0b96b6d067555a777510f6fc5847f699a2dd705e9b5837d21510daa4
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-retry@npm:^4.5.7":
-  version: 4.5.7
-  resolution: "@smithy/middleware-retry@npm:4.5.7"
-  dependencies:
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/service-error-classification": "npm:^4.3.1"
-    "@smithy/smithy-client": "npm:^4.12.13"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-middleware": "npm:^4.2.14"
-    "@smithy/util-retry": "npm:^4.3.6"
-    "@smithy/uuid": "npm:^1.1.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/44ba622d961f83935aa13210fc92edfbf017f655ad4f4fb2024f7e880a70867d547b358be2089966689ed92c5deedcdf4723177c015babaf332ba3b55a40fe9b
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-serde@npm:^4.2.20":
-  version: 4.2.20
-  resolution: "@smithy/middleware-serde@npm:4.2.20"
-  dependencies:
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/2db736d58c0d628a33febad86259eedd6d025135fc403458e4469a077a6adbb909587408acb62c982fa1b2d8b1376507da90661a4315a544c7d73a62179a3453
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-stack@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/middleware-stack@npm:4.2.14"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/5a0323c50b399c4a2ff0d91b219c7c285b006f905f66b291b6013a4e94f14c036ff5a74c565989afc3c6f0fafc6c266bca6746b79e242403713b7d18dc266a92
-  languageName: node
-  linkType: hard
-
-"@smithy/node-config-provider@npm:^4.3.14":
-  version: 4.3.14
-  resolution: "@smithy/node-config-provider@npm:4.3.14"
-  dependencies:
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/59033a2fde5327d9ae1a0304a0eb2c3145141024cb4dcb58c5cd3c48371cd3a55d7228a3d2f33a5785b2d6a0a35475cbd0d1b2435d964c824683ac89a664e926
-  languageName: node
-  linkType: hard
-
-"@smithy/node-http-handler@npm:^4.6.1":
-  version: 4.6.1
-  resolution: "@smithy/node-http-handler@npm:4.6.1"
-  dependencies:
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/querystring-builder": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/6c07fbfd8326cd5369283bd19c1af923ee49b7dcf42fdd199bb7132e4c25eaa6db8573e3b669fb60be0d8f9757a3f2482cd0cf6d6631494255f08239d3036ed2
-  languageName: node
-  linkType: hard
-
-"@smithy/property-provider@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/property-provider@npm:4.2.14"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/8d3da90e228b53885d1e82f28b33c095b72f3b1cb5dcd7f7edcd96292d90848e9cdfed85cef00040e198343e850acef61540e4de24bd10b07fbc8e1e8f4a1fdd
-  languageName: node
-  linkType: hard
-
-"@smithy/protocol-http@npm:^5.3.14":
-  version: 5.3.14
-  resolution: "@smithy/protocol-http@npm:5.3.14"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/ed7306e7e4b919fdacf60d1928f003ac4c4679cffd7472b078547fbed7b6cb9ba524f105b1871c2cd79222871169d3183257fd0a1a81c172fa7cf0a9abaf35f9
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-builder@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/querystring-builder@npm:4.2.14"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-uri-escape": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/ae2ceec55b4f32b73fe2eca710563b9dbe65c81157ed58c12c282bad6445998f1fe99d723591f9bac4ae6106d84213b57e960176865fb2dec78fc3bdf024b14b
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-parser@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/querystring-parser@npm:4.2.14"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/245923618197bbae5eb38b72807368f397fafccee8e98cd98ee7d8961a34acb57b5176fa5fe8083b796229043f135ea775060f17e14aa12080a5d7cdfbf56333
-  languageName: node
-  linkType: hard
-
-"@smithy/service-error-classification@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "@smithy/service-error-classification@npm:4.3.1"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-  checksum: 10c0/1bc927f53693035165f4b15232c644be579cdd432cf2d3e026faa746d26693e6b1e0f35bcd5d812dd89445695fd1eb7188e415e2523d6d8991e8db900cecdf36
-  languageName: node
-  linkType: hard
-
-"@smithy/shared-ini-file-loader@npm:^4.4.9":
-  version: 4.4.9
-  resolution: "@smithy/shared-ini-file-loader@npm:4.4.9"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/9bf96ea80cedff027373c5547ffa53b35d272292b7d142a86211726343061953a34610f3dbd02153bb285c7c0f3802c5a25b4e27870e8068d777abdcaa9c1748
-  languageName: node
-  linkType: hard
-
-"@smithy/signature-v4@npm:^5.3.14":
-  version: 5.3.14
-  resolution: "@smithy/signature-v4@npm:5.3.14"
-  dependencies:
-    "@smithy/is-array-buffer": "npm:^4.2.2"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-hex-encoding": "npm:^4.2.2"
-    "@smithy/util-middleware": "npm:^4.2.14"
-    "@smithy/util-uri-escape": "npm:^4.2.2"
-    "@smithy/util-utf8": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/ccc788992e281a681984e079b7194a219af40cf4f7087988eba69c4947264b9a83ac00a806164b9074c7e2f0697e492fa2b377b56b783316d247be02aaccbdb3
-  languageName: node
-  linkType: hard
-
-"@smithy/smithy-client@npm:^4.12.13":
-  version: 4.12.13
-  resolution: "@smithy/smithy-client@npm:4.12.13"
-  dependencies:
-    "@smithy/core": "npm:^3.23.17"
-    "@smithy/middleware-endpoint": "npm:^4.4.32"
-    "@smithy/middleware-stack": "npm:^4.2.14"
-    "@smithy/protocol-http": "npm:^5.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-stream": "npm:^4.5.25"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/0680d4d0720d110a637fabb8bdc85175e1471191925f5c55f08636f5327de1bc29c8db75318aac1396491fa83c8a319dd4cd26c5e9fff619207c9a96b9dbd9fe
+  checksum: 10c0/7d7db13f4ddb09cca0a902dd760d83ff9770c085657e577153e4a93c0cd0314a36cbafaaae58c7be1aa1162e81ecab8b1395b0b0e488b20c22eb0dd9714b2b25
   languageName: node
   linkType: hard
 
@@ -6054,43 +5589,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/url-parser@npm:4.2.14"
-  dependencies:
-    "@smithy/querystring-parser": "npm:^4.2.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/360463fe1fb51b8a1c5b80f4a16df993ee4e87221e60ce51c428b0737d6f1325434ec572bb7afca7d65bb9a09c750f307822a23e42be675706ee71fedd7c6c06
-  languageName: node
-  linkType: hard
-
-"@smithy/util-base64@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "@smithy/util-base64@npm:4.3.2"
-  dependencies:
-    "@smithy/util-buffer-from": "npm:^4.2.2"
-    "@smithy/util-utf8": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/acc08ff0b482ef4473289be655e0adc21c33555a837bbbc1cc7121d70e3ad595807bcaaec7456d92e93d83c2e8773729d42f78d716ac7d91552845b50cd87d89
-  languageName: node
-  linkType: hard
-
-"@smithy/util-body-length-browser@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/util-body-length-browser@npm:4.2.2"
+"@smithy/types@npm:^4.14.2, @smithy/types@npm:^4.14.3":
+  version: 4.14.3
+  resolution: "@smithy/types@npm:4.14.3"
   dependencies:
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4444039b995068eeda3dd0b143eb22cf86c7ef7632a590559dad12b0e681a728a7d82f8ed4f4019cdc09a72e4b5f14281262b64db75514dbcc08d170d9e8f1db
-  languageName: node
-  linkType: hard
-
-"@smithy/util-body-length-node@npm:^4.2.3":
-  version: 4.2.3
-  resolution: "@smithy/util-body-length-node@npm:4.2.3"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/5345d75e8c3e0a726ed6e2fe604dfe97b0bcc37e940b30b045e3e116fced9555d8a9fa684d9f898111773eeef548bcb5f0bb03ee67c206ee498064842d6173b5
+  checksum: 10c0/c80244d5ca88992e5609e372eaf2441497d36063688af44e9f0e81ab0ee8d5a4cbdb644822243e4cdfad2dd6484c6274e618dc2a9e91b3b9befe7c7b55e09ddc
   languageName: node
   linkType: hard
 
@@ -6104,118 +5608,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-buffer-from@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/util-buffer-from@npm:4.2.2"
-  dependencies:
-    "@smithy/is-array-buffer": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/d9acea42ee035e494da0373de43a25fa14f81d11e3605a2c6c5f56efef9a4f901289ec2ba343ebb3ad32ae4e0cfe517e8b6b3449a4297d1c060889c83cd1c94f
-  languageName: node
-  linkType: hard
-
-"@smithy/util-config-provider@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/util-config-provider@npm:4.2.2"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/cfd3350607ec00b6294724033aa3e469f8d9d258a7a70772e67d80c301f2eae62b17850ea0c8d8a20208b3f4f1ea5aa0019f45545a6c0577a94a47a05c81d8e8
-  languageName: node
-  linkType: hard
-
-"@smithy/util-defaults-mode-browser@npm:^4.3.49":
-  version: 4.3.49
-  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.49"
-  dependencies:
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/smithy-client": "npm:^4.12.13"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/0979b09f1108aa41f5bf623e32fa138e129fbffe3adc23c46308afa310b925635428f9d7e36e3e2a312cafe9af325cb5f01667791ee672418d4f302c1961623b
-  languageName: node
-  linkType: hard
-
-"@smithy/util-defaults-mode-node@npm:^4.2.54":
-  version: 4.2.54
-  resolution: "@smithy/util-defaults-mode-node@npm:4.2.54"
-  dependencies:
-    "@smithy/config-resolver": "npm:^4.4.17"
-    "@smithy/credential-provider-imds": "npm:^4.2.14"
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/property-provider": "npm:^4.2.14"
-    "@smithy/smithy-client": "npm:^4.12.13"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/7146087fa1d7758b37da456719d589f63300843ff5610891de02a0434c5abbd49fd257712c2d9e0bede904f4ec62c9d3c9eddcd6ec0372134f998e4f9c0bce09
-  languageName: node
-  linkType: hard
-
-"@smithy/util-endpoints@npm:^3.4.2":
-  version: 3.4.2
-  resolution: "@smithy/util-endpoints@npm:3.4.2"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.14"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/602e05c8dc43d8902604bac74b717d09da5b4f1994dcdd5025bffeced6002eaa0612ae1ccbe7a0e636a3d92a60747715e22cbacf8feeb672394d15b6ae211b13
-  languageName: node
-  linkType: hard
-
-"@smithy/util-hex-encoding@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/util-hex-encoding@npm:4.2.2"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/b2f2bca85475cd599b998e169b7026db40edc2a0a338ad7988b9c94d9f313c5f7e08451aced4f8e62dbeaa54e15d1300d76c572b83ffa36f9f8ca22b6fc84bd7
-  languageName: node
-  linkType: hard
-
-"@smithy/util-middleware@npm:^4.2.14":
-  version: 4.2.14
-  resolution: "@smithy/util-middleware@npm:4.2.14"
-  dependencies:
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/6ba5026b70ad7b58fac89d7428c0b1679be2a97a8fb47811a39e0183901a3c6ca8732ee225ddfda28e7b86223d49983ff709421905da571bc00b82c660e4fc27
-  languageName: node
-  linkType: hard
-
-"@smithy/util-retry@npm:^4.3.6":
-  version: 4.3.6
-  resolution: "@smithy/util-retry@npm:4.3.6"
-  dependencies:
-    "@smithy/service-error-classification": "npm:^4.3.1"
-    "@smithy/types": "npm:^4.14.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/a2d3b34ca48edd4f58885c91de28f7ccbe48d0e4a8f005eb569197cf37640b5c04043fd556b0e1ecf6d8623b6c384b52b1c34c898acf77260e517f7d00641811
-  languageName: node
-  linkType: hard
-
-"@smithy/util-stream@npm:^4.5.25":
-  version: 4.5.25
-  resolution: "@smithy/util-stream@npm:4.5.25"
-  dependencies:
-    "@smithy/fetch-http-handler": "npm:^5.3.17"
-    "@smithy/node-http-handler": "npm:^4.6.1"
-    "@smithy/types": "npm:^4.14.1"
-    "@smithy/util-base64": "npm:^4.3.2"
-    "@smithy/util-buffer-from": "npm:^4.2.2"
-    "@smithy/util-hex-encoding": "npm:^4.2.2"
-    "@smithy/util-utf8": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/4b222c975eca2018831f1ab4067f122f4ef5e68f3abb71776003309f1a27f67d509a2d86f5f1f81a91656236db0e29c38314c005b17dbf63f053de4d97be7b59
-  languageName: node
-  linkType: hard
-
-"@smithy/util-uri-escape@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/util-uri-escape@npm:4.2.2"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/33b6546086c975278d16b5029e6555df551b4bd1e3a84042544d1ef956a287fe033b317954b1737b2773e82b6f27ebde542956ff79ef0e8a813dc0dbf9d34a58
-  languageName: node
-  linkType: hard
-
 "@smithy/util-utf8@npm:^2.0.0":
   version: 2.3.0
   resolution: "@smithy/util-utf8@npm:2.3.0"
@@ -6223,25 +5615,6 @@ __metadata:
     "@smithy/util-buffer-from": "npm:^2.2.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e18840c58cc507ca57fdd624302aefd13337ee982754c9aa688463ffcae598c08461e8620e9852a424d662ffa948fc64919e852508028d09e89ced459bd506ab
-  languageName: node
-  linkType: hard
-
-"@smithy/util-utf8@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/util-utf8@npm:4.2.2"
-  dependencies:
-    "@smithy/util-buffer-from": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/55b5119873237519a9175491c74fd0a14acd4f9c54c7eec9ae547de6c554098912d46572edb12d5b52a0b9675c0577e2e63d1f7cb8e022ca342f5bf80b56a466
-  languageName: node
-  linkType: hard
-
-"@smithy/uuid@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@smithy/uuid@npm:1.1.2"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/cbedfe5e2c1ec5ee05ae0cd6cc3c9f6f5e600207362d62470278827488794e19148a05a61ee9b6a2359bb460985af1a528c48d54f365891fe1c4913504250667
   languageName: node
   linkType: hard
 
@@ -6258,13 +5631,6 @@ __metadata:
   dependencies:
     defer-to-connect: "npm:^2.0.0"
   checksum: 10c0/73946918c025339db68b09abd91fa3001e87fc749c619d2e9c2003a663039d4c3cb89836c98a96598b3d47dec2481284ba85355392644911f5ecd2336536697f
-  languageName: node
-  linkType: hard
-
-"@tootallnate/quickjs-emscripten@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "@tootallnate/quickjs-emscripten@npm:0.23.0"
-  checksum: 10c0/2a939b781826fb5fd3edd0f2ec3b321d259d760464cf20611c9877205aaca3ccc0b7304dea68416baa0d568e82cd86b17d29548d1e5139fa3155a4a86a2b4b49
   languageName: node
   linkType: hard
 
@@ -7557,15 +6923,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types@npm:^0.13.4":
-  version: 0.13.4
-  resolution: "ast-types@npm:0.13.4"
-  dependencies:
-    tslib: "npm:^2.0.1"
-  checksum: 10c0/3a1a409764faa1471601a0ad01b3aa699292991aa9c8a30c7717002cabdf5d98008e7b53ae61f6e058f757fc6ba965e147967a93c13e62692c907d79cfb245f8
-  languageName: node
-  linkType: hard
-
 "async-sema@npm:^3.1.1":
   version: 3.1.1
   resolution: "async-sema@npm:3.1.1"
@@ -7759,13 +7116,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.3.1
-  resolution: "basic-ftp@npm:5.3.1"
-  checksum: 10c0/03511b488cd292abfa82a8c0ea3b9573b40d12d2f1518d6f41a9461b012b3376d3e6d50679b38d9b2b4f48fd6e8e0418ac196312ee7e2da13cb801169940d1c3
-  languageName: node
-  linkType: hard
-
 "before-after-hook@npm:^2.2.0":
   version: 2.2.2
   resolution: "before-after-hook@npm:2.2.2"
@@ -7930,7 +7280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.24.0":
+"browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
   version: 4.28.2
   resolution: "browserslist@npm:4.28.2"
   dependencies:
@@ -7973,6 +7323,13 @@ __metadata:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.1.13"
   checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
+  languageName: node
+  linkType: hard
+
+"builtin-modules@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "builtin-modules@npm:3.3.0"
+  checksum: 10c0/2cb3448b4f7306dc853632a4fcddc95e8d4e4b9868c139400027b71938fc6806d4ff44007deffb362ac85724bd40c2c6452fb6a0aa4531650eeddb98d8e5ee8a
   languageName: node
   linkType: hard
 
@@ -8305,6 +7662,15 @@ __metadata:
   version: 1.0.1
   resolution: "ci-parallel-vars@npm:1.0.1"
   checksum: 10c0/80952f699cbbc146092b077b4f3e28d085620eb4e6be37f069b4dbb3db0ee70e8eec3beef4ebe70ff60631e9fc743b9d0869678489f167442cac08b260e5ac08
+  languageName: node
+  linkType: hard
+
+"clean-regexp@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "clean-regexp@npm:1.0.0"
+  dependencies:
+    escape-string-regexp: "npm:^1.0.5"
+  checksum: 10c0/fd9c7446551b8fc536f95e8a286d431017cd4ba1ec2e53997ec9159385e9c317672f6dfc4d49fdb97449fdb53b0bacd0a8bab9343b8fdd2e46c7ddf6173d0db7
   languageName: node
   linkType: hard
 
@@ -8848,6 +8214,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js-compat@npm:^3.38.1":
+  version: 3.49.0
+  resolution: "core-js-compat@npm:3.49.0"
+  dependencies:
+    browserslist: "npm:^4.28.1"
+  checksum: 10c0/546e64b7ce45f724825bc13c1347f35c0459a6e71c0dcccff3ec21fbff463f5b0b97fc1220e6d90302153863489301793276fe2bf96f46001ff555ead4140308
+  languageName: node
+  linkType: hard
+
 "core-js@npm:^3.31.0":
   version: 3.49.0
   resolution: "core-js@npm:3.49.0"
@@ -8939,13 +8314,6 @@ __metadata:
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
   checksum: 10c0/20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
-  languageName: node
-  linkType: hard
-
-"data-uri-to-buffer@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "data-uri-to-buffer@npm:6.0.2"
-  checksum: 10c0/f76922bf895b3d7d443059ff278c9cc5efc89d70b8b80cd9de0aa79b3adc6d7a17948eefb8692e30398c43635f70ece1673d6085cc9eba2878dbc6c6da5292ac
   languageName: node
   linkType: hard
 
@@ -9203,17 +8571,6 @@ __metadata:
     has-property-descriptors: "npm:^1.0.0"
     object-keys: "npm:^1.1.1"
   checksum: 10c0/88a152319ffe1396ccc6ded510a3896e77efac7a1bfbaa174a7b00414a1747377e0bb525d303794a47cf30e805c2ec84e575758512c6e44a993076d29fd4e6c3
-  languageName: node
-  linkType: hard
-
-"degenerator@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "degenerator@npm:5.0.1"
-  dependencies:
-    ast-types: "npm:^0.13.4"
-    escodegen: "npm:^2.1.0"
-    esprima: "npm:^4.0.1"
-  checksum: 10c0/e48d8a651edeb512a648711a09afec269aac6de97d442a4bb9cf121a66877e0eec11b9727100a10252335c0666ae1c84a8bc1e3a3f47788742c975064d2c7b1c
   languageName: node
   linkType: hard
 
@@ -9997,24 +9354,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escodegen@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "escodegen@npm:2.1.0"
-  dependencies:
-    esprima: "npm:^4.0.1"
-    estraverse: "npm:^5.2.0"
-    esutils: "npm:^2.0.2"
-    source-map: "npm:~0.6.1"
-  dependenciesMeta:
-    source-map:
-      optional: true
-  bin:
-    escodegen: bin/escodegen.js
-    esgenerate: bin/esgenerate.js
-  checksum: 10c0/e1450a1f75f67d35c061bf0d60888b15f62ab63aef9df1901cffc81cffbbb9e8b3de237c5502cf8613a017c1df3a3003881307c78835a1ab54d8c8d2206e01d3
-  languageName: node
-  linkType: hard
-
 "eshost-cli@npm:^9.0.0":
   version: 9.0.0
   resolution: "eshost-cli@npm:9.0.0"
@@ -10253,6 +9592,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-unicorn@npm:^56.0.1":
+  version: 56.0.1
+  resolution: "eslint-plugin-unicorn@npm:56.0.1"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.24.7"
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    ci-info: "npm:^4.0.0"
+    clean-regexp: "npm:^1.0.0"
+    core-js-compat: "npm:^3.38.1"
+    esquery: "npm:^1.6.0"
+    globals: "npm:^15.9.0"
+    indent-string: "npm:^4.0.0"
+    is-builtin-module: "npm:^3.2.1"
+    jsesc: "npm:^3.0.2"
+    pluralize: "npm:^8.0.0"
+    read-pkg-up: "npm:^7.0.1"
+    regexp-tree: "npm:^0.1.27"
+    regjsparser: "npm:^0.10.0"
+    semver: "npm:^7.6.3"
+    strip-indent: "npm:^3.0.0"
+  peerDependencies:
+    eslint: ">=8.56.0"
+  checksum: 10c0/3b853ecde6ab597b12e28b962ba6ad7d3594f7f066d90135db2d3366ac13361c72500119163e13e1c38ca6fbdd331b1cc31dce9e8673880bff050fe51d6c64db
+  languageName: node
+  linkType: hard
+
 "eslint-rule-docs@npm:^1.1.5":
   version: 1.1.235
   resolution: "eslint-rule-docs@npm:1.1.235"
@@ -10379,7 +9744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0, esprima@npm:^4.0.1, esprima@npm:~4.0.0":
+"esprima@npm:^4.0.0, esprima@npm:~4.0.0":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -10398,7 +9763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.7.0":
+"esquery@npm:^1.6.0, esquery@npm:^1.7.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
   dependencies:
@@ -10644,26 +10009,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "fast-xml-builder@npm:1.1.5"
+"fast-xml-builder@npm:^1.1.7":
+  version: 1.2.0
+  resolution: "fast-xml-builder@npm:1.2.0"
   dependencies:
-    path-expression-matcher: "npm:^1.1.3"
-  checksum: 10c0/b814ba5559cb3140de46d2846045607ab4d4c0bfc312a49d22c91efb9f7cd7004971314841e5823eeb467a5bf403e3ade8371b7912200e111df027d42ae51715
+    path-expression-matcher: "npm:^1.5.0"
+    xml-naming: "npm:^0.1.0"
+  checksum: 10c0/84bb105cd04e91d6dcb746c4dbaeb12903b510e7ab9a06ffde55b5a582e005559a87d84467f18a655c6c4baf098f696fd74cee3cbe1aea9d01385907768ba32d
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.7.2":
-  version: 5.7.2
-  resolution: "fast-xml-parser@npm:5.7.2"
+"fast-xml-parser@npm:5.7.3":
+  version: 5.7.3
+  resolution: "fast-xml-parser@npm:5.7.3"
   dependencies:
     "@nodable/entities": "npm:^2.1.0"
-    fast-xml-builder: "npm:^1.1.5"
+    fast-xml-builder: "npm:^1.1.7"
     path-expression-matcher: "npm:^1.5.0"
     strnum: "npm:^2.2.3"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/d48439ce0700add82f5e7c6ccc5a1f06483beb7cd8e88caa83c6406843e52f14988e60d05cbb3a86ffe07e073807674c807e0764d94a280e1c96d7e2011dae8e
+  checksum: 10c0/eeb802855e852ce16121396297f04131c6dbc74f863be94f19e26e386656bdb31677af469ddc6627983a48b99d8842888460ac5413063cb648fde547bb579978
   languageName: node
   linkType: hard
 
@@ -11334,17 +10700,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-uri@npm:^6.0.1":
-  version: 6.0.5
-  resolution: "get-uri@npm:6.0.5"
-  dependencies:
-    basic-ftp: "npm:^5.0.2"
-    data-uri-to-buffer: "npm:^6.0.2"
-    debug: "npm:^4.3.4"
-  checksum: 10c0/c7ff5d5d55de53d23ecce7c5108cc3ed0db1174db43c9aa15506d640283d36ee0956fd8ba1fc50b06a718466cc85794ae9d8860193f91318afe846e3e7010f3a
-  languageName: node
-  linkType: hard
-
 "git-raw-commits@npm:^3.0.0":
   version: 3.0.0
   resolution: "git-raw-commits@npm:3.0.0"
@@ -11526,6 +10881,13 @@ __metadata:
   version: 14.0.0
   resolution: "globals@npm:14.0.0"
   checksum: 10c0/b96ff42620c9231ad468d4c58ff42afee7777ee1c963013ff8aabe095a451d0ceeb8dcd8ef4cbd64d2538cef45f787a78ba3a9574f4a634438963e334471302d
+  languageName: node
+  linkType: hard
+
+"globals@npm:^15.9.0":
+  version: 15.15.0
+  resolution: "globals@npm:15.15.0"
+  checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
   languageName: node
   linkType: hard
 
@@ -11856,7 +11218,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.1":
+"http-proxy-agent@npm:7.0.2, http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -11886,7 +11248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5, https-proxy-agent@npm:^7.0.6":
+"https-proxy-agent@npm:7.0.6, https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -11987,17 +11349,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:7.0.5, ignore@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "ignore@npm:7.0.5"
+  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.0.4, ignore@npm:^5.0.5, ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^7.0.5":
-  version: 7.0.5
-  resolution: "ignore@npm:7.0.5"
-  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
   languageName: node
   linkType: hard
 
@@ -12244,13 +11606,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
-  languageName: node
-  linkType: hard
-
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -12327,6 +11682,15 @@ __metadata:
     call-bound: "npm:^1.0.2"
     has-tostringtag: "npm:^1.0.2"
   checksum: 10c0/2ef601d255a39fdbde79cfe6be80c27b47430ed6712407f29b17d002e20f64c1e3d6692f1d842ba16bf1e9d8ddf1c4f13cac3ed7d9a4a21290f44879ebb4e8f5
+  languageName: node
+  linkType: hard
+
+"is-builtin-module@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "is-builtin-module@npm:3.2.1"
+  dependencies:
+    builtin-modules: "npm:^3.3.0"
+  checksum: 10c0/5a66937a03f3b18803381518f0ef679752ac18cdb7dd53b5e23ee8df8d440558737bd8dcc04d2aae555909d2ecb4a81b5c0d334d119402584b61e6a003e31af1
   languageName: node
   linkType: hard
 
@@ -13292,6 +12656,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsesc@npm:~0.5.0":
+  version: 0.5.0
+  resolution: "jsesc@npm:0.5.0"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 10c0/f93792440ae1d80f091b65f8ceddf8e55c4bb7f1a09dee5dcbdb0db5612c55c0f6045625aa6b7e8edb2e0a4feabd80ee48616dbe2d37055573a84db3d24f96d9
+  languageName: node
+  linkType: hard
+
 "json-bigint@npm:^1.0.0":
   version: 1.0.0
   resolution: "json-bigint@npm:1.0.0"
@@ -13894,13 +13267,6 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^7.14.1":
-  version: 7.18.3
-  resolution: "lru-cache@npm:7.18.3"
-  checksum: 10c0/b3a452b491433db885beed95041eb104c157ef7794b9c9b4d647be503be91769d11206bb573849a16b4cc0d03cbd15ffd22df7960997788b74c1d399ac7a4fed
   languageName: node
   linkType: hard
 
@@ -15700,32 +15066,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pac-proxy-agent@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "pac-proxy-agent@npm:7.2.0"
-  dependencies:
-    "@tootallnate/quickjs-emscripten": "npm:^0.23.0"
-    agent-base: "npm:^7.1.2"
-    debug: "npm:^4.3.4"
-    get-uri: "npm:^6.0.1"
-    http-proxy-agent: "npm:^7.0.0"
-    https-proxy-agent: "npm:^7.0.6"
-    pac-resolver: "npm:^7.0.1"
-    socks-proxy-agent: "npm:^8.0.5"
-  checksum: 10c0/0265c17c9401c2ea735697931a6553a0c6d8b20c4d7d4e3b3a0506080ba69a8d5ad656e2a6be875411212e2b6ed7a4d9526dd3997e08581fdfb1cbcad454c296
-  languageName: node
-  linkType: hard
-
-"pac-resolver@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "pac-resolver@npm:7.0.1"
-  dependencies:
-    degenerator: "npm:^5.0.0"
-    netmask: "npm:^2.0.2"
-  checksum: 10c0/5f3edd1dd10fded31e7d1f95776442c3ee51aa098c28b74ede4927d9677ebe7cebb2636750c24e945f5b84445e41ae39093d3a1014a994e5ceb9f0b1b88ebff5
-  languageName: node
-  linkType: hard
-
 "package-config@npm:^5.0.0":
   version: 5.0.0
   resolution: "package-config@npm:5.0.0"
@@ -15901,7 +15241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"partial-json@npm:^0.1.7":
+"partial-json@npm:0.1.7":
   version: 0.1.7
   resolution: "partial-json@npm:0.1.7"
   checksum: 10c0/cd5f994c3a5ca903918c028a6947ebc1d46459234c1c57c7ab98e234d8dca49cb46b05a71889ee422b39d1f66b95c59a5ce3a6ae06966aca95a8960ad20c12d2
@@ -15929,7 +15269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-expression-matcher@npm:^1.1.3, path-expression-matcher@npm:^1.5.0":
+"path-expression-matcher@npm:^1.5.0":
   version: 1.5.0
   resolution: "path-expression-matcher@npm:1.5.0"
   checksum: 10c0/646cb5bc66cd7d809a52288336f3ac1e6223f156fd8e912936e490e590f7f93e8056d4fd25fcbcc7da61bb698fa520112cb050372a3f65e7b79bd4afa0f77610
@@ -16143,6 +15483,13 @@ __metadata:
   dependencies:
     irregular-plurals: "npm:^4.2.0"
   checksum: 10c0/5c54badee70debea38e7153b197c1235847edc10952c3dd959c9610005f75013c2053be1cba87acde4531498d7a9e8b16c6b358f3940f05aa6e1aeedbc991b7a
+  languageName: node
+  linkType: hard
+
+"pluralize@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "pluralize@npm:8.0.0"
+  checksum: 10c0/2044cfc34b2e8c88b73379ea4a36fc577db04f651c2909041b054c981cd863dd5373ebd030123ab058d194ae615d3a97cfdac653991e499d10caf592e8b3dc33
   languageName: node
   linkType: hard
 
@@ -16403,22 +15750,6 @@ __metadata:
     uint8arraylist: "npm:^2.4.8"
     uint8arrays: "npm:^5.1.0"
   checksum: 10c0/95e47c06e14559b4eafa64f837a664e8c5b2e36f30e9c7f1daf44e2556e7a97f4df55dd62a546e7e0636da6206471a124fe4fa2409a56a9e99b7b6357fdbb004
-  languageName: node
-  linkType: hard
-
-"proxy-agent@npm:^6.5.0":
-  version: 6.5.0
-  resolution: "proxy-agent@npm:6.5.0"
-  dependencies:
-    agent-base: "npm:^7.1.2"
-    debug: "npm:^4.3.4"
-    http-proxy-agent: "npm:^7.0.1"
-    https-proxy-agent: "npm:^7.0.6"
-    lru-cache: "npm:^7.14.1"
-    pac-proxy-agent: "npm:^7.1.0"
-    proxy-from-env: "npm:^1.1.0"
-    socks-proxy-agent: "npm:^8.0.5"
-  checksum: 10c0/7fd4e6f36bf17098a686d4aee3b8394abfc0b0537c2174ce96b0a4223198b9fafb16576c90108a3fcfc2af0168bd7747152bfa1f58e8fee91d3780e79aab7fd8
   languageName: node
   linkType: hard
 
@@ -16785,6 +16116,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexp-tree@npm:^0.1.27":
+  version: 0.1.27
+  resolution: "regexp-tree@npm:0.1.27"
+  bin:
+    regexp-tree: bin/regexp-tree
+  checksum: 10c0/f636f44b4a0d93d7d6926585ecd81f63e4ce2ac895bc417b2ead0874cd36b337dcc3d0fedc63f69bf5aaeaa4340f36ca7e750c9687cceaf8087374e5284e843c
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
@@ -16796,6 +16136,17 @@ __metadata:
     gopd: "npm:^1.2.0"
     set-function-name: "npm:^2.0.2"
   checksum: 10c0/83b88e6115b4af1c537f8dabf5c3744032cb875d63bc05c288b1b8c0ef37cbe55353f95d8ca817e8843806e3e150b118bc624e4279b24b4776b4198232735a77
+  languageName: node
+  linkType: hard
+
+"regjsparser@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "regjsparser@npm:0.10.0"
+  dependencies:
+    jsesc: "npm:~0.5.0"
+  bin:
+    regjsparser: bin/parser
+  checksum: 10c0/0f0508c142eddbceae55dab9715e714305c19e1e130db53168e8fa5f9f7ff9a4901f674cf6f71e04a0973b2f883882ba05808c80778b2d52b053d925050010f4
   languageName: node
   linkType: hard
 
@@ -17156,6 +16507,7 @@ __metadata:
     eslint-import-resolver-exports: "npm:^1.0.0-beta.5"
     eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-jsdoc: "npm:^62.5.5"
+    eslint-plugin-unicorn: "npm:^56.0.1"
     lerna: "npm:^8.2.4"
     prettier: "npm:^3.5.3"
     ses: "workspace:^"
@@ -17708,17 +17060,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^8.0.5":
-  version: 8.0.5
-  resolution: "socks-proxy-agent@npm:8.0.5"
-  dependencies:
-    agent-base: "npm:^7.1.2"
-    debug: "npm:^4.3.4"
-    socks: "npm:^2.8.3"
-  checksum: 10c0/5d2c6cecba6821389aabf18728325730504bf9bb1d9e342e7987a5d13badd7a98838cc9a55b8ed3cb866ad37cc23e1086f09c4d72d93105ce9dfe76330e9d2a6
-  languageName: node
-  linkType: hard
-
 "socks@npm:^2.7.1":
   version: 2.8.3
   resolution: "socks@npm:2.8.3"
@@ -17726,16 +17067,6 @@ __metadata:
     ip-address: "npm:^9.0.5"
     smart-buffer: "npm:^4.2.0"
   checksum: 10c0/d54a52bf9325165770b674a67241143a3d8b4e4c8884560c4e0e078aace2a728dffc7f70150660f51b85797c4e1a3b82f9b7aa25e0a0ceae1a243365da5c51a7
-  languageName: node
-  linkType: hard
-
-"socks@npm:^2.8.3":
-  version: 2.8.8
-  resolution: "socks@npm:2.8.8"
-  dependencies:
-    ip-address: "npm:^10.1.1"
-    smart-buffer: "npm:^4.2.0"
-  checksum: 10c0/4777edf8b554182ddf472524a1855c0fc684c7a3778466851dca687ae81cfa19ea9261856765789e51f7cec12e575e2652d5bd69d98fdbbbc947eabd12e9891d
   languageName: node
   linkType: hard
 
@@ -18610,7 +17941,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.8.1":
+"tslib@npm:^2.0.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -18788,10 +18119,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typebox@npm:^1.1.24":
-  version: 1.1.37
-  resolution: "typebox@npm:1.1.37"
-  checksum: 10c0/da63b444904d439cbec5fb347039c71c7075c8cd2223a8ef8c4d0fee2e299362785bc4a410f4427a8d45b51e2547b4f896ca09cf3796fac90e147d382152b840
+"typebox@npm:1.1.38":
+  version: 1.1.38
+  resolution: "typebox@npm:1.1.38"
+  checksum: 10c0/b4a5996a25b9265e88335a75697630be82822fae5e7b1993d5eb52ac6b71e80fec924ffa1976269a05524a0954b3f9e6e52f380348ea6836f76920e556fa3ca1
   languageName: node
   linkType: hard
 
@@ -19033,13 +18364,6 @@ __metadata:
   version: 6.25.0
   resolution: "undici@npm:6.25.0"
   checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
-  languageName: node
-  linkType: hard
-
-"undici@npm:^7.19.1":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
   languageName: node
   linkType: hard
 
@@ -19791,6 +19115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml-naming@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "xml-naming@npm:0.1.0"
+  checksum: 10c0/8c7614865361bcb7e53e3e091dac21c567e2b92d447919b2f072775aa9dcfc94a5255bd52fbaa0fd53c93513e53a23a6a835218ad2af512451dbc678392f85fe
+  languageName: node
+  linkType: hard
+
 "xmlbuilder@npm:^15.1.1":
   version: 15.1.1
   resolution: "xmlbuilder@npm:15.1.1"
@@ -19851,6 +19182,15 @@ __metadata:
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
   checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
+  languageName: node
+  linkType: hard
+
+"yaml@npm:2.9.0":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 
@@ -20021,7 +19361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.24.6, zod-to-json-schema@npm:^3.25.0":
+"zod-to-json-schema@npm:^3.25.0":
   version: 3.25.2
   resolution: "zod-to-json-schema@npm:3.25.2"
   peerDependencies:


### PR DESCRIPTION
Refs: #290, #416

## Description

Adds `@endo/agent-tools`, a provider-independent package for capability-bound agent tools. The core pattern is a hand-authored JSON Schema advertised to the caller, paired with runtime `@endo/patterns` guards before dispatch to an Endo capability.

Critical files to review:

- `packages/agent-tools/README.md` — consumer-facing package API docs, import paths, named-argument convention, and available tool makers.
- `packages/agent-tools/package.json`, `types-index.js`, and `types-index.d.ts` — package exports for the root API, public tool subpaths, and consumer type entrypoint.
- `packages/agent-tools/src/tool.js` and `src/types.ts` — guarded tool factory plus checked `ToolSpec`, `ToolRecord`, `MountReadToolRecord`, and public function declarations.
- `packages/agent-tools/src/git-tool.js` — Git capability tool records for the non-remotable Git method slice.
- `packages/agent-tools/src/mount-fs.js` — `mountReadText` backed by an `@endo/endo-fs` `Filesystem`.
- `packages/agent-tools/test/divergence.test.js` — schema/guard conformance coverage using `ajv` as the independent JSON Schema oracle.
- `designs/agent-tools-mount-fs-tools.md` — design notes for the filesystem-backed tool group.
- `packages/daemon/package.json` — additive exports for mount-related daemon node power entry points.

### Security Considerations

Tools hold Endo capabilities rather than ambient authority. `makeTool` rejects unknown argument keys, requires advertised required args before dispatch, copy-hardens incoming parsed JSON objects, and validates positional arguments with `mustMatch`.

The filesystem tool receives a `Filesystem` capability and resolves reads through `walk`; containment, symlink handling, read-only attenuation, subtree scoping, and revocation remain properties of the supplied filesystem capability. The Git tool exposes only the selected non-remotable method slice and validates calls against guards derived from `GitInterface`.

### Scaling Considerations

The filesystem read tool retains the existing 50k character text cap. The schema/guard conformance checks run only in tests. No new unbounded production resource use is introduced.

### Documentation Considerations

`packages/agent-tools/README.md` documents the package API, root and subpath imports, type exports, tool record shape, named-argument convention, and Git/filesystem tool makers. `designs/agent-tools-mount-fs-tools.md` documents the filesystem-backed tool group design.

### Testing Considerations

Added package tests for:

- `makeTool` record shape, required args, unknown args, parsed JSON object hardening, and positional guard validation.
- `makeGitTool` tool selection, positional marshaling, and runtime guard rejection.
- `makeMountReadTool` schema shape, extra-argument rejection, path validation, truncation, read-only/chroot behavior, symlink escape rejection, and revocation behavior.
- Schema/guard conformance for the Git tool schemas, including bigint schema mapping coverage.

### Compatibility Considerations

This adds a new package and additive daemon package exports. No existing package API is removed or changed.

### Upgrade Considerations

None, new package.