### PR TITLE
test(lal,familiar): lock the lal<->familiar<->chat contract (#290)

### DIFF
--- a/packages/familiar/package.json
+++ b/packages/familiar/package.json
@@ -36,6 +36,7 @@
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint --ignore-pattern out '**/*.js'",
     "lint:types": "tsc",
+    "test": "node --test 'test/**/*.test.mjs'",
     "generate-icons": "./scripts/generate-icons.sh"
   },
   "dependencies": {

--- a/packages/familiar/test/bundle-smoke.test.mjs
+++ b/packages/familiar/test/bundle-smoke.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Contract test (#290): the highest-risk, least-covered seam.
+ *
+ * `packages/familiar/scripts/bundle.mjs` bundles `packages/lal/setup.js` (as
+ * CJS) and `packages/lal/agent.js` (as an ESM caplet the daemon worker
+ * `import()`s at runtime via `makeUnconfined`). Since #290 rewrote agent.js
+ * onto genie's pi-agent harness, agent.js now imports `agent-round.js`,
+ * `transcript-persistence.js`, and the `@earendil-works/pi-*` packages. If
+ * the bundler cannot resolve and inline those into a single loadable caplet,
+ * the familiar app's agent loop is broken at runtime even though every unit
+ * test passes — a failure mode no other test in the repo catches.
+ *
+ * This test runs the real familiar bundle step as a subprocess, then asserts
+ * the emitted artifacts:
+ *   - the ESM agent.js bundle parses as a module (`node --check`),
+ *   - it inlined the new lal modules and the pi packages (no dangling
+ *     unresolved import to a file the worker cannot reach),
+ *   - the CJS setup.js bundle parses,
+ *   - the bundle's only runtime externals are node builtins plus the known
+ *     optional native deps the bundle config marks external.
+ *
+ * Uses Node's built-in `node:test` runner so the familiar package needs no
+ * new test dependency. Run with: `node --test test/bundle-smoke.test.mjs`
+ * from `packages/familiar/` (or wire `"test": "node --test test/"`).
+ *
+ * The bundle step is slow (it also bundles the cli/daemon/worker). The test
+ * carries a generous timeout; CI should give it room or split the lal-only
+ * bundle into its own script if this proves too coarse.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const familiarRoot = path.resolve(dirname, '..');
+const bundlesDir = path.join(familiarRoot, 'bundles');
+const agentBundle = path.join(bundlesDir, 'agent.js');
+const setupBundle = path.join(bundlesDir, 'endo-lal-setup.cjs');
+
+// Run the real bundle step once before the assertions.
+test('familiar bundle step succeeds (lal agent + setup caplets)', () => {
+  // `node scripts/bundle.mjs` is the `step:bundle` script. execFileSync
+  // throws on non-zero exit, which fails the test with the build error.
+  execFileSync('node', ['scripts/bundle.mjs'], {
+    cwd: familiarRoot,
+    stdio: 'pipe',
+    timeout: 5 * 60 * 1000,
+  });
+  assert.ok(existsSync(agentBundle), 'agent.js ESM caplet was emitted');
+  assert.ok(existsSync(setupBundle), 'endo-lal-setup.cjs was emitted');
+});
+
+test('emitted agent.js caplet parses as an ES module', () => {
+  // `node --check` over stdin as a module: the worker import()s this file as
+  // ESM, so it must be syntactically valid module source.
+  execFileSync('node', ['--check', '--input-type=module'], {
+    input: readFileSync(agentBundle),
+    stdio: 'pipe',
+  });
+});
+
+test('emitted setup.js bundle parses as CJS', () => {
+  execFileSync('node', ['--check', setupBundle], { stdio: 'pipe' });
+});
+
+test('agent.js caplet inlined the new lal modules and pi packages', () => {
+  const src = readFileSync(agentBundle, 'utf8');
+  // The #290 modules and the pi harness must be inlined into the single
+  // caplet — not left as bare imports the runtime worker cannot resolve.
+  for (const marker of [
+    'runAgentRound', // from ./agent-round.js
+    'persistTurnDelta', // from ./transcript-persistence.js
+    'loadPersistedTranscript', // from ./transcript-persistence.js
+  ]) {
+    assert.ok(
+      src.includes(marker),
+      `expected the bundle to inline "${marker}"; a bare/unresolved import ` +
+        `here means the worker would fail to load the caplet at runtime`,
+    );
+  }
+  // No dangling ESM import of a sibling lal source file should survive
+  // bundling (those must be inlined, not left as ./agent-round.js etc.).
+  assert.ok(
+    !/from\s+["']\.\/agent-round\.js["']/.test(src),
+    'agent-round.js should be inlined, not left as a bare relative import',
+  );
+  assert.ok(
+    !/from\s+["']\.\/transcript-persistence\.js["']/.test(src),
+    'transcript-persistence.js should be inlined, not a bare relative import',
+  );
+});
+
+test('agent.js caplet top-level externals are node builtins + known optionals', async () => {
+  const src = readFileSync(agentBundle, 'utf8');
+  // The contract that matters at runtime: every module the worker caplet
+  // genuinely defers to a runtime `require()` must be resolvable in the
+  // worker's environment (node builtins) or be a guarded optional. esbuild
+  // rewrites internal cross-module references to a private `__require(...)`
+  // shim, so a naive `__require("X")` scan over the whole bundle catches
+  // false positives (a package's own self-name require, doc-comment strings).
+  //
+  // We therefore restrict the check to the bundle's BANNER-LEVEL `require`
+  // (the createRequire shim) plus the small set of genuinely-external bare
+  // requires that survive esbuild's bundling: those are the ones marked
+  // `external` in scripts/bundle.mjs plus transitive optionals required in a
+  // try/catch (color/auth). The allow-list below is the deliberate contract;
+  // a NEW non-builtin, NON-guarded external would be the regression we want
+  // to catch, and a reviewer should confirm any addition is guarded.
+  const { builtinModules } = await import('node:module');
+  const builtins = new Set(builtinModules.map(n => n.replace(/^node:/, '')));
+  const KNOWN_OPTIONAL_EXTERNALS = new Set([
+    'bufferutil', // optional ws native, marked external in bundle.mjs
+    'utf-8-validate', // optional ws native, marked external in bundle.mjs
+    'supports-color', // debug's color probe, required in try/catch
+    'google-auth-library', // pi-ai Gemini/Vertex provider, inlined+self-req
+  ]);
+
+  // Heuristic external scan, reported as DIAGNOSTIC rather than a hard fail
+  // on the heuristic itself: assert only that every flagged non-builtin is on
+  // the reviewed allow-list. New unreviewed externals fail loudly here.
+  const externals = new Set();
+  for (const m of src.matchAll(/\b(?:__)?require\(["']([^"']+)["']\)/g)) {
+    const name = m[1].replace(/^node:/, '');
+    // Skip obvious non-specifiers (absolute/relative paths, doc-comment
+    // example strings that happen to look like requires).
+    if (!name.startsWith('/') && !name.startsWith('.')) {
+      externals.add(name);
+    }
+  }
+  const unreviewed = [...externals].filter(
+    e => !builtins.has(e) && !KNOWN_OPTIONAL_EXTERNALS.has(e),
+  );
+  assert.deepEqual(
+    unreviewed,
+    [],
+    `bundle defers unreviewed non-builtin module(s) to runtime require: ` +
+      `${unreviewed.join(', ')}. The worker caplet has no node_modules; ` +
+      `confirm each is inlined or guarded (try/catch), then add it to ` +
+      `KNOWN_OPTIONAL_EXTERNALS with a one-line justification.`,
+  );
+});

--- a/packages/familiar/test/bundle-smoke.test.mjs
+++ b/packages/familiar/test/bundle-smoke.test.mjs
@@ -112,6 +112,18 @@ test('agent.js caplet top-level externals are node builtins + known optionals', 
   // to catch, and a reviewer should confirm any addition is guarded.
   const { builtinModules } = await import('node:module');
   const builtins = new Set(builtinModules.map(n => n.replace(/^node:/, '')));
+  // NOTE: this allow-list is curated BY HAND on purpose, and the test failing
+  // loudly when a new external appears is the feature, not a bug. Each entry
+  // is a non-builtin module the bundle legitimately defers to a runtime
+  // require — an optional native dep marked `external` in scripts/bundle.mjs
+  // (bufferutil, utf-8-validate) or a transitive optional required in a
+  // try/catch (supports-color) or inlined-but-self-requiring (the pi-ai
+  // google-auth-library provider). When a NEW external surfaces here, the
+  // intended action is to REVIEW it first (confirm it is genuinely inlined or
+  // guarded so the worker caplet — which has no node_modules — will not crash
+  // at load), THEN add it deliberately with a one-line justification. Do not
+  // silence the failure by reflexively widening the set; the loud failure is
+  // exactly the regression signal this smoke test exists to raise.
   const KNOWN_OPTIONAL_EXTERNALS = new Set([
     'bufferutil', // optional ws native, marked external in bundle.mjs
     'utf-8-validate', // optional ws native, marked external in bundle.mjs

--- a/packages/lal/test/protocol-surface.test.js
+++ b/packages/lal/test/protocol-surface.test.js
@@ -116,6 +116,32 @@ const EXPECTED_CHAT_FACING_METHODS = harden([
   'locate', // @self locator used by setup scripts' form matching
 ]);
 
+/**
+ * Pump microtasks until `predicate()` is true, up to `maxTurns` turns.
+ *
+ * The startup contract we assert is synchronous-on-the-microtask-queue: the
+ * `form('@host', 'Add an agent', ...)` emission is the FIRST `await` in
+ * agent.js's `runManager()`, so it lands within one microtask turn today.
+ * Rather than hard-code that turn count (a fixed `await Promise.resolve()`
+ * tally that a future `await` inserted ahead of the form emission would
+ * silently desync), we poll the recording stub until the form call is
+ * observed. The bounded `maxTurns` keeps the wait deterministic and prevents
+ * a hang if the emission is dropped entirely — the predicate simply never
+ * holds and the caller's assertion fails loudly on the empty recording.
+ *
+ * @param {() => boolean} predicate
+ * @param {number} [maxTurns]
+ */
+const pumpUntil = async (predicate, maxTurns = 16) => {
+  // Leading separator so the loop's await is not the function's first await
+  // (@jessie.js/safe-await-separator); also yields one turn before polling.
+  await null;
+  for (let turn = 0; turn < maxTurns && !predicate(); turn += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+};
+
 const makeRecordingPowers = () => {
   /** @type {string[]} */
   const calls = [];
@@ -177,9 +203,11 @@ test('lal startup emits the "Add an agent" form chat/setup-lal consume', async t
   const exo = make(powers, undefined);
   t.truthy(exo, 'make() returns the Lal exo');
 
-  // Let the manager microtasks run up to the parked lookup('host-agent').
-  await Promise.resolve();
-  await Promise.resolve();
+  // Pump microtasks until the startup form is recorded (the manager then
+  // parks at the lookup('host-agent') await). Polling, rather than a fixed
+  // tick count, keeps the test correct if a future await is inserted ahead
+  // of the form emission.
+  await pumpUntil(() => forms.length > 0);
 
   t.is(forms.length, 1, 'lal emits exactly one startup form');
   const [form] = forms;
@@ -202,8 +230,9 @@ test('lal startup emits the "Add an agent" form chat/setup-lal consume', async t
 test('lal startup drives only the expected chat-facing guest-power methods', async t => {
   const { powers, calls } = makeRecordingPowers();
   make(powers, undefined);
-  await Promise.resolve();
-  await Promise.resolve();
+  // Pump until the manager emits the form (its first guest-power call), by
+  // which point every method it touches before parking at lookup is recorded.
+  await pumpUntil(() => calls.includes('form'));
 
   // Every method the manager touched on the way to the parked lookup must be
   // a member of the expected chat-facing surface. (Subset, not equality:

--- a/packages/lal/test/protocol-surface.test.js
+++ b/packages/lal/test/protocol-surface.test.js
@@ -1,0 +1,220 @@
+// @ts-check
+/**
+ * Contract test (#290): pin the lal <-> chat runtime protocol surface so a
+ * future lal refactor cannot silently rename or drop a tool name or a
+ * guest-power method that the chat UI / setup scripts depend on.
+ *
+ * This is a thin characterization / snapshot test, NOT an end-to-end run.
+ * It asserts three frozen sets by inspection of `agent.js`:
+ *
+ *   1. The LLM-facing tool surface (`toolDefs[].name`) — exactly the tool
+ *      names the worker exposes to the model. A rename here changes the
+ *      prompt contract and the per-tool `@endo/patterns` validation seam.
+ *
+ *   2. The guest-power method surface (`E(powers).<method>` in agent.js) —
+ *      the daemon-guest methods the worker drives. The chat UI and the
+ *      `setup-lal.js` / `setup-llm-provider.js` scripts talk to the SAME
+ *      daemon inbox surface (`form` / `submit` / `followMessages` /
+ *      `listMessages` / `reply` / `send` / `lookup` / `adopt` / `dismiss`),
+ *      so dropping one of these from lal's vocabulary is the failure mode
+ *      that breaks the chat-facing inbox flow.
+ *
+ *   3. The startup `form('@host', 'Add an agent', ...)` emission — the
+ *      single message the chat "Add an agent" flow (and setup-lal.js)
+ *      consumes. If lal stops emitting it, or renames the label, the chat
+ *      setup form never appears.
+ *
+ * The EXPECTED_* sets below are the load-bearing contract. Bumping them is a
+ * deliberate act: a reviewer must confirm the corresponding chat consumer
+ * (grep `packages/chat` for the name) was migrated in the same change.
+ */
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import { makePromiseKit } from '@endo/promise-kit';
+
+import { toolDefs, make } from '../agent.js';
+
+// ---------------------------------------------------------------------------
+// 1. LLM-facing tool surface.
+// ---------------------------------------------------------------------------
+
+// The exact tool names lal exposes to the model. Source of truth: the
+// `name:` fields of `toolDefs` in agent.js as of #290.
+const EXPECTED_TOOL_NAMES = harden([
+  'help',
+  'has',
+  'list',
+  'lookup',
+  'inspect',
+  'readText',
+  'writeText',
+  'remove',
+  'move',
+  'copy',
+  'makeDirectory',
+  'locate',
+  'listMessages',
+  'resolve',
+  'reject',
+  'adopt',
+  'dismiss',
+  'request',
+  'send',
+  'reply',
+  'evaluate',
+  'define',
+]);
+
+test('lal tool surface: toolDefs exposes exactly the expected tool names', t => {
+  const actual = toolDefs.map(d => d.name).sort();
+  t.deepEqual(
+    actual,
+    [...EXPECTED_TOOL_NAMES].sort(),
+    'toolDefs tool names drifted; a rename/drop here changes the LLM tool ' +
+      'contract. If intentional, update EXPECTED_TOOL_NAMES and confirm any ' +
+      'chat-side consumer of the renamed tool was migrated.',
+  );
+});
+
+test('lal tool surface: every toolDef carries a name, summary, and params matcher', t => {
+  for (const def of toolDefs) {
+    t.is(typeof def.name, 'string', `tool name must be a string: ${def.name}`);
+    t.is(
+      typeof def.summary,
+      'string',
+      `tool "${def.name}" must carry a summary (sent to the model)`,
+    );
+    t.truthy(
+      def.params,
+      `tool "${def.name}" must carry a params matcher (the @endo/patterns ` +
+        `validation seam that guards E(powers) dispatch)`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2 & 3. Guest-power method surface + startup form emission.
+//
+// A recording stand-in for the daemon guest powers. It logs every method the
+// worker invokes and lets `runManager`'s post-form `lookup('host-agent')`
+// hang harmlessly so the test observes only the synchronous startup path.
+// ---------------------------------------------------------------------------
+
+/**
+ * The daemon-guest methods the chat-facing inbox flow depends on lal driving.
+ * These are the same method names `packages/chat` and the setup scripts call
+ * on the agent/host capability (grep chat for `.form(`, `.submit(`,
+ * `followMessages(`, `listMessages(`, `.reply(`). Dropping one here is the
+ * silent break the maintainer asked us to lock.
+ */
+const EXPECTED_CHAT_FACING_METHODS = harden([
+  'form', // emits the "Add an agent" setup form chat/setup-lal consume
+  'followMessages', // the live inbox stream chat follows
+  'listMessages', // pre-scan + chat inbox listing
+  'reply', // threaded inbox replies
+  'lookup', // resolve host-agent / capabilities
+  'locate', // @self locator used by setup scripts' form matching
+]);
+
+const makeRecordingPowers = () => {
+  /** @type {string[]} */
+  const calls = [];
+  /** @type {Array<{ recipient: unknown, label: unknown, fields: unknown }>} */
+  const forms = [];
+  // A never-resolving promise so the manager parks at the first await after
+  // the form emission (the `lookup('host-agent')`), keeping the test to the
+  // synchronous startup contract.
+  const hang = makePromiseKit().promise;
+
+  // A recording stand-in for the FarRef<GuestPowers> make() expects; cast at
+  // this boundary (as agent.js itself does internally) so the test drives the
+  // real startup path without reconstructing the full guest-powers type.
+  /** @type {any} */
+  const powers = harden({
+    form(recipient, label, fields) {
+      calls.push('form');
+      forms.push({ recipient, label, fields });
+      return Promise.resolve();
+    },
+    lookup(_name) {
+      calls.push('lookup');
+      return hang;
+    },
+    locate(_name) {
+      calls.push('locate');
+      return Promise.resolve('self-locator');
+    },
+    listMessages() {
+      calls.push('listMessages');
+      return Promise.resolve(harden([]));
+    },
+    followMessages() {
+      calls.push('followMessages');
+      // An async iterable that immediately completes.
+      return harden({
+        [Symbol.asyncIterator]() {
+          return harden({
+            next() {
+              return Promise.resolve(harden({ value: undefined, done: true }));
+            },
+          });
+        },
+      });
+    },
+    reply() {
+      calls.push('reply');
+      return Promise.resolve();
+    },
+  });
+
+  return { powers, calls, forms };
+};
+
+test('lal startup emits the "Add an agent" form chat/setup-lal consume', async t => {
+  const { powers, forms } = makeRecordingPowers();
+
+  // make() fires runManager() and returns the exo synchronously.
+  const exo = make(powers, undefined);
+  t.truthy(exo, 'make() returns the Lal exo');
+
+  // Let the manager microtasks run up to the parked lookup('host-agent').
+  await Promise.resolve();
+  await Promise.resolve();
+
+  t.is(forms.length, 1, 'lal emits exactly one startup form');
+  const [form] = forms;
+  t.is(form.recipient, '@host', 'the setup form is sent to @host');
+  t.is(
+    form.label,
+    'Add an agent',
+    'the form label is the string the chat "Add an agent" flow keys on',
+  );
+  const fieldNames = /** @type {Array<{ name: string }>} */ (form.fields).map(
+    f => f.name,
+  );
+  t.deepEqual(
+    fieldNames,
+    ['name', 'host', 'model', 'authToken'],
+    'the setup form fields match what setup-lal.js submits',
+  );
+});
+
+test('lal startup drives only the expected chat-facing guest-power methods', async t => {
+  const { powers, calls } = makeRecordingPowers();
+  make(powers, undefined);
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // Every method the manager touched on the way to the parked lookup must be
+  // a member of the expected chat-facing surface. (Subset, not equality:
+  // spawnWorkerLoop's per-tool methods are exercised by pi-agent-tools.test.)
+  for (const method of calls) {
+    t.true(
+      [...EXPECTED_CHAT_FACING_METHODS].includes(method),
+      `manager invoked unexpected guest-power method "${method}"; if this is ` +
+        `a deliberate new dependency, add it to EXPECTED_CHAT_FACING_METHODS ` +
+        `and confirm the daemon/chat surface provides it`,
+    );
+  }
+  t.true(calls.includes('form'), 'the manager must emit the setup form');
+});


### PR DESCRIPTION
Refs: #290

## Description

Guardrail tests locking the lal↔familiar↔chat runtime contract that #290's
pi-harness rewrite touches but no existing test covers.

1. `test(lal): pin the lal<->chat runtime protocol surface` —
   `packages/lal/test/protocol-surface.test.js`, a characterization test over
   `agent.js` asserting three frozen sets: the LLM-facing `toolDefs` names, the
   chat-facing guest-power methods (`form` / `followMessages` / `listMessages` /
   `reply` / `lookup` / `locate`), and the startup `form('@host', 'Add an
   agent', ...)` emission the chat "Add an agent" flow and the setup scripts
   consume. A rename or drop here is a silent break the model/chat contract
   would otherwise carry unannounced.

2. `test(familiar): smoke-test the lal agent+setup bundle caplet` —
   `packages/familiar/test/bundle-smoke.test.mjs`, runs the real
   `scripts/bundle.mjs` step as a subprocess and asserts the emitted agent.js
   ESM caplet and setup.js CJS bundle parse, inline the new lal pi modules
   (`runAgentRound`, `persistTurnDelta`, `loadPersistedTranscript`), and defer
   only node builtins plus reviewed optional externals to a runtime `require`.
   This is the highest-risk, least-covered seam: a bundle that fails to inline
   the pi harness breaks the familiar agent loop at runtime even when every unit
   test passes. Uses node's built-in test runner, so familiar needs no new test
   dependency; the `"test": "node --test 'test/**/*.test.mjs'"` script wires it.

Stacked on #290 (head `feat/lal-pi-harness`) because both tests assert the
post-rewrite surface; GitHub auto-retargets this PR to `llm` when #290 merges.

### Security Considerations

N/A — test-only.

### Scaling Considerations

The familiar bundle smoke test runs the real bundle step (slow); it carries a
5-minute timeout and runs as a single subprocess.

### Documentation Considerations

N/A.

### Testing Considerations

`cd packages/lal && yarn test test/protocol-surface.test.js` (4 passed);
`cd packages/familiar && yarn test` (5 passed). Both green on `feat/lal-pi-harness`.

### Compatibility Considerations

N/A.

### Upgrade Considerations

N/A — no changeset (lal and familiar are private/unpublished; test-infra only).
