### PR TITLE
[experiment] CI affected-set scoping — Option A (filter override)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,13 +190,13 @@ jobs:
 
       # end macro
 
-      - name: Run yarn build
-        working-directory: ${{ env.WORKDIR }}
-        run: yarn build
-
       # Use turbo's `--filter='...[origin/llm]'` to test only the packages
-      # affected by this PR (and their dependents) rather than the full matrix.
-      # The base `origin/llm` is the repo's default branch on this fork.
+      # affected by this PR and their dependents (the leading `...` selects the
+      # changed set plus everything that depends on it), rather than the full
+      # matrix. The base `origin/llm` is the repo's default branch on this fork.
+      # The `test` task `dependsOn` `build` and `^build`, so turbo builds only
+      # the affected closure on demand; a separate full `yarn build` step would
+      # rebuild all ~83 packages and is therefore omitted.
       - name: Run yarn test (affected set)
         working-directory: ${{ env.WORKDIR }}
         run: yarn turbo run test --filter='...[origin/llm]'
@@ -321,6 +321,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Fetch full history so turbo can compute the affected set against
+          # `origin/llm` for the `--filter='...[origin/llm]'` invocation below.
+          fetch-depth: 0
           persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
@@ -337,11 +340,12 @@ jobs:
 
       # end macro
 
-      - name: Run yarn build
-        run: yarn build
-
-      - name: Run yarn test:c8
-        run: yarn test:c8
+      # As with the `test` job, scope coverage to the affected packages and
+      # their dependents. The `test:c8` turbo task `dependsOn` `build` and
+      # `^build`, so turbo builds only the affected closure on demand; a
+      # separate full `yarn build` step is therefore omitted.
+      - name: Run yarn test:c8 (affected set)
+        run: yarn turbo run test:c8 --filter='...[origin/llm]'
 
   test262:
     name: test262

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       # rebuild all ~83 packages and is therefore omitted.
       - name: Run yarn test (affected set)
         working-directory: ${{ env.WORKDIR }}
-        run: yarn turbo run test --filter='...[origin/llm]'
+        run: yarn turbo run test --filter='...[origin/kumavis-ci-affected-tests]'
 
       - name: Restore working directory
         if: ${{ steps.move-wd.outcome == 'success' }}
@@ -345,7 +345,7 @@ jobs:
       # `^build`, so turbo builds only the affected closure on demand; a
       # separate full `yarn build` step is therefore omitted.
       - name: Run yarn test:c8 (affected set)
-        run: yarn turbo run test:c8 --filter='...[origin/llm]'
+        run: yarn turbo run test:c8 --filter='...[origin/kumavis-ci-affected-tests]'
 
   test262:
     name: test262

--- a/packages/memoize/test/memoize.test.js
+++ b/packages/memoize/test/memoize.test.js
@@ -1,3 +1,4 @@
+// CI affected-set scoping experiment (Option A) — trivial leaf-package edit.
 import test from '@endo/ses-ava/test.js';
 
 import harden from '@endo/harden';

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,10 @@
     "test": {
       "dependsOn": ["build", "^build"],
       "outputs": []
+    },
+    "test:c8": {
+      "dependsOn": ["build", "^build"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
**Throwaway experiment — DO NOT MERGE.** Validates the affected-set scoping from #457.

#457 itself can't demonstrate the speedup because it edits `turbo.json` (a turbo global dependency), so `...[origin/llm]` selected all 82 packages and `test` still ran ~20 min.

This branch isolates a leaf-only change:
- Trivial edit to `@endo/memoize` (zero dependents, `build: exit 0`).
- Temporary filter override `...[origin/kumavis-ci-affected-tests]` (the #457 branch) instead of `origin/llm`, so turbo's diff excludes the infra commit's `turbo.json` change.

**Expected:** `test`/`cover` log "Running test in 1 packages" (just `@endo/memoize`) and finish in a couple minutes instead of ~20.

Companion: Option B PR uses a post-merge base instead of a filter override.