### PR TITLE
feat(daemon): citable passable EndoMountEntry mount substrate

### DIFF
--- a/.changeset/daemon-citable-mount-entry.md
+++ b/.changeset/daemon-citable-mount-entry.md
@@ -1,0 +1,23 @@
+---
+'@endo/daemon': minor
+'@endo/exo-git': minor
+---
+
+Model `EndoMountEntry` as a citable passable record.
+
+`EndoMount.entry()` now returns a hardened passable record
+`{ mountGrant, segments, displayPath }` instead of an
+`EndoMountEntry` exo. Because the record's only capability slot is the
+formula-backed `mountGrant`, it marshals through the daemon: an entry
+can now be bound under a petname with `storeValue(entry, petname)` and
+resolved back with `lookup(petname)`, which previously failed with
+`No corresponding formula`.
+
+- The entry's `segments` and `displayPath` are plain record fields, no
+  longer `segments()` / `displayPath()` methods.
+- The `child(name)` method is replaced by the free helper
+  `childEntry(entry, name)` exported from `@endo/daemon`.
+- `@endo/exo-git` git methods (`add` / `restore`) and the
+  `GitStatusEntry.entry` field accept the entry-record shape rather
+  than an `EndoMountEntry` remotable; mount-lineage provenance is still
+  enforced through `mountGrant`.

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -526,7 +526,21 @@ export const BlobInterface = M.interface('EndoBlob', {
 });
 
 const PathSegmentsShape = M.arrayOf(M.string());
-const MountEntryShape = M.remotable('EndoMountEntry');
+// A mount entry is a passable **value**, not a capability: a hardened
+// record whose only capability slot is the formula-backed `mountGrant`
+// (the minting `EndoMount`), plus normalized mount-root-relative
+// `segments` and a presentation `displayPath`.  Modeling the entry as a
+// record (rather than an `M.remotable('EndoMountEntry')` exo) is what lets
+// `storeValue(entry, petname)` marshal it: the marshaller resolves the
+// single `mountGrant` slot to its formula id and copies the plain data.
+const MountEntryShape = M.splitRecord(
+  {
+    mountGrant: M.remotable('EndoMount'),
+    segments: PathSegmentsShape,
+    displayPath: M.string(),
+  },
+  {},
+);
 const PathArgShape = M.or(M.string(), PathSegmentsShape, MountEntryShape);
 
 // `EndoMount` extends `Directory` from `@endo/platform/fs`.  Method
