### PR TITLE
perf(ci): drop redundant full builds, scope coverage to affected set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,13 +190,13 @@ jobs:
 
       # end macro
 
-      - name: Run yarn build
-        working-directory: ${{ env.WORKDIR }}
-        run: yarn build
-
       # Use turbo's `--filter='...[origin/llm]'` to test only the packages
-      # affected by this PR (and their dependents) rather than the full matrix.
-      # The base `origin/llm` is the repo's default branch on this fork.
+      # affected by this PR and their dependents (the leading `...` selects the
+      # changed set plus everything that depends on it), rather than the full
+      # matrix. The base `origin/llm` is the repo's default branch on this fork.
+      # The `test` task `dependsOn` `build` and `^build`, so turbo builds only
+      # the affected closure on demand; a separate full `yarn build` step would
+      # rebuild all ~83 packages and is therefore omitted.
       - name: Run yarn test (affected set)
         working-directory: ${{ env.WORKDIR }}
         run: yarn turbo run test --filter='...[origin/llm]'
@@ -321,6 +321,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Fetch full history so turbo can compute the affected set against
+          # `origin/llm` for the `--filter='...[origin/llm]'` invocation below.
+          fetch-depth: 0
           persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
@@ -337,11 +340,12 @@ jobs:
 
       # end macro
 
-      - name: Run yarn build
-        run: yarn build
-
-      - name: Run yarn test:c8
-        run: yarn test:c8
+      # As with the `test` job, scope coverage to the affected packages and
+      # their dependents. The `test:c8` turbo task `dependsOn` `build` and
+      # `^build`, so turbo builds only the affected closure on demand; a
+      # separate full `yarn build` step is therefore omitted.
+      - name: Run yarn test:c8 (affected set)
+        run: yarn turbo run test:c8 --filter='...[origin/llm]'
 
   test262:
     name: test262

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,10 @@
     "test": {
       "dependsOn": ["build", "^build"],
       "outputs": []
+    },
+    "test:c8": {
+      "dependsOn": ["build", "^build"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

CI timing analysis of PR #454's most recent run showed the four `test`
matrix jobs (~18 min each) on the critical path, with `cover` (~9–10 min ×2)
and `lint` (~8.5 min) next. Two sources of waste are unrelated to the matrix
or to remote caching:

- **`test` job:** already scopes via `yarn turbo run test --filter='...[origin/llm]'`.
  The leading `...` selects the changed packages **plus their dependents** —
  empirically verified (`...@endo/cli` → cli + its 6 dependents; the trailing
  form `@endo/cli...` pulls in 48 dependencies instead), so the affected set is
  already correct. But the job preceded the turbo run with a full `yarn build`
  of all ~83 packages.
- **`cover` job:** ran an unscoped full `yarn build` followed by `yarn test:c8`
  across **every** package.

Both turbo tasks (`test`, and the new `test:c8`) `dependsOn` `build` and
`^build`, so turbo already builds exactly the affected closure on demand. This
PR drops the redundant standalone `yarn build` from both jobs and scopes
`cover` to the affected set the same way `test` is.

## Changes

- `turbo.json`: add a `test:c8` task (`dependsOn: ["build", "^build"]`).
- `.github/workflows/ci.yml`:
  - `test` job: remove the separate full `yarn build` step (turbo builds the
    affected closure via `dependsOn`).
  - `cover` job: scope to the affected set via
    `yarn turbo run test:c8 --filter='...[origin/llm]'`, remove the full build,
    and add `fetch-depth: 0` so the git-based filter can resolve `origin/llm`.

Per the request: **no test-matrix reduction** and **no remote caching**.

## Notes / things for CI to validate

- Removing the explicit `yarn build` relies on each package's tests building
  via turbo's `^build`. Full-repo build coverage is still exercised by other
  jobs (`lint`, `viable-release`, `familiar-bundle`, `sandbox-drivers`).
- `cover` now reports coverage only for affected packages on a given PR.
- Possible follow-up (not included): scope the `lint` job similarly.

## Test plan

- [ ] CI green on this PR (a no-op-to-most-packages change, so the affected set
      should be small and the `test`/`cover` jobs should be noticeably faster).
- [ ] Confirm `cover` resolves `origin/llm` (fetch-depth: 0 present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)