### PR TITLE
test(agent-tools): north-star loop forcing-function test + tool-API contract

### DIFF
--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@endo/daemon": "workspace:^",
+    "@endo/git": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/promise-kit": "workspace:^",
     "ajv": "^8.17.1",

--- a/packages/agent-tools/src/north-star-tools.js
+++ b/packages/agent-tools/src/north-star-tools.js
@@ -1,0 +1,385 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { ERef } from '@endo/far' */
+/** @import { Filesystem } from '@endo/endo-fs' */
+/** @import { ToolPowers, ToolRecord } from './types.js' */
+
+/**
+ * North-star tool-API contract — Phase 1 stubs.
+ *
+ * These factories define the *intended* signatures and the petname-binding
+ * contract for the agent-tools surface the north-star loop drives end to end
+ * (see `test/north-star-loop.test.js`). Every body throws `not implemented:
+ * <tool>` so the contract compiles and type-checks today while the follow-on
+ * builds make `test/north-star-loop.test.js` go green tool by tool. Nothing
+ * here implements real behavior.
+ *
+ * Two boundary shapes recur and are named once here:
+ *
+ * - **Argument-side wire-ify** (already implemented in `tool.js` `resolveArg`):
+ *   an LLM passes a petname *string*; the invoke boundary resolves it to a live
+ *   cap via `E(powers).lookup(petname)` before the tool body runs. The `add`
+ *   tool (which already exists on this branch via `makeGitTool`) is the live
+ *   example the loop reuses.
+ * - **Return-side wire-ify** (the new direction these stubs introduce): a tool
+ *   that *returns* live caps (a `status` row's `EndoMountEntry`, a
+ *   `filesystemAt` `Filesystem`) cannot hand an LLM a live object. It binds
+ *   each returned cap under a petname in the guest's own directory via
+ *   `E(powers).storeValue(cap, petname)` and returns the *petname* in the
+ *   plain-JSON result. The agent then names that petname in a later
+ *   capref-taking tool (`add`), closing the loop. `storeValue` is the inverse
+ *   of the `lookup` that argument-side resolution uses; the two together let a
+ *   cap make a full round-trip through an LLM that only ever sees strings.
+ *
+ * The unblocking these stubs target: `git-tool.js` deferred the Git methods
+ * that *return* live caps (`status`, `filesystemAt`) precisely because no
+ * return-side-wire-ify shape existed yet. Naming `storeValue(cap, petname)` as
+ * the return-side call is what lets those methods join the tool surface.
+ */
+
+/**
+ * @param {string} tool
+ * @returns {never}
+ */
+const notImplemented = tool => {
+  throw new Error(`not implemented: ${tool}`);
+};
+
+/**
+ * Filesystem **edit** tool: write (create or overwrite) a UTF-8 text file at a
+ * root-relative path through a writable `EndoMount` / endo-fs `Filesystem`.
+ * The mirror-image write counterpart to `makeMountReadTool`'s read-one-file.
+ *
+ * Contract:
+ * - Tool name `mountWriteText`.
+ * - Parameters `{ path: string, content: string }`, both required, no extras.
+ * - Resolves `path` to a `File` through the mount (minting intermediate
+ *   directories is out of scope for the loop; the loop edits a path whose
+ *   parent already exists), opens it `{ write: true }`, and writes the UTF-8
+ *   bytes of `content`, truncating any prior contents.
+ * - Returns a plain-JSON ack (e.g. `{ path, bytesWritten }`) — never a live cap.
+ * - Rejects a `../` escape structurally (the `Filesystem` enforces it, as in
+ *   `makeMountReadTool`), not via a string check.
+ *
+ * @param {ERef<Filesystem>} fs A writable `@endo/endo-fs` `Filesystem` ERef
+ *   (the daemon `EndoMount`'s worktree view).
+ * @returns {ToolRecord}
+ */
+export const makeMountWriteTool = fs => {
+  void fs;
+  return harden({
+    name: 'mountWriteText',
+    description:
+      'Write a UTF-8 text file into the mounted project directory, ' +
+      'creating or overwriting it. Path is mount-relative; "../" escapes ' +
+      'are rejected.',
+    parameters: harden({
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Mount-relative path to the file to write.',
+        },
+        content: {
+          type: 'string',
+          description: 'UTF-8 text to write, replacing any prior contents.',
+        },
+      },
+      required: ['path', 'content'],
+      additionalProperties: false,
+    }),
+    inputSchema: harden({
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        content: { type: 'string' },
+      },
+      required: ['path', 'content'],
+      additionalProperties: false,
+    }),
+    invoke: async _args => notImplemented('mountWriteText'),
+  });
+};
+harden(makeMountWriteTool);
+
+/**
+ * Filesystem **list** tool: enumerate the entry names directly under a
+ * root-relative directory path through an endo-fs `Filesystem`.
+ *
+ * Contract:
+ * - Tool name `mountList`.
+ * - Parameters `{ path?: string }` (absent / `''` lists the root), no extras.
+ * - Resolves the directory through the mount and returns a plain-JSON
+ *   `{ entries: string[] }` of single-segment child names in directory order.
+ *   Names only — never live `Directory` / `File` caps.
+ *
+ * @param {ERef<Filesystem>} fs An `@endo/endo-fs` `Filesystem` ERef.
+ * @returns {ToolRecord}
+ */
+export const makeMountListTool = fs => {
+  void fs;
+  return harden({
+    name: 'mountList',
+    description:
+      'List the entry names directly under a directory in the mounted ' +
+      'project directory. Path is mount-relative; absent lists the root.',
+    parameters: harden({
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Mount-relative directory path; absent lists the root.',
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    }),
+    inputSchema: harden({
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: [],
+      additionalProperties: false,
+    }),
+    invoke: async _args => notImplemented('mountList'),
+  });
+};
+harden(makeMountListTool);
+
+/**
+ * Filesystem **stat** tool: report metadata for one root-relative path through
+ * an endo-fs `Filesystem`.
+ *
+ * Contract:
+ * - Tool name `mountStat`.
+ * - Parameters `{ path: string }`, required, no extras.
+ * - Resolves the entry through the mount and returns a plain-JSON record
+ *   (e.g. `{ path, type: 'file' | 'directory', size? }`) drawn from the entry's
+ *   qid / stat. Never a live cap.
+ *
+ * @param {ERef<Filesystem>} fs An `@endo/endo-fs` `Filesystem` ERef.
+ * @returns {ToolRecord}
+ */
+export const makeMountStatTool = fs => {
+  void fs;
+  return harden({
+    name: 'mountStat',
+    description:
+      'Report metadata (type, size) for one path in the mounted project ' +
+      'directory. Path is mount-relative.',
+    parameters: harden({
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Mount-relative path to stat.',
+        },
+      },
+      required: ['path'],
+      additionalProperties: false,
+    }),
+    inputSchema: harden({
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+      additionalProperties: false,
+    }),
+    invoke: async _args => notImplemented('mountStat'),
+  });
+};
+harden(makeMountStatTool);
+
+/**
+ * Git **status** tool: report the worktree status as plain-JSON rows AND bind
+ * each changed entry's live `EndoMountEntry` cap to a petname in the guest's
+ * own directory so the agent can name it in a later capref-taking tool.
+ *
+ * This is the return-side-wire-ify direction `git-tool.js` deferred. The Git
+ * exo's `status()` mints an `EndoMountEntry` per row (`r.entry`); an LLM cannot
+ * hold that live cap, so the tool binds it under a petname and returns the
+ * petname in the row.
+ *
+ * Contract:
+ * - Tool name `status`.
+ * - No parameters.
+ * - Calls `E(gitCap).status()`, then for each returned row binds its `entry`
+ *   cap under a deterministic petname via the return-side-wire-ify call
+ *   **`E(powers).storeValue(row.entry, petname)`** (the inverse of the
+ *   `E(powers).lookup(petname)` that `tool.js` `resolveArg` uses on the
+ *   argument side). The petname is derived from the row's `path` so the agent
+ *   can correlate it (e.g. slugified `path`); collisions across calls overwrite,
+ *   which is the intended "latest status binds the name" semantics.
+ * - Returns plain JSON only: `{ rows: Array<{ path, index, worktree, petname,
+ *   renamedFrom? }> }`. The `index` / `worktree` status codes pass through
+ *   verbatim; `petname` is the name the agent then passes to `add`. No live cap
+ *   is ever placed in the JSON.
+ * - Requires `powers` (it binds names); a tool built without `powers` throws a
+ *   clear error when invoked, matching the `add`-without-powers contract.
+ *
+ * @param {ERef<import('./types.js').GitToolCapability & {
+ *   status: () => Promise<Array<Record<string, unknown>>>,
+ * }>} gitCap A live daemon-minted `Git` capability whose `status()` mints
+ *   `EndoMountEntry` caps per row.
+ * @param {ERef<ToolPowers & {
+ *   storeValue: (value: unknown, petName: string | string[]) => Promise<void>,
+ * }>} powers The guest directory the tool binds returned caps into and that
+ *   capref args later resolve against. Required.
+ * @returns {ToolRecord}
+ */
+export const makeGitStatusTool = (gitCap, powers) => {
+  void gitCap;
+  void powers;
+  return harden({
+    name: 'status',
+    description:
+      'Report the working-tree status as JSON rows and bind each changed ' +
+      "entry to a petname in the agent's directory so it can be named in a " +
+      'later add/restore call.',
+    parameters: harden({
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    }),
+    inputSchema: harden({
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    }),
+    invoke: async _args => notImplemented('status'),
+  });
+};
+harden(makeGitStatusTool);
+
+/**
+ * Git **remote** tool set: the bounded fetch / pull / push surface over a live
+ * `GitRemote` cap (`@endo/exo-git` `makeGitRemote`). The `GitRemote` already
+ * enforces direction / refspec / credential policy; this tool is the thin
+ * agent-facing adapter that exposes its three verbs.
+ *
+ * Contract — one record per verb, names `gitFetch` / `gitPull` / `gitPush`:
+ * - Each takes an options record passed straight through to the matching
+ *   `E(gitRemote).<verb>(options)` method (`{ prune?, tags? }` for fetch,
+ *   `{ branch?, strategy? }` for pull, `{ source?, destination?, force?,
+ *   setUpstream? }` for push). All options are optional.
+ * - Returns the `GitRemote` operation result as plain JSON (the audit-friendly
+ *   `{ updatedRefs?, integration?, head? }` shape the remote already produces);
+ *   no live cap crosses back.
+ * - The tool grants no authority the bound `GitRemote` does not already permit:
+ *   a fetch-only remote rejects `gitPush` at the `GitRemote` boundary, surfaced
+ *   verbatim.
+ *
+ * @param {ERef<{
+ *   fetch: (options?: object) => Promise<unknown>,
+ *   pull: (options?: object) => Promise<unknown>,
+ *   push: (options?: object) => Promise<unknown>,
+ * }>} gitRemote A live, policy-bound `GitRemote` cap.
+ * @returns {ToolRecord[]}
+ */
+export const makeGitRemoteTool = gitRemote => {
+  void gitRemote;
+  const optionsParam = harden({
+    type: 'object',
+    properties: {
+      options: {
+        type: 'object',
+        description:
+          'Options record passed through to the bounded GitRemote verb.',
+      },
+    },
+    required: [],
+    additionalProperties: false,
+  });
+  /**
+   * @param {string} name
+   * @param {string} description
+   * @returns {ToolRecord}
+   */
+  const makeRemoteVerb = (name, description) =>
+    harden({
+      name,
+      description,
+      parameters: optionsParam,
+      inputSchema: optionsParam,
+      invoke: async _args => notImplemented(name),
+    });
+  return harden([
+    makeRemoteVerb(
+      'gitFetch',
+      'Fetch from the bounded remote (policy-limited refspecs).',
+    ),
+    makeRemoteVerb(
+      'gitPull',
+      'Fetch and integrate from the bounded remote (ff-only by default).',
+    ),
+    makeRemoteVerb(
+      'gitPush',
+      'Push to the bounded remote (policy-limited refspecs).',
+    ),
+  ]);
+};
+harden(makeGitRemoteTool);
+
+/**
+ * Git **filesystemAt** tool: open a read-only filesystem view of any git ref
+ * (e.g. `HEAD~1`, a branch name, a remote-tracking ref) and bind the resulting
+ * `Filesystem` cap to a petname so the agent can read historical file versions
+ * through a read tool over that view.
+ *
+ * This is the second return-side-wire-ify case `git-tool.js` deferred: the Git
+ * exo's `filesystemAt(ref)` returns a live read-only `Filesystem` cap, which an
+ * LLM cannot hold.
+ *
+ * Contract:
+ * - Tool name `filesystemAt`.
+ * - Parameters `{ ref: string }`, required, no extras (a ref string the backend
+ *   resolves — `HEAD`, `HEAD~1`, a branch, a remote-tracking ref).
+ * - Calls `E(gitCap).filesystemAt(ref)` to obtain the read-only `Filesystem`,
+ *   then binds it under a petname via the same return-side-wire-ify call the
+ *   status tool uses — **`E(powers).storeValue(filesystem, petname)`** — and
+ *   returns plain JSON `{ ref, petname }`. The agent then constructs / drives an
+ *   FS read tool (`makeMountReadTool`) over `lookup(petname)` to read the prior
+ *   version of a file. No live cap is placed in the JSON.
+ * - Requires `powers`; built without it, invoking throws a clear error.
+ *
+ * @param {ERef<{ filesystemAt: (ref: string) => Promise<unknown> }>} gitCap A
+ *   live daemon-minted `Git` capability.
+ * @param {ERef<ToolPowers & {
+ *   storeValue: (value: unknown, petName: string | string[]) => Promise<void>,
+ * }>} powers The guest directory the returned `Filesystem` is bound into.
+ *   Required.
+ * @returns {ToolRecord}
+ */
+export const makeGitFilesystemAtTool = (gitCap, powers) => {
+  void gitCap;
+  void powers;
+  return harden({
+    name: 'filesystemAt',
+    description:
+      'Open a read-only filesystem view of a git ref (HEAD~1, a branch, a ' +
+      "remote-tracking ref) and bind it to a petname in the agent's " +
+      'directory so its files can be read through a read tool.',
+    parameters: harden({
+      type: 'object',
+      properties: {
+        ref: {
+          type: 'string',
+          description:
+            'A git ref to open read-only: "HEAD", "HEAD~1", a branch ' +
+            'name, or a remote-tracking ref.',
+        },
+      },
+      required: ['ref'],
+      additionalProperties: false,
+    }),
+    inputSchema: harden({
+      type: 'object',
+      properties: { ref: { type: 'string' } },
+      required: ['ref'],
+      additionalProperties: false,
+    }),
+    invoke: async _args => notImplemented('filesystemAt'),
+  });
+};
+harden(makeGitFilesystemAtTool);