@@ -621,13 +635,6 @@ export const MountFileInterface = M.interface('EndoMountFile', {
 // `./interfaces.js` can reach the platform shapes without a second
 // import line.
 export { PlatformDirectoryInterface, PlatformFileInterface };
-
-export const MountEntryInterface = M.interface('EndoMountEntry', {
-  segments: M.call().returns(PathSegmentsShape),
-  displayPath: M.call().returns(M.string()),
-  child: M.call(M.string()).returns(MountEntryShape),
-  help: M.call().optional(M.string()).returns(M.string()),
-});
 
 // The git-only interface guards and shape constants moved into
 // `@endo/exo-git/src/interfaces.js`.  Re-exported here for daemon-

--- a/packages/daemon/src/mount.js
+++ b/packages/daemon/src/mount.js
@@ -19,13 +19,8 @@ import { makeReaderPump } from '@endo/exo-stream/reader-pump.js';
 
 import { fromHex } from './hex.js';
 import { mountHelp, mountFileHelp, makeHelp } from './help-text.js';
-import {
-  MountEntryInterface,
-  MountFileInterface,
-  MountInterface,
-} from './interfaces.js';
+import { MountFileInterface, MountInterface } from './interfaces.js';
 
-const mountEntryRecords = new WeakMap();
 const mountRecords = new WeakMap();
 
 /**
@@ -86,16 +81,38 @@ const reserveScratchPath = async (target, filePowers) => {
 harden(reserveScratchPath);
 
 /**
- * Returns the daemon-private lineage sentinel for a mount or mount entry.
+ * Returns the daemon-private lineage sentinel for a mount.
+ *
+ * Mount entries are passable records (`{ mountGrant, segments, displayPath }`)
+ * rather than capabilities, so an entry's lineage is the lineage of its
+ * `mountGrant` slot; callers that hold an entry pass `entry.mountGrant` here.
  *
  * @param {unknown} value
  * @returns {object | undefined}
  */
 export const lineageOf = value => {
   const key = /** @type {object} */ (value);
-  return mountEntryRecords.get(key)?.rootId || mountRecords.get(key)?.rootId;
+  return mountRecords.get(key)?.rootId;
 };
 harden(lineageOf);
+
+/**
+ * Type-guard for a daemon-minted mount-entry record.  Entries are pure
+ * passable records whose only capability slot is the formula-backed
+ * `mountGrant`; their provenance is verified by checking `mountGrant`'s
+ * lineage (`lineageOf(entry.mountGrant)`), never by object identity of the
+ * record itself (a marshalled round-trip produces a fresh record).
+ *
+ * @param {unknown} value
+ * @returns {value is { mountGrant: object, segments: string[], displayPath: string }}
+ */
+export const isMountEntry = value =>
+  typeof value === 'object' &&
+  value !== null &&
+  lineageOf(/** @type {{ mountGrant?: unknown }} */ (value).mountGrant) !==
+    undefined &&
+  Array.isArray(/** @type {{ segments?: unknown }} */ (value).segments);
+harden(isMountEntry);
 
 /**
  * Host-private accessor for daemon-minted physical mount backing.
@@ -116,16 +133,6 @@ export const getMountBacking = mount => {
   });
 };
 harden(getMountBacking);
-
-/**
- * Host-private accessor for daemon-minted mount entry paths.
- *
- * @param {unknown} entry
- * @returns {string | undefined}
- */
-export const getEntryPhysicalPath = entry =>
-  mountEntryRecords.get(/** @type {object} */ (entry))?.physicalPath;
-harden(getEntryPhysicalPath);
 
 /**
  * Validate a single path segment.
@@ -449,14 +456,27 @@ const makeMountExo = ctx => {
       return normalizeSegments(currentSegments, pathArg);
     }
     if (typeof pathArg === 'object' && pathArg !== null) {
-      const record = mountEntryRecords.get(pathArg);
-      if (record === undefined) {
+      // A mount entry is a passable record `{ mountGrant, segments, … }`.
+      // Its provenance is its `mountGrant`'s lineage, not the identity of
+      // the record (a marshalled round-trip produces a fresh record).
+      const grant =
+        /** @type {{ mountGrant?: unknown, segments?: unknown }} */ (pathArg)
+          .mountGrant;
+      const grantLineage = lineageOf(grant);
+      if (grantLineage === undefined) {
         throw new Error('Path argument is not a daemon-minted mount entry');
       }
-      if (record.rootId !== rootId) {
+      if (grantLineage !== rootId) {
         throw new Error('Mount entry belongs to a different mount root');
       }
-      return record.segments;
+      const entrySegments = /** @type {{ segments?: unknown }} */ (pathArg)
+        .segments;
+      if (!Array.isArray(entrySegments)) {
+        throw new Error('Mount entry is missing its segments');
+      }
+      // The entry's segments are already mount-root-relative and
+      // normalized; resolve them from the root, not the current dir.
+      return normalizeSegments(harden([]), entrySegments);
     }
     if (typeof pathArg !== 'string') {
       throw new Error(`Path must be a string, array, or mount entry`);
@@ -548,28 +568,29 @@ const makeMountExo = ctx => {
   };
 
   /**
-   * @param {string[]} segments
+   * Mint a mount-entry **value**: a hardened passable record carrying its
+   * minting mount as `mountGrant` plus normalized, mount-root-relative
+   * `segments` and a presentation-friendly `displayPath`.  The entry is a
+   * pure value (no observational or handle-minting authority of its own);
+   * a method that accepts it verifies provenance by `mountGrant`'s lineage.
+   * Because the only capability slot is the formula-backed `mountGrant`,
+   * the record marshals through the daemon — `storeValue(entry, petname)`
+   * binds it, the inverse of the `lookup(petname)` that resolves it back.
+   *
+   * @param {string[]} segments  mount-root-relative, already normalized
+   * @returns {{ mountGrant: object, segments: string[], displayPath: string }}
    */
-  const makeEntryRecord = segments =>
+  const makeEntry = segments =>
     harden({
-      rootId,
-      segments,
-      physicalPath: resolveFromRoot(segments),
+      mountGrant: selfMount,
+      segments: harden([...segments]),
+      displayPath: segments.length === 0 ? '.' : segments.join('/'),
     });
-
-  /**
-   * @param {string[]} segments
-   */
-  const makeEntry = segments => {
-    const entry = makeMountEntryExo({
-      ...ctx,
-      entrySegments: segments,
-    });
-    mountEntryRecords.set(entry, makeEntryRecord(segments));
-    return entry;
-  };
 
   const help = makeHelp(mountHelp);
+
+  /** @type {object} */
+  let selfMount;
 
   const exo = makeExo('EndoMount', MountInterface, {
     help,
@@ -907,6 +928,7 @@ const makeMountExo = ctx => {
     },
   });
 
+  selfMount = exo;
   mountRecords.set(
     exo,
     harden({ rootId, currentDir, confinementRoot, readOnly }),
@@ -961,52 +983,36 @@ const makeReadableTreeView = readOnlyMount => {
 harden(makeReadableTreeView);
 
 /**
- * Create a mount-scoped logical entry descriptor.  Entries are values
- * with no observational authority and no handle-minting authority of
- * their own — those operations live on `EndoMount` and accept the
- * entry as the path-bearing argument.
+ * Free helper that narrows a mount-entry **value** to a child entry by one
+ * segment, without granting any access outside the mount.  Entries are pure
+ * passable records (`{ mountGrant, segments, displayPath }`) so the
+ * `child()` ergonomic the design's interface sketched as a method is a free
+ * helper over the value: it validates the name segment, appends it to the
+ * entry's `segments`, and re-derives `displayPath`.  The child carries the
+ * same `mountGrant` as its parent, so its provenance (and confinement) is
+ * identical and any mount method that accepts it re-checks lineage.
  *
- * @param {MountContext & { entrySegments: string[] }} ctx
- * @returns {object}
+ * @param {{ mountGrant: object, segments: string[], displayPath?: string }} entry
+ * @param {string} name
+ * @returns {{ mountGrant: object, segments: string[], displayPath: string }}
  */
-const makeMountEntryExo = ctx => {
-  const { entrySegments, rootId } = ctx;
-
-  const help = makeHelp({});
-
-  return makeExo('EndoMountEntry', MountEntryInterface, {
-    help,
-    segments() {
-      return harden([...entrySegments]);
-    },
-    displayPath() {
-      return entrySegments.length === 0 ? '.' : entrySegments.join('/');
-    },
-    child(name) {
-      assertValidSegment(name);
-      const childSegments = [...entrySegments, name];
-      const child = makeMountEntryExo({
-        ...ctx,
-        entrySegments: childSegments,
-      });
-      mountEntryRecords.set(
-        child,
-        harden({
-          rootId,
-          segments: childSegments,
-          physicalPath: resolveSegments(
-            ctx.confinementRoot,
-            ctx.confinementRoot,
-            childSegments,
-            ctx.filePowers,
-          ),
-        }),
-      );
-      return child;
-    },
+export const childEntry = (entry, name) => {
+  assertValidSegment(name);
+  if (
+    typeof entry !== 'object' ||
+    entry === null ||
+    !Array.isArray(entry.segments)
+  ) {
+    throw new Error('childEntry requires a mount entry value');
+  }
+  const childSegments = harden([...entry.segments, name]);
+  return harden({
+    mountGrant: entry.mountGrant,
+    segments: childSegments,
+    displayPath: childSegments.join('/'),
   });
 };
-harden(makeMountEntryExo);
+harden(childEntry);
 
 /**
  * Create a transient file exo for a file within a mount.

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1134,11 +1134,24 @@ export type EndoMountStat = {
   atime: bigint;
 };
 
+/**
+ * An `EndoMountEntry` is a mount-scoped logical path **value**, not a
+ * capability.  It is a hardened passable record carrying its minting mount
+ * as `mountGrant`, the normalized mount-root-relative `segments`, and a
+ * presentation-friendly `displayPath`.  It holds no observational authority
+ * and no handle-minting authority of its own; mount methods accept it as the
+ * path-bearing argument and verify provenance by `mountGrant`'s lineage.
+ *
+ * Because its only capability slot is the formula-backed `mountGrant`, the
+ * record marshals through the daemon — `storeValue(entry, petname)` binds it,
+ * the inverse of the `lookup(petname)` that resolves it back.  The `child()`
+ * narrowing the design sketched as a method is the free helper `childEntry`
+ * in `src/mount.js`.
+ */
 export interface EndoMountEntry {
-  segments(): string[];
-  displayPath(): string;
-  child(name: string): EndoMountEntry;
-  help(method?: string): string;
+  mountGrant: EndoMount;
+  segments: string[];
+  displayPath: string;
 }
 
 /**

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -34,6 +34,7 @@ import {
   addressesFromLocator,
   idFromLocator,
 } from '../src/locator.js';
+import { childEntry } from '../src/mount.js';
 
 /**
  * @import {EReturn} from '@endo/eventual-send';
@@ -5351,8 +5352,10 @@ test('mount entry descriptors support has, lookup, stat, makeFile, and provenanc
   const otherMount = await E(host).lookup(['test-mount-entry-other']);
 
   const createdEntry = await E(mount).entry(['src', 'created.txt']);
-  t.is(await E(createdEntry).displayPath(), 'src/created.txt');
-  t.deepEqual(await E(createdEntry).segments(), ['src', 'created.txt']);
+  // Entries are passable records: `displayPath` / `segments` are plain
+  // fields that survive the CapTP round-trip from the daemon.
+  t.is(createdEntry.displayPath, 'src/created.txt');
+  t.deepEqual(createdEntry.segments, ['src', 'created.txt']);
   t.false(await E(mount).has(createdEntry));
   t.is(await E(mount).stat(createdEntry), undefined);
 
@@ -5372,8 +5375,8 @@ test('mount entry descriptors support has, lookup, stat, makeFile, and provenanc
   const srcDir = await E(mount).lookup(srcEntry);
   t.deepEqual(await E(srcDir).list(), ['created.txt', 'existing.txt']);
 
-  const childEntry = await E(srcEntry).child('created.txt');
-  const openedFile = await E(mount).lookup(childEntry);
+  const createdChildEntry = childEntry(srcEntry, 'created.txt');
+  const openedFile = await E(mount).lookup(createdChildEntry);
   t.is(await E(openedFile).text(), 'created and appended');
 
   await t.throwsAsync(() => E(otherMount).readText(createdEntry), {

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -545,11 +545,18 @@ test('Git scaffold methods all surface a clear "not yet implemented"', async t =
   // backend never sees a path because the public exo refuses before
   // dispatching.  ("not yet implemented" reaches the backend's own
   // methods that the public exo dispatches to directly, like status.)
-  // The fake intentionally lacks `displayPath` / `child`; cast through
-  // the EndoMountEntry shape so the boundary type is satisfied at
-  // call-site even though the runtime guard is what fires.
+  // The fake is a well-shaped mount-entry record (so it passes the `add`
+  // argument guard) but carries a `mountGrant` minted outside the daemon,
+  // so the lineage check (`lineageOf(entry.mountGrant)` is undefined) is
+  // what fires.
   const fakeEntry = /** @type {import('../src/types.js').EndoMountEntry} */ (
-    /** @type {unknown} */ (Far('FakeEntry', { segments: () => ['foo.txt'] }))
+    /** @type {unknown} */ (
+      harden({
+        mountGrant: Far('FakeMount', {}),
+        segments: ['foo.txt'],
+        displayPath: 'foo.txt',
+      })
+    )
   );
   await t.throwsAsync(E(git).add([fakeEntry]), {
     message: /not an EndoMountEntry/,
@@ -1863,7 +1870,7 @@ test('Git.status reports merge conflicts with mount entries', async t => {
   }
   t.is(row.index, 'conflicted');
   t.is(row.worktree, 'conflicted');
-  t.deepEqual(await E(row.entry).segments(), ['conflict.txt']);
+  t.deepEqual(row.entry.segments, ['conflict.txt']);
   // The conflicted entry is a file, so its live node exposes `text()`.
   const node = /** @type {import('../src/types.js').EndoMountFile} */ (
     row.node
@@ -1896,9 +1903,10 @@ test('Git.status wraps backend rows into GitStatusEntry with mount entries', asy
   t.is(row.path, 'src/new.js');
   t.is(row.index, 'clean');
   t.is(row.worktree, 'untracked');
-  // The entry is an EndoMountEntry minted on the bound mount.  Its
-  // segments reflect the repo-relative path split by `/`.
-  t.deepEqual(await E(row.entry).segments(), ['src', 'new.js']);
+  // The entry is an EndoMountEntry value minted on the bound mount.  Its
+  // segments (a plain field on the record) reflect the repo-relative path
+  // split by `/`.
+  t.deepEqual(row.entry.segments, ['src', 'new.js']);
   t.true(await E(mount).has(row.entry));
   // `src/new.js` resolves to an EndoMountFile.
   const node = /** @type {import('../src/types.js').EndoMountFile} */ (

--- a/packages/daemon/test/mount-platform-fs-conformance.test.js
+++ b/packages/daemon/test/mount-platform-fs-conformance.test.js
@@ -274,8 +274,8 @@ test('EndoMount.makeDirectory returns a sub-mount (Directory.makeDirectory shape
 test('EndoMount.entry accepts slash-joined string selectors', async t => {
   const { mount } = makeConfiguredMount(t);
   const entry = await E(mount).entry('a/b/../c.txt');
-  t.deepEqual(await E(entry).segments(), ['a', 'c.txt']);
-  t.is(await E(entry).displayPath(), 'a/c.txt');
+  t.deepEqual(entry.segments, ['a', 'c.txt']);
+  t.is(entry.displayPath, 'a/c.txt');
 
   await E(mount).writeText(entry, 'via-entry');
   t.is(await E(mount).readText(['a', 'c.txt']), 'via-entry');

--- a/packages/daemon/test/mount.test.js
+++ b/packages/daemon/test/mount.test.js
@@ -16,7 +16,7 @@ import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
 import { checkinTree } from '@endo/platform/fs/lite';
 
 import { makeFilePowers } from '../src/daemon-node-powers.js';
-import { makeMount } from '../src/mount.js';
+import { makeMount, childEntry } from '../src/mount.js';
 import { makeMemoryStore } from './_mount-test-helpers.js';
 
 /**
@@ -315,32 +315,37 @@ test('entry() default of root has displayPath "."', async t => {
   const rootPath = makeTempRoot(t);
   const mount = makeMount({ rootPath, readOnly: false, filePowers });
   const rootEntry = await E(mount).entry([]);
-  t.is(await E(rootEntry).displayPath(), '.');
-  t.deepEqual(await E(rootEntry).segments(), []);
+  // Entries are passable records; `segments` / `displayPath` are plain
+  // fields, not methods.
+  t.is(rootEntry.displayPath, '.');
+  t.deepEqual(rootEntry.segments, []);
 });
 
 test('entry() with array path mints a nested entry with matching segments', async t => {
   const rootPath = makeTempRoot(t);
   const mount = makeMount({ rootPath, readOnly: false, filePowers });
   const entry = await E(mount).entry(['a', 'b']);
-  t.deepEqual(await E(entry).segments(), ['a', 'b']);
-  t.is(await E(entry).displayPath(), 'a/b');
+  t.deepEqual(entry.segments, ['a', 'b']);
+  t.is(entry.displayPath, 'a/b');
 });
 
-test('entry().child() extends the entry by one segment', async t => {
+test('childEntry() extends the entry by one segment', async t => {
   const rootPath = makeTempRoot(t);
   const mount = makeMount({ rootPath, readOnly: false, filePowers });
   const e = await E(mount).entry(['a']);
-  const c = await E(e).child('b');
-  t.deepEqual(await E(c).segments(), ['a', 'b']);
+  const c = childEntry(e, 'b');
+  t.deepEqual(c.segments, ['a', 'b']);
+  // The child carries the same mount grant as its parent, so its lineage
+  // (and confinement) is identical.
+  t.is(c.mountGrant, e.mountGrant);
 });
 
-test('entry().child() rejects an invalid name segment', async t => {
+test('childEntry() rejects an invalid name segment', async t => {
   const rootPath = makeTempRoot(t);
   const mount = makeMount({ rootPath, readOnly: false, filePowers });
   const e = await E(mount).entry(['a']);
-  await t.throwsAsync(() => E(e).child(''), { message: /must not be empty/ });
-  await t.throwsAsync(() => E(e).child('x/y'), { message: /must not contain/ });
+  t.throws(() => childEntry(e, ''), { message: /must not be empty/ });
+  t.throws(() => childEntry(e, 'x/y'), { message: /must not contain/ });
 });
 
 test('entry() rejects a non-string, non-array argument', async t => {

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -254,15 +254,19 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
   };
 
   /**
-   * Translate an array of EndoMountEntry caps into the repo-relative
-   * path strings that the backend (and the underlying git binary)
-   * accept.  Entries from a different mount lineage are rejected
-   * before any path is exposed to git.
+   * Translate an array of `EndoMountEntry` **values** into the repo-relative
+   * path strings that the backend (and the underlying git binary) accept.
+   * An entry is a passable record `{ mountGrant, segments, displayPath }`;
+   * its provenance is the lineage of its `mountGrant` slot (the minting
+   * mount), checked against this Git's bound mount so an entry from a
+   * different mount lineage is rejected before any path is exposed to git.
+   * The `segments` are plain data on the record — no eventual-send needed.
    *
    * @param {readonly object[]} entries
    * @returns {Promise<string[]>}
    */
   const entriesToRepoPaths = async entries => {
+    await null;
     if (!Array.isArray(entries) || entries.length === 0) {
       throw new Error(
         'entries must be a non-empty array of EndoMountEntry values',
@@ -270,7 +274,10 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
     }
     const paths = [];
     for (const entry of entries) {
-      const otherLineage = lineageOf(/** @type {object} */ (entry));
+      const grant =
+        /** @type {{ mountGrant?: unknown, segments?: unknown }} */ (entry)
+          ?.mountGrant;
+      const otherLineage = lineageOf(/** @type {object} */ (grant));
       if (otherLineage === undefined) {
         throw new Error('entry is not an EndoMountEntry minted by this daemon');
       }
@@ -279,8 +286,10 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
           'entry was minted by a different mount lineage and cannot be used here',
         );
       }
-      // eslint-disable-next-line no-await-in-loop
-      const segments = await E(entry).segments();
+      const segments = /** @type {{ segments?: unknown }} */ (entry).segments;
+      if (!Array.isArray(segments)) {
+        throw new Error('entry is not an EndoMountEntry minted by this daemon');
+      }
       paths.push(segments.join('/'));
     }
     return paths;

--- a/packages/exo-git/src/interfaces.js
+++ b/packages/exo-git/src/interfaces.js
@@ -26,9 +26,24 @@ const GitWorktreeStatusShape = M.or(
   'conflicted',
 );
 
+// A status row's `entry` is a mount-entry **value** — a passable record
+// `{ mountGrant, segments, displayPath }` whose only capability slot is the
+// formula-backed `mountGrant`.  Modeling it as a record (not an
+// `M.remotable('EndoMountEntry')`) is what lets a status row's entry be bound
+// under a petname via `storeValue`, so an agent can name it in a later
+// `add` / `restore` call.
+const MountEntryValueShape = M.splitRecord(
+  {
+    mountGrant: M.remotable('EndoMount'),
+    segments: M.arrayOf(M.string()),
+    displayPath: M.string(),
+  },
+  {},
+);
+
 const GitStatusEntryShape = M.splitRecord(
   {
-    entry: M.remotable('EndoMountEntry'),
+    entry: MountEntryValueShape,
     path: M.string(),
     index: GitIndexStatusShape,
     worktree: GitWorktreeStatusShape,
@@ -79,8 +94,8 @@ export const GitInterface = M.interface('Git', {
     .returns(M.arrayOf(GitCommitShape)),
   show: M.callWhen(RefArgShape).returns(M.string()),
   revParse: M.callWhen(RefArgShape).returns(GitRefShape),
-  add: M.callWhen(M.arrayOf(M.remotable())).returns(M.undefined()),
-  restore: M.callWhen(M.arrayOf(M.remotable()))
+  add: M.callWhen(M.arrayOf(MountEntryValueShape)).returns(M.undefined()),
+  restore: M.callWhen(M.arrayOf(MountEntryValueShape))
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.undefined()),
   commit: M.callWhen(M.string()).returns(GitCommitShape),


### PR DESCRIPTION
Refs: #424

## Description

Model `EndoMountEntry` as a **citable passable record**, the daemon substrate
that lets a live mount-derived path value survive `storeValue` and round-trip
through a petname. This is the keystone for caps-across-turns in the agentry
pipeline (it unblocks the status / `filesystemAt` petname round-trip that
`@endo/agent-tools` builds on top, tracked separately).

Per `designs/daemon-mount-capabilities.md`, `EndoMount.entry()` now returns a
hardened passable record `{ mountGrant, segments, displayPath }` instead of a
transient `makeExo('EndoMountEntry')`. Because the record's only capability slot
is the formula-backed `mountGrant` (the minting `EndoMount`),
`marshaller.toCapData` resolves that one slot to a formula id and copies the
plain `segments` / `displayPath` fields — so a status row's entry can now be
bound under a petname via `storeValue(entry, petname)` and resolved back with
`lookup(petname)`, where previously it failed with `No corresponding formula`.

Most-critical files to review:

- `packages/daemon/src/interfaces.js` — `MountEntryShape` becomes an
  `M.splitRecord({ mountGrant, segments, displayPath })`; the
  `MountEntryInterface` exo guard is removed.
- `packages/daemon/src/mount.js` — `EndoMount.entry()` mints the record; the
  `segments()` / `displayPath()` methods become plain fields and the `child()`
  ergonomic becomes the free helper `childEntry(entry, name)`. The
  per-entry `mountEntryRecords` WeakMap and the dead `getEntryPhysicalPath`
  export are removed; provenance is now checked by `lineageOf(entry.mountGrant)`.
- `packages/exo-git/src/git.js` / `interfaces.js` — `entriesToRepoPaths` reads
  `entry.mountGrant` lineage and the plain `entry.segments`; `add` / `restore`
  and the `GitStatusEntry.entry` guard accept the entry-record shape rather than
  `M.remotable('EndoMountEntry')`.

### Security Considerations

Mount-lineage identity checking is preserved: an `EndoMountEntry` confers no
authority on its own — the only capability it carries is `mountGrant`, and every
mount method that accepts an entry verifies provenance by that grant's mount
lineage. A cross-mount or fabricated entry is still rejected exactly as before.
The change narrows nothing and grants nothing new; it only makes an existing
authority-bearing value marshallable so it can be persisted under a petname.

### Scaling Considerations

None. The record is strictly cheaper than the prior exo (no remotable
allocation, no WeakMap entry per minted entry).

### Documentation Considerations

The entry's `segments` / `displayPath` are now record fields, not methods, and
`child()` is now the free helper `childEntry`. The exported `EndoMountEntry`
TypeScript interface in `packages/daemon/src/types.d.ts` reflects the record
shape. A `minor` changeset for `@endo/daemon` and `@endo/exo-git` documents the
shape change for downstream consumers.

### Testing Considerations

The mount, git, endo, and platform-fs-conformance suites are updated to the
field/helper shape and all pass locally
(`yarn workspace @endo/daemon test` — mount 73, git 87, conformance 19,
endo 178). The `Git stash methods preserve path authority through
EndoMountEntry` test exercises the preserved lineage check over the new shape.

### Compatibility Considerations

Breaking for any caller that called `entry.segments()` / `entry.displayPath()`
as methods or `entry.child(name)`; those become `entry.segments` /
`entry.displayPath` fields and `childEntry(entry, name)`. Captured in the
changeset.

### Upgrade Considerations

No persisted-data migration: the entry was never previously persistable. After
this change it becomes persistable, which is the point.

---

This PR was re-homed onto `llm` as a **substrate-only** slice carved out of the
former north-star-loop branch; it carries only the daemon + exo-git substrate.
The `@endo/agent-tools` loop wiring that depended on it lands separately.
