### PR TITLE
fix(daemon): add iroh heartbeat and connection lifecycle

### DIFF
--- a/.changeset/iroh-heartbeat.md
+++ b/.changeset/iroh-heartbeat.md
@@ -1,0 +1,24 @@
+---
+'@endo/daemon': minor
+---
+
+Add a QUIC DATAGRAM heartbeat and keep-alive watchdog to the iroh
+transport.
+
+iroh's QUIC stack closes a connection after its default max idle
+timeout (~2 minutes) and `@number0/iroh`'s `NodeOptions` exposes no
+transport config to enable QUIC-level keep-alive, so a quiet but
+healthy CapTP session over iroh was being torn down after about two
+minutes of silence and surfacing as `iroh stream closed`. The
+transport now emits a one-byte QUIC datagram every 30 s to reset both
+endpoints' idle timers (RFC 9000 § 10.1) without disturbing the
+netstring frame the CapTP reader and writer share, and arms a
+keep-alive watchdog at twice the heartbeat interval so a peer that
+has heartbeated and then fallen silent is presumed dead and torn down
+promptly instead of waiting on the opaque QUIC idle timeout.
+
+The watchdog is armed lazily by the peer's first inbound datagram, so
+a peer that never heartbeats (an older daemon without this module) is
+not torn down by the watchdog and falls back to iroh's QUIC idle
+timeout exactly as before. The heartbeat is therefore safe to roll
+out before every peer has it.

--- a/packages/daemon/designs/iroh-network-design.md
+++ b/packages/daemon/designs/iroh-network-design.md
@@ -199,6 +199,41 @@ is unit-testable with a fake stream and needs no native binding.
 - The disposal hook (`addDisposalHook`) shuts the iroh node down and waits
   for in-flight connections to drain, matching the `libp2p` transport.
 
+### Keep-alive and liveness
+
+iroh's QUIC stack closes a connection after its default max idle timeout
+(~2 minutes), and `@number0/iroh`'s `NodeOptions` exposes no transport config
+to shorten that or to enable QUIC-level keep-alive.
+A quiet but healthy CapTP session — two daemons that have swapped bootstrap
+references and are each awaiting the other — was therefore being torn down
+after about two minutes of silence, surfacing as `iroh stream closed`.
+
+`makeIrohHeartbeat(connection)` (see `src/networks/iroh-heartbeat.js`) keeps
+such sessions alive and detects a genuinely dead peer:
+
+- **Heartbeat.** Every `HEARTBEAT_INTERVAL_MS` (30 s) it sends a one-byte QUIC
+  **datagram**.
+  DATAGRAM frames are ack-eliciting and travel out-of-band from the CapTP bi
+  stream, so a beat resets both endpoints' QUIC idle timers (RFC 9000 § 10.1)
+  without disturbing the netstring frame the reader and writer share.
+  Both peers run the module, so beats flow in both directions.
+- **Keep-alive watchdog.** `KEEPALIVE_TIMEOUT_MS` is twice the heartbeat
+  interval (60 s), so a single dropped beat is tolerated.
+  If a peer that has been heartbeating falls silent for a full window, the
+  session is presumed dead.
+- **Lazy arming.** The watchdog is armed by the peer's *first* inbound
+  datagram, not at connection start.
+  A peer that never heartbeats — an older daemon without this module — is left
+  to iroh's QUIC idle timeout instead of being torn down at 60 s, so the
+  heartbeat is safe to roll out before every peer has it.
+
+On a keep-alive timeout (and on any stream close), `serveStream` tears the
+session down so reachable objects break promptly rather than hanging:
+`capTp.close(reason)` aborts CapTP — rejecting every outstanding question and
+revoking imported presences with `reason` — and the QUIC connection is closed.
+On the outbound path that, via the existing `capTp.closed → cancelConnection`
+wiring, also cancels the peer's connection context.
+
 ## Identity and trust
 
 This is the crux of the "dial keys" property and deserves care.

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -5139,7 +5139,15 @@ const makeDaemonCore = async (
           console.log(
             `Endo daemon peer node ${nodeId.slice(0, 8)} connection disposed`,
           );
-          dropLiveValue(context.id);
+          // Cancel the peer formula's context so the formula-lifecycle
+          // machinery tears down and drops all dependent remote presences
+          // via thisDiesIfThatDies.  The next use of any remote presence
+          // reincarnates the peer formula and re-dials from scratch.
+          // dropLiveValue alone was insufficient: it removed the peer from
+          // the live-value cache but left the formula context alive, so
+          // dependent remote presences were not revoked and the stale
+          // currentGatewayP prevented re-dial on subsequent use.
+          context.cancel(new Error('peer connection lost'));
         },
       );
     };
@@ -5219,6 +5227,20 @@ const makeDaemonCore = async (
     // If crossed-hellos accept bias abandons our dial, retry once.
     // The state machine should now be in `accepted` state, and the
     // retry will return the already-accepted gateway without dialing.
+    //
+    // TODO(option-a-simplification): After the dispose-callback change
+    // to context.cancel (Option A), the peer formula's context is
+    // cancelled on any connection loss.  That means this formula
+    // instance is torn down before it could ever see a second
+    // connection.  The `isAbandonError` predicate and the resilient-dial
+    // retry inside `resilientDial` are therefore unreachable for any
+    // post-connect abandon.  They remain for the initial-dial crossed-
+    // hellos case (where the state machine rejects our outgoing dial
+    // while accepting an inbound one, producing an abandon error before
+    // the first successful connection).  A follow-up can simplify by
+    // removing the `isAbandonError` catch in `ResilientPeerGateway.
+    // provide` and collapsing `currentGatewayP` to a plain `dialAttempt`
+    // call.
     const isAbandonError = err =>
       err &&
       typeof err.message === 'string' &&
@@ -5243,12 +5265,14 @@ const makeDaemonCore = async (
       }
     };
 