--- a/packages/agent-tools/test/helpers/daemon-petstore.js
+++ b/packages/agent-tools/test/helpers/daemon-petstore.js
@@ -17,11 +17,22 @@
 // full daemon per test and share filesystem state under `test/tmp`, so every
 // caller runs `test.serial` and this helper registers a `t.teardown`.
 
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import url from 'url';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { start, stop, purge, makeEndoClient } from '@endo/daemon';
+import { makeFilePowers } from '@endo/daemon/src/daemon-node-powers.js';
+import { lineageOf, makeMount } from '@endo/daemon/src/mount.js';
+import { makeReaderRef } from '@endo/daemon/reader-ref.js';
+import { makeGit } from '@endo/exo-git';
+import { makeNativeGitBackend } from '@endo/git';
+
+const execFileAsync = promisify(execFile);
 
 const dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -124,4 +135,75 @@ export const bindCap = async (t, powers, petname) => {
     petname,
   );
   return cap;
+};
+
+/**
+ * Initialize a real git repository at a fresh tmp path with one committed file
+ * on `main`, returning the host path. Registers an AVA teardown that removes
+ * the directory. Mirrors `packages/daemon/test/git.test.js`'s
+ * `provisionGitWorktree` so the north-star loop runs against the same substrate
+ * proof.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} fileName
+ * @param {string} content
+ * @returns {Promise<string>} the repo root path
+ */
+const provisionGitRepo = async (t, fileName, content) => {
+  const root = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'north-star-git-'),
+  );
+  t.teardown(() => fs.promises.rm(root, { recursive: true, force: true }));
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  // Pin repo-local config so a user-global commit.gpgsign does not bleed in.
+  await execFileAsync('git', ['config', '--local', 'commit.gpgsign', 'false'], {
+    cwd: root,
+  });
+  await execFileAsync('git', ['config', '--local', 'tag.gpgsign', 'false'], {
+    cwd: root,
+  });
+  await fs.promises.writeFile(path.join(root, fileName), content);
+  await execFileAsync('git', ['add', fileName], { cwd: root });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      `add ${fileName}`,
+    ],
+    { cwd: root },
+  );
+  return root;
+};
+
+/**
+ * Provision the north-star loop's shared substrate: one physical git worktree,
+ * a daemon-backed `EndoMount` over its root, and a `Git` exo wired to a native
+ * git backend over the same root. The Git's `worktree()` and the mount share a
+ * lineage, so an `EndoMountEntry` minted by `status()` can be staged through
+ * `add` exactly as in `packages/daemon/test/git.test.js`.
+ *
+ * Reuses the in-process `makeGit` / `makeNativeGitBackend` / `makeMount`
+ * composition the daemon's git test proves, rather than a daemon-resident Git
+ * formula, so the loop test stays focused on the tool boundary while still
+ * driving a real native-git substrate over one shared root.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {object} [opts]
+ * @param {string} [opts.fileName] initial committed file (default `README.md`)
+ * @param {string} [opts.content] initial committed content (default `hello\n`)
+ * @returns {Promise<{ repoRoot: string, git: any, mount: any, backend: any }>}
+ */
+export const prepareGitWorkspace = async (t, opts = {}) => {
+  const { fileName = 'README.md', content = 'hello\n' } = opts;
+  const repoRoot = await provisionGitRepo(t, fileName, content);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot, makeReaderRef });
+  const git = makeGit({ mount, backend, lineageOf });
+  return { repoRoot, git, mount, backend };
 };

--- a/packages/agent-tools/test/north-star-loop.test.js
+++ b/packages/agent-tools/test/north-star-loop.test.js
@@ -1,0 +1,153 @@
+// @ts-check
+
+// Establish a SES perimeter (provides the `harden` global).
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+/** @import { ToolRecord } from '../src/types.js' */
+
+import test from 'ava';
+import { E } from '@endo/far';
+
+import { makeGitTool } from '../src/git-tool.js';
+import { makeMountReadTool } from '../src/mount-fs.js';
+import {
+  makeMountWriteTool,
+  makeMountListTool,
+  makeMountStatTool,
+  makeGitStatusTool,
+  makeGitRemoteTool,
+  makeGitFilesystemAtTool,
+} from '../src/north-star-tools.js';
+import {
+  prepareGuestPowers,
+  prepareGitWorkspace,
+} from './helpers/daemon-petstore.js';
+
+/**
+ * The north-star forcing-function test.
+ *
+ * This is a CONTRACT, not a passing test. It drives the entire north-star
+ * agent loop at the `@endo/agent-tools` *tool* layer, over ONE shared
+ * workspace, exactly tool-to-tool:
+ *
+ *   1. provision a workspace — a real native-git-backed `Git` + daemon
+ *      `EndoMount` over one physical root (`prepareGitWorkspace`), and a real
+ *      daemon-backed guest petstore for the petname round-trip
+ *      (`prepareGuestPowers`);
+ *   2. EDIT a file through the FS write tool;
+ *   3. call the `status` tool — plain-JSON rows whose changed entries are bound
+ *      to PETNAMES via the return-side-wire-ify call `storeValue(cap, petname)`;
+ *   4. call `add` with a petname (this tool EXISTS on this branch — used for
+ *      real, resolving the petname back to the live cap via the petstore);
+ *   5. call `commit` (EXISTS — used for real);
+ *   6. push through a bounded `GitRemote` tool;
+ *   7. call `filesystemAt('HEAD~1')` → a read-only `Filesystem` bound to a
+ *      petname;
+ *   8. read the prior version of the file through an FS read tool over that
+ *      view.
+ *
+ * Steps 2, 3, 6, 7, 8 drive the Phase-1 STUBS in `src/north-star-tools.js`,
+ * which throw `not implemented: <tool>`. The follow-on builds make this test
+ * go green one tool at a time. It is wrapped in `test.failing` (ava's
+ * expected-failure) so the deliberate red lives in the suite without breaking
+ * CI: ava reports a `test.failing` body that throws as a *pass*, and would fail
+ * CI only if the body unexpectedly stopped throwing — i.e. once the contract is
+ * fully implemented, at which point this wrapper is flipped to `test.serial`.
+ *
+ * Forks a full daemon (for the guest petstore) and shares filesystem state, so
+ * it is serial via `test.serial.failing` with both helpers' teardowns.
+ */
+
+/**
+ * @param {ToolRecord[]} tools
+ * @returns {(name: string) => ToolRecord}
+ */
+const byNameOf = tools => name => {
+  const found = tools.find(tool => tool.name === name);
+  if (!found) throw new Error(`no tool named ${name}`);
+  return found;
+};
+
+test.serial.failing(
+  'north-star loop: edit, status, add, commit, push, filesystemAt(HEAD~1), read prior',
+  async t => {
+    t.timeout(120_000);
+
+    // (1) Provision the shared substrate and the petstore powers.
+    const powers = await prepareGuestPowers(t);
+    const { git, mount } = await prepareGitWorkspace(t, {
+      fileName: 'README.md',
+      content: 'v1\n',
+    });
+
+    // The Git tool set: `add` / `commit` are real (they exist on this branch);
+    // `status` and `filesystemAt` are the deferred return-side-wire-ify tools
+    // these stubs introduce.
+    const gitTools = byNameOf(makeGitTool(git, powers));
+    const addTool = gitTools('add');
+    const commitTool = gitTools('commit');
+    const statusTool = makeGitStatusTool(git, powers);
+    const filesystemAtTool = makeGitFilesystemAtTool(git, powers);
+
+    // The FS tool surface over the mount's worktree view.
+    const worktree = await E(mount).readOnly();
+    const writeTool = makeMountWriteTool(/** @type {any} */ (mount));
+    const listTool = makeMountListTool(/** @type {any} */ (worktree));
+    const statTool = makeMountStatTool(/** @type {any} */ (worktree));
+    void listTool;
+    void statTool;
+
+    // (2) EDIT README.md through the FS write tool. (Stub → fails here first.)
+    await writeTool.invoke({ path: 'README.md', content: 'v2\n' });
+
+    // (3) status: plain-JSON rows, changed entries bound to petnames.
+    const statusResult =
+      /** @type {{ rows: Array<{ path: string, petname: string }> }} */ (
+        await statusTool.invoke({})
+      );
+    const readmeRow = statusResult.rows.find(row => row.path === 'README.md');
+    t.truthy(readmeRow, 'status should report README.md as changed');
+    const { petname } = /** @type {{ petname: string }} */ (readmeRow);
+    t.is(typeof petname, 'string');
+
+    // (4) add the changed entry BY PETNAME — the real capref[] tool resolves
+    // the petname back to the live EndoMountEntry via the guest petstore.
+    await addTool.invoke({ arg0: [petname] });
+
+    // (5) commit for real.
+    const commit = /** @type {{ oid?: string }} */ (
+      await commitTool.invoke({ arg0: 'north-star: bump README to v2' })
+    );
+    t.regex(commit.oid || '', /^[0-9a-f]{40,64}$/, 'commit returns a new oid');
+
+    // (6) push through the bounded GitRemote tool. The remote here is a
+    // policy-bound GitRemote the host would have minted; the loop only needs
+    // the verb surface. (Stub.)
+    const remoteTools = byNameOf(
+      makeGitRemoteTool(
+        // A real GitRemote is minted by the host from `git`; the contract under
+        // test is the tool wiring, so the implementing build supplies the live
+        // remote here. Until then the push stub throws.
+        /** @type {any} */ (git),
+      ),
+    );
+    await remoteTools('gitPush').invoke({});
+
+    // (7) filesystemAt('HEAD~1'): a read-only Filesystem bound to a petname.
+    const fsResult = /** @type {{ ref: string, petname: string }} */ (
+      await filesystemAtTool.invoke({ ref: 'HEAD~1' })
+    );
+    t.is(fsResult.ref, 'HEAD~1');
+    const priorFsPetname = fsResult.petname;
+    t.is(typeof priorFsPetname, 'string');
+
+    // (8) read the PRIOR version of README.md through an FS read tool over the
+    // historical view. The agent resolves the bound Filesystem petname and
+    // drives a read tool over it; the prior content was 'v1\n'.
+    const priorFs = await E(powers).lookup(priorFsPetname);
+    const priorReadTool = makeMountReadTool(/** @type {any} */ (priorFs));
+    const prior = await priorReadTool.execute({ path: 'README.md' });
+    t.is(prior, 'v1\n', 'HEAD~1 view reads the pre-edit content');
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,6 +1301,7 @@ __metadata:
     "@endo/endo-fs": "workspace:^"
     "@endo/exo-git": "workspace:^"
     "@endo/far": "workspace:^"
+    "@endo/git": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/patterns": "workspace:^"
     "@endo/promise-kit": "workspace:^"


### PR DESCRIPTION
Refs: #425

## Description

This is the Phase-1, test-first deliverable for the north-star agent loop at the `@endo/agent-tools` tool layer: a single end-to-end forcing-function test plus the target tool API expressed as compiling, type-checking stubs. The test is the contract the follow-on builds make green tool by tool; this PR implements none of the stubbed tools' real behavior.

The test drives the whole loop over one shared workspace, tool-to-tool: edit a file through a filesystem write tool; call a `status` tool that returns plain-JSON rows and binds each changed entry to a petname; `add` the entry by that petname (the real capref[] tool already on this stack); `commit` for real; push through a bounded `GitRemote` tool; open a read-only filesystem view of `HEAD~1`; and read the prior version of the file through a read tool over that historical view. The workspace is a real native-git-backed `Git` and daemon `EndoMount` over one physical root, plus a real daemon-backed guest petstore for the petname round-trip; `add` and `commit` run against that substrate for real, while the still-stubbed tools throw `not implemented`.

The stubbed surface: filesystem edit / list / stat tools over the mount; a `status` tool; a `GitRemote` fetch/pull/push tool set; and a `filesystemAt` tool. The `status` and `filesystemAt` stubs name the return-side wire-ify call shape — `storeValue(cap, petname)`, the inverse of the existing argument-side `lookup(petname)` capref resolution — which is precisely what unblocks the Git methods that return live capabilities and were deferred when `add`/`restore` landed.

### Security Considerations

No new authority is granted. The contract preserves the petname-mediated boundary already established: an LLM only ever sees petname strings, never live caps. Argument-side caprefs resolve through `E(powers).lookup` (fail-closed on unknown names); the new return-side direction binds returned caps under petnames via `E(powers).storeValue` so a returned `EndoMountEntry` or read-only `Filesystem` can make a full round-trip through a model that handles only strings. The `GitRemote` tool grants nothing the bound, policy-limited remote does not already permit. Because the tools are stubs, the security shape is documented in the contract and enforced by the follow-on implementation.

### Scaling Considerations

None. The test forks one daemon for the petstore and one native-git worktree, consistent with the existing daemon-backed tests in this package.

### Documentation Considerations

The stub factories and the test carry the contract as JSDoc; the return-side wire-ify shape is named explicitly so the follow-on builds have an unambiguous target. No downstream user-facing docs change.

### Testing Considerations

The loop test is wrapped in `test.serial.failing` (ava's expected-failure) so the deliberate red lives in the suite without breaking CI: ava reports the throwing body as a known failure and would fail only once the body stops throwing — i.e. once every stub is implemented, at which point the wrapper flips to `test.serial`. The test fails at the first unimplemented stub with its `not implemented` message, proving it is a real forcing function rather than a setup or import error.

### Compatibility Considerations

No prior usage pattern changes. The stub module is new; the only change to existing code is a new `@endo/git` devDependency for the native backend the test substrate uses.

### Upgrade Considerations

None.
