### PR TITLE
feat(agent-tools): resolve capref petnames at the makeTool invoke boundary

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -162,7 +162,7 @@ LLM-agent stack).*
 | [endo-fs-from-git](endo-fs-from-git.md) | 2026-05-28 | 2026-05-28 | In Progress |
 | [daemon-message-streaming](daemon-message-streaming.md) | 2026-03-26 | 2026-05-19 | In Progress (PR #287) |
 | [daemon-mount](daemon-mount.md) | 2026-03-20 | 2026-05-27 | In Progress |
-| [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-05-27 | **Complete** |
+| [daemon-mount-capabilities](daemon-mount-capabilities.md) | 2026-05-18 | 2026-06-23 | **Complete** |
 | [daemon-worker-import-from-mount](daemon-worker-import-from-mount.md) | 2026-05-22 | 2026-06-02 | Proposed |
 | [registry-capability](registry-capability.md) | 2026-06-02 | 2026-06-02 | Proposed |
 | [mvs-resolver](mvs-resolver.md) | 2026-06-02 | 2026-06-02 | Proposed |

--- a/designs/daemon-mount-capabilities.md
+++ b/designs/daemon-mount-capabilities.md
@@ -3,7 +3,7 @@
 | | |
 |---|---|
 | **Created** | 2026-05-18 |
-| **Updated** | 2026-05-27 |
+| **Updated** | 2026-06-23 |
 | **Author** | 0xPatrick (prompted) |
 | **Status** | **Complete** |
 
@@ -274,7 +274,22 @@ An entry:
 - does not claim inode stability;
 - can carry enough relative presentation data for user interfaces and status reports without leaking host absolute paths.
 
-The implementation can model an entry as `{ mountGrant, normalizedSegments }` inside an Exo (or as a passable record under SES `harden`), with `mountGrant` checked by identity when another capability accepts the entry.
+The implementation models an entry as an inert `EndoMountEntry` exo whose
+authority is established by **object identity**, never by a field it exposes.
+The daemon holds a private table — a `WeakMap` keyed by the entry exo —
+binding each entry to its `{ rootId, normalizedSegments }`.
+A mount method that accepts an entry recovers the segments from that private
+table and checks the `rootId` against its own mount, so neither the path nor
+the provenance is ever read from a caller-supplied field.
+
+Do **not** model the entry as a passable record that carries the mount grant
+(for example `{ mountGrant, normalizedSegments }`).
+Putting a live mount cap in a slot makes the entry a handle that can recover
+mount authority — even a read-only mount leaks whole-worktree observation — and
+trusting a caller-authored `segments` field after only a `lineageOf(mountGrant)`
+check makes the path forgeable.
+An entry carries no live cap and no caller-trusted authority data; a value an
+agent passes around freely must be inert.
 
 #### Alternative Considered: Entries as Mini-Capabilities
 
@@ -314,6 +329,41 @@ Rejected for these reasons:
 The chosen shape — entries hold neither observational authority nor handle-minting authority — is the strict ocap version.
 The trade-off is a small ergonomic loss (`mount.lookup(entry)` and `mount.has(entry)` are one extra noun per call vs. `entry.openFile()` and `entry.exists()`) for a substantial authority-reasoning gain.
 If a real use case surfaces where the value shape is awkward enough to warrant revisiting, the implementation can re-add either axis to the entry as a sugar layer over the mount's authority; that addition would not break the mount-is-authority discipline as long as the entries continue to delegate to the mount rather than holding authority directly.
+
+#### Alternative Considered (and rejected): Passable entry carrying the grant
+
+A shape that makes the entry a hardened passable record carrying the mount
+grant and its path was considered and rejected:
+
+```ts
+// Considered and rejected:
+type EndoMountEntry = {
+  mountGrant: EndoMount; // the live minting mount
+  segments: string[];    // caller-visible path
+  displayPath: string;
+};
+```
+
+Its appeal was marshallability: because the record's only capability slot is
+the formula-backed `mountGrant`, `storeValue(entry, petname)` resolves that
+slot to a formula id and persists the entry, so an agent could name a returned
+entry and reuse it later.
+
+Rejected because it breaks the "entry is a value, not a handle" invariant on
+two fronts:
+
+- **The grant slot makes the entry a handle.** A live `mountGrant` lets any
+  holder recover the mount's authority; even a `readOnly()` mount leaks
+  whole-worktree observation. The entry stops being inert.
+- **Caller-authored segments make the path forgeable.** Verifying provenance
+  with `lineageOf(mountGrant)` and then trusting the record's own `segments`
+  lets a caller pair a legitimately-held grant with arbitrary segments.
+
+The need that motivated it — a workspace location surviving across agent turns
+— does not require a passable entry. Persist the mount as a petname and the
+path as plain data, and reconstruct with `mount.entry(path)`, where the mount
+re-normalizes the path against its own root. The location's authority stays on
+the mount; the entry stays an inert, identity-authenticated value.
 
 ### `EndoMount.lookup()` semantics on missing nodes
 

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -80,6 +80,7 @@
     "@endo/daemon": "workspace:^",
     "@endo/git": "workspace:^",
     "@endo/init": "workspace:^",
+    "@endo/promise-kit": "workspace:^",
     "ajv": "^8.17.1",
     "ava": "catalog:dev",
     "c8": "catalog:dev",

--- a/packages/agent-tools/src/tool.js
+++ b/packages/agent-tools/src/tool.js
@@ -3,6 +3,7 @@
 
 /** @import { ToolSpec, ToolRecord } from './types.js' */
 
+import { E } from '@endo/far';
 import { mustMatch } from '@endo/patterns';
 
 /**
@@ -85,6 +86,66 @@ const copyHardenArgsRecord = argsRecord => {
 };
 
 /**
+ * Re-key a positional array back to a named record for `execute`, using the
+ * schema's declared property-name order (the inverse of `namedToPositional`).
+ * The input is already trimmed, so there is no trailing-undefined handling
+ * here; only the slots actually present are re-keyed, which preserves the
+ * "omitted optional tail arg" semantics that `execute` sees.
+ *
+ * @param {unknown[]} positional
+ * @param {string[]} paramNames Ordered declared property names.
+ * @returns {Record<string, unknown>}
+ */
+const positionalToNamed = (positional, paramNames) => {
+  /** @type {Record<string, unknown>} */
+  const record = {};
+  for (let i = 0; i < positional.length; i += 1) {
+    record[paramNames[i]] = positional[i];
+  }
+  return harden(record);
+};
+
+/**
+ * Resolve one positional according to its `argKind`. `'value'` passes through;
+ * `'capref'` resolves a single petname string to a live cap via the guest
+ * petstore (`E(powers).lookup`); `'capref[]'` resolves an array of petname
+ * strings element-wise. Capref kinds require `powers`; resolution fails closed
+ * on an unknown petname (the daemon directory throws on a name it does not
+ * recognize), so a name the host never bound can never dereference a cap.
+ *
+ * @param {unknown} value
+ * @param {'value'|'capref'|'capref[]'} kind
+ * @param {import('@endo/far').ERef<import('./types.js').ToolPowers>|undefined} powers
+ * @param {string} name
+ * @param {string} paramName Declared property name of this positional.
+ * @returns {Promise<unknown>}
+ */
+const resolveArg = async (value, kind, powers, name, paramName) => {
+  if (kind === 'value') {
+    return value;
+  }
+  if (powers === undefined) {
+    throw new Error(
+      `${name} ${paramName} is a capref but no powers were provided`,
+    );
+  }
+  if (kind === 'capref') {
+    return E(powers).lookup(/** @type {string} */ (value));
+  }
+  // 'capref[]': each element is a petname string; resolve them all through the
+  // petstore (one unknown name fails the whole call). Harden the resolved array
+  // so an `M.arrayOf(M.remotable())` guard — which rejects a non-frozen array —
+  // matches it.
+  if (!Array.isArray(value)) {
+    throw new Error(`${name} ${paramName} expected an array of petnames`);
+  }
+  const resolved = await Promise.all(
+    value.map(petname => E(powers).lookup(petname)),
+  );
+  return harden(resolved);
+};
+
+/**
  * Build a tool record from its JSON Schema, optional positional guards, and
  * dispatch function. The schema is advertised to callers; the guards enforce
  * the same positional argument contract at runtime.
@@ -98,7 +159,15 @@ const copyHardenArgsRecord = argsRecord => {
  * @returns {ToolRecord}
  */
 export const makeTool = spec => {
-  const { name, description, parameters, argGuards, execute } = spec;
+  const {
+    name,
+    description,
+    parameters,
+    argGuards,
+    argKinds,
+    powers,
+    execute,
+  } = spec;
   // Avoid retaining a mutable caller-owned schema object.
   const hardenedParameters = harden(parameters);
   const paramNames = getParamNames(hardenedParameters);
@@ -124,6 +193,21 @@ export const makeTool = spec => {
      */
     invoke: async argsRecord => {
       const hardenedArgsRecord = copyHardenArgsRecord(argsRecord);
+      // `argKinds` is the authority-bearing switch: it (not `argGuards`) decides
+      // whether a positional crosses the wire as a capref petname that must be
+      // resolved to a live cap before `execute` sees it. So capref resolution
+      // runs whenever `argKinds` is present, INDEPENDENT of `argGuards`. A tool
+      // that marks `argKinds: ['capref']` without guards still gets the resolved
+      // cap, never the raw petname string. When both are present, resolution
+      // happens BEFORE guard validation so a guard such as `M.remotable()`
+      // matches the live cap rather than the petname string (a string would fail
+      // the remotable guard). Plain tools (no `argGuards` and no `argKinds`)
+      // pass the original record through untouched, so the landed plain tools
+      // are byte-for-byte unaffected.
+      if (argGuards === undefined && argKinds === undefined) {
+        return execute(hardenedArgsRecord);
+      }
+
       if (argGuards !== undefined) {
         // Reject keys outside the declared property list.
         const allowed = new Set(paramNames);
@@ -140,16 +224,49 @@ export const makeTool = spec => {
             throw new Error(`missing required tool argument "${key}"`);
           }
         }
-        const positional = namedToPositional(
-          hardenedArgsRecord,
-          paramNames,
-          requiredCount,
-        );
-        // `namedToPositional` drops omitted optional tail args.
-        for (let i = 0; i < positional.length; i += 1) {
-          mustMatch(positional[i], argGuards[i], `${name} ${paramNames[i]}`);
+      }
+
+      // Marshal the named-args record into positionals by the schema's declared
+      // property order (#518). A missing `argKinds` entry (a short array, or no
+      // array at all) defaults to `'value'` per the ToolSpec contract — so a
+      // tool can mark only its leading capref positional and leave a trailing
+      // options arg implicitly a plain value. Capref resolution is async (it
+      // sends `E(powers).lookup(petname)` against the guest petstore), so
+      // resolve all positionals concurrently and await before the guard runs.
+      const positional = namedToPositional(
+        hardenedArgsRecord,
+        paramNames,
+        requiredCount,
+      );
+      const resolved = await Promise.all(
+        positional.map((value, i) =>
+          resolveArg(
+            value,
+            argKinds?.[i] ?? 'value',
+            powers,
+            name,
+            paramNames[i],
+          ),
+        ),
+      );
+      if (argGuards !== undefined) {
+        // `namedToPositional` drops omitted optional tail args, so we match
+        // only the args actually supplied. The guard label names the real
+        // declared property (#518).
+        for (let i = 0; i < resolved.length; i += 1) {
+          mustMatch(resolved[i], argGuards[i], `${name} ${paramNames[i]}`);
         }
       }
+      // When `argKinds` is present, any positional may have been resolved from a
+      // capref, so rebuild the named record from the resolved positionals — keyed
+      // by the same declared property names `execute` expects (#518), not the
+      // legacy `arg0/arg1` convention.
+      if (argKinds !== undefined) {
+        return execute(positionalToNamed(resolved, paramNames));
+      }
+      // `argGuards` present, no `argKinds`: every positional resolved as a plain
+      // value (the identity), so the original record is unchanged. Pass it
+      // through so guard-only tools see the exact record they were called with.
       return execute(hardenedArgsRecord);
     },
   });

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -3,6 +3,27 @@ import type { Filesystem } from '@endo/platform/fs/extended';
 import type { EndoGit } from '@endo/exo-git';
 import type { Pattern } from '@endo/patterns';
 
+export type ArgKind = 'value' | 'capref' | 'capref[]';
+
+/**
+ * The guest authority a tool set closes over to resolve a capref-typed
+ * argument. A capref arg crosses the wire as a **petname string** and is
+ * resolved against the guest's own petstore via `E(powers).lookup(petname)` —
+ * the same directory lookup every lal tool already uses. `lookup` fails closed:
+ * the daemon directory throws on a petname it does not recognize, so a name the
+ * host never bound can never dereference a cap.
+ *
+ * This is the `make(powers)` guest convention: the host passes `powers` once at
+ * tool-set construction and every tool closes over it; `powers` is never an
+ * argument the LLM supplies and is never ambient. Only the `lookup` capability
+ * is exercised here, so this is the minimal structural type the tool layer
+ * depends on (a full guest facet — an `EndoGuest` / directory — satisfies it).
+ */
+export interface ToolPowers {
+  /** Petname → live cap. Throws on an unknown petname (fail closed). */
+  lookup: (petNamePath: string | string[]) => Promise<unknown>;
+}
+
 /**
  * The read- and branch-navigation slice of `EndoGit` the git tool catalog
  * exposes to an LLM.
@@ -46,9 +67,28 @@ export interface ToolSpec {
    */
   argGuards?: Pattern[];
   /**
+   * Optional per-positional marker, parallel to `argGuards`. `'value'` (the
+   * default for an absent entry, and for the whole array when omitted) passes
+   * the JSON value through unchanged; `'capref'` resolves a petname string to a
+   * live cap via the guest petstore (`E(powers).lookup`) *before* the guard
+   * runs; `'capref[]'` resolves an array of petname strings element-wise. This
+   * is how an LLM names and passes a live capability as a tool argument — by
+   * uttering the friendly petname the host bound it under. Plain
+   * (non-capability) tools omit it, in which case `invoke` behaves exactly as it
+   * did without any capref resolution.
+   */
+  argKinds?: ArgKind[];
+  /**
+   * The guest authority capref resolution sends `lookup` to. Threaded in at
+   * tool-set construction (the `make(powers)` guest convention), never supplied
+   * by the LLM. Required when `argKinds` marks any positional as a capref.
+   */
+  powers?: ERef<ToolPowers>;
+  /**
    * Dispatch target. Receives the named-args record keyed by the schema's
    * declared `parameters.properties` names (e.g. `{ message }`, `{ name,
-   * options }`).
+   * options }`) — with capref positionals already resolved to live caps (via
+   * the petstore) when `argKinds` is set.
    */
   execute: (args: Record<string, unknown>) => Promise<unknown>;
 }

--- a/packages/agent-tools/test/divergence.test.js
+++ b/packages/agent-tools/test/divergence.test.js
@@ -16,10 +16,12 @@ import {
   getInterfaceGuardPayload,
   getMethodGuardPayload,
 } from '@endo/patterns';
-import { Far } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { GitInterface } from '@endo/exo-git';
 
 import { makeGitTool } from '../src/git-tool.js';
+import { makeTool } from '../src/tool.js';
+import { prepareGuestPowers, bindCap } from './helpers/daemon-petstore.js';
 
 /**
  * Conformance checks for hand-authored JSON Schemas and runtime guards.
@@ -267,4 +269,271 @@ test('{type:integer} schema diverges from a bigint guard', t => {
     divergences >= 1,
     'an {type:integer} schema diverges from a bigint guard',
   );
+});
+
+// --- capref args: remotable guard ⟷ petname-string schema ----------------
+//
+// An LLM cannot put a live object in JSON, so a capref arg crosses the wire as
+// a friendly **petname string** that the invoke layer resolves to the live cap
+// via the guest petstore (`E(powers).lookup`) BEFORE the guard runs. The schema
+// for such an arg is therefore `{type:'string'}` (a petname), and the guard is
+// `M.remotable()`; `M.arrayOf(M.remotable())` ⟷ a petname-string array. The two
+// agree when the strings the schema accepts are exactly the names the petstore
+// resolves to caps the guard accepts. This is the gate that will unblock git
+// `add`/`restore` (#425).
+//
+// The behavioral round-trips bind petnames in a REAL daemon-backed guest
+// petstore and resolve through the live `lookup` — never a hand-rolled `Map`.
+// They fork a daemon per test, so they are `test.serial` with a `t.teardown`.
+
+const PETNAME_SCHEMA = harden({
+  type: 'string',
+  description: 'petname of a capability',
+});
+const PETNAME_ARRAY_SCHEMA = harden({
+  type: 'array',
+  items: {
+    type: 'string',
+    description: 'petname of a capability',
+  },
+});
+
+test('remotable guard ⟷ petname-string schema agree (capref)', t => {
+  const validate = ajv.compile(PETNAME_SCHEMA);
+
+  // A petname is just a friendly string; the schema accepts any string and the
+  // guard accepts the live cap the petstore resolves it to.
+  t.true(validate('gitReadOnly'));
+  t.true(validate('endoRepo'));
+  t.true(matches(Far('SomeCap', {}), M.remotable()));
+
+  // Non-strings can never be a valid wire value for a petname.
+  t.false(validate(42));
+  t.false(validate({}));
+  t.false(validate([]));
+});
+
+test('arrayOf(remotable) guard ⟷ petname-array schema agree (capref[])', t => {
+  const validate = ajv.compile(PETNAME_ARRAY_SCHEMA);
+
+  // An array of petnames: schema-valid, and the resolved caps match
+  // arrayOf(remotable).
+  t.true(validate(['endoRepo', 'gardenRepo']));
+  t.true(
+    matches(harden([Far('A', {}), Far('B', {})]), M.arrayOf(M.remotable())),
+  );
+
+  // Empty array: both accept (an empty arrayOf matches).
+  t.true(validate([]));
+  t.true(matches(harden([]), M.arrayOf(M.remotable())));
+
+  // A mixed array with a non-string element: the schema rejects it.
+  t.false(validate(['endoRepo', 42]));
+});
+
+test.serial(
+  'capref resolution at the makeTool invoke boundary (round-trip)',
+  async t => {
+    t.timeout(120_000);
+    const powers = await prepareGuestPowers(t);
+    // Bind a formula-backed cap under a friendly petname, host-side.
+    const cap = await bindCap(t, powers, 'theCounter');
+
+    /** @type {unknown} */
+    let received;
+    const tool = makeTool({
+      name: 'useCap',
+      description: 'takes a live cap by petname',
+      // `makeTool.invoke` receives a NAMED record (`{ arg0: petname }`), so the
+      // advertised parameters schema is an object schema keyed by `arg0`, with
+      // the petname-string schema as the `arg0` property.
+      parameters: harden({
+        type: 'object',
+        properties: { arg0: PETNAME_SCHEMA },
+        required: ['arg0'],
+        additionalProperties: false,
+      }),
+      argGuards: [M.remotable()],
+      argKinds: ['capref'],
+      powers,
+      execute: async args => {
+        received = args.arg0;
+        return 'ok';
+      },
+    });
+
+    // A bound petname resolves to the live cap before `execute` sees it.
+    t.is(await tool.invoke({ arg0: 'theCounter' }), 'ok');
+    // The resolved value is the live cap: it answers an eventual-send the way
+    // the original does (proving it is the cap, not the petname string).
+    t.is(await E(/** @type {any} */ (received)).incr(), 1);
+    t.is(await E(cap).incr(), 2);
+
+    // An unbound petname fails closed before `execute` runs (the daemon
+    // directory throws on an unknown name).
+    await t.throwsAsync(() => tool.invoke({ arg0: 'neverBound' }), {
+      message: /[Uu]nknown pet name/,
+    });
+  },
+);
+
+test.serial(
+  'capref[] resolution at the makeTool invoke boundary (round-trip)',
+  async t => {
+    t.timeout(120_000);
+    const powers = await prepareGuestPowers(t);
+    const c0 = await bindCap(t, powers, 'first');
+    const c1 = await bindCap(t, powers, 'second');
+
+    /** @type {unknown} */
+    let received;
+    const tool = makeTool({
+      name: 'useCaps',
+      description: 'takes live caps by petname array',
+      parameters: harden({
+        type: 'object',
+        properties: { arg0: PETNAME_ARRAY_SCHEMA },
+        required: ['arg0'],
+        additionalProperties: false,
+      }),
+      argGuards: [M.arrayOf(M.remotable())],
+      argKinds: ['capref[]'],
+      powers,
+      execute: async args => {
+        received = args.arg0;
+        return 'ok';
+      },
+    });
+
+    t.is(await tool.invoke({ arg0: ['first', 'second'] }), 'ok');
+    const receivedArray = /** @type {unknown[]} */ (received);
+    t.is(receivedArray.length, 2);
+    // Each element is the live cap, resolved in order.
+    t.is(await E(/** @type {any} */ (receivedArray[0])).incr(), 1);
+    t.is(await E(/** @type {any} */ (receivedArray[1])).incr(), 1);
+    t.is(await E(c0).incr(), 2);
+    t.is(await E(c1).incr(), 2);
+
+    // One unbound element fails the whole call, before `execute`.
+    await t.throwsAsync(() => tool.invoke({ arg0: ['first', 'neverBound'] }), {
+      message: /[Uu]nknown pet name/,
+    });
+  },
+);
+
+test.serial(
+  'NEGATIVE CONTROL: argKinds resolves caprefs even with NO argGuards',
+  async t => {
+    // `argKinds` is the authority-bearing switch, so a tool that marks a capref
+    // positional but supplies no `argGuards` must STILL receive the resolved
+    // live cap, never the raw petname string. Before the fix, resolution lived
+    // inside the `argGuards !== undefined` branch, so a guard-less capref tool
+    // leaked the petname string straight to `execute`. This is the #1
+    // product-risk regression this gate exists to catch.
+    t.timeout(120_000);
+    const powers = await prepareGuestPowers(t);
+    const cap = await bindCap(t, powers, 'unguarded');
+
+    /** @type {unknown} */
+    let received;
+    const tool = makeTool({
+      name: 'unguardedCap',
+      description: 'a capref arg with no runtime guard',
+      parameters: harden({
+        type: 'object',
+        properties: { arg0: PETNAME_SCHEMA },
+        required: ['arg0'],
+        additionalProperties: false,
+      }),
+      // Deliberately NO argGuards.
+      argKinds: ['capref'],
+      powers,
+      execute: async args => {
+        received = args.arg0;
+        return 'ok';
+      },
+    });
+
+    t.is(await tool.invoke({ arg0: 'unguarded' }), 'ok');
+    // `execute` must see the live cap, NOT the petname string.
+    t.not(received, 'unguarded', 'execute did NOT receive the raw petname');
+    t.is(await E(/** @type {any} */ (received)).incr(), 1);
+    t.is(await E(cap).incr(), 2);
+
+    // An unbound petname still fails closed before `execute` runs, even without
+    // a guard.
+    await t.throwsAsync(() => tool.invoke({ arg0: 'neverBound' }), {
+      message: /[Uu]nknown pet name/,
+    });
+  },
+);
+
+test.serial(
+  'a short argKinds defaults the trailing positional to a plain value',
+  async t => {
+    // A tool like `restore` marks only its leading capref positional; the
+    // trailing options arg is left implicitly a plain value. A missing argKinds
+    // entry must default to 'value' (NOT be misread as a capref), so the plain
+    // value passes through unresolved.
+    t.timeout(120_000);
+    const powers = await prepareGuestPowers(t);
+    const cap = await bindCap(t, powers, 'entry');
+
+    /** @type {unknown} */
+    let received;
+    const tool = makeTool({
+      name: 'restoreLike',
+      description: 'a leading capref[] and a trailing plain options record',
+      parameters: harden({
+        type: 'object',
+        properties: {
+          arg0: PETNAME_ARRAY_SCHEMA,
+          arg1: { type: 'object' },
+        },
+        required: ['arg0'],
+        additionalProperties: false,
+      }),
+      argGuards: [M.arrayOf(M.remotable()), M.recordOf(M.string(), M.any())],
+      // Deliberately short: only the first positional is marked.
+      argKinds: ['capref[]'],
+      powers,
+      execute: async args => {
+        received = [args.arg0, args.arg1];
+        return 'ok';
+      },
+    });
+
+    const options = harden({ staged: true });
+    t.is(await tool.invoke({ arg0: ['entry'], arg1: options }), 'ok');
+    // arg0 resolved to the live cap; arg1 passed through untouched.
+    const pair = /** @type {unknown[]} */ (received);
+    const resolvedCap = /** @type {unknown[]} */ (pair[0])[0];
+    t.is(await E(/** @type {any} */ (resolvedCap)).incr(), 1);
+    t.is(await E(cap).incr(), 2);
+    t.is(pair[1], options);
+  },
+);
+
+test('NEGATIVE CONTROL: a raw petname string is NOT a remotable (resolve is required)', t => {
+  // If an implementation skipped resolution and handed the raw petname string
+  // to the guard, the guard would reject it — a string is not a remotable. This
+  // proves resolution before `mustMatch` is mandatory.
+  const validate = ajv.compile(PETNAME_SCHEMA);
+  t.true(validate('endoRepo'), 'schema accepts the wire petname string');
+  t.false(
+    matches('endoRepo', M.remotable()),
+    'the guard rejects the raw petname string (resolution is mandatory)',
+  );
+});
+
+test('NEGATIVE CONTROL: {type:object} schema DIVERGES from a remotable arg', t => {
+  // A careless author might schema a remotable arg as {type:'object'} ("a
+  // remotable is an object"). But an LLM cannot put a live object in JSON; the
+  // only correct wire form is the petname string. The two schemas diverge: the
+  // object schema accepts a bare {} that the (correct) petname-string schema
+  // rejects.
+  const validateObject = ajv.compile(harden({ type: 'object' }));
+  const validatePetname = ajv.compile(PETNAME_SCHEMA);
+  t.true(validateObject({}), 'object-schema accepts a bare object');
+  t.false(validatePetname({}), 'petname-string schema (correct) rejects it');
 });

--- a/packages/agent-tools/test/helpers/daemon-petstore.js
+++ b/packages/agent-tools/test/helpers/daemon-petstore.js
@@ -1,0 +1,127 @@
+// @ts-nocheck
+/* global process */
+
+// Real daemon-backed guest petstore harness for the capref tests.
+//
+// agent-tools resolves a capref-typed tool arg by sending
+// `E(powers).lookup(petname)` against the guest's own petstore — exactly what
+// every lal tool already does. The capref tests must exercise that live path,
+// not a hand-rolled `Map`, so this helper spins up a real Endo daemon, takes a
+// host, provisions a guest (the `powers` a tool closes over), and binds a
+// formula-backed cap under a friendly petname the way a host does in
+// production.
+//
+// It reuses the daemon's public `start` / `stop` / `purge` / `makeEndoClient`
+// building blocks (the same set `@endo/endo-fs-exec`'s daemon test uses) rather
+// than reaching into the daemon's private test harness. Daemon tests fork a
+// full daemon per test and share filesystem state under `test/tmp`, so every
+// caller runs `test.serial` and this helper registers a `t.teardown`.
+
+import path from 'path';
+import url from 'url';
+import { E } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+import { start, stop, purge, makeEndoClient } from '@endo/daemon';
+
+const dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+let testCounter = 0;
+
+/**
+ * Build a fresh daemon config under `test/tmp/NNNN/`. Socket paths are kept
+ * short because `sockaddr_un` bounds the Unix-domain socket path length
+ * (~108 bytes on Linux).
+ */
+const makeConfig = () => {
+  testCounter += 1;
+  const tag = String(testCounter).padStart(4, '0');
+  const base = path.join(dirname, '..', 'tmp', tag);
+  return {
+    statePath: path.join(base, 'state'),
+    ephemeralStatePath: path.join(base, 'run'),
+    cachePath: path.join(base, 'cache'),
+    sockPath:
+      process.platform === 'win32'
+        ? `\\\\?\\pipe\\agent-tools-${tag}.sock`
+        : path.join(base, 'endo.sock'),
+    address: '127.0.0.1:0',
+    pets: new Map(),
+    values: new Map(),
+  };
+};
+
+/**
+ * Start a daemon, take a host, and provision a guest. The guest exo is the
+ * `powers` a tool set closes over: it carries `lookup` (resolve a petname),
+ * `storeIdentifier` / `storeValue` (host-side bind), and `evaluate` (mint a
+ * formula-backed cap). Registers a teardown that stops the daemon.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @returns {Promise<any>} the guest powers (an `EndoGuest` facet)
+ */
+export const prepareGuestPowers = async t => {
+  const config = makeConfig();
+  const { reject: cancel, promise: cancelled } = makePromiseKit();
+  cancelled.catch(() => {});
+
+  await purge(config);
+  await start(config);
+  t.teardown(async () => {
+    cancel(new Error('test teardown'));
+    await stop(config).catch(() => {});
+  });
+
+  const { getBootstrap, closed } = await makeEndoClient(
+    'client',
+    config.sockPath,
+    cancelled,
+  );
+  closed.catch(() => {});
+
+  const bootstrap = getBootstrap();
+  const host = E(bootstrap).host();
+  const guest = await E(host).provideGuest('agent-tools-test-guest');
+  return guest;
+};
+
+/**
+ * Mint a small formula-backed cap (a counter exo) inside the guest and bind it
+ * under `petname`, the way a host binds a granted cap at provisioning. The cap
+ * is evaluated in a guest worker so it has a daemon formula and therefore
+ * resolves through `E(powers).lookup(petname)` like any granted capability.
+ *
+ * The counter's `incr()` lets a test prove the resolved value is the *live*
+ * cap (it answers an eventual-send and advances shared state), not the petname
+ * string.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {any} powers the guest from {@link prepareGuestPowers}
+ * @param {string} petname
+ * @returns {Promise<any>} the live cap, also reachable via `lookup(petname)`
+ */
+export const bindCap = async (t, powers, petname) => {
+  // `evaluate(worker, source, codeNames, petNames, resultName)` formulates the
+  // exo (auto-provisioning the named worker), stores it under `resultName`, and
+  // returns the live value. Storing it under `petname` is the host-side bind;
+  // the tool later resolves the same name via `lookup`.
+  const cap = await E(powers).evaluate(
+    'agent-tools-test-worker',
+    `
+      (() => {
+        let value = 0;
+        return makeExo(
+          'Counter',
+          M.interface('Counter', {}, { defaultGuards: 'passable' }),
+          {
+            incr: () => (value += 1),
+            decr: () => (value -= 1),
+          },
+        );
+      })();
+    `,
+    [],
+    [],
+    petname,
+  );
+  return cap;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,7 @@ __metadata:
     "@endo/init": "workspace:^"
     "@endo/patterns": "workspace:^"
     "@endo/platform": "workspace:^"
+    "@endo/promise-kit": "workspace:^"
     ajv: "npm:^8.17.1"
     ava: "catalog:dev"
     c8: "catalog:dev"


### PR DESCRIPTION
Stacked on #408 (`agent-tools-mount-fs-tools`, merged); a sibling of #423. Base is `llm`.

## Why

An LLM calls a tool by emitting JSON, which has no live object references — but several tool args are guarded by `M.remotable()` / `M.arrayOf(M.remotable())` and demand a *live capability*. A capref-typed arg therefore has to cross the wire as a string the tool can turn back into a live cap. The settled design (endo-agent-tools, "Capability arguments are petnames" + Design Decision §8): that string is a **petname**, resolved against the guest's own petstore.

## What

A `ToolSpec` may mark each positional with `argKinds` (`'value' | 'capref' | 'capref[]'`). When `argKinds` is present, `makeTool`'s `invoke` resolves each capref **before** the guards run, so a guard such as `M.remotable()` matches the live cap rather than the wire string.

- **Capref args are petnames.** A capref crosses the wire as a friendly camelCase petname string (`gitReadOnly`, `endoRepo`) and resolves via `await E(powers).lookup(petname)` against the guest's own petstore — the same directory lookup every lal tool already does. `lookup` **fails closed**: the daemon directory throws on a petname it does not recognize, so a name the host never bound can never dereference a cap. A `capref[]` maps the lookup over the array.
- **One resolution path.** `agent-tools` is always used in the context of an endo daemon; the petstore is the single system of record. There is no bespoke in-memory handle registry and no opaque `cap:<hex>` handle on the LLM-facing surface.
- **`powers` is threaded at construction.** The host passes `powers` once when it builds the tool set (the `make(powers)` guest convention) and every tool closes over it; `powers` is never an argument the LLM supplies and is never ambient. The LLM never binds — binding (`E(powers).storeIdentifier` / `storeValue`) is a host act at provisioning.
- **The resolve-before-guard seam.** `resolveArg` runs at the `makeTool` invoke boundary, before `mustMatch`, and is now async (it sends `E(powers).lookup`). `invoke` awaits resolution of all positionals; `execute` is already `E`-based/async, so awaiting at the boundary is consistent. Resolution is gated on `argKinds`, **independent of `argGuards`**: a tool that marks a capref without supplying guards still receives the resolved cap, never the raw petname. Plain tools (no `argGuards` and no `argKinds`) pass their record through untouched and are unaffected.

The divergence gate is extended to the capref boundary: a `'capref'` positional is `{type:'string'}` on the wire but `M.remotable()` at the guard, deliberately different shapes; `M.arrayOf` wraps the array case.

## Tests

The capref round-trips bind petnames in a **real daemon-backed guest petstore** and resolve through the live `E(powers).lookup` — never a hand-rolled `Map`. A small helper (`test/helpers/daemon-petstore.js`) spins up an Endo daemon, takes a host, provisions a guest (the `powers` a tool closes over), and binds a formula-backed cap under a friendly petname the way a host does in production, reusing the daemon's public `start` / `stop` / `purge` / `makeEndoClient` (the same pattern `@endo/endo-fs-exec`'s daemon test uses). The tests prove the resolved value is the live cap (it answers an eventual-send and advances shared state) and that an unbound petname fails closed at the directory.

Negative controls pin resolution as mandatory: `argKinds` resolves caprefs even with NO `argGuards` (a guard-less capref tool must not leak the petname string to `execute`), a raw petname string is not a remotable, and a `{type:object}` schema diverges from a remotable arg. Daemon-backed tests fork a daemon per test, so they are `test.serial` with a `t.teardown`.

## Test plan

- `cd packages/agent-tools && yarn test` — the schema⟷guard gate, the bigint cases, and the capref round-trips (daemon-backed) all pass.
- `yarn lint` (scoped `tsc` + `eslint`) and `prettier --check` clean; `yarn docs` (TypeDoc typecheck) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
