### PR TITLE
fix(genie): correct trace_reply reply detection in integration harness

### DIFF
--- a/packages/genie/test/integration.sh
+++ b/packages/genie/test/integration.sh
@@ -160,64 +160,101 @@ trace_reply() {
   echo "[integration] Waiting up to ${max_wait}s for reply after message #${after_msg}..." >&2
 
   while (( $(date +%s) < deadline )); do
-    echo "are you still there" >&2
-    endo inbox \
-    | grep -E '^[0-9]+\.' \
-    | while IFS= read -r line; do
+    # Read the inbox via PROCESS SUBSTITUTION (`done < <(endo inbox ...)`)
+    # so the loop body runs in the CURRENT shell.  Two properties depend
+    # on that: `return 0` returns from trace_reply itself the moment a
+    # reply is seen (an early exit, not just a loop break), and the
+    # `after_msg` watermark we advance below persists across `while`
+    # iterations.
+    while IFS= read -r line; do
       msg_num="${line%%.*}"
-      if (( msg_num <= after_msg )); then
+      # Only consider strictly-newer messages than the watermark.
+      if [[ ! "$msg_num" =~ ^[0-9]+$ ]] || (( msg_num <= after_msg )); then
         continue
       fi
-
-      echo "  ??? $after_msg $msg_num $line" >&2
       after_msg=$msg_num
 
-      # Classify each line using shell builtins; echo skipped
-      # (insubstantive) lines to stderr so the TTY-repl shows
-      # live progress while callers can still discard noise via
-      # 2>/dev/null.
+      # Inbox line shapes (see packages/cli/src/commands/inbox.js):
+      #   ours → agent : `N. sent "agent" "..."`  (verb FIRST — provenance
+      #                   for from==self is `${verb} "${toName}" `)
+      #   agent → us   : `N. "agent" sent "..."`  or `N. "agent" replied to "..."`
+      #                   (sender NAME first — provenance for to==self is
+      #                   `"${fromName}" ${verb} `)
+      #   tool call    : `N. "agent" requested "..."`
+      #   proposal     : `N. "agent" proposed definition "..."`
+      # The discriminator that distinguishes the agent's substantive
+      # reply from OUR echoed prompt is therefore structural: a real
+      # reply is a `sent`/`replied to` package whose verb is PRECEDED by
+      # the quoted sender name, i.e. it matches `N. "<name>" sent ` (or
+      # `replied to`).  Our own prompts put the verb first (`N. sent
+      # "<name>" `) and tool-calls/proposals use `requested`/`proposed`.
+      #
+      # NB: the patterns are UNQUOTED on the right of `==` so bash treats
+      # them as globs and matches them against the inbox line shapes
+      # above.  Quoting a pattern would make bash compare the line
+      # against the literal pattern text instead, so the skip branches
+      # must keep their right-hand sides unquoted to glob-match.
 
-      # Skip messages we sent (". sent " from us)
-      if [[ "$line" == "[0-9]*. sent *" ]]; then
-        echo "  (skip sent) $line" >&2
+      # Skip our own outbound messages (verb first: `N. sent ...` /
+      # `N. replied to ...` / `N. sent form ...`).
+      if [[ "$line" == [0-9]*.\ sent\ * || "$line" == [0-9]*.\ replied\ to\ * ]]; then
+        echo "  (skip ours) $line" >&2
         continue
 
-      # Skip "Thinking..." status messages (case-insensitive via extglob)
-      elif [[ "$line" == "*[Tt][Hh][Ii][Nn][Kk][Ii][Nn][Gg]...*" ]]; then
+      # Skip "Thinking..." status messages.
+      elif [[ "$line" == *[Tt]hinking...* ]]; then
         echo "  (skip thinking) $line" >&2
         continue
 
-      # Skip request/tool-call messages ("requested")
-      elif [[ "$line" == "[0-9]* requested*" ]]; then
+      # Skip request/tool-call messages (`N. "agent" requested ...`).
+      elif [[ "$line" == *\"\ requested\ * ]]; then
         echo "  (skip requested) $line" >&2
         continue
 
-      # Skip definition proposals
-      elif [[ "$line" == "[0-9]* proposed*" ]]; then
+      # Skip definition proposals (`N. "agent" proposed definition ...`).
+      elif [[ "$line" == *\"\ proposed\ * ]]; then
         echo "  (skip proposed) $line" >&2
         continue
 
-      # This is a substantive reply from the agent
-      else
-        echo "$line"
-
+      # A substantive reply FROM the agent: sender name first, then a
+      # `sent` / `replied to` verb (`N. "agent" sent "..."`).
+      elif [[ "$line" == [0-9]*.\ \"*\"\ sent\ * \
+           || "$line" == [0-9]*.\ \"*\"\ replied\ to\ * ]]; then
         echo "[integration] Got reply: $line" >&2
-        # Strip inbox metadata: remove leading "N. <verb> <agent> " prefix
-        # to get the raw message content.
-        echo "$line" | sed 's/^[0-9]*\. [^ ]* [^ ]* //'
+        # Strip the inbox metadata prefix `N. "agent" <verb> ` to leave
+        # the raw message text.  `sent` is one word; `replied to` is two,
+        # so strip the optional ` to` that may follow the verb word.
+        echo "$line" | sed -E 's/^[0-9]+\. "[^"]*" [^ ]+( to)? //'
         return 0
 
+      # Anything else (forms, values, unrecognized) is not a reply.
+      else
+        echo "  (skip other) $line" >&2
+        continue
       fi
 
-      echo "  ??? next" >&2
-
-    done
+    done < <(endo inbox 2>/dev/null | grep -E '^[0-9]+\.')
 
     sleep "$interval"
   done
 
-  echo "[integration] Timed out waiting for reply." >&2
-  endo inbox 2>/dev/null || true
+  echo "[integration] Timed out waiting for reply after message #${after_msg}." >&2
+  # Dump the daemon + worker logs so a model-side failure (bad/expired
+  # key, a free model that won't emit tool calls, blocked egress to
+  # openrouter.ai) is visible to the operator instead of a silent spin.
+  # Mirrors the Phase-3 readiness-timeout dump below.
+  echo "[integration] --- daemon log (tail) ---" >&2
+  endo log 2>&1 | tail -80 >&2 || true
+  echo "[integration] --- worker logs ---" >&2
+  if [[ -n "${ENDO_STATE_PATH:-}" && -d "$ENDO_STATE_PATH/worker" ]]; then
+    for w in "$ENDO_STATE_PATH"/worker/*/worker.log; do
+      [[ -f "$w" ]] || continue
+      echo "[integration] ---- $w ----" >&2
+      tail -60 "$w" >&2 || true
+    done
+  fi
+  echo "[integration] --- inbox ---" >&2
+  endo inbox 2>&1 | tail -40 >&2 || true
   return 1
 }
 


### PR DESCRIPTION
## Description

Corrects reply detection in `@endo/genie`'s live-model integration harness. The harness's `trace_reply()` helper had three independent defects that combined to make every run spin to its 180-second deadline and report a false timeout even when the agent answered promptly.

This is a correctness fix to a manual / live-model integration harness, not a CI-coverage closure: the script is not exercised by automated CI (it boots a real Endo daemon and round-trips a live model), so the bug surfaced only when an operator ran it by hand and watched it hang.

The three defects:

1. **Piped `while` ran in a subshell.** The inbox loop was an `endo inbox | grep | while` pipe, so the loop body ran in a subshell. `return 0` exited only that subshell — never `trace_reply` — so a live reply never short-circuited the wait, and the `after_msg` watermark advanced inside the subshell was discarded each iteration. The loop now reads via process substitution (`done < <(...)`) and runs in the current shell, so `return 0` returns from the function and the watermark persists.

2. **Quoted glob classifiers matched literally.** The line classifiers were quoted on the right of `==`, so bash compared them as literal text rather than globs; no skip branch ever fired. The patterns are now unquoted globs keyed on the structural sender discriminator the inbox command guarantees: an incoming reply renders the quoted sender name before the verb (`N. "agent" sent ...`), whereas our own outbound prompts render the verb first (`N. sent "agent" ...`).

3. **`sed` prefix-strip mishandled the two-word verb.** The metadata strip assumed a single-word verb and removed exactly two space-delimited tokens after the number, mangling the two-word `replied to` verb. The strip now tolerates the optional ` to`, leaving the raw message text intact for both `sent` and `replied to` packages.

The timeout branch also gained a daemon-and-worker-log dump that mirrors the existing Phase-3 readiness-timeout dump, so a model-side failure (expired key, a free model that emits no tool calls, blocked egress) is visible to the operator instead of a silent spin.

### Security Considerations

None. The change touches a test harness shell script only; no runtime code, capability surface, or trust boundary is affected.

### Scaling Considerations

None — if anything the harness now exits as soon as a reply arrives rather than always running to the full deadline.

### Documentation Considerations

No documentation changes. No backward-compatibility impact: the script is a developer-run integration harness with no saved data or deployment surface.

### Testing Considerations

The fixed code is itself the integration harness, and it is not run by automated CI (it requires a live daemon and a reachable model), so there is no unit-test seam to add a failing-test-first regression against without standing up CI scaffolding the harness has never had. The classifier and strip logic are validated against the inbox-line shapes that `packages/cli/src/commands/inbox.js` produces (verb-first for outbound, sender-name-first for inbound), and the script passes `bash -n`.

### Compatibility Considerations

No usage-pattern change. Operators invoke the harness exactly as before; it now succeeds instead of hanging.

### Upgrade Considerations

None.