-    // Return a facade gateway whose `provide` method consults the
-    // current state of the remote-control on each call.  If the
-    // current connection is lost mid-flight (e.g., due to crossed
-    // hellos accept bias switching to a different TCP), subsequent
-    // `provide` calls will go through whatever connection the
-    // remote-control currently holds.
+    // TODO(option-a-simplification): After the dispose-callback change,
+    // the peer formula is destroyed on any connection loss, so this
+    // formula instance never sees a post-connect re-dial.  The
+    // `currentGatewayP` one-shot promise is still used for the initial
+    // connection (including the retention-set follower below) but the
+    // re-dial path in `ResilientPeerGateway.provide` is now unreachable.
+    // A follow-up can drop the ResilientPeerGateway wrapper and inline
+    // the single `dialAttempt()` call directly.
     const currentGatewayP = resilientDial();
 
     // Follow retention set changes in the background once connected.
@@ -5326,6 +5350,15 @@ const makeDaemonCore = async (
           // Try with the current gateway; on failure, re-dial and try
           // once more.  This handles the case where the initial dial
           // succeeded but the connection was later abandoned.
+          //
+          // TODO(option-a-simplification): The isAbandonError catch
+          // below is now unreachable for post-connect errors.  After
+          // the dispose-callback change (Option A), any connection loss
+          // cancels the peer formula's context, so this formula instance
+          // is torn down before `provide` could be called after a loss.
+          // The catch arm was the "retry within the existing formula
+          // instance" path; it is superseded by reincarnation.  A
+          // follow-up can remove the catch arm entirely.
           try {
             const gateway = await currentGatewayP;
             return await E(gateway).provide(requestedId);

--- a/packages/daemon/src/networks/iroh-heartbeat.js
+++ b/packages/daemon/src/networks/iroh-heartbeat.js
@@ -1,0 +1,168 @@
+// @ts-check
+/* global setInterval, clearInterval, setTimeout, clearTimeout */
+
+// iroh's QUIC stack closes a connection after its default max idle timeout
+// (~2 minutes) and @number0/iroh's `NodeOptions` exposes no transport config
+// to shorten that or to enable QUIC-level keep-alive. A quiet but healthy
+// CapTP session — two daemons that have swapped bootstrap references and are
+// each awaiting the other — is therefore torn down. The heartbeat emits a
+// small QUIC datagram on an interval to keep the connection from going idle,
+// and presumes the peer dead if it falls silent for a full keep-alive window
+// (twice the heartbeat interval, so a single dropped beat is tolerated),
+// tearing the session down promptly instead of waiting on the opaque QUIC
+// idle timeout.
+//
+// QUIC DATAGRAM frames are ack-eliciting and travel out-of-band from the
+// CapTP bi-stream, so a heartbeat resets both endpoints' idle timers (RFC
+// 9000 § 10.1) without disturbing the netstring frame the CapTP reader and
+// writer share. Both Endo peers run this module, so datagrams flow in both
+// directions and each side's watchdog observes the other's liveness.
+//
+// The watchdog is armed lazily, by the peer's first inbound datagram, not at
+// connection start. A peer that never heartbeats — an older daemon without
+// this module — therefore is not presumed dead here; its connection falls
+// back to iroh's QUIC idle timeout, exactly as before. Only a peer that has
+// demonstrably heartbeated and then stopped is torn down at the keep-alive
+// window.
+
+/**
+ * Heartbeat send period. Comfortably below iroh's QUIC idle timeout so a
+ * single beat keeps the connection alive.
+ */
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+harden(HEARTBEAT_INTERVAL_MS);
+
+/**
+ * Keep-alive window: presume the peer dead after two missed heartbeats.
+ */
+export const KEEPALIVE_TIMEOUT_MS = 2 * HEARTBEAT_INTERVAL_MS;
+harden(KEEPALIVE_TIMEOUT_MS);
+
+/**
+ * Keep an iroh QUIC connection alive with a datagram heartbeat and detect a
+ * dead peer with a keep-alive watchdog. The caller owns teardown: `onTimeout`
+ * fires at most once, after the watchdog has been disarmed, and is expected to
+ * cancel the CapTP session and the connection.
+ *
+ * @param {object} connection - An iroh Connection (duck-typed for testing).
+ * @param {(data: Uint8Array) => void} connection.sendDatagram
+ * @param {() => Promise<unknown>} connection.readDatagram
+ * @param {object} [options]
+ * @param {number} [options.intervalMs] - Heartbeat send period.
+ * @param {number} [options.timeoutMs] - Keep-alive window before `onTimeout`.
+ * @param {() => void} [options.onTimeout] - Invoked once when the peer misses
+ *   the keep-alive window.
+ * @param {(message: string) => void} [options.log] - Diagnostic sink; silent
+ *   by default.
+ * @returns {{ stop: () => void }} A handle whose `stop()` halts the heartbeat
+ *   and disarms the watchdog. Idempotent.
+ */
+export const makeIrohHeartbeat = (
+  connection,
+  {
+    intervalMs = HEARTBEAT_INTERVAL_MS,
+    timeoutMs = KEEPALIVE_TIMEOUT_MS,
+    onTimeout = () => {},
+    log = () => {},
+  } = {},
+) => {
+  const { sendDatagram, readDatagram } = connection;
+  const datagramsSupported =
+    typeof sendDatagram === 'function' && typeof readDatagram === 'function';
+
+  let stopped = false;
+  /** @type {ReturnType<typeof setInterval> | undefined} */
+  let beatTimer;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let watchdog;
+
+  const stop = () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    if (beatTimer !== undefined) {
+      clearInterval(beatTimer);
+    }
+    if (watchdog !== undefined) {
+      clearTimeout(watchdog);
+    }
+  };
+
+  // Arm or re-arm the keep-alive watchdog. Any inbound datagram is proof of
+  // life and pushes the deadline out by a full window; the first such call is
+  // also what first arms the watchdog (see the lazy-arming note in the header).
+  const touch = () => {
+    if (stopped) {
+      return;
+    }
+    if (watchdog !== undefined) {
+      clearTimeout(watchdog);
+    }
+    watchdog = setTimeout(() => {
+      // Disarm before notifying so the callback sees a settled heartbeat and
+      // cannot re-arm by re-entry.
+      stop();
+      onTimeout();
+    }, timeoutMs);
+    if (typeof watchdog.unref === 'function') {
+      watchdog.unref();
+    }
+  };
+
+  const sendBeat = () => {
+    if (stopped) {
+      return;
+    }
+    try {
+      // A one-byte payload suffices to generate traffic; the content is
+      // ignored. A fresh buffer avoids handing native code a shared view.
+      connection.sendDatagram(new Uint8Array([0]));
+    } catch (error) {
+      // A full send buffer or transient datagram error is not fatal: the next
+      // beat retries and the peer's watchdog tolerates a single miss.
+      log(
+        `iroh heartbeat send failed: ${/** @type {Error} */ (error).message}`,
+      );
+    }
+  };
+
+  // Drain inbound datagrams, re-arming the watchdog on each. `readDatagram`
+  // rejects when the connection closes, which ends the pump.
+  const pump = () => {
+    if (stopped) {
+      return;
+    }
+    try {
+      Promise.resolve(connection.readDatagram()).then(
+        () => {
+          touch();
+          pump();
+        },
+        () => {
+          // Connection closed or datagrams ended; stop draining. The CapTP and
+          // stream teardown paths own closing the session.
+        },
+      );
+    } catch {
+      // `readDatagram` unavailable; leave the watchdog to the bi-stream path.
+    }
+  };
+
+  if (datagramsSupported) {
+    beatTimer = setInterval(sendBeat, intervalMs);
+    if (typeof beatTimer.unref === 'function') {
+      beatTimer.unref();
+    }
+    // Send one beat immediately and start draining inbound datagrams. The
+    // watchdog is left disarmed until the peer's first datagram arms it via
+    // `pump` → `touch`, so a non-heartbeating peer is not torn down here.
+    sendBeat();
+    pump();
+  } else {
+    log('iroh heartbeat disabled: connection does not support datagrams');
+  }
+
+  return harden({ stop });
+};
+harden(makeIrohHeartbeat);

--- a/packages/daemon/src/networks/iroh-heartbeat.js
+++ b/packages/daemon/src/networks/iroh-heartbeat.js
@@ -39,6 +39,26 @@ export const KEEPALIVE_TIMEOUT_MS = 2 * HEARTBEAT_INTERVAL_MS;
 harden(KEEPALIVE_TIMEOUT_MS);
 
 /**
+ * Render an unknown thrown value (which may not be an `Error`) for a log
+ * message without itself throwing. Mirrors the structure of `String(value)`
+ * but reaches for `.message` when one is present, so an `Error` renders as
+ * its message rather than `"Error"`.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+const renderThrown = value => {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  try {
+    return String(value);
+  } catch {
+    return '<unrenderable thrown value>';
+  }
+};
+
+/**
  * Keep an iroh QUIC connection alive with a datagram heartbeat and detect a
  * dead peer with a keep-alive watchdog. The caller owns teardown: `onTimeout`
  * fires at most once, after the watchdog has been disarmed, and is expected to
@@ -50,6 +70,8 @@ harden(KEEPALIVE_TIMEOUT_MS);
  * @param {object} [options]
  * @param {number} [options.intervalMs] - Heartbeat send period.
  * @param {number} [options.timeoutMs] - Keep-alive window before `onTimeout`.
+ *   Defaults to twice the effective `intervalMs`, so the "tolerate a single
+ *   dropped beat" invariant holds for callers that only override `intervalMs`.
  * @param {() => void} [options.onTimeout] - Invoked once when the peer misses
  *   the keep-alive window.
  * @param {(message: string) => void} [options.log] - Diagnostic sink; silent
@@ -61,7 +83,7 @@ export const makeIrohHeartbeat = (
   connection,
   {
     intervalMs = HEARTBEAT_INTERVAL_MS,
-    timeoutMs = KEEPALIVE_TIMEOUT_MS,
+    timeoutMs = 2 * intervalMs,
     onTimeout = () => {},
     log = () => {},
   } = {},
@@ -121,9 +143,10 @@ export const makeIrohHeartbeat = (
     } catch (error) {
       // A full send buffer or transient datagram error is not fatal: the next
       // beat retries and the peer's watchdog tolerates a single miss.
-      log(
-        `iroh heartbeat send failed: ${/** @type {Error} */ (error).message}`,
-      );
+      // Stringify defensively: `sendDatagram` is native code and may throw a
+      // non-Error value, in which case reaching for `.message` would itself
+      // throw and crash the heartbeat loop.
+      log(`iroh heartbeat send failed: ${renderThrown(error)}`);
     }
   };
 

--- a/packages/daemon/src/networks/iroh-heartbeat.js
+++ b/packages/daemon/src/networks/iroh-heartbeat.js
@@ -4,8 +4,8 @@
 // iroh's QUIC stack closes a connection after its default max idle timeout
 // (~2 minutes) and @number0/iroh's `NodeOptions` exposes no transport config
 // to shorten that or to enable QUIC-level keep-alive. A quiet but healthy
-// CapTP session — two daemons that have swapped bootstrap references and are
-// each awaiting the other — is therefore torn down. The heartbeat emits a
+// CapTP session (two daemons that have swapped bootstrap references and are
+// each awaiting the other) is therefore torn down. The heartbeat emits a
 // small QUIC datagram on an interval to keep the connection from going idle,
 // and presumes the peer dead if it falls silent for a full keep-alive window
 // (twice the heartbeat interval, so a single dropped beat is tolerated),
@@ -14,13 +14,13 @@
 //
 // QUIC DATAGRAM frames are ack-eliciting and travel out-of-band from the
 // CapTP bi-stream, so a heartbeat resets both endpoints' idle timers (RFC
-// 9000 § 10.1) without disturbing the netstring frame the CapTP reader and
+// 9000 sec. 10.1) without disturbing the netstring frame the CapTP reader and
 // writer share. Both Endo peers run this module, so datagrams flow in both
 // directions and each side's watchdog observes the other's liveness.
 //
 // The watchdog is armed lazily, by the peer's first inbound datagram, not at
-// connection start. A peer that never heartbeats — an older daemon without
-// this module — therefore is not presumed dead here; its connection falls
+// connection start. A peer that never heartbeats (an older daemon without
+// this module) is therefore not presumed dead here; its connection falls
 // back to iroh's QUIC idle timeout, exactly as before. Only a peer that has
 // demonstrably heartbeated and then stopped is torn down at the keep-alive
 // window.
@@ -179,7 +179,7 @@ export const makeIrohHeartbeat = (
     }
     // Send one beat immediately and start draining inbound datagrams. The
     // watchdog is left disarmed until the peer's first datagram arms it via
-    // `pump` → `touch`, so a non-heartbeating peer is not torn down here.
+    // `pump` -> `touch`, so a non-heartbeating peer is not torn down here.
     sendBeat();
     pump();
   } else {

--- a/packages/daemon/src/networks/iroh-heartbeat.js
+++ b/packages/daemon/src/networks/iroh-heartbeat.js
@@ -1,6 +1,8 @@
 // @ts-check
 /* global setInterval, clearInterval, setTimeout, clearTimeout */
 
+import harden from '@endo/harden';
+
 // iroh's QUIC stack closes a connection after its default max idle timeout
 // (~2 minutes) and @number0/iroh's `NodeOptions` exposes no transport config
 // to shorten that or to enable QUIC-level keep-alive. A quiet but healthy
@@ -139,7 +141,7 @@ export const makeIrohHeartbeat = (
     try {
       // A one-byte payload suffices to generate traffic; the content is
       // ignored. A fresh buffer avoids handing native code a shared view.
-      connection.sendDatagram(new Uint8Array([0]));
+      sendDatagram(new Uint8Array([0]));
     } catch (error) {
       // A full send buffer or transient datagram error is not fatal: the next
       // beat retries and the peer's watchdog tolerates a single miss.
@@ -157,7 +159,7 @@ export const makeIrohHeartbeat = (
       return;
     }
     try {
-      Promise.resolve(connection.readDatagram()).then(
+      Promise.resolve(readDatagram()).then(
         () => {
           touch();
           pump();

--- a/packages/daemon/src/networks/iroh.js
+++ b/packages/daemon/src/networks/iroh.js
@@ -6,6 +6,7 @@ import { E, Far } from '@endo/far';
 import { fromHex } from '../hex.js';
 import { makeNetstringCapTP } from '../connection.js';
 import { adaptIrohStream } from './iroh-stream-adapter.js';
+import { KEEPALIVE_TIMEOUT_MS, makeIrohHeartbeat } from './iroh-heartbeat.js';
 import {
   buildIrohAddress,
   parseIrohAddress,
@@ -91,8 +92,8 @@ export const make = async (powers, context) => {
    * Wire one accepted or dialed iroh bidi stream up to CapTP and track it
    * until it closes.
    *
-   * @param {object} bi - iroh BiStream.
-   * @param {object} connection - iroh Connection.
+   * @param {any} bi - iroh BiStream.
+   * @param {any} connection - iroh Connection.
    * @param {number} connectionNumber
    * @param {boolean} inbound
    * @returns {ReturnType<typeof makeNetstringCapTP>}
@@ -112,6 +113,37 @@ export const make = async (powers, context) => {
       bootstrap,
     );
 
+    // Tear the session down so any objects reachable across it break.
+    // Aborting CapTP rejects every outstanding question and revokes imported
+    // presences with `reason`; closing the QUIC connection releases the socket
+    // and, on the outbound path, lets `capTp.closed` fire the
+    // connection-context cancellation that disposes the peer.
+    const tearDown = (/** @type {Error} */ reason) => {
+      capTp.close(reason);
+      try {
+        connection.close(0n, new TextEncoder().encode(reason.message));
+      } catch {
+        // Best-effort; the connection may already be gone.
+      }
+    };
+
+    // Keep the connection alive against iroh's QUIC idle timeout, and presume
+    // the peer dead if it stops answering so a hung peer surfaces as broken
+    // capabilities rather than a stall.
+    const heartbeat = makeIrohHeartbeat(connection, {
+      onTimeout: () => {
+        console.error(
+          `Endo daemon iroh connection ${connectionNumber} missed keep-alive (no datagram within ${KEEPALIVE_TIMEOUT_MS}ms) at ${new Date().toISOString()}`,
+        );
+        tearDown(
+          new Error(
+            `iroh keep-alive timeout: peer silent for ${KEEPALIVE_TIMEOUT_MS}ms`,
+          ),
+        );
+      },
+      log: message => console.error(`Endo daemon ${message}`),
+    });
+
     streamClosed.then(
       () => capTp.close(new Error('iroh stream closed')),
       () => {},
@@ -120,6 +152,7 @@ export const make = async (powers, context) => {
     const closed = Promise.race([streamClosed, capTp.closed]);
     connectionClosedPromises.add(closed);
     closed.finally(() => {
+      heartbeat.stop();
       connectionClosedPromises.delete(closed);
       console.error(
         `Endo daemon closed iroh connection ${connectionNumber} at ${new Date().toISOString()}`,

--- a/packages/daemon/src/networks/iroh.js
+++ b/packages/daemon/src/networks/iroh.js
@@ -1,6 +1,7 @@
 // @ts-check
 /* global globalThis, setInterval, clearInterval */
 
+import harden from '@endo/harden';
 import { E, Far } from '@endo/far';
 
 import { fromHex } from '../hex.js';

--- a/packages/daemon/test/iroh-heartbeat.test.js
+++ b/packages/daemon/test/iroh-heartbeat.test.js
@@ -193,3 +193,60 @@ test('a failing sendDatagram is caught and reported', async t => {
     'send failures surface through the log sink',
   );
 });
+
+test('a non-Error thrown by sendDatagram is rendered without re-throwing', async t => {
+  // Native bindings can throw arbitrary values, not just `Error` instances.
+  // Reaching for `.message` on a `null` throw would itself throw and crash
+  // the heartbeat loop; the loop must survive that case.
+  t.timeout(5000);
+  const logs = [];
+  let beats = 0;
+  const connection = {
+    sendDatagram() {
+      beats += 1;
+      // eslint-disable-next-line no-throw-literal
+      throw null;
+    },
+    readDatagram() {
+      return new Promise(() => {});
+    },
+  };
+  const heartbeat = makeIrohHeartbeat(connection, {
+    intervalMs: 20,
+    timeoutMs: 10_000,
+    log: message => logs.push(message),
+  });
+  t.teardown(() => heartbeat.stop());
+
+  await delay(80);
+  t.true(beats >= 2, 'the heartbeat loop survives a non-Error throw');
+  t.true(
+    logs.some(message => message.includes('heartbeat send failed')),
+    'a non-Error throw still surfaces through the log sink',
+  );
+});
+
+test('timeoutMs defaults to twice the chosen intervalMs', async t => {
+  // The documented "tolerate a single dropped beat" invariant must hold for
+  // callers that only override `intervalMs`. A 30ms interval should yield a
+  // ~60ms watchdog window, so silence past ~80ms must fire the timeout.
+  t.timeout(5000);
+  const connection = makeFakeConnection();
+  let timeouts = 0;
+  const heartbeat = makeIrohHeartbeat(connection, {
+    intervalMs: 30,
+    onTimeout: () => {
+      timeouts += 1;
+    },
+  });
+  t.teardown(() => heartbeat.stop());
+
+  // Arm the watchdog with one inbound beat, then let the peer fall silent.
+  connection.push(new Uint8Array([1]));
+  await delay(140);
+  t.is(
+    timeouts,
+    1,
+    'derived timeoutMs (2 * intervalMs) fires after the silence window',
+  );
+});

--- a/packages/daemon/test/iroh-heartbeat.test.js
+++ b/packages/daemon/test/iroh-heartbeat.test.js
@@ -1,0 +1,195 @@
+// @ts-nocheck
+/* global setTimeout, setInterval, clearInterval */
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { makeIrohHeartbeat } from '../src/networks/iroh-heartbeat.js';
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * A controllable fake iroh Connection. `sendDatagram` records outbound beats;
+ * `readDatagram` resolves once a datagram is pushed in, modelling inbound
+ * traffic from the peer.
+ */
+const makeFakeConnection = () => {
+  const sent = [];
+  const inbox = [];
+  const waiters = [];
+  const deliver = () => {
+    while (waiters.length > 0 && inbox.length > 0) {
+      const resolve = waiters.shift();
+      resolve(inbox.shift());
+    }
+  };
+  return {
+    sent,
+    push(datagram) {
+      inbox.push(datagram);
+      deliver();
+    },
+    sendDatagram(data) {
+      sent.push(data);
+    },
+    readDatagram() {
+      return new Promise(resolve => {
+        waiters.push(resolve);
+        deliver();
+      });
+    },
+  };
+};
+
+test('emits heartbeat datagrams on the interval', async t => {
+  t.timeout(5000);
+  const connection = makeFakeConnection();
+  const heartbeat = makeIrohHeartbeat(connection, {
+    intervalMs: 20,
+    timeoutMs: 10_000,
+  });
+  t.teardown(() => heartbeat.stop());
+
+  await delay(95);
+  heartbeat.stop();
+  // One immediate beat plus several interval beats.
+  t.true(
+    connection.sent.length >= 3,
+    `expected several beats, got ${connection.sent.length}`,
+  );
+});
+
+test('inbound datagrams keep the session alive', async t => {
+  t.timeout(5000);
+  const connection = makeFakeConnection();
+  let timeouts = 0;
+  // A long send interval so only the injected inbound datagrams re-arm the
+  // watchdog.
+  const heartbeat = makeIrohHeartbeat(connection, {
+    intervalMs: 10_000,
+    timeoutMs: 50,
+    onTimeout: () => {
+      timeouts += 1;
+    },
+  });
+  t.teardown(() => heartbeat.stop());
+
+  const feed = setInterval(() => connection.push(new Uint8Array([1])), 20);
+  t.teardown(() => clearInterval(feed));
+
+  await delay(160);
+  t.is(timeouts, 0, 'a peer that keeps answering is never presumed dead');
+});
+
+test('presumes the peer dead after the keep-alive window of silence', async t => {
+  t.timeout(5000);
+  const connection = makeFakeConnection();
+  let timeouts = 0;
+  // A long send interval so only the inbound datagram drives the watchdog.
+  const heartbeat = makeIrohHeartbeat(connection, {
+    intervalMs: 10_000,
+    timeoutMs: 50,
+    onTimeout: () => {
+      timeouts += 1;
+    },
+  });
+  t.teardown(() => heartbeat.stop());
+
+  // One inbound beat arms the watchdog; then the peer falls silent.
+  connection.push(new Uint8Array([1]));
+  await delay(180);
+  t.is(timeouts, 1, 'onTimeout fires exactly once after the peer falls silent');
+  const afterTimeout = connection.sent.length;
+  await delay(80);
+  t.is(
+    connection.sent.length,
+    afterTimeout,
+    'beats halt once the peer is dead',
+  );
+});
+
+test('does not presume death until the peer has first heartbeated', async t => {
+  t.timeout(5000);
+  const connection = makeFakeConnection();
+  let timeouts = 0;
+  const heartbeat = makeIrohHeartbeat(connection, {
+    intervalMs: 10_000,
+    timeoutMs: 50,
+    onTimeout: () => {
+      timeouts += 1;
+    },
+  });
+  t.teardown(() => heartbeat.stop());
+
+  // The peer never sends a datagram (e.g. an older daemon without heartbeats).
+  // The watchdog stays disarmed, leaving teardown to iroh's QUIC idle timeout.
+  await delay(160);
+  t.is(
+    timeouts,
+    0,
+    'a never-heartbeating peer is not torn down by the watchdog',
+  );
+});
+
+test('stop halts heartbeats and disarms the watchdog', async t => {
+  t.timeout(5000);
+  const connection = makeFakeConnection();
+  let timeouts = 0;
+  const heartbeat = makeIrohHeartbeat(connection, {
+    intervalMs: 20,
+    timeoutMs: 50,
+    onTimeout: () => {
+      timeouts += 1;
+    },
+  });
+  heartbeat.stop();
+  const sentAtStop = connection.sent.length;
+
+  await delay(160);
+  t.is(timeouts, 0, 'no keep-alive timeout after stop');
+  t.is(connection.sent.length, sentAtStop, 'no beats after stop');
+});
+
+test('disables itself when the connection lacks datagram support', async t => {
+  t.timeout(5000);
+  let timeouts = 0;
+  // No sendDatagram/readDatagram on the connection.
+  const heartbeat = makeIrohHeartbeat(
+    {},
+    {
+      intervalMs: 20,
+      timeoutMs: 50,
+      onTimeout: () => {
+        timeouts += 1;
+      },
+    },
+  );
+  t.teardown(() => heartbeat.stop());
+
+  await delay(120);
+  t.is(timeouts, 0, 'no watchdog without a datagram channel to observe');
+});
+
+test('a failing sendDatagram is caught and reported', async t => {
+  t.timeout(5000);
+  const logs = [];
+  const connection = {
+    sendDatagram() {
+      throw new Error('buffer full');
+    },
+    readDatagram() {
+      return new Promise(() => {});
+    },
+  };
+  const heartbeat = makeIrohHeartbeat(connection, {
+    intervalMs: 20,
+    timeoutMs: 10_000,
+    log: message => logs.push(message),
+  });
+  t.teardown(() => heartbeat.stop());
+
+  await delay(60);
+  heartbeat.stop();
+  t.true(
+    logs.some(message => message.includes('heartbeat send failed')),
+    'send failures surface through the log sink',
+  );
+});

--- a/packages/daemon/test/peer-formula-revocation.test.js
+++ b/packages/daemon/test/peer-formula-revocation.test.js
@@ -1,0 +1,251 @@
+// @ts-nocheck
+/* global setTimeout */
+// Tests for Option A: peer formula context cancellation on connection loss.
+//
+// Option A changes the dispose callback in `makePeer` from:
+//   dropLiveValue(context.id)
+// to:
+//   context.cancel(new Error('peer connection lost'))
+//
+// This ensures that any connection loss cascades via `thisDiesIfThatDies`
+// to all dependent remote presences, revoking them.  The next use of any
+// remote presence reincarnates the peer formula and re-dials from scratch.
+//
+// These tests verify the lifecycle contract at the level of the context and
+// remote-control primitives, without spinning up a full daemon.
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import harden from '@endo/harden';
+import { makePromiseKit as _makePromiseKit } from '@endo/promise-kit';
+
+import { makeContextMaker } from '../src/context.js';
+import { makeRemoteControlProvider } from '../src/remote-control.js';
+
+/** @import { PromiseKit } from '@endo/promise-kit' */
+
+/** @type {<T = never>() => PromiseKit<T>} */
+const makePromiseKit = _makePromiseKit;
+
+/** @typedef {import('../src/types.js').FormulaIdentifier} FormulaIdentifier */
+
+const id = /** @param {string} s @returns {FormulaIdentifier} */ s =>
+  /** @type {FormulaIdentifier} */ (s);
+
+/**
+ * Build a minimal context maker wired up to the real context implementation.
+ * Returns a `makeContext` factory and the shared `controllerForId` map.
+ */
+const setupContextMaker = () => {
+  /** @type {Map<FormulaIdentifier, { context: any }>} */
+  const controllerForId = new Map();
+  const formulaTypes = new Map();
+
+  const makeContext = makeContextMaker({
+    controllerForId,
+    provideController: formulaId => {
+      let controller = controllerForId.get(formulaId);
+      if (!controller) {
+        const ctx = makeContext(formulaId);
+        controller = { context: ctx };
+        controllerForId.set(formulaId, controller);
+      }
+      return controller;
+    },
+    getFormulaType: formulaId => formulaTypes.get(formulaId),
+  });
+
+  /**
+   * @param {FormulaIdentifier} formulaId
+   * @param {string} [type]
+   */
+  const createContext = (formulaId, type = 'test') => {
+    formulaTypes.set(formulaId, type);
+    const ctx = makeContext(formulaId);
+    controllerForId.set(formulaId, { context: ctx });
+    return ctx;
+  };
+
+  return { createContext, controllerForId };
+};
+
+// ---------------------------------------------------------------------------
+// Test 1: connection dispose triggers context.cancel on the peer formula.
+//
+// Simulates the Option A dispose callback shape:
+//   () => { context.cancel(new Error('peer connection lost')); }
+// The peer formula's `cancelled` promise must reject with that error.
+// ---------------------------------------------------------------------------
+test('connection dispose cancels the peer formula context', async t => {
+  t.timeout(5000);
+  const { createContext } = setupContextMaker();
+  const peerFormulaId = id('peer:local');
+  const peerContext = createContext(peerFormulaId, 'peer');
+
+  // Simulate the Option A dispose callback.
+  const disposeCallback = () => {
+    peerContext.cancel(new Error('peer connection lost'));
+  };
+
+  // Verify the context is alive before dispose.
+  let isCancelled = false;
+  peerContext.cancelled.catch(() => {
+    isCancelled = true;
+  });
+
+  // Fire the dispose callback (mimicking what remote-control does on loss).
+  disposeCallback();
+
+  // Wait for microtask queue to drain.
+  await Promise.resolve();
+
+  t.true(isCancelled, 'peer formula context must be cancelled after dispose');
+  await t.throwsAsync(() => peerContext.cancelled, {
+    message: 'peer connection lost',
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: cancelling the peer formula cascades via thisDiesIfThatDies
+// to all dependent remote presences.
+//
+// `evaluateFormulaForId` registers remote formulas with:
+//   context.thisDiesIfThatDies(peerId)
+// so when the peer formula is cancelled, every remote presence is revoked.
+// ---------------------------------------------------------------------------
+test('peer formula cancellation cascades to dependent remote presences', async t => {
+  t.timeout(5000);
+  const { createContext } = setupContextMaker();
+
+  const peerFormulaId = id('peer:local');
+  const peerContext = createContext(peerFormulaId, 'peer');
+
+  // Two remote presences that depend on the peer formula.
+  const remotePresence1Id = id('rp1:local');
+  const remotePresence2Id = id('rp2:local');
+  const rp1Context = createContext(remotePresence1Id, 'remote-slot');
+  const rp2Context = createContext(remotePresence2Id, 'remote-slot');
+
+  // Wire dependencies: each remote presence dies if the peer formula dies.
+  // This matches evaluateFormulaForId: context.thisDiesIfThatDies(peerId).
+  rp1Context.thisDiesIfThatDies(peerFormulaId);
+  rp2Context.thisDiesIfThatDies(peerFormulaId);
+
+  // Option A dispose callback: cancel the peer formula's context.
+  // The cancel call itself is synchronous in its initial effects;
+  // cascade via thatDiesIfThisDies is also synchronous.
+  peerContext.cancel(new Error('peer connection lost'));
+
+  // Both remote presences must be revoked with the same error.
+  // The cascade is synchronous in the context implementation (cancel
+  // iterates dependents and calls their cancel immediately), so the
+  // cancelled promises are already rejected at this point.
+  await t.throwsAsync(() => rp1Context.cancelled, {
+    message: 'peer connection lost',
+  });
+  await t.throwsAsync(() => rp2Context.cancelled, {
+    message: 'peer connection lost',
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: prior behavior (dropLiveValue only) did NOT cancel remote presences.
+//
+// This is a regression-evidence test: it demonstrates the exact failure mode
+// that Option A fixes.  Without context.cancel, `thisDiesIfThatDies` never
+// fires, so remote presences remain live after connection loss.
+// ---------------------------------------------------------------------------
+test('regression evidence: dropLiveValue alone does not cancel remote presences', async t => {
+  t.timeout(5000);
+  const { createContext, controllerForId } = setupContextMaker();
+
+  const peerFormulaId = id('peer:regression');
+  // peerContext is intentionally not captured: the regression test only needs
+  // the formula to be registered in the context map so that thisDiesIfThatDies
+  // can find it.  The returned context is not exercised directly.
+  createContext(peerFormulaId, 'peer');
+
+  const remotePresenceId = id('rp:regression');
+  const rpContext = createContext(remotePresenceId, 'remote-slot');
+
+  rpContext.thisDiesIfThatDies(peerFormulaId);
+
+  // Old dispose callback: only dropLiveValue (remove from cache, no cancel).
+  const oldDisposeCallback = () => {
+    controllerForId.delete(peerFormulaId);
+  };
+
+  oldDisposeCallback();
+
+  // The remote presence context must NOT be cancelled by dropLiveValue alone.
+  // We race its `cancelled` promise against a short delay; it should stay
+  // pending.
+  const raceResult = await Promise.race([
+    rpContext.cancelled.then(() => 'resolved').catch(() => 'rejected'),
+    new Promise(resolve => setTimeout(resolve, 50)).then(() => 'pending'),
+  ]);
+  t.is(
+    raceResult,
+    'pending',
+    'remote presence must remain live after dropLiveValue alone (pre-Option-A behavior)',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: remote-control dispose callback integration.
+//
+// The dispose callback is called by the remote-control state machine after
+// the connection's `cancelled` promise rejects (via `.then(currentDispose)` in
+// remote-control.js).  This test wires together the remote-control and the
+// Option A dispose callback to verify end-to-end cascade.
+// ---------------------------------------------------------------------------
+test('remote-control dispose triggers peer formula cancellation and cascades', async t => {
+  t.timeout(5000);
+  const { createContext } = setupContextMaker();
+
+  const peerFormulaId = id('peer:rc-test');
+  const peerContext = createContext(peerFormulaId, 'peer');
+
+  const remotePresenceId = id('rp:rc-test');
+  const rpContext = createContext(remotePresenceId, 'remote-slot');
+  rpContext.thisDiesIfThatDies(peerFormulaId);
+
+  // Option A dispose callback (what makePeer installs via remoteControl.connect).
+  const disposeCallback = () => {
+    peerContext.cancel(new Error('peer connection lost'));
+  };
+
+  const provideRemoteControl = makeRemoteControlProvider('local-node');
+  const remoteControl = provideRemoteControl('remote-node');
+
+  const { promise: connCancelled, reject: cancelConn } = makePromiseKit();
+
+  // A minimal fake gateway stub (the returned value is not exercised in
+  // this test; we only care that the dispose callback fires on cancel).
+  const fakeGateway = harden({});
+
+  // Install the dispose callback via remoteControl.connect.
+  remoteControl.connect(
+    () => fakeGateway,
+    cancelConn,
+    connCancelled,
+    disposeCallback,
+  );
+
+  // Simulate connection loss by cancelling the connection.
+  cancelConn(new Error('QUIC connection closed'));
+
+  // The remote-control calls disposeCallback after connCancelled rejects.
+  // The dispose is chained via `.then(currentDispose)` in remote-control.js
+  // so it fires asynchronously in the next microtask turn.
+  // Awaiting a short Promise.resolve() chain is sufficient to drain it.
+  await Promise.resolve();
+  await Promise.resolve();
+
+  await t.throwsAsync(() => rpContext.cancelled, {
+    message: 'peer connection lost',
+  });
+  await t.throwsAsync(() => peerContext.cancelled, {
+    message: 'peer connection lost',
+  });
+});


### PR DESCRIPTION
Refs: #449

## Description

This PR extends the iroh QUIC transport in two related ways.

First, it adds a datagram heartbeat and keep-alive watchdog. iroh's QUIC stack closes a connection after its default idle timeout (~2 minutes) with no way to configure QUIC-level keep-alive. A quiet but healthy CapTP session was therefore torn down after about two minutes of silence. The fix emits a one-byte QUIC DATAGRAM every 30 s to keep the connection alive, and arms a watchdog that tears the session down promptly if the peer goes silent for two consecutive heartbeat intervals. A peer that never sends datagrams (an older daemon without this module) is not affected by the watchdog, so the feature is safe to roll out gradually.

Second, it changes how a peer formula is cleaned up on connection loss. Previously `dropLiveValue` was called, which removed the peer from the live-value cache but left the formula context alive. That meant dependent remote presences were not revoked and a stale `currentGatewayP` prevented re-dial on next use. The fix calls `context.cancel` instead, which cascades through `thisDiesIfThatDies` to revoke all dependent remote presences. The next use of any remote presence reincarnates the peer formula and re-dials from scratch.

The critical files are `packages/daemon/src/networks/iroh-heartbeat.js` (the new heartbeat module), `packages/daemon/src/networks/iroh.js` (wires heartbeat into the per-stream setup), and `packages/daemon/src/daemon.js` (the `context.cancel` change in the dispose callback).

### Security Considerations

The heartbeat sends a single zero byte over an existing authenticated QUIC connection; it introduces no new authority and no new trust surface. The `context.cancel` change revokes remote presences more aggressively on connection loss, which is safer than the prior behavior of leaving stale presences alive.

### Scaling Considerations

One 30-second `setInterval` per active iroh connection is the only new overhead. The datagram is a single byte. On idle connections this is negligible; on busy connections the connection was already carrying traffic.

### Documentation Considerations

No public API changes. The heartbeat is internal to the iroh transport and requires no user action. Behavior change: dependent remote presences are now revoked on connection loss rather than left stale; any code that was relying on stale presences surviving a connection drop will now see rejections sooner.

### Testing Considerations

`packages/daemon/test/iroh-heartbeat.test.js` covers the heartbeat module unit: send interval, watchdog arming, timeout callback, graceful stop, and datagram-unavailable fallback. `packages/daemon/test/peer-formula-revocation.test.js` covers the `context.cancel` lifecycle contract: that a dispose callback cancels the peer formula context, that cancellation cascades to dependent remote presences via `thisDiesIfThatDies`, and that `dropLiveValue` alone (the prior behavior) does not produce that cascade.

### Compatibility Considerations

Remote presences that cross an iroh connection are now revoked on connection loss instead of going stale. Code that catches the rejection and re-looks-up the capability will work correctly. Code that silently held a stale presence and expected it to remain callable will see a rejection. This is the correct behavior; the prior behavior was a bug.

### Upgrade Considerations

No upgrade steps required. Rolling out to a subset of peers is safe: a new daemon connecting to an old daemon sends heartbeats but the old daemon never sends datagrams, so the new daemon's watchdog is never armed and both sides fall back to iroh's QUIC idle timeout.
