### PR TITLE
feat(daemon): upgrade iroh transport to @number0/iroh 1.0

### DIFF
--- a/.changeset/iroh-1-0.md
+++ b/.changeset/iroh-1-0.md
@@ -1,0 +1,21 @@
+---
+'@endo/daemon': minor
+---
+
+Upgrade the iroh network transport to `@number0/iroh` 1.0.
+
+1.0 is a ground-up overhaul of the binding's surface: the `Iroh` node
+class (`Iroh.memory`, `node`, `net`) and the inbound `protocols` table are
+gone, replaced by `Endpoint.bind(options)` plus an explicit
+`acceptNext()` accept loop; identity and addressing moved to
+`endpoint.id()` (an `EndpointId`) and the now-synchronous
+`endpoint.addr()` (an `EndpointAddr`); dialing takes an `EndpointAddr`
+instance rather than a plain `NodeAddr` object; byte payloads (ALPNs,
+datagrams, stream writes, close reasons) are passed as plain
+`Array<number>` rather than `Uint8Array`; and `RecvStream.read` now takes
+a size limit and returns the bytes read (an empty result signals EOF)
+rather than filling a caller-supplied buffer. The transport, stream
+adapter, heartbeat, integration test, and discovery-check script were
+migrated accordingly. Behaviour is otherwise unchanged: the endpoint
+still binds with iroh's n0 preset (relays + discovery) by default, so
+peers remain dialable by NodeId alone.

--- a/packages/daemon/MULTIPLAYER.md
+++ b/packages/daemon/MULTIPLAYER.md
@@ -195,7 +195,7 @@ Fill in the fields:
 - **Module**: The `file://` URL to the iroh network module.
   Typically `file:///path/to/endo/packages/daemon/src/networks/iroh.js`
 
-The module starts an in-memory iroh node, derives a stable NodeId, and
+The module binds an in-memory iroh endpoint, derives a stable NodeId, and
 registers itself in the daemon's `NETS/iroh` directory. No listen address
 or relay configuration is needed.
 

--- a/packages/daemon/designs/iroh-network-design.md
+++ b/packages/daemon/designs/iroh-network-design.md
@@ -1,6 +1,6 @@
 # Iroh Network Transport for the Endo Daemon
 
-Status: Draft / proposal with an initial implementation.
+Status: Implemented.
 Owner: networking.
 
 ## Motivation
@@ -222,7 +222,7 @@ is unit-testable with a fake stream and needs no native binding.
 ### Keep-alive and liveness
 
 iroh's QUIC stack closes a connection after its default max idle timeout
-(~2 minutes), and `@number0/iroh`'s `NodeOptions` exposes no transport config
+(~2 minutes), and `@number0/iroh`'s `EndpointOptions` exposes no transport config
 to shorten that or to enable QUIC-level keep-alive.
 A quiet but healthy CapTP session — two daemons that have swapped bootstrap
 references and are each awaiting the other — was therefore being torn down

--- a/packages/daemon/designs/iroh-network-design.md
+++ b/packages/daemon/designs/iroh-network-design.md
@@ -139,29 +139,44 @@ For CapTP we use exactly one bidi stream per connection.
 
 ```js
 const nodeAddr = parseIrohAddress(address);          // { nodeId, relayUrl, addresses }
-const conn = await endpoint.connect(nodeAddr, ALPN);  // QUIC, TLS-authenticated
+const addr = new EndpointAddr(                        // 1.0 dials an EndpointAddr
+  EndpointId.fromString(nodeAddr.nodeId),
+  nodeAddr.relayUrl,
+  nodeAddr.addresses,
+);
+const conn = await endpoint.connect(addr, ALPN);      // QUIC, TLS-authenticated
 const bi = await conn.openBi();                       // { send, recv }
 const { reader, writer, closed } = adaptIrohStream(bi, conn);
 const { getBootstrap } = makeNetstringCapTP('Endo', writer, reader, cancelled, localGateway);
 return E(getBootstrap()).hello(localNodeId, localGateway, canceller, cancelled);
 ```
 
-**Inbound** is registered through iroh's `protocols` option at node
-construction.
-The handler's `accept(err, conn)` callback fires per inbound connection:
+`ALPN` is the CapTP protocol identifier as a plain `Array<number>` byte array
+(the binding marshals `Vec<u8>` from a JS Array, not a TypedArray).
+
+**Inbound** is driven by an explicit accept loop. 1.0 removed the 0.35
+`protocols` table; instead the endpoint advertises the ALPN at bind time and
+`acceptNext()` yields one inbound connection attempt at a time (or `null` once
+the endpoint closes), each driven through `Incoming → Accepting → Connection`:
 
 ```js
-const protocols = {
-  [ALPN]: (err, ep) => ({
-    accept: async (err, conn) => {
-      const bi = await conn.acceptBi();
-      const { reader, writer } = adaptIrohStream(bi, conn);
-      makeNetstringCapTP('Endo', writer, reader, cancelled, localGreeter);
-      await conn.closed();
-    },
-  }),
+const endpoint = await Endpoint.bind({ secretKey, alpns: [ALPN] });
+
+const acceptLoop = async () => {
+  for (;;) {
+    const incoming = await endpoint.acceptNext();
+    if (!incoming) return;                  // endpoint closed
+    handleIncoming(incoming).catch(logAndIgnore); // isolate per-connection errors
+  }
 };
-const iroh = await Iroh.memory({ secretKey, protocols });
+
+const handleIncoming = async incoming => {
+  const conn = await (await incoming.accept()).connect();
+  const bi = await conn.acceptBi();
+  const { reader, writer } = adaptIrohStream(bi, conn);
+  makeNetstringCapTP('Endo', writer, reader, cancelled, localGreeter);
+  await conn.closed();
+};
 ```
 
 By convention the dialer opens the bi stream and writes the first CapTP
@@ -174,13 +189,15 @@ stream arrives.
 `@endo/stream` `Reader<Uint8Array>` / `Writer<Uint8Array>` that
 `makeNetstringCapTP` consumes:
 
-- **Read**: each `reader.next()` does one `recv.read(buf)` into a freshly
-  allocated buffer (so the returned view is never overwritten by a later
-  read); a `null` return means EOF (resolve `closed`); otherwise yield the
-  filled slice.
+- **Read**: each `reader.next()` does one `recv.read(sizeLimit)`, which
+  resolves with the next chunk of bytes; an empty result means EOF (iroh's
+  QUIC read only yields zero bytes once the stream has finished), which
+  resolves `closed`. Otherwise the chunk (an `Array<number>` or Buffer) is
+  normalised to a `Uint8Array` and yielded.
   Netstring reframes across read boundaries, so short reads are fine.
-- **Write**: `writer.next(bytes)` → `send.writeAll(bytes)`;
-  `writer.return()` → `send.finish()`; `writer.throw()` → `send.reset()`.
+- **Write**: `writer.next(bytes)` → `send.writeAll(Array.from(bytes))` (the
+  binding takes a plain `Array<number>`); `writer.return()` → `send.finish()`;
+  `writer.throw()` → `send.reset()`.
 - **closed**: resolves on EOF, on `conn.closed()`, or on writer teardown.
 
 The adapter depends only on the duck-typed shape of the stream object, so it
@@ -188,16 +205,19 @@ is unit-testable with a fake stream and needs no native binding.
 
 ### Node lifecycle
 
-- One `Iroh.memory({ secretKey, protocols })` per transport instance.
-  We do not use iroh's blob/doc store; `enableDocs` stays default-off and gc
-  is disabled.
-  Endo owns identity and persistence, so an in-memory iroh node is correct —
-  the key is supplied deterministically (below), not persisted by iroh.
-- `addresses()` must be synchronous, but `iroh.net.nodeAddr()` is async, so
-  the transport caches the latest `NodeAddr`, refreshes it on an interval,
-  and returns the cached value built into an address string.
-- The disposal hook (`addDisposalHook`) shuts the iroh node down and waits
-  for in-flight connections to drain, matching the `libp2p` transport.
+- One `Endpoint.bind({ secretKey, alpns: [ALPN] })` per transport instance.
+  `bind` applies iroh's n0 preset (relays + discovery), then our options, so
+  the transport keeps the "dial keys, not IPs" default.
+  Endo owns identity and persistence, so the key is supplied deterministically
+  (below) rather than persisted by iroh.
+- `addresses()` must be synchronous; since 1.0 `endpoint.addr()` is also
+  synchronous, so the current `EndpointAddr` is read on demand and built into
+  an address string (no interval-based cache is needed). If the read throws,
+  the transport falls back to a bare-key address — the peer is still dialable
+  by NodeId through discovery.
+- The disposal hook (`addDisposalHook`) closes the endpoint (which also ends
+  the accept loop, since `acceptNext()` then resolves to `null`) and waits for
+  in-flight connections to drain, matching the `libp2p` transport.
 
 ### Keep-alive and liveness
 
@@ -338,16 +358,17 @@ out of scope for the initial transport.
 
 The headline property — dialing a peer by its **NodeId alone**, with no
 relay or direct-address hints — depends on iroh's default discovery
-(`discovery_n0`, enabled because the transport leaves `nodeDiscovery`
-unset). This cannot be exercised in a restricted sandbox (which blocks
-iroh's DNS/pkarr endpoints and reports placeholder addresses), so it is
-verified manually on a real network.
+(`discovery_n0`, enabled because the transport binds with the n0 preset).
+This cannot be exercised in a restricted sandbox (which blocks iroh's
+DNS/pkarr endpoints and reports placeholder addresses), so it is verified
+manually on a real network.
 
 `scripts/iroh-discovery-check.mjs` runs two checks in one process and prints
-a verdict: it dials by NodeId only with discovery enabled (expected to
-succeed) and again with the server's discovery disabled (expected to fail
-with "No addressing information for NodeId"). A success-then-failure proves
-discovery is what carried the dial.
+a verdict: it dials by NodeId only with the server bound under the n0 preset
+(discovery enabled — expected to succeed) and again with the server bound
+under the minimal preset (no discovery or relay — expected to fail with "No
+addressing information for NodeId"). A success-then-failure proves discovery
+is what carried the dial.
 
 ```sh
 cd packages/daemon
@@ -367,50 +388,47 @@ run two nodes on **different machines/networks**. Server (prints its NodeId
 and stays up):
 
 ```js
-import { Iroh, NodeDiscoveryConfig } from '@number0/iroh';
-const ALPN = 'endo/captp/0';
+import { Endpoint } from '@number0/iroh';
+const ALPN = Array.from(new TextEncoder().encode('endo/captp/0'));
 const enc = new TextEncoder();
-const protocols = {
-  [ALPN]: () => ({
-    accept: async (err, conn) => {
-      if (err) return;
-      const bi = await conn.acceptBi();
-      await bi.recv.readToEnd(64);
-      await bi.send.writeAll(enc.encode('pong'));
-      await bi.send.finish();
-      await conn.closed();
-    },
-  }),
-};
-const node = await Iroh.memory({
+const node = await Endpoint.bind({
   secretKey: Array.from(crypto.getRandomValues(new Uint8Array(32))),
-  protocols,
-  nodeDiscovery: NodeDiscoveryConfig.Default,
-});
-console.log('Dial me by this NodeId:', await node.net.nodeId());
+  alpns: [ALPN],
+}); // n0 preset (relays + discovery) by default
+console.log('Dial me by this NodeId:', node.id().toString());
+(async () => {
+  for (;;) {
+    const incoming = await node.acceptNext();
+    if (!incoming) return;
+    const conn = await (await incoming.accept()).connect();
+    const bi = await conn.acceptBi();
+    await bi.recv.readToEnd(64);
+    await bi.send.writeAll(Array.from(enc.encode('pong')));
+    await bi.send.finish();
+    await conn.closed();
+  }
+})();
 await new Promise(() => {}); // keep running
 ```
 
 Client on the other machine (`node client.mjs <NodeId>`):
 
 ```js
-import { Iroh, NodeDiscoveryConfig } from '@number0/iroh';
-const ALPN = 'endo/captp/0';
+import { Endpoint, EndpointAddr, EndpointId } from '@number0/iroh';
+const ALPN = Array.from(new TextEncoder().encode('endo/captp/0'));
 const enc = new TextEncoder();
 const dec = new TextDecoder();
-const client = await Iroh.memory({
+const client = await Endpoint.bind({
   secretKey: Array.from(crypto.getRandomValues(new Uint8Array(32))),
-  nodeDiscovery: NodeDiscoveryConfig.Default,
 });
-const ep = client.node.endpoint();
-const conn = await ep.connect({ nodeId: process.argv[2] }, enc.encode(ALPN));
+const addr = new EndpointAddr(EndpointId.fromString(process.argv[2]));
+const conn = await client.connect(addr, ALPN);
 const bi = await conn.openBi();
-await bi.send.writeAll(enc.encode('ping'));
+await bi.send.writeAll(Array.from(enc.encode('ping')));
 await bi.send.finish();
-const out = Buffer.alloc(4);
-await bi.recv.readExact(out);
-console.log('SUCCESS:', dec.decode(out), '— dialed by key across networks');
-await client.node.shutdown();
+const out = await bi.recv.readExact(4);
+console.log('SUCCESS:', dec.decode(Uint8Array.from(out)), '— dialed by key across networks');
+await client.close();
 ```
 
 Note: the Endo daemon path does not exercise *pure* discovery by default,

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -99,7 +99,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "@number0/iroh": "^0.35.0"
+    "@number0/iroh": "^1.0.0"
   },
   "devDependencies": {
     "@endo/bundle-source": "workspace:^",

--- a/packages/daemon/scripts/iroh-discovery-check.mjs
+++ b/packages/daemon/scripts/iroh-discovery-check.mjs
@@ -1,4 +1,4 @@
-/* global crypto, process, Buffer, setTimeout, console */
+/* global crypto, process, setTimeout */
 /**
  * Manually verify iroh "dial keys, not IPs" discovery for the Endo iroh
  * transport.
@@ -35,9 +35,10 @@
 // Non-literal specifier: keeps any future type checker from resolving the
 // package's malformed type declarations.
 const irohSpecifier = '@number0/iroh';
-const { Iroh, NodeDiscoveryConfig } = await import(irohSpecifier);
+const { Endpoint, EndpointAddr, EndpointId } = await import(irohSpecifier);
 
-const ALPN = 'endo/captp/0';
+// The 1.0 binding takes ALPNs and byte payloads as plain `Array<number>`.
+const ALPN = Array.from(new TextEncoder().encode('endo/captp/0'));
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
@@ -46,39 +47,61 @@ const randomSecret = () =>
 
 const waitMs = Number(process.env.IROH_DISCOVERY_WAIT_MS || '8000');
 
-const protocols = {
-  [ALPN]: (_err, _endpoint) => ({
-    accept: async (err, connection) => {
-      if (err) return;
+/**
+ * Run the server-side accept loop: echo a 'pong' for each inbound bi stream.
+ * Replaces the 0.35 `protocols` table, which 1.0 removed in favour of an
+ * explicit `acceptNext()` loop.
+ *
+ * @param {import('@number0/iroh').Endpoint} server
+ */
+const serveEcho = async server => {
+  await null;
+  for (;;) {
+    // eslint-disable-next-line no-await-in-loop
+    const incoming = await server.acceptNext();
+    if (!incoming) return;
+    (async () => {
+      const accepting = await incoming.accept();
+      const connection = await accepting.connect();
       const bi = await connection.acceptBi();
       await bi.recv.readToEnd(64);
-      await bi.send.writeAll(enc.encode('pong'));
+      await bi.send.writeAll(Array.from(enc.encode('pong')));
       await bi.send.finish();
       await connection.closed();
-    },
-  }),
+    })().catch(() => {});
+  }
 };
 
 /**
- * Stand up a server (with the given discovery mode) and a client (default
- * discovery), then dial the server by NodeId only.
+ * Stand up a server (with discovery on or off) and a client (discovery on),
+ * then dial the server by NodeId only.
  *
- * @param {string} serverDiscovery - NodeDiscoveryConfig.Default | .None
+ * Discovery on uses the n0 preset (relays + discovery); discovery off uses the
+ * minimal preset, so the server publishes no address and cannot be reached by
+ * key alone.
+ *
+ * @param {boolean} serverDiscovery
  * @returns {Promise<string>}
  */
 const dialByKeyOnly = async serverDiscovery => {
-  const server = await Iroh.memory({
-    secretKey: randomSecret(),
-    protocols,
-    nodeDiscovery: serverDiscovery,
-  });
-  const serverNodeId = await server.net.nodeId();
+  const serverBuilder = Endpoint.builder();
+  if (serverDiscovery) {
+    serverBuilder.applyN0();
+  } else {
+    serverBuilder.applyMinimal();
+  }
+  serverBuilder.secretKey(randomSecret());
+  serverBuilder.alpns([ALPN]);
+  const server = await serverBuilder.bind();
+  const serverNodeId = server.id().toString();
 
-  const client = await Iroh.memory({
-    secretKey: randomSecret(),
-    nodeDiscovery: NodeDiscoveryConfig.Default,
-  });
-  const endpoint = client.node.endpoint();
+  const clientBuilder = Endpoint.builder();
+  clientBuilder.applyN0();
+  clientBuilder.secretKey(randomSecret());
+  const client = await clientBuilder.bind();
+
+  const serving = serveEcho(server);
+  serving.catch(() => {});
 
   // Give the server time to publish its record to n0 DNS/pkarr.
   await new Promise(resolve => setTimeout(resolve, waitMs));
@@ -86,32 +109,31 @@ const dialByKeyOnly = async serverDiscovery => {
   const startedAt = Date.now();
   let result;
   try {
-    // KEY ONLY: a NodeAddr carrying just the nodeId — no relayUrl, no
+    // KEY ONLY: an EndpointAddr carrying just the id — no relay, no direct
     // addresses. Reaching the server therefore requires discovery.
-    const connection = await endpoint.connect(
-      { nodeId: serverNodeId },
-      enc.encode(ALPN),
-    );
+    const addr = new EndpointAddr(EndpointId.fromString(serverNodeId));
+    const connection = await client.connect(addr, ALPN);
     const bi = await connection.openBi();
-    await bi.send.writeAll(enc.encode('ping'));
+    await bi.send.writeAll(Array.from(enc.encode('ping')));
     await bi.send.finish();
-    const out = Buffer.alloc(4);
-    await bi.recv.readExact(out);
-    result = `SUCCESS (${dec.decode(out)}) in ${Date.now() - startedAt}ms`;
+    const out = await bi.recv.readExact(4);
+    result = `SUCCESS (${dec.decode(Uint8Array.from(out))}) in ${
+      Date.now() - startedAt
+    }ms`;
   } catch (error) {
     result = `FAIL: ${String(error.message).split('\n')[0]}`;
   }
-  await client.node.shutdown();
-  await server.node.shutdown();
+  await client.close();
+  await server.close();
   return result;
 };
 
 console.log(`iroh discovery check (publish wait ${waitMs}ms)\n`);
 
-const withDiscovery = await dialByKeyOnly(NodeDiscoveryConfig.Default);
+const withDiscovery = await dialByKeyOnly(true);
 console.log(`  discovery ON  (expect SUCCESS): ${withDiscovery}`);
 
-const withoutDiscovery = await dialByKeyOnly(NodeDiscoveryConfig.None);
+const withoutDiscovery = await dialByKeyOnly(false);
 console.log(`  discovery OFF (expect FAIL)   : ${withoutDiscovery}`);
 
 const pass =

--- a/packages/daemon/src/networks/iroh-address.js
+++ b/packages/daemon/src/networks/iroh-address.js
@@ -90,8 +90,8 @@ export const buildIrohAddress = (nodeAddr, options = {}) => {
 harden(buildIrohAddress);
 
 /**
- * Parse an iroh address string into an iroh NodeAddr. The result is a plain
- * object suitable to pass directly to `Endpoint.connect`.
+ * Parse an iroh address string into the fields needed to construct an
+ * `EndpointAddr` (node id plus optional relay/direct-address dialing hints).
  *
  * @param {string} address
  * @returns {{ nodeId: string, relayUrl?: string, addresses?: string[] }}

--- a/packages/daemon/src/networks/iroh-heartbeat.js
+++ b/packages/daemon/src/networks/iroh-heartbeat.js
@@ -4,15 +4,15 @@
 import harden from '@endo/harden';
 
 // iroh's QUIC stack closes a connection after its default max idle timeout
-// (~2 minutes) and @number0/iroh's `NodeOptions` exposes no transport config
-// to shorten that or to enable QUIC-level keep-alive. A quiet but healthy
-// CapTP session (two daemons that have swapped bootstrap references and are
-// each awaiting the other) is therefore torn down. The heartbeat emits a
-// small QUIC datagram on an interval to keep the connection from going idle,
-// and presumes the peer dead if it falls silent for a full keep-alive window
-// (twice the heartbeat interval, so a single dropped beat is tolerated),
-// tearing the session down promptly instead of waiting on the opaque QUIC
-// idle timeout.
+// (~2 minutes) and @number0/iroh's `EndpointOptions` exposes no transport
+// config to shorten that or to enable QUIC-level keep-alive. A quiet but
+// healthy CapTP session (two daemons that have swapped bootstrap references
+// and are each awaiting the other) is therefore torn down. The heartbeat
+// emits a small QUIC datagram on an interval to keep the connection from
+// going idle, and presumes the peer dead if it falls silent for a full
+// keep-alive window (twice the heartbeat interval, so a single dropped beat
+// is tolerated), tearing the session down promptly instead of waiting on the
+// opaque QUIC idle timeout.
 //
 // QUIC DATAGRAM frames are ack-eliciting and travel out-of-band from the
 // CapTP bi-stream, so a heartbeat resets both endpoints' idle timers (RFC
@@ -67,7 +67,7 @@ const renderThrown = value => {
  * cancel the CapTP session and the connection.
  *
  * @param {object} connection - An iroh Connection (duck-typed for testing).
- * @param {(data: Uint8Array) => void} connection.sendDatagram
+ * @param {(data: number[]) => void} connection.sendDatagram
  * @param {() => Promise<unknown>} connection.readDatagram
  * @param {object} [options]
  * @param {number} [options.intervalMs] - Heartbeat send period.
@@ -140,8 +140,10 @@ export const makeIrohHeartbeat = (
     }
     try {
       // A one-byte payload suffices to generate traffic; the content is
-      // ignored. A fresh buffer avoids handing native code a shared view.
-      sendDatagram(new Uint8Array([0]));
+      // ignored. The binding's `sendDatagram` takes a plain `Array<number>`
+      // (napi marshals `Vec<u8>` from a JS Array, not a TypedArray), and a
+      // fresh array avoids handing native code a shared view.
+      sendDatagram([0]);
     } catch (error) {
       // A full send buffer or transient datagram error is not fatal: the next
       // beat retries and the peer's watchdog tolerates a single miss.

--- a/packages/daemon/src/networks/iroh-stream-adapter.js
+++ b/packages/daemon/src/networks/iroh-stream-adapter.js
@@ -4,9 +4,9 @@ import { makePromiseKit } from '@endo/promise-kit';
 
 /** @import { Reader, Writer } from '@endo/stream' */
 
-// Size of the buffer handed to iroh's `recv.read` for each chunk. Netstring
-// framing downstream reassembles messages across chunk boundaries, so this
-// only bounds the per-read syscall size, not message size.
+// Maximum number of bytes requested from iroh's `recv.read` per chunk.
+// Netstring framing downstream reassembles messages across chunk boundaries,
+// so this only bounds the per-read syscall size, not message size.
 const READ_CHUNK_SIZE = 64 * 1024;
 
 /**
@@ -14,18 +14,22 @@ const READ_CHUNK_SIZE = 64 * 1024;
  * Reader<Uint8Array> and Writer<Uint8Array> pairs, suitable for use with
  * makeNetstringCapTP.
  *
- * iroh streams expose:
- *   - bi.send: SendStream with writeAll(Uint8Array), finish(), reset(code)
- *   - bi.recv: RecvStream with read(buf) -> bigint | null (null == EOF)
+ * iroh streams (as of `@number0/iroh` 1.0) expose:
+ *   - bi.send: SendStream with writeAll(Array<number>), finish(), reset(code)
+ *   - bi.recv: RecvStream with read(sizeLimit) -> bytes (empty == EOF)
  *   - connection.closed(): Promise that settles when the connection closes
+ *
+ * The binding takes byte payloads as plain `Array<number>` (napi marshals
+ * `Vec<u8>` from a JS Array, not a TypedArray) and returns reads as a
+ * byte-valued array-like, so the adapter converts at the boundary.
  *
  * The adapter depends only on this duck-typed shape, so it can be unit
  * tested with a fake stream and connection.
  *
  * @param {object} bi - An iroh BiStream.
- * @param {{ writeAll(buf: Uint8Array): Promise<unknown>, finish(): Promise<unknown>, reset(code: bigint): Promise<unknown> }} bi.send
- * @param {{ read(buf: Uint8Array): Promise<bigint | number | null> }} bi.recv
- * @param {{ closed?: () => Promise<unknown>, close?: (code: bigint, reason: Uint8Array) => void }} [connection]
+ * @param {{ writeAll(buf: number[]): Promise<unknown>, finish(): Promise<unknown>, reset(code: bigint): Promise<unknown> }} bi.send
+ * @param {{ read(sizeLimit: number): Promise<ArrayLike<number> | null | undefined> }} bi.recv
+ * @param {{ closed?: () => Promise<unknown>, close?: (code: bigint, reason: number[]) => void }} [connection]
  * @returns {{ reader: Reader<Uint8Array>, writer: Writer<Uint8Array>, closed: Promise<void> }}
  */
 export const adaptIrohStream = (bi, connection = {}) => {
@@ -47,19 +51,17 @@ export const adaptIrohStream = (bi, connection = {}) => {
     async next() {
       await null;
       try {
-        const buf = new Uint8Array(READ_CHUNK_SIZE);
-        const n = await recv.read(buf);
-        if (n === null || n === undefined) {
+        const chunk = await recv.read(READ_CHUNK_SIZE);
+        // An empty (or absent) result signals EOF: iroh's QUIC `read` only
+        // resolves with zero bytes once the stream has finished — it never
+        // yields an empty, non-EOF read while the stream is open.
+        if (chunk === null || chunk === undefined || chunk.length === 0) {
           resolveClosed(undefined);
           return harden({ value: undefined, done: true });
         }
-        const count = Number(n);
-        if (count === 0) {
-          // No bytes this turn but not EOF; yield an empty chunk and let the
-          // caller poll again. Netstring tolerates empty reads.
-          return harden({ value: new Uint8Array(0), done: false });
-        }
-        return harden({ value: buf.subarray(0, count), done: false });
+        // `read` returns an `Array<number>` (or Buffer); normalise to a
+        // Uint8Array for the netstring/CapTP layer.
+        return harden({ value: new Uint8Array(chunk), done: false });
       } catch (err) {
         resolveClosed(undefined);
         throw err;
@@ -83,7 +85,9 @@ export const adaptIrohStream = (bi, connection = {}) => {
   const writer = harden({
     async next(value) {
       await null;
-      await send.writeAll(value);
+      // The binding's `writeAll` takes a plain `Array<number>`, not a
+      // TypedArray.
+      await send.writeAll(Array.from(value));
       return harden({ value: undefined, done: false });
     },
     async return() {
@@ -105,7 +109,7 @@ export const adaptIrohStream = (bi, connection = {}) => {
       }
       if (typeof connection.close === 'function') {
         try {
-          connection.close(0n, new TextEncoder().encode('error'));
+          connection.close(0n, Array.from(new TextEncoder().encode('error')));
         } catch {
           // Best-effort.
         }

--- a/packages/daemon/src/networks/iroh.js
+++ b/packages/daemon/src/networks/iroh.js
@@ -191,9 +191,25 @@ export const make = async (powers, context) => {
     console.error(
       `Endo daemon accepted iroh connection ${connectionNumber} at ${new Date().toISOString()}`,
     );
-    const bi = await connection.acceptBi();
-    serveStream(bi, connection, connectionNumber, true);
-    await connection.closed();
+    let handedOff = false;
+    try {
+      const bi = await connection.acceptBi();
+      serveStream(bi, connection, connectionNumber, true);
+      handedOff = true;
+      await connection.closed();
+    } catch (error) {
+      // If we accepted a connection but failed before handing it to
+      // serveStream (which then owns teardown), close it so the QUIC
+      // connection does not linger until the peer's idle timeout.
+      if (!handedOff) {
+        try {
+          connection.close(0n, toByteArray('inbound setup failed'));
+        } catch {
+          // Best-effort; the connection may already be gone.
+        }
+      }
+      throw error;
+    }
   };
 
   const acceptLoop = async () => {

--- a/packages/daemon/src/networks/iroh.js
+++ b/packages/daemon/src/networks/iroh.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global globalThis, setInterval, clearInterval */
+/* global globalThis */
 
 import harden from '@endo/harden';
 import { E, Far } from '@endo/far';
@@ -14,20 +14,29 @@ import {
   supportsIrohAddress,
 } from './iroh-address.js';
 
-// ALPN identifying the Endo CapTP protocol over iroh QUIC. iroh keys its
-// inbound `protocols` table by the UTF-8 string form of the ALPN bytes, so a
-// plain string key here is equivalent to the byte array the native binding
-// expects (see @number0/iroh test/node.mjs).
+// ALPN identifying the Endo CapTP protocol over iroh QUIC. The native binding
+// takes ALPNs as plain `Array<number>` byte arrays (napi marshals `Vec<u8>`
+// from a JS Array, not a TypedArray), both when advertised at bind time and
+// when dialing (see @number0/iroh test/endpoint.mjs).
 const ALPN_STRING = 'endo/captp/0';
-const ALPN_BYTES = new TextEncoder().encode(ALPN_STRING);
+const textEncoder = new TextEncoder();
+const ALPN_BYTES = textEncoder.encode(ALPN_STRING);
+const ALPN_ARRAY = Array.from(ALPN_BYTES);
+
+/**
+ * Encode a string as the `Array<number>` byte form the native binding's
+ * `Vec<u8>` parameters expect (close reasons, datagrams, etc.).
+ *
+ * @param {string} text
+ * @returns {number[]}
+ */
+const toByteArray = text => Array.from(textEncoder.encode(text));
 
 const processEnv = /** @type {any} */ (globalThis).process?.env;
 // Publish loopback/private direct addresses as dialing hints. Off by default
 // (they are useless to remote dialers); enable for same-host integration
 // tests where discovery has no public path to advertise.
 const PUBLISH_PRIVATE = processEnv?.ENDO_IROH_PUBLISH_PRIVATE === '1';
-
-const ADDRESS_REFRESH_MS = 15_000;
 
 /**
  * Derive a deterministic 32-byte Ed25519 secret for the iroh node from the
@@ -67,7 +76,7 @@ export const make = async (powers, context) => {
   // specifier is held in a variable so the type checker does not resolve the
   // package's (malformed) type declarations.
   const irohSpecifier = '@number0/iroh';
-  const { Iroh } = await import(irohSpecifier);
+  const { Endpoint, EndpointAddr, EndpointId } = await import(irohSpecifier);
 
   const cancelled = /** @type {Promise<never>} */ (E(context).whenCancelled());
   const cancelServer = (/** @type {Error} */ error) => E(context).cancel(error);
@@ -122,7 +131,7 @@ export const make = async (powers, context) => {
     const tearDown = (/** @type {Error} */ reason) => {
       capTp.close(reason);
       try {
-        connection.close(0n, new TextEncoder().encode(reason.message));
+        connection.close(0n, toByteArray(reason.message));
       } catch {
         // Best-effort; the connection may already be gone.
       }
@@ -162,69 +171,85 @@ export const make = async (powers, context) => {
     return capTp;
   };
 
-  // --- Inbound connection handler ---
-  const protocols = {
-    [ALPN_STRING]: (/** @type {any} */ _err, /** @type {any} */ _endpoint) => ({
-      accept: async (/** @type {any} */ err, /** @type {any} */ connection) => {
-        if (err) {
-          // A single failed inbound connection must not tear down the whole
-          // transport; log and ignore it.
-          console.error(
-            `Endo daemon iroh inbound connection error: ${
-              /** @type {Error} */ (err).message
-            }`,
-          );
-          return;
-        }
-        await (async () => {
-          const { value: connectionNumber } = connectionNumbers.next();
-          console.error(
-            `Endo daemon accepted iroh connection ${connectionNumber} at ${new Date().toISOString()}`,
-          );
-          const bi = await connection.acceptBi();
-          serveStream(bi, connection, connectionNumber, true);
-          await connection.closed();
-        })().catch(cancelServer);
-      },
-    }),
+  // Bind the endpoint. `Endpoint.bind` applies iroh's n0 preset (relays +
+  // discovery), then our options, so the transport keeps the "dial keys, not
+  // IPs" default. Advertising the CapTP ALPN here is what lets inbound dials
+  // negotiate our protocol; the accept loop below pulls those connections.
+  const endpoint = await Endpoint.bind({ secretKey, alpns: [ALPN_ARRAY] });
+  const localIrohNodeId = endpoint.id().toString();
+
+  // --- Inbound accept loop ---
+  // 1.0 replaced the `protocols` table with an explicit accept loop:
+  // `acceptNext()` yields one inbound connection attempt at a time (or null
+  // once the endpoint closes), and the server-side handshake is driven by
+  // hand through `Incoming -> Accepting -> Connection`.
+  /** @param {any} incoming */
+  const handleIncoming = async incoming => {
+    const accepting = await incoming.accept();
+    const connection = await accepting.connect();
+    const { value: connectionNumber } = connectionNumbers.next();
+    console.error(
+      `Endo daemon accepted iroh connection ${connectionNumber} at ${new Date().toISOString()}`,
+    );
+    const bi = await connection.acceptBi();
+    serveStream(bi, connection, connectionNumber, true);
+    await connection.closed();
   };
 
-  const iroh = await Iroh.memory({ secretKey, protocols });
-  const endpoint = iroh.node.endpoint();
-  const localIrohNodeId = endpoint.nodeId();
-
-  // `addresses()` must be synchronous but `net.nodeAddr()` is async, so we
-  // cache the latest NodeAddr and refresh it on an interval.
-  /** @type {{ nodeId: string, relayUrl?: string, addresses?: string[] }} */
-  let cachedNodeAddr = { nodeId: localIrohNodeId };
-  const refreshNodeAddr = async () => {
-    try {
-      const nodeAddr = await iroh.net.nodeAddr();
-      cachedNodeAddr = {
-        nodeId: localIrohNodeId,
-        relayUrl: nodeAddr.relayUrl,
-        addresses: nodeAddr.addresses,
-      };
-    } catch (error) {
-      console.error(
-        `Endo iroh: failed to refresh node address: ${
-          /** @type {Error} */ (error).message
-        }`,
-      );
+  const acceptLoop = async () => {
+    await null;
+    for (;;) {
+      // Accept connections one at a time; the work for each is dispatched
+      // concurrently below, so the serial await here is intentional.
+      // eslint-disable-next-line no-await-in-loop
+      const incoming = await endpoint.acceptNext();
+      if (!incoming) {
+        // `acceptNext` resolves to null once the endpoint is closed; the loop
+        // is done and the disposal path below has already torn things down.
+        return;
+      }
+      // Handle each inbound connection independently. A single failed inbound
+      // connection must not tear down the whole transport, so its errors are
+      // logged and swallowed here rather than propagated to cancelServer.
+      handleIncoming(incoming).catch((/** @type {Error} */ error) => {
+        console.error(
+          `Endo daemon iroh inbound connection error: ${error.message}`,
+        );
+      });
     }
   };
-  await refreshNodeAddr();
-
-  const refreshTimer = setInterval(() => {
-    refreshNodeAddr().catch(() => {});
-  }, ADDRESS_REFRESH_MS);
-  if (typeof refreshTimer.unref === 'function') {
-    refreshTimer.unref();
-  }
+  // Only a fatal failure of the loop itself (not a per-connection error) tears
+  // the transport down.
+  acceptLoop().catch(cancelServer);
 
   console.error(
     `Endo daemon started local iroh network device, NodeId ${localIrohNodeId}`,
   );
+
+  // `addresses()` is synchronous and, since 1.0, so is `endpoint.addr()`, so
+  // the current NodeAddr is read on demand rather than cached on an interval.
+  const currentAddress = () => {
+    try {
+      const addr = endpoint.addr();
+      return buildIrohAddress(
+        {
+          nodeId: addr.id().toString(),
+          relayUrl: addr.relayUrl() ?? undefined,
+          addresses: addr.directAddresses(),
+        },
+        { includePrivate: PUBLISH_PRIVATE },
+      );
+    } catch (error) {
+      console.error(
+        `Endo iroh: failed to read node address: ${
+          /** @type {Error} */ (error).message
+        }`,
+      );
+      // Fall back to a bare-key address; the peer is still dialable by NodeId
+      // through discovery.
+      return buildIrohAddress({ nodeId: localIrohNodeId });
+    }
+  };
 
   // --- Outbound connect ---
   /**
@@ -248,8 +273,16 @@ export const make = async (powers, context) => {
     let connection;
     let handedOff = false;
     try {
+      // 1.0 dials an `EndpointAddr` instance (built from an `EndpointId` plus
+      // optional relay/direct-address hints) rather than a plain NodeAddr
+      // object. Passing no hints lets discovery resolve the NodeId.
+      const endpointAddr = new EndpointAddr(
+        EndpointId.fromString(nodeAddr.nodeId),
+        nodeAddr.relayUrl,
+        nodeAddr.addresses,
+      );
       connection = await Promise.race([
-        endpoint.connect(nodeAddr, ALPN_BYTES),
+        endpoint.connect(endpointAddr, ALPN_ARRAY),
         connectionCancelled,
       ]);
       const bi = await Promise.race([connection.openBi(), connectionCancelled]);
@@ -279,7 +312,7 @@ export const make = async (powers, context) => {
       // QUIC connection does not leak.
       if (connection && !handedOff) {
         try {
-          connection.close(0n, new TextEncoder().encode('cancelled'));
+          connection.close(0n, toByteArray('cancelled'));
         } catch {
           // Best-effort.
         }
@@ -290,9 +323,10 @@ export const make = async (powers, context) => {
 
   // --- Shutdown ---
   const stopped = cancelled.catch(async () => {
-    clearInterval(refreshTimer);
     try {
-      await iroh.node.shutdown();
+      // Closing the endpoint also ends the accept loop: `acceptNext` resolves
+      // to null once the endpoint is closed.
+      await endpoint.close();
     } catch {
       // Best-effort shutdown.
     }
@@ -302,10 +336,7 @@ export const make = async (powers, context) => {
   E.sendOnly(context).addDisposalHook(() => stopped);
 
   return Far('IrohNetwork', {
-    addresses: () =>
-      harden([
-        buildIrohAddress(cachedNodeAddr, { includePrivate: PUBLISH_PRIVATE }),
-      ]),
+    addresses: () => harden([currentAddress()]),
     supports: supportsIrohAddress,
     connect,
   });

--- a/packages/daemon/src/networks/iroh.js
+++ b/packages/daemon/src/networks/iroh.js
@@ -107,7 +107,7 @@ export const make = async (powers, context) => {
    * @param {any} connection - iroh Connection.
    * @param {number} connectionNumber
    * @param {boolean} inbound
-   * @returns {ReturnType<typeof makeNetstringCapTP>}
+   * @returns {{ capTp: ReturnType<typeof makeNetstringCapTP>, tearDown: (reason: Error) => void }}
    */
   const serveStream = (bi, connection, connectionNumber, inbound) => {
     const {
@@ -169,7 +169,7 @@ export const make = async (powers, context) => {
         `Endo daemon closed iroh connection ${connectionNumber} at ${new Date().toISOString()}`,
       );
     });
-    return capTp;
+    return { capTp, tearDown };
   };
 
   // Bind the endpoint. `Endpoint.bind` applies iroh's n0 preset (relays +
@@ -304,16 +304,37 @@ export const make = async (powers, context) => {
       ]);
       const bi = await Promise.race([connection.openBi(), connectionCancelled]);
 
-      const capTp = serveStream(bi, connection, connectionNumber, false);
+      const { capTp, tearDown } = serveStream(
+        bi,
+        connection,
+        connectionNumber,
+        false,
+      );
       handedOff = true;
 
-      // Cancel the connection context once CapTP closes. Consume the
-      // connectionCancelled rejection so a cancelled connection does not
-      // surface as an unhandled rejection during teardown.
+      // Bridge the per-connection context and the CapTP session in both
+      // directions. Consume the connectionCancelled rejection so teardown does
+      // not surface as an unhandled rejection.
       Promise.race([capTp.closed, connectionCancelled])
-        .finally(() => {
-          cancelConnection();
-        })
+        .then(
+          () => {
+            // CapTP closed first (normal session end): cancel the context to
+            // dispose the peer.
+            cancelConnection();
+          },
+          () => {
+            // The connection context was cancelled before CapTP closed (e.g.
+            // the peer was disposed externally). serveStream wires capTp to the
+            // transport-level `cancelled`, not this per-connection signal, so
+            // nothing else closes it — tear the session down explicitly, or the
+            // QUIC connection and CapTP session linger until iroh's idle
+            // timeout. tearDown is idempotent.
+            tearDown(
+              new Error(`iroh connection ${connectionNumber} cancelled`),
+            );
+            cancelConnection();
+          },
+        )
         .catch(() => {});
 
       const remoteGreeter = capTp.getBootstrap();

--- a/packages/daemon/src/networks/iroh.js
+++ b/packages/daemon/src/networks/iroh.js
@@ -1,10 +1,11 @@
 // @ts-check
 /* global globalThis */
 
-import harden from '@endo/harden';
+import { bytesFromText } from '@endo/bytes/from-string.js';
 import { E, Far } from '@endo/far';
+import harden from '@endo/harden';
+import { decodeHex } from '@endo/hex/decode.js';
 
-import { fromHex } from '../hex.js';
 import { makeNetstringCapTP } from '../connection.js';
 import { adaptIrohStream } from './iroh-stream-adapter.js';
 import { KEEPALIVE_TIMEOUT_MS, makeIrohHeartbeat } from './iroh-heartbeat.js';
@@ -19,18 +20,18 @@ import {
 // from a JS Array, not a TypedArray), both when advertised at bind time and
 // when dialing (see @number0/iroh test/endpoint.mjs).
 const ALPN_STRING = 'endo/captp/0';
-const textEncoder = new TextEncoder();
-const ALPN_BYTES = textEncoder.encode(ALPN_STRING);
-const ALPN_ARRAY = Array.from(ALPN_BYTES);
+const ALPN_ARRAY = Array.from(bytesFromText(ALPN_STRING));
 
 /**
  * Encode a string as the `Array<number>` byte form the native binding's
- * `Vec<u8>` parameters expect (close reasons, datagrams, etc.).
+ * `Vec<u8>` parameters expect: napi marshals `Vec<u8>` from a JS Array, not a
+ * TypedArray, so the UTF-8 bytes from `@endo/bytes` are spread into an array
+ * (used for close reasons, datagrams, etc.).
  *
  * @param {string} text
  * @returns {number[]}
  */
-const toByteArray = text => Array.from(textEncoder.encode(text));
+const toByteArray = text => Array.from(bytesFromText(text));
 
 const processEnv = /** @type {any} */ (globalThis).process?.env;
 // Publish loopback/private direct addresses as dialing hints. Off by default
@@ -52,7 +53,7 @@ const PUBLISH_PRIVATE = processEnv?.ENDO_IROH_PUBLISH_PRIVATE === '1';
  * @returns {number[]} 32-byte secret as an array of byte values.
  */
 export const deriveIrohSecretKey = nodeIdHex => {
-  const seed = fromHex(nodeIdHex);
+  const seed = decodeHex(nodeIdHex);
   return Array.from(seed.slice(0, 32));
 };
 harden(deriveIrohSecretKey);

--- a/packages/daemon/test/iroh-network.test.js
+++ b/packages/daemon/test/iroh-network.test.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 /* global process */
-// Integration test for the iroh transport's byte path: two real iroh memory
-// nodes exchange a CapTP message through the same stream adapter and
+// Integration test for the iroh transport's byte path: two real iroh
+// endpoints exchange a CapTP message through the same stream adapter and
 // netstring/CapTP layering the transport uses. Guarded so CI stays green
 // when the optional native `@number0/iroh` binding is unavailable.
 import test from '@endo/ses-ava/prepare-endo.js';
@@ -35,7 +35,7 @@ const ALPN = Array.from(new TextEncoder().encode('endo/captp/0'));
 // (network-dependent and occasionally flaky). Run it explicitly with
 // ENDO_IROH_INTEGRATION=1 to validate the end-to-end byte path. The pure
 // logic it covers (framing, adapter, key derivation) is also unit tested in
-// iroh-stream-adapter.test.js and iroh-address.test.js.
+// iroh-stream-adapter.test.js (and the address scheme in iroh-address.test.js).
 const integrationEnabled =
   Endpoint && process.env.ENDO_IROH_INTEGRATION === '1';
 const itIroh = integrationEnabled ? test.serial : test.serial.skip;

--- a/packages/daemon/test/iroh-network.test.js
+++ b/packages/daemon/test/iroh-network.test.js
@@ -12,12 +12,12 @@ import { makePromiseKit } from '@endo/promise-kit';
 import { adaptIrohStream } from '../src/networks/iroh-stream-adapter.js';
 import { makeNetstringCapTP } from '../src/connection.js';
 
-let Iroh;
+let Endpoint;
 try {
   // Non-literal specifier so the type checker does not resolve the package's
   // (malformed) type declarations.
   const irohSpecifier = '@number0/iroh';
-  ({ Iroh } = await import(irohSpecifier));
+  ({ Endpoint } = await import(irohSpecifier));
 } catch (error) {
   // The native binding is an optional dependency. Tolerate its absence by
   // default (the test skips), but when the integration test is explicitly
@@ -27,7 +27,8 @@ try {
   }
 }
 
-const ALPN = 'endo/captp/0';
+// The 1.0 binding takes ALPNs as plain `Array<number>` byte arrays.
+const ALPN = Array.from(new TextEncoder().encode('endo/captp/0'));
 
 // Opt-in: this exercises a real iroh node pair, which reaches iroh's public
 // relay/discovery network and is therefore unsuitable for unattended CI
@@ -35,7 +36,8 @@ const ALPN = 'endo/captp/0';
 // ENDO_IROH_INTEGRATION=1 to validate the end-to-end byte path. The pure
 // logic it covers (framing, adapter, key derivation) is also unit tested in
 // iroh-stream-adapter.test.js and iroh-address.test.js.
-const integrationEnabled = Iroh && process.env.ENDO_IROH_INTEGRATION === '1';
+const integrationEnabled =
+  Endpoint && process.env.ENDO_IROH_INTEGRATION === '1';
 const itIroh = integrationEnabled ? test.serial : test.serial.skip;
 
 itIroh('CapTP round-trip over two real iroh nodes', async t => {
@@ -48,35 +50,38 @@ itIroh('CapTP round-trip over two real iroh nodes', async t => {
     greet: async name => `hello ${name}`,
   });
 
-  const protocols = {
-    [ALPN]: (_err, _ep) => ({
-      accept: async (err, connection) => {
-        if (err) return;
-        const bi = await connection.acceptBi();
-        const { reader, writer } = adaptIrohStream(bi, connection);
-        makeNetstringCapTP('server', writer, reader, cancelled, bootstrap);
-        await connection.closed();
-      },
-    }),
-  };
-
   const serverSecret = Array.from(new Uint8Array(32).fill(11));
   const clientSecret = Array.from(new Uint8Array(32).fill(13));
 
-  const server = await Iroh.memory({ secretKey: serverSecret, protocols });
-  const client = await Iroh.memory({ secretKey: clientSecret });
+  // The server advertises the CapTP ALPN; the client supplies it when dialing.
+  const server = await Endpoint.bind({
+    secretKey: serverSecret,
+    alpns: [ALPN],
+  });
+  const client = await Endpoint.bind({ secretKey: clientSecret });
   t.teardown(async () => {
-    await client.node.shutdown().catch(() => {});
-    await server.node.shutdown().catch(() => {});
+    await client.close().catch(() => {});
+    await server.close().catch(() => {});
   });
 
-  const serverAddr = await server.net.nodeAddr();
-  const endpoint = client.node.endpoint();
+  // 1.0 replaced the `protocols` table with an explicit accept loop. Drive one
+  // inbound connection through the server-side handshake in the background.
+  const serving = (async () => {
+    const incoming = await server.acceptNext();
+    const accepting = await incoming.accept();
+    const connection = await accepting.connect();
+    const bi = await connection.acceptBi();
+    const { reader, writer } = adaptIrohStream(bi, connection);
+    makeNetstringCapTP('server', writer, reader, cancelled, bootstrap);
+    await connection.closed();
+  })();
+  serving.catch(() => {});
 
-  const connection = await endpoint.connect(
-    serverAddr,
-    new TextEncoder().encode(ALPN),
-  );
+  // `addr()` is synchronous in 1.0 and returns an EndpointAddr that can be
+  // dialed directly.
+  const serverAddr = server.addr();
+
+  const connection = await client.connect(serverAddr, ALPN);
   const bi = await connection.openBi();
   const { reader, writer } = adaptIrohStream(bi, connection);
   const { getBootstrap } = makeNetstringCapTP(

--- a/packages/daemon/test/iroh-stream-adapter.test.js
+++ b/packages/daemon/test/iroh-stream-adapter.test.js
@@ -5,26 +5,26 @@ import { adaptIrohStream } from '../src/networks/iroh-stream-adapter.js';
 import { deriveIrohSecretKey } from '../src/networks/iroh.js';
 
 /**
- * A fake iroh RecvStream: serves queued chunks, then EOF (null).
+ * A fake iroh RecvStream (1.0 contract): `read(sizeLimit)` returns the next
+ * queued chunk as an `Array<number>`, then an empty array to signal EOF.
  *
  * @param {Uint8Array[]} chunks
  */
 const makeFakeRecv = chunks => {
   const queue = [...chunks];
   return {
-    async read(buf) {
+    async read(_sizeLimit) {
       if (queue.length === 0) {
-        return null;
+        return [];
       }
-      const chunk = queue.shift();
-      buf.set(chunk);
-      return BigInt(chunk.length);
+      return Array.from(queue.shift());
     },
   };
 };
 
 /**
- * A fake iroh SendStream that records writes and lifecycle calls.
+ * A fake iroh SendStream that records writes and lifecycle calls. The adapter
+ * hands `writeAll` a plain `Array<number>`, matching the 1.0 binding.
  */
 const makeFakeSend = () => {
   const writes = [];
@@ -33,7 +33,7 @@ const makeFakeSend = () => {
     writes,
     calls,
     async writeAll(buf) {
-      writes.push(Uint8Array.prototype.slice.call(buf));
+      writes.push(Uint8Array.from(buf));
     },
     async finish() {
       calls.finished += 1;
@@ -68,29 +68,40 @@ test('reader yields chunks then completes at EOF', async t => {
   t.pass();
 });
 
-test('reader yields an empty chunk on a 0-byte read without ending', async t => {
-  const enc = new TextEncoder();
-  // recv returns 0 (no bytes this turn, not EOF), then a real chunk, then EOF.
-  let phase = 0;
+test('reader treats an empty read as EOF and resolves closed', async t => {
+  // Under the 1.0 contract `read` only resolves with zero bytes at end of
+  // stream, so an empty result must complete the reader rather than yield an
+  // empty chunk.
   const recv = {
-    async read(buf) {
-      phase += 1;
-      if (phase === 1) return 0n;
-      if (phase === 2) {
-        buf.set(enc.encode('hi'));
-        return 2n;
-      }
-      return null;
+    async read(_sizeLimit) {
+      return [];
+    },
+  };
+  const { reader, closed } = adaptIrohStream({ send: makeFakeSend(), recv });
+
+  const end = await reader.next();
+  t.true(end.done);
+  t.is(end.value, undefined);
+  await closed;
+  t.pass();
+});
+
+test('reader accepts a Buffer/Uint8Array chunk, not just a plain array', async t => {
+  // napi may marshal the `Vec<u8>` return as a Buffer on some platforms; the
+  // adapter must normalise either array-like to a Uint8Array.
+  let served = false;
+  const recv = {
+    async read(_sizeLimit) {
+      if (served) return [];
+      served = true;
+      return new Uint8Array([0x68, 0x69]); // "hi"
     },
   };
   const { reader } = adaptIrohStream({ send: makeFakeSend(), recv });
 
-  const empty = await reader.next();
-  t.false(empty.done);
-  t.is(empty.value.length, 0);
-
   const data = await reader.next();
   t.false(data.done);
+  t.true(data.value instanceof Uint8Array);
   t.is(new TextDecoder().decode(data.value), 'hi');
 
   const end = await reader.next();

--- a/packages/daemon/test/iroh-stream-adapter.test.js
+++ b/packages/daemon/test/iroh-stream-adapter.test.js
@@ -28,11 +28,17 @@ const makeFakeRecv = chunks => {
  */
 const makeFakeSend = () => {
   const writes = [];
+  // Record whether each writeAll argument was a plain Array<number>. The napi
+  // `Vec<u8>` binding rejects a TypedArray, so the adapter must convert; this
+  // lets a test assert the argument type, which Uint8Array.from would mask.
+  const writeArgIsArray = [];
   const calls = { finished: 0, reset: 0 };
   return {
     writes,
+    writeArgIsArray,
     calls,
     async writeAll(buf) {
+      writeArgIsArray.push(Array.isArray(buf));
       writes.push(Uint8Array.from(buf));
     },
     async finish() {
@@ -132,6 +138,11 @@ test('writer.next forwards bytes via writeAll', async t => {
   await writer.next(enc.encode('!'));
 
   t.is(send.writes.length, 2);
+  t.deepEqual(
+    send.writeArgIsArray,
+    [true, true],
+    'writeAll receives a plain Array<number>, not a TypedArray',
+  );
   t.is(new TextDecoder().decode(send.writes[0]), 'yo');
   t.is(new TextDecoder().decode(send.writes[1]), '!');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1697,7 +1697,7 @@ __metadata:
     "@libp2p/webrtc": "npm:^5.2.24"
     "@libp2p/websockets": "npm:^9.2.19"
     "@multiformats/multiaddr": "npm:^12.4.4"
-    "@number0/iroh": "npm:^0.35.0"
+    "@number0/iroh": "npm:^1.0.0"
     "@types/ws": "npm:^8.18.1"
     ava: "catalog:dev"
     better-sqlite3: "npm:^11.0.0"
@@ -4620,114 +4620,104 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@number0/iroh-android-arm-eabi@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-android-arm-eabi@npm:0.35.0"
+"@number0/iroh-android-arm-eabi@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-android-arm-eabi@npm:1.0.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@number0/iroh-android-arm64@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-android-arm64@npm:0.35.0"
+"@number0/iroh-android-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-android-arm64@npm:1.0.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@number0/iroh-darwin-arm64@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-darwin-arm64@npm:0.35.0"
+"@number0/iroh-darwin-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-darwin-arm64@npm:1.0.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@number0/iroh-darwin-universal@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-darwin-universal@npm:0.35.0"
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"@number0/iroh-linux-arm-gnueabihf@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-linux-arm-gnueabihf@npm:0.35.0"
+"@number0/iroh-linux-arm-gnueabihf@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-linux-arm-gnueabihf@npm:1.0.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@number0/iroh-linux-arm-musleabihf@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-linux-arm-musleabihf@npm:0.35.0"
+"@number0/iroh-linux-arm-musleabihf@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-linux-arm-musleabihf@npm:1.0.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@number0/iroh-linux-arm64-gnu@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-linux-arm64-gnu@npm:0.35.0"
+"@number0/iroh-linux-arm64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-linux-arm64-gnu@npm:1.0.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@number0/iroh-linux-arm64-musl@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-linux-arm64-musl@npm:0.35.0"
+"@number0/iroh-linux-arm64-musl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-linux-arm64-musl@npm:1.0.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@number0/iroh-linux-x64-gnu@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-linux-x64-gnu@npm:0.35.0"
+"@number0/iroh-linux-x64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-linux-x64-gnu@npm:1.0.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@number0/iroh-linux-x64-musl@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-linux-x64-musl@npm:0.35.0"
+"@number0/iroh-linux-x64-musl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-linux-x64-musl@npm:1.0.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@number0/iroh-win32-arm64-msvc@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-win32-arm64-msvc@npm:0.35.0"
+"@number0/iroh-win32-arm64-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-win32-arm64-msvc@npm:1.0.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@number0/iroh-win32-x64-msvc@npm:0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh-win32-x64-msvc@npm:0.35.0"
+"@number0/iroh-win32-x64-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh-win32-x64-msvc@npm:1.0.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@number0/iroh@npm:^0.35.0":
-  version: 0.35.0
-  resolution: "@number0/iroh@npm:0.35.0"
+"@number0/iroh@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@number0/iroh@npm:1.0.0"
   dependencies:
-    "@number0/iroh-android-arm-eabi": "npm:0.35.0"
-    "@number0/iroh-android-arm64": "npm:0.35.0"
-    "@number0/iroh-darwin-arm64": "npm:0.35.0"
-    "@number0/iroh-darwin-universal": "npm:0.35.0"
-    "@number0/iroh-linux-arm-gnueabihf": "npm:0.35.0"
-    "@number0/iroh-linux-arm-musleabihf": "npm:0.35.0"
-    "@number0/iroh-linux-arm64-gnu": "npm:0.35.0"
-    "@number0/iroh-linux-arm64-musl": "npm:0.35.0"
-    "@number0/iroh-linux-x64-gnu": "npm:0.35.0"
-    "@number0/iroh-linux-x64-musl": "npm:0.35.0"
-    "@number0/iroh-win32-arm64-msvc": "npm:0.35.0"
-    "@number0/iroh-win32-x64-msvc": "npm:0.35.0"
+    "@number0/iroh-android-arm-eabi": "npm:1.0.0"
+    "@number0/iroh-android-arm64": "npm:1.0.0"
+    "@number0/iroh-darwin-arm64": "npm:1.0.0"
+    "@number0/iroh-linux-arm-gnueabihf": "npm:1.0.0"
+    "@number0/iroh-linux-arm-musleabihf": "npm:1.0.0"
+    "@number0/iroh-linux-arm64-gnu": "npm:1.0.0"
+    "@number0/iroh-linux-arm64-musl": "npm:1.0.0"
+    "@number0/iroh-linux-x64-gnu": "npm:1.0.0"
+    "@number0/iroh-linux-x64-musl": "npm:1.0.0"
+    "@number0/iroh-win32-arm64-msvc": "npm:1.0.0"
+    "@number0/iroh-win32-x64-msvc": "npm:1.0.0"
   dependenciesMeta:
     "@number0/iroh-android-arm-eabi":
       optional: true
     "@number0/iroh-android-arm64":
       optional: true
     "@number0/iroh-darwin-arm64":
-      optional: true
-    "@number0/iroh-darwin-universal":
       optional: true
     "@number0/iroh-linux-arm-gnueabihf":
       optional: true
@@ -4745,7 +4735,7 @@ __metadata:
       optional: true
     "@number0/iroh-win32-x64-msvc":
       optional: true
-  checksum: 10c0/8dd611065d07f0b3539bb19339569ef5ebd5ccfe87adda4cb42a3d8cdd151a092f38df437402e5275f9a23a9015fcaf8fe6ec720382c882845adad557c698069
+  checksum: 10c0/891a38a4274b9f3f734e67196ea1b74e98559ca2490582c59d89fc6d4133127dde14f1a210883582306df78348dafb6672e193aef8947e567db640312f834bb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1.0 is a ground-up overhaul of the binding's surface. Migrate the iroh
network transport off the removed APIs:

- Replace the `Iroh` node class (`Iroh.memory`, `.node`, `.net`) and the
  inbound `protocols` table with `Endpoint.bind(options)` plus an explicit
  `acceptNext()` accept loop (Incoming -> Accepting -> Connection).
- Read identity/address via `endpoint.id()` (EndpointId) and the
  now-synchronous `endpoint.addr()` (EndpointAddr), dropping the
  interval-based NodeAddr cache in favour of on-demand reads.
- Dial an `EndpointAddr` instance built from `EndpointId.fromString(...)`
  rather than a plain NodeAddr object.
- Pass all byte payloads (ALPNs, datagrams, stream writes, close reasons)
  as plain `Array<number>` rather than `Uint8Array`, as the binding's
  `Vec<u8>` parameters require.
- Adapt the stream reader to `recv.read(sizeLimit)` returning the bytes
  read (empty result == EOF) instead of filling a caller buffer.
- Shut down via `endpoint.close()` (which also ends the accept loop).

Behaviour is otherwise unchanged: the endpoint still binds with iroh's n0
preset (relays + discovery) by default, so peers remain dialable by NodeId
alone. The stream adapter, heartbeat, integration test, and
discovery-check script are migrated to match, and the offline byte path is
covered by the existing unit tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019Fm1SzxG7Z4BAP7VsrxERr