### PR TITLE
docs: Record PR merge-method preference (rebase, not squash)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,3 +197,10 @@ Running the following before pushing avoids the churn:
 - Workspace dependencies use `"workspace:^"` version specifiers.
 - Each package has its own `tsconfig.json` and `tsconfig.build.json`.
 - No copyright headers in source files; license is declared in `package.json`.
+
+## Pull Requests
+
+- When merging a pull request, **rebase** (rebase-and-merge) by default.
+- Do **not** squash-merge, and do not create a merge commit, unless the
+  pull request author explicitly asks for that method.
+- If the intended merge method is unclear, confirm it before merging.


### PR DESCRIPTION
Records a pull-request merge-method preference in the root `CLAUDE.md`, since none was documented anywhere in the repo (the only existing "Merge Policy" note, in `packages/daemon/CLAUDE.md`, covers conflict resolution — `--ours`/`--theirs` — not squash vs. rebase vs. merge-commit).

New guidance:
- Rebase-and-merge by default.
- No squash / no merge commit unless the author explicitly asks.
- Confirm the method when unclear.

Context: #446 was squash-merged without confirming the method; this records the intended default (rebase) so future sessions follow it.

Note: please merge this one with **rebase**, not squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B2X6YycGTrbuWCnSzAiJq

---
_Generated by [Claude Code](https://claude.ai/code/session_019B2X6YycGTrbuWCnSzAiJq)_