### PR TITLE
chore: sync SECURITY.md to canonical in chacha12/random packages

### DIFF
--- a/packages/chacha12-fast-check-test/SECURITY.md
+++ b/packages/chacha12-fast-check-test/SECURITY.md
@@ -21,7 +21,7 @@ SES stands for fearless cooperation, and strong security requires strong collabo
 * A bug reporter can expect acknowledgment of a potential vulnerability reported through  [security@agoric.com](mailto:security@agoric.com)  within one business day of submitting a report. If an acknowledgement of an issue is not received within this time frame, especially during a weekend or holiday period, please reach out again. Any issues reported to the HackerOne program will be acknowledged within the time frames posted on the program page.
 	* The bug triage team and Agoric code maintainers are primarily located in the San Francisco Bay Area with business hours in  [Pacific Time](https://www.timeanddate.com/worldclock/usa/san-francisco) .
 
-* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public Github issues during the coordination process.
+* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public GitHub issues during the coordination process.
 
 * Once a vulnerability report has been received and triaged:
 	* Agoric code maintainers will confirm whether it is valid, and will provide updates to the reporter on validity of the report.

--- a/packages/chacha12/SECURITY.md
+++ b/packages/chacha12/SECURITY.md
@@ -21,7 +21,7 @@ SES stands for fearless cooperation, and strong security requires strong collabo
 * A bug reporter can expect acknowledgment of a potential vulnerability reported through  [security@agoric.com](mailto:security@agoric.com)  within one business day of submitting a report. If an acknowledgement of an issue is not received within this time frame, especially during a weekend or holiday period, please reach out again. Any issues reported to the HackerOne program will be acknowledged within the time frames posted on the program page.
 	* The bug triage team and Agoric code maintainers are primarily located in the San Francisco Bay Area with business hours in  [Pacific Time](https://www.timeanddate.com/worldclock/usa/san-francisco) .
 
-* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public Github issues during the coordination process.
+* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public GitHub issues during the coordination process.
 
 * Once a vulnerability report has been received and triaged:
 	* Agoric code maintainers will confirm whether it is valid, and will provide updates to the reporter on validity of the report.

--- a/packages/random/SECURITY.md
+++ b/packages/random/SECURITY.md
@@ -21,7 +21,7 @@ SES stands for fearless cooperation, and strong security requires strong collabo
 * A bug reporter can expect acknowledgment of a potential vulnerability reported through  [security@agoric.com](mailto:security@agoric.com)  within one business day of submitting a report. If an acknowledgement of an issue is not received within this time frame, especially during a weekend or holiday period, please reach out again. Any issues reported to the HackerOne program will be acknowledged within the time frames posted on the program page.
 	* The bug triage team and Agoric code maintainers are primarily located in the San Francisco Bay Area with business hours in  [Pacific Time](https://www.timeanddate.com/worldclock/usa/san-francisco) .
 
-* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public Github issues during the coordination process.
+* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public GitHub issues during the coordination process.
 
 * Once a vulnerability report has been received and triaged:
 	* Agoric code maintainers will confirm whether it is valid, and will provide updates to the reporter on validity of the report.


### PR DESCRIPTION
## Summary
- The `actual/master` merge into `llm` (`f9ff85c`) introduced the `chacha12`, `chacha12-fast-check-test`, and `random` packages whose `SECURITY.md` spells "Github" instead of the canonical "GitHub".
- This trips `scripts/check-security-md.sh` (the "Check SECURITY.md uniformity" lint step), failing CI on **every** PR targeting `llm`.
- Copies the canonical `SECURITY.md` (sha256 `d9acd9c…`, used by the majority of packages) into all three so the gate passes. Only diff is `Github` → `GitHub`.

## Test plan
- [x] `bash scripts/check-security-md.sh` exits 0 locally
- [ ] CI "Check SECURITY.md uniformity" step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)