### PR TITLE
[experiment] CI affected-set scoping — Option B (post-merge base)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       # rebuild all ~83 packages and is therefore omitted.
       - name: Run yarn test (affected set)
         working-directory: ${{ env.WORKDIR }}
-        run: yarn turbo run test --filter='...[origin/llm]'
+        run: yarn turbo run test --filter='...[origin/llm-plus-457]'
 
       - name: Restore working directory
         if: ${{ steps.move-wd.outcome == 'success' }}
@@ -345,7 +345,7 @@ jobs:
       # `^build`, so turbo builds only the affected closure on demand; a
       # separate full `yarn build` step is therefore omitted.
       - name: Run yarn test:c8 (affected set)
-        run: yarn turbo run test:c8 --filter='...[origin/llm]'
+        run: yarn turbo run test:c8 --filter='...[origin/llm-plus-457]'
 
   test262:
     name: test262

--- a/packages/memoize/test/memoize.test.js
+++ b/packages/memoize/test/memoize.test.js
@@ -1,3 +1,4 @@
+// CI affected-set scoping experiment (Option B) — trivial leaf-package edit.
 import test from '@endo/ses-ava/test.js';
 
 import harden from '@endo/harden';


### PR DESCRIPTION
**Throwaway experiment — DO NOT MERGE.** Faithful companion to #458.

Simulates a normal contributor PR *after* #457 merges:
- Base branch `llm-plus-457` = current `llm` + the #457 CI commit (cherry-picked), so `turbo.json` already carries the scoping infra.
- This PR touches only `@endo/memoize` (zero dependents). Since `turbo.json` is identical to the base, it's not in the diff and doesn't poison the affected set.
- Filter points at `origin/llm-plus-457`.

**Expected:** identical to Option A — "Running test in 1 packages", `test`/`cover` finish in minutes. This version proves it works with the production-style flow (real base, no per-PR filter hack) rather than a one-off override.

Cleanup: delete branches `kumavis-ci-test-optB` and `llm-plus-457` after observing results.