### PR TITLE
feat: add 9P mount caplet for projecting endo-fs via kernel

### DIFF
--- a/packages/9p-server/DEMO.md
+++ b/packages/9p-server/DEMO.md
@@ -11,6 +11,14 @@ of the server's cap.
 > commands are accurate against the CLI and caplets on this branch but
 > have not been wired into CI. See the compatibility caveats in
 > [`README.md`](./README.md) § "Expected `Filesystem` compatibility".
+>
+> The Part A / Part B steps below describe the **two-machine, iroh**
+> topology. The flow has also been executed **end-to-end on a single
+> host** (both daemons on one box) — see
+> [§ "Verified single-host run"](#verified-single-host-run), which
+> carries CapTP over a loopback-TCP transport instead of iroh and notes
+> two environment gotchas (the optional iroh binding, and iroh stream
+> stability for two peers behind one NAT).
 
 ## Roles
 
@@ -46,6 +54,26 @@ Binds an in-memory iroh endpoint, derives a stable Ed25519 NodeId, and
 registers the transport at `@nets/iroh`. No open ports; iroh discovery +
 relays handle NAT traversal (needs outbound internet). Relies on the
 optional `@number0/iroh` native binding.
+
+> **Gotcha — the iroh binding may be skipped at install time.**
+> `@number0/iroh` is an `optionalDependency` of `@endo/daemon`; if the
+> platform-specific prebuilt isn't pulled in by the initial
+> `yarn install` (observed on `linux/arm64`), `setup-iroh.js` instantiates
+> nothing and `@nets/iroh` never appears. Confirm and, if missing, force
+> it explicitly:
+>
+> ```bash
+> node -e 'require("@number0/iroh")'   # should not throw
+> # if it throws "Cannot find module":
+> yarn add -D @number0/iroh@^1.0.0 @number0/iroh-linux-arm64-gnu@1.0.0
+> ```
+>
+> **Same-host only:** when both daemons share one machine, set
+> `ENDO_IROH_PUBLISH_PRIVATE=1` in each daemon's environment *before*
+> `endo start` so the iroh endpoint advertises its loopback/private
+> address (otherwise the locator only carries the public/relay path,
+> which two co-located peers can't usefully use). See the caveat in
+> [§ "Verified single-host run"](#verified-single-host-run).
 
 ### A3. Expose a directory as a `Filesystem` cap
 
@@ -120,6 +148,25 @@ workspace-fs` on server.)
 
 ### B4. Install the mount caplet
 
+`mount(2)` / `umount(2)` need `CAP_SYS_ADMIN`. How you grant it decides
+whether you pass `NINEP_SUDO=1`:
+
+**Privileged / root daemon (verified path — containers, dev VMs).** If
+the daemon (hence its caplet workers) already runs as root with
+`CAP_SYS_ADMIN` — e.g. a `--privileged` container — install the caplet
+*without* `NINEP_SUDO`; it then calls `mount` / `umount` directly:
+
+```bash
+laptop$ yarn exec endo make --UNCONFINED \
+  packages/9p-server/mount-caplet.js \
+  --powers @none \
+  --name fs-mounter
+```
+
+**Unprivileged daemon (typical laptop).** Pass `-E NINEP_SUDO=1` to route
+through `sudo mount` / `sudo umount`, and grant passwordless sudo for
+exactly those binaries:
+
 ```bash
 laptop$ yarn exec endo make --UNCONFINED \
   packages/9p-server/mount-caplet.js \
@@ -128,10 +175,8 @@ laptop$ yarn exec endo make --UNCONFINED \
   --name fs-mounter
 ```
 
-`-E NINEP_SUDO=1` routes through `sudo mount` / `sudo umount` (the daemon
-worker is not root). You need passwordless sudo for those binaries:
-
 ```
+# /etc/sudoers.d/endo-9p
 youruser ALL=(root) NOPASSWD: /usr/bin/mount, /usr/bin/umount
 ```
 
@@ -157,6 +202,123 @@ laptop$ yarn exec endo eval 'E(m).mount(fs, "/mnt/endo", harden({ readOnly: true
 laptop$ yarn exec endo eval 'E(h).unmount()' h:endo-mount   # this mount
 laptop$ yarn exec endo cancel fs-mounter                    # or: tear down all mounts
 ```
+
+## Verified single-host run
+
+The Part A / B flow above targets two machines over iroh. To exercise the
+*entire* pipeline on one box — and to sidestep two environment issues
+found while doing so — this variant runs both daemons locally and carries
+CapTP over a **loopback-TCP** transport instead of iroh. Everything else
+(the `node-fs` export, invite/accept, send/adopt, the mount caplet, the
+kernel 9P mount) is identical and transport-agnostic.
+
+### Why not iroh here
+
+iroh's handshake, pairing, and cap transfer all succeed on a single host
+(with `ENDO_IROH_PUBLISH_PRIVATE=1`, A2) — a one-shot
+`E(remote-fs).root()` returns a live `Directory`. But for two peers
+behind one NAT, the relay/hole-punched QUIC stream tears down under
+sustained traffic (`Error: iroh stream closed` on both daemons), which is
+enough to break continuous 9P I/O. On two real machines iroh negotiates a
+stable path and this doesn't bite; on one box, use the loopback-TCP
+carrier below. (To keep chasing iroh locally, try a direct-only profile —
+`presetN0DisableRelay` — so it never falls back to the relay.)
+
+### Two daemons on one box
+
+Per [`MULTIPLAYER.md`](../daemon/MULTIPLAYER.md): the `server` persona
+uses the default state tree; the `laptop` persona gets its own via env.
+Define a `laptop` helper, then create its dirs:
+
+```bash
+laptop() { env XDG_STATE_HOME=/tmp/endo-laptop/state \
+  XDG_RUNTIME_DIR=/tmp/endo-laptop/run XDG_CACHE_HOME=/tmp/endo-laptop/cache \
+  ENDO_SOCK=/tmp/endo-laptop/endo.sock ENDO_ADDR=127.0.0.1:8921 \
+  yarn exec endo "$@"; }
+mkdir -p /tmp/endo-laptop/{state,run,cache}
+```
+
+### Loopback-TCP transport
+
+`setup-tcp.js` (companion to `setup-iroh.js`) stores a listen address
+under the agent pet name `tcp-listen-addr` and registers the repo's
+`tcp-netstring` transport at `@nets/tcp`. Install on both daemons; the
+default `127.0.0.1:0` auto-assigns a free port:
+
+```bash
+server$ yarn exec endo run --UNCONFINED \
+  packages/daemon/src/networks/setup-tcp.js --powers @agent
+laptop run --UNCONFINED \
+  packages/daemon/src/networks/setup-tcp.js --powers @agent   # laptop helper
+```
+
+With only `@nets/tcp` registered, `endo invite host` emits a
+`tcp+netstring+json+captp0://127.0.0.1:<port>` locator. The remainder is
+verbatim Part A3–A5 / B2–B5, using the `laptop` helper for the laptop
+persona and installing the mount caplet **without** `NINEP_SUDO` (the
+daemon runs as root here — see B4).
+
+### What was verified
+
+Against a `node-fs` export of `/srv/data`, mounted at `/mnt/endo-remote`
+on the laptop daemon:
+
+- `ls -la /mnt/endo-remote`, `cat HELLO.txt`, `cat docs/readme.md` — reads
+  and directory walks across the CapTP link ✓
+- `mkdir /mnt/endo-remote/from-laptop` — propagated to the server's real
+  disk at `/srv/data/from-laptop` ✓
+- write to an existing file — round-tripped to the server backing ✓
+
+The `O_CREAT | O_TRUNC`-on-new-file failure in
+[§ "Fixed issues"](#fixed-issues) was first reproduced through this exact
+remote stack; with that commit applied, `echo x > newfile` round-trips
+too.
+
+## Variant: adopt the cap into another daemon's inventory (no mount)
+
+Mounting is Linux-only (it needs v9fs + `CAP_SYS_ADMIN`). But the
+`Filesystem` cap is useful on its own: a second daemon can hold it in its
+inventory and drive it programmatically (`E(fs).root()`, `list()`,
+`read`/`write`) over CapTP — including on a host that can't 9P-mount at
+all (e.g. macOS). This variant stops at `adopt`; it skips Part B4–B5.
+
+**Reachability decides the dial direction, not the cap direction.** The
+acceptor always dials the inviter, but mail (`send`/`adopt`) flows either
+way once the session is up. So make the **reachable** side the inviter/
+listener regardless of which side holds the cap. Example: a daemon in a
+Docker container can reach the host's LAN IP, but the host can't reach
+into the container — so the **host** is the inviter/listener and the
+**container** (which holds the cap) dials out and then `send`s.
+
+```bash
+# 1. On the reachable side (here: the host) — listen on an address the
+#    other daemon can actually dial, and invite a guest for it.
+host$ endo run --UNCONFINED packages/daemon/src/networks/setup-tcp.js \
+  --powers @agent -E ENDO_TCP_LISTEN=192.168.1.105:9200   # host LAN IP
+host$ endo invite box                                     # -> locator (tcp+netstring://192.168.1.105:9200)
+
+# 2. On the cap-holder (here: the container's server daemon) — accept,
+#    which dials the host, then send the cap back over the session.
+box$  endo accept mac < locator.txt                       # peer 'mac' dials 192.168.1.105:9200
+box$  endo send mac 'workspace fs @workspace-fs'
+
+# 3. Back on the host — adopt from the inbox into the local inventory.
+host$ endo inbox                                          # note the message number, e.g. 79
+host$ endo adopt 79 workspace-fs --name container-fs
+host$ endo eval 'E(fs).root()' fs:container-fs            # -> Object [Alleged: Directory]
+```
+
+`container-fs` now lives in the host daemon's inventory and resolves —
+over the network — to the remote backing dir. On Linux you could then
+feed it to the mount caplet (B4–B5); on macOS you use it as a capability
+only. `setup-tcp.js` is the same companion script from
+[§ "Verified single-host run"](#verified-single-host-run); pass
+`-E ENDO_TCP_LISTEN=<reachable-host:port>` (or bake a default) so the
+locator advertises an address the dialing peer can reach.
+
+> Cross-version note: this was exercised between two daemons on
+> *different branches* over `tcp+netstring+json+captp0` — the handshake
+> and locator format are compatible across the versions tried here.
 
 ## Useful information
 

--- a/packages/9p-server/DEMO.md
+++ b/packages/9p-server/DEMO.md
@@ -1,0 +1,237 @@
+# Demo: mount a remote daemon's filesystem over iroh + 9P
+
+This walks through projecting a `Filesystem` capability held by one Endo
+daemon into the Linux kernel of another machine, dialed over iroh
+(peer-to-peer, no open ports). The `Filesystem` cap travels
+`server → laptop` over CapTP; the 9P bridge and the kernel `mount` run on
+`laptop` (the machine whose kernel mounts), holding a *remote presence*
+of the server's cap.
+
+> Status: this is a recorded runbook, **not** an automated test. The
+> commands are accurate against the CLI and caplets on this branch but
+> have not been wired into CI. See the compatibility caveats in
+> [`README.md`](./README.md) § "Expected `Filesystem` compatibility".
+
+## Roles
+
+- **`server`** — the remote daemon holding the files (e.g. `/srv/data`)
+  and printing the invitation.
+- **`laptop`** — where the files should appear at `/mnt/endo`.
+
+Both machines need an Endo repo checkout (several commands reference
+caplets by repo-relative path). To run both daemons on one box, use the
+`XDG_*` / `ENDO_SOCK` alias trick in
+[`MULTIPLAYER.md`](../daemon/MULTIPLAYER.md) § "Single-Machine Setup".
+
+## Part A — the remote `server` daemon
+
+### A1. Install + start
+
+```bash
+server$ git clone https://github.com/endojs/endo-but-for-bots && cd endo-but-for-bots
+server$ npx corepack yarn install
+server$ yarn exec endo start
+server$ yarn exec endo ping        # -> ok
+```
+
+### A2. Enable iroh networking
+
+```bash
+server$ yarn exec endo run --UNCONFINED \
+  packages/daemon/src/networks/setup-iroh.js --powers @agent
+# -> "iroh network installed at @nets/iroh"
+```
+
+Binds an in-memory iroh endpoint, derives a stable Ed25519 NodeId, and
+registers the transport at `@nets/iroh`. No open ports; iroh discovery +
+relays handle NAT traversal (needs outbound internet). Relies on the
+optional `@number0/iroh` native binding.
+
+### A3. Expose a directory as a `Filesystem` cap
+
+The shipped `node-fs-module.js` caplet reads `ENDO_FS_ROOT` and returns a
+`makeNodeFilesystem({ rootPath })` — the highest-fidelity backing for 9P
+(real stat, atomic rename, real fsync, ranged I/O):
+
+```bash
+server$ yarn exec endo make --UNCONFINED \
+  packages/platform/src/fs/extended/node-fs-module.js \
+  --powers @none \
+  -E ENDO_FS_ROOT=/srv/data \
+  --name workspace-fs
+# read-only export: also pass  -E ENDO_FS_READ_ONLY=1
+```
+
+### A4. Invite the host — print the invitation code
+
+```bash
+server$ yarn exec endo invite host
+```
+
+Prints the `endo://` **locator** (the invitation code). With iroh
+enabled it carries an `iroh+captp0://<NodeId>` address:
+
+```
+endo://<key>?id=<n>&from=<n>&at=iroh%2Bcaptp0%3A%2F%2F<nodeid>...
+```
+
+Copy the whole string to `laptop`. It is a pairing locator, not a secret
+cap. This creates a guest named `host` representing `laptop`.
+
+### A5. Share the cap (after `laptop` accepts, B2)
+
+```bash
+server$ yarn exec endo send host 'workspace fs @workspace-fs'
+```
+
+## Part B — the local `laptop` daemon
+
+### B1. Install, start, enable iroh (same as A1–A2)
+
+```bash
+laptop$ git clone https://github.com/endojs/endo-but-for-bots && cd endo-but-for-bots
+laptop$ npx corepack yarn install
+laptop$ yarn exec endo start
+laptop$ yarn exec endo run --UNCONFINED \
+  packages/daemon/src/networks/setup-iroh.js --powers @agent
+```
+
+### B2. Accept the invitation
+
+```bash
+laptop$ echo 'endo://<key>?id=...&at=iroh+captp0://...' \
+  | yarn exec endo accept server
+```
+
+Now `laptop` has a peer `server`, and `server` has `host` → `laptop`. A
+CapTP session is live over iroh.
+
+### B3. Adopt the remote `Filesystem` cap
+
+```bash
+laptop$ yarn exec endo inbox                       # note the message number, e.g. 1
+laptop$ yarn exec endo adopt 1 workspace-fs --name remote-fs
+```
+
+`remote-fs` now resolves — through the iroh peer connection — to the
+server's live `Filesystem`. (Pull-style alternative: `endo request
+'workspace fs' -t server` on laptop, then `endo resolve <msg#>
+workspace-fs` on server.)
+
+### B4. Install the mount caplet
+
+```bash
+laptop$ yarn exec endo make --UNCONFINED \
+  packages/9p-server/mount-caplet.js \
+  --powers @none \
+  -E NINEP_SUDO=1 \
+  --name fs-mounter
+```
+
+`-E NINEP_SUDO=1` routes through `sudo mount` / `sudo umount` (the daemon
+worker is not root). You need passwordless sudo for those binaries:
+
+```
+youruser ALL=(root) NOPASSWD: /usr/bin/mount, /usr/bin/umount
+```
+
+### B5. Mount
+
+```bash
+laptop$ yarn exec endo eval 'E(m).mount(fs, "/mnt/endo")' \
+  m:fs-mounter fs:remote-fs --name endo-mount
+```
+
+`/mnt/endo` now shows the server's `/srv/data` to any process. Options go
+in a third arg (`E` and `harden` are available in `endo eval`):
+
+```bash
+# read-only:
+laptop$ yarn exec endo eval 'E(m).mount(fs, "/mnt/endo", harden({ readOnly: true }))' \
+  m:fs-mounter fs:remote-fs -n endo-mount
+```
+
+### B6. Unmount
+
+```bash
+laptop$ yarn exec endo eval 'E(h).unmount()' h:endo-mount   # this mount
+laptop$ yarn exec endo cancel fs-mounter                    # or: tear down all mounts
+```
+
+## Useful information
+
+- **What works over 9P**: read/write/mkdir/unlink/rename/truncate, `ls`,
+  sizes, timestamps. **No-ops regardless of backing**: chmod/chown,
+  xattrs, locks, symlinks. See [`README.md`](./README.md) § "Expected
+  `Filesystem` compatibility" for the full matrix.
+- **Privilege / namespaces**: `mount(2)` needs `CAP_SYS_ADMIN`. Under
+  systemd `PrivateMounts`, a `sudo mount` may land in a different mount
+  namespace than the daemon — mount from a shell in the daemon's
+  namespace, or drop `PrivateMounts`.
+- **Latency**: the endo-fs interface pipelines `walk+open+read` into one
+  CapTP round-trip, so a kernel mount tolerates the iroh hop; expect
+  interactive latency ≈ the iroh path RTT. `cache=loose` (pass
+  `extraMountOptions: 'cache=loose'`) helps read-heavy workloads at the
+  cost of liveness.
+- **Locator**: encodes the inviter's NodeId, host-handle id, and
+  transport address(es); with both TCP and iroh enabled it lists all,
+  tried in order. Re-run `endo invite host` for a fresh one if paths
+  change.
+
+## Fixed issues
+
+- **`O_CREAT | O_TRUNC` on a missing path** (e.g. `echo x > newfile.txt`,
+  a single `Tlcreate`) used to create the backend file (0 bytes) but
+  return `ENOENT` from the kernel `open()`. Root cause: `onLcreate` in
+  [`src/server.js`](./src/server.js) dispatched `lookup(name)`
+  concurrently with `create(name)` in one batch, and on a disk-backed
+  (`node-fs`) backing the same-turn lookup raced ahead of the async
+  entry write and ENOENT'd — while `create` still wrote the file. Only
+  the in-memory backend registers entries eagerly, which is why the
+  in-memory test suite missed it. Fixed by sequencing the lookup after
+  `create` resolves; regression-tested against node-fs in
+  `test/server.test.js`.
+
+## Proposed: an auto-mount host
+
+> Status: proposal, not implemented. Recorded here so the demo can grow
+> into a one-command experience.
+
+A small unconfined caplet — call it the **mount host** — that turns
+"send me a filesystem" into "it's mounted at this path". It composes the
+existing pieces (the `fs-mounter` from `mount-caplet.js` plus a guest's
+mailbox powers) into an inbox-follow loop, in the same shape as the
+`lal` / `fae` agents.
+
+Behavior, per inbound message:
+
+1. Scan the message for attached `Filesystem` caps (edges whose value
+   passes a shape probe — `E(cap).__getMethodNames__()` includes
+   `root` / `statfs`). Ignore messages with none.
+2. For each, derive a deterministic mountpoint under a configured base
+   dir, e.g. `${BASE}/${peer}/${edge}` (or `${BASE}/${formulaId}`), and
+   call `E(fsMounter).mount(fs, mountPoint, options)` with the host's
+   default options (read-only? network profile? lazy unmount?).
+3. **On success**, reply to the sender with the mountpoint (and, if
+   useful, the socket path) — `E(powers).reply(msgNumber, 'mounted at
+   ${mountPoint}')`.
+4. **On failure**, reply with the structured error the mount caplet
+   already surfaces (`mount` stderr, EBUSY, privilege, etc.).
+
+Lifecycle and config:
+
+- Teardown is already handled: the mount caplet unmounts every live
+  mount when its cancellation context fires, so cancelling the mount host
+  cleans up the kernel mounts it created.
+- Config via the caplet's `env` / a configuration form: base mountpoint
+  dir, an allowlist of peers permitted to auto-mount, default mount
+  options (`readOnly`, `extraMountOptions`, `lazyUnmount`), and a cap on
+  concurrent mounts.
+- Idempotency: re-mounting the same `(peer, edge)` should reuse the
+  existing handle rather than stack mounts on one path — keep a
+  `Map<mountPoint, handle>` and short-circuit.
+
+Open questions: how to name/clean up mountpoints across daemon restarts
+(the handles are not persisted); whether to auto-`adopt` the cap or mount
+it transiently; and whether the reply should hand back an *unmount*
+capability so the sender can release it remotely.

--- a/packages/9p-server/README.md
+++ b/packages/9p-server/README.md
@@ -92,6 +92,95 @@ wait for the first ack.
 | Tauth | `Rlerror(ENOSYS)` |
 | Txattrwalk | `Rlerror(ENOSYS)` |
 
+## Mounting into the Linux kernel
+
+[`mount-caplet.js`](./mount-caplet.js) is an unconfined Endo caplet that
+projects a `Filesystem` cap (possibly a remote CapTP presence) into the
+host Linux kernel: it stands up `makeFsBridge9p` on a per-mount Unix
+socket and runs `mount -t 9p -o trans=unix,version=9p2000.L,…`. Its
+`make()` returns a *mounter* exo whose `mount(fs, mountPoint, options)`
+returns a handle with `unmount()`; every live mount is torn down when
+the caplet's cancellation context fires.
+
+For an end-to-end walkthrough — fresh daemon, iroh networking, printing
+an invitation on the remote daemon, sharing a `Filesystem` cap, and
+mounting it on another machine — see [`DEMO.md`](./DEMO.md). That doc
+also sketches a proposed *auto-mount host* that mounts fs caps arriving
+in messages and replies with their mountpoint.
+
+## Expected `Filesystem` compatibility
+
+> **Status: expected, not test-verified.** The tables below are derived
+> from reading [`src/server.js`](./src/server.js) and the
+> `@endo/platform/fs/extended` backends, *not* from integration tests.
+> The only path exercised by `test/server.test.js` today is the
+> in-memory backend. Treat the rest as the intended contract pending a
+> backend-parametrised test matrix (see "Known gaps").
+
+### Mountability by fs object
+
+The bridge consumes the `@endo/platform/fs/extended` `Filesystem` exo
+only. Other fs shapes reach it (or not) as follows:
+
+| fs object | Mountable | How |
+|---|---|---|
+| `makeNodeFilesystem({ rootPath })` | expected ✅ direct | highest fidelity (real stat / atomic rename / real fsync / ranged I/O) |
+| `makeInMemoryFilesystem()` | expected ✅ direct | ephemeral; vat-local timestamps |
+| `readOnly` / `compose` (CoW) / `chroot` / `bind` / `namespace` / `cached-fs` wrappers | expected ✅ direct | each returns a `Filesystem` |
+| daemon **`Mount`** (`packages/daemon/src/mount.js`) | expected ✅ via adapter | `mountAsFilesystem` (`from-mount`) |
+| daemon **`ReadableTree`** (immutable snapshot) | ❌ not yet | `from-readable-tree.js` is roadmap **F6, open** |
+| the other `@endo/platform/fs` interface (`File` / `Directory` / `SnapshotTree`) | ❌ | different contract; no adapter ships |
+
+### Behavior ceiling — expected for every backing
+
+These are limits of the 9P server plus the base `Filesystem`, so no
+choice of backing changes them:
+
+| 9P op / feature | Expected behavior | Source |
+|---|---|---|
+| `Tattach`, `Twalk`, `Tlopen`, `Tread`, `Twrite`, `Treaddir`, `Tmkdir`, `Tunlinkat`, `Trenameat`, `Tclunk`, `Tflush`, `Tstatfs` | supported | `src/server.js` dispatch |
+| `Tgetattr` | size + a/m/c/btime real; **mode synthesized** `0o755`/`0o644`, uid/gid `1000`, nlink `1` | `server.js:611` |
+| `Tsetattr` size / atime / mtime | forwarded to `setAttrs` | `server.js:901` |
+| `Tsetattr` mode / uid / gid (chmod / chown) | **silently ignored** | `server.js:886` (read off the wire, discarded) |
+| `Txattrwalk` (xattrs) | `ENOSYS` (vat-local `user.*` sidecar not exposed) | `server.js:264` |
+| `Tlock` / `Tgetlock` (byte-range locks) | not implemented | — |
+| `Tsymlink` / `Tmknod` (symlinks, device nodes) | not implemented (tree-shaped base) | — |
+| `Tauth` | `ENOSYS` (the cap is the authority; mount `access=any`) | `server.js:232` |
+
+`readOnly(fs)` additionally rejects every mutating op; the mounting
+process sees `EACCES`.
+
+### Variance by backing — expected
+
+Driven by which optional `FsBackend` methods each implements
+(`getStat` / `fsync` / `rename` / range I/O); `wrapBackend` synthesizes
+the rest:
+
+| behavior | `node-fs` | `in-memory` | daemon `Mount` (`from-mount`) |
+|---|---|---|---|
+| `ls -l` timestamps | real disk (`getStat`) | vat-local | vat-local (no `getStat`) |
+| `rename` (`Trenameat`) | atomic (`fs.rename`) | atomic (Map swap) | via `Mount.move` |
+| `fsync` durability | real | no-op | no-op |
+| range `Tread`/`Twrite` | true ranged | true ranged | read-whole-then-slice / write-whole, O(filesize)×1.33 |
+| persistence | on disk | ephemeral | the Mount's backing store |
+
+`PosixFs` (roadmap F15) would lift the ceiling — real mode/uid/gid,
+real `flock`/`fcntl`, native xattrs — but it is scaffolded only and
+**not wired into the 9P server**, so none of that is reachable today.
+
+### Known gaps
+
+- No backend-parametrised conformance test for the 9P surface; the
+  backings are exercised only by the in-memory suite, **except**
+  `Tlcreate`, which now has a node-fs regression test (it caught a
+  create-vs-lookup race that ENOENT'd `echo x > newfile.txt` on disk
+  backings — see [`DEMO.md`](./DEMO.md) § "Fixed issues"). The rest of
+  the matrix above is still unverified on disk / Mount backings.
+- `from-readable-tree.js` (F6) is unimplemented, so daemon
+  `ReadableTree` snapshots cannot be mounted.
+- `PosixFs` is not composed into the bridge; chmod/chown/xattrs/locks
+  are no-ops or ENOSYS regardless of backing.
+
 ## Tests
 
 ```sh

--- a/packages/9p-server/mount-caplet.js
+++ b/packages/9p-server/mount-caplet.js
@@ -67,7 +67,7 @@ const MountHandleInterface = M.interface('Fs9pMountHandle', {
 });
 
 const MounterInterface = M.interface('Fs9pMounter', {
-  mount: M.call(M.any(), M.string()).optional(M.any()).returns(M.promise()),
+  mount: M.call(M.any(), M.string()).optional(M.record()).returns(M.promise()),
   list: M.call().returns(M.array()),
   help: M.call().returns(M.string()),
 });
@@ -195,22 +195,24 @@ export const make = async (_powers, context, options = {}) => {
   /**
    * @param {ERef<any>} fs - endo-fs `Filesystem` capability to project.
    * @param {string} mountPoint - host path to mount onto.
-   * @param {Record<string, unknown>} [mountOptions]
+   * @param {object} [mountOptions]
    */
   const mount = async (fs, mountPoint, mountOptions = {}) => {
     if (cancelled) {
       throw makeError(X`mounter is cancelled; refusing to mount`);
     }
-    // Defensively deep-copy + harden the caller's options before any
-    // field flows toward a privileged `mount(2)`.  `mountOptions`
-    // arrives over CapTP from a potentially adversarial caller; a
-    // Proxy whose getters drift between reads could differentiate the
-    // value validated here from the one passed to `mount`.  The
-    // null-proto shallow spread reads every own-enumerable property
-    // exactly once and `harden` freezes the result (cf.
+    // Defensively copy + harden the caller's options before any field
+    // flows toward a privileged `mount(2)`.  `mountOptions` arrives
+    // over CapTP from a potentially adversarial caller; the shallow
+    // spread reads every own-enumerable property exactly once,
+    // defeating a `Proxy`-backed record whose per-access getter could
+    // otherwise differentiate the value validated here from the one
+    // passed to `mount`, and `harden` freezes the result (cf.
     // `packages/genie/CLAUDE.md` § "deep-harden every structured
     // input").
-    const opts = harden({ __proto__: null, ...mountOptions });
+    const opts = /** @type {Record<string, unknown>} */ (
+      harden({ ...mountOptions })
+    );
 
     mountCounter += 1;
     const resolvedMountPoint = nodePath.resolve(mountPoint);

--- a/packages/9p-server/mount-caplet.js
+++ b/packages/9p-server/mount-caplet.js
@@ -91,7 +91,10 @@ const buildMountOptionString = options => {
   const {
     trans = 'unix',
     version = '9p2000.L',
-    msize = 512_000,
+    // The bridge's server caps msize at 128 KiB (DEFAULT_MSIZE in
+    // src/server.js); offering more just gets shrunk in the Rversion
+    // reply, so default to the value the kernel will actually get.
+    msize = 131_072,
     access = 'any',
     cache = 'none',
     readOnly = false,
@@ -151,6 +154,17 @@ export const make = async (_powers, context, options = {}) => {
   /** @type {Set<{ unmount: () => Promise<void> }>} */
   const handles = new Set();
 
+  // Monotonic per-caplet counter so concurrent mount() calls never
+  // collide on the default socket name (handles.size is read before a
+  // handle is registered, so two interleaved calls would otherwise
+  // compute the same path within the same millisecond).
+  let mountCounter = 0;
+
+  // Set once the caplet's context is cancelled, so a mount() that
+  // races (or follows) teardown refuses rather than leaking a kernel
+  // mount + socket the sweeper has already run past.
+  let cancelled = false;
+
   const unmountAll = async () => {
     await Promise.all(
       [...handles].map(handle =>
@@ -166,7 +180,16 @@ export const make = async (_powers, context, options = {}) => {
   if (cancelledP) {
     // The cancelled promise is reject-only; attach to both arms so a
     // future resolve-style trigger still sweeps.
-    Promise.resolve(cancelledP).then(unmountAll, unmountAll);
+    Promise.resolve(cancelledP).then(
+      () => {
+        cancelled = true;
+        return unmountAll();
+      },
+      () => {
+        cancelled = true;
+        return unmountAll();
+      },
+    );
   }
 
   /**
@@ -175,31 +198,50 @@ export const make = async (_powers, context, options = {}) => {
    * @param {Record<string, unknown>} [mountOptions]
    */
   const mount = async (fs, mountPoint, mountOptions = {}) => {
+    if (cancelled) {
+      throw makeError(X`mounter is cancelled; refusing to mount`);
+    }
+    // Defensively deep-copy + harden the caller's options before any
+    // field flows toward a privileged `mount(2)`.  `mountOptions`
+    // arrives over CapTP from a potentially adversarial caller; a
+    // Proxy whose getters drift between reads could differentiate the
+    // value validated here from the one passed to `mount`.  The
+    // null-proto shallow spread reads every own-enumerable property
+    // exactly once and `harden` freezes the result (cf.
+    // `packages/genie/CLAUDE.md` § "deep-harden every structured
+    // input").
+    const opts = harden({ __proto__: null, ...mountOptions });
+
+    mountCounter += 1;
     const resolvedMountPoint = nodePath.resolve(mountPoint);
     const socketPath =
-      typeof mountOptions.socketPath === 'string'
-        ? mountOptions.socketPath
+      typeof opts.socketPath === 'string'
+        ? opts.socketPath
         : nodePath.join(
             defaultSocketDir(env),
-            `endo-9p-${process.pid}-${handles.size}-${Date.now()}.sock`,
+            `endo-9p-${process.pid}-${mountCounter}-${Date.now()}.sock`,
           );
 
     const sudo = env.NINEP_SUDO === '1';
-    const mountProgram = Array.isArray(mountOptions.mountProgram)
-      ? mountOptions.mountProgram.map(String)
+    const mountProgram = Array.isArray(opts.mountProgram)
+      ? opts.mountProgram.map(String)
       : sudo
         ? ['sudo', 'mount']
         : ['mount'];
-    const umountProgram = Array.isArray(mountOptions.umountProgram)
-      ? mountOptions.umountProgram.map(String)
+    const umountProgram = Array.isArray(opts.umountProgram)
+      ? opts.umountProgram.map(String)
       : sudo
         ? ['sudo', 'umount']
         : ['umount'];
-    const removeMountPointOnUnmount =
-      mountOptions.removeMountPointOnUnmount === true;
+    const removeMountPointOnUnmount = opts.removeMountPointOnUnmount === true;
+    // Lazy detach (`umount -l`) so an unattended teardown can release a
+    // busy mount instead of leaving a live mount over a dead bridge
+    // socket.  Off by default; opt in per-call or via NINEP_LAZY_UMOUNT.
+    const lazyUnmount =
+      opts.lazyUnmount === true || env.NINEP_LAZY_UMOUNT === '1';
 
     // 1. Ensure the mount point exists (unless told not to).
-    if (mountOptions.makeMountPoint !== false) {
+    if (opts.makeMountPoint !== false) {
       await mkdir(resolvedMountPoint, { recursive: true });
     }
 
@@ -213,11 +255,14 @@ export const make = async (_powers, context, options = {}) => {
     });
     await E(bridge).start();
 
-    // 3. Attach the socket to the kernel.  `trans=unix` makes v9fs's
-    //    fd transport connect to the UDS named by the mount "device"
-    //    (the socket path).  `version=9p2000.L` is mandatory — the
-    //    bridge only speaks the .L dialect.
-    const optionString = buildMountOptionString(mountOptions);
+    // 3. Attach the socket to the kernel.  `trans=unix` is the v9fs
+    //    transport that connects to a UNIX-domain socket whose path is
+    //    the mount "device" (kernel docs: `mount -t 9p -o trans=unix
+    //    /run/9p/srv mnt`).  `version=9p2000.L` is mandatory — the
+    //    bridge only speaks the .L dialect.  `--` terminates options so
+    //    a socketPath/mountPoint beginning with `-` can't be parsed as
+    //    a flag by `mount`.
+    const optionString = buildMountOptionString(opts);
     const [mountBin, ...mountPre] = mountProgram;
     const mountArgv = [
       ...mountPre,
@@ -225,6 +270,7 @@ export const make = async (_powers, context, options = {}) => {
       '9p',
       '-o',
       optionString,
+      '--',
       socketPath,
       resolvedMountPoint,
     ];
@@ -243,29 +289,53 @@ export const make = async (_powers, context, options = {}) => {
     }
 
     let unmounted = false;
+    /** @type {Promise<void> | null} */
+    let unmountInFlight = null;
+
+    const doUnmount = async () => {
+      // Detach the kernel mount FIRST and only commit the rest on
+      // success.  If `umount` fails (e.g. EBUSY), we deliberately leave
+      // the bridge running and the handle registered: tearing the
+      // socket out from under a still-mounted tree would leave a live
+      // mount over a dead transport (every I/O then errors).  The
+      // caller can free the mount and retry, or pass lazyUnmount.
+      const [umountBin, ...umountPre] = umountProgram;
+      const umountArgv = [
+        ...umountPre,
+        ...(lazyUnmount ? ['-l'] : []),
+        '--',
+        resolvedMountPoint,
+      ];
+      try {
+        await execFileP(umountBin, umountArgv);
+      } catch (cause) {
+        const reason = /** @type {Error} */ (cause).message;
+        const stderr = /** @type {{ stderr?: string }} */ (cause).stderr || '';
+        throw makeError(
+          X`umount of ${q(resolvedMountPoint)} failed (mount may be busy; retry or pass lazyUnmount): ${q(reason)} ${q(stderr)}`,
+        );
+      }
+      unmounted = true;
+      handles.delete(handle);
+      await E(bridge)
+        .stop()
+        .catch(() => {});
+      if (removeMountPointOnUnmount) {
+        await rmdir(resolvedMountPoint).catch(() => {});
+      }
+    };
+
     const handle = makeExo('Fs9pMountHandle', MountHandleInterface, {
       async unmount() {
         if (unmounted) return;
-        unmounted = true;
-        handles.delete(handle);
-        // Detach the kernel mount first so no process is mid-syscall
-        // against the bridge when we tear the socket down.
-        const [umountBin, ...umountPre] = umountProgram;
-        await execFileP(umountBin, [...umountPre, resolvedMountPoint]).catch(
-          err => {
-            // eslint-disable-next-line no-console
-            console.error(
-              `[9p mount-caplet] umount ${resolvedMountPoint} failed`,
-              err,
-            );
-          },
-        );
-        await E(bridge)
-          .stop()
-          .catch(() => {});
-        if (removeMountPointOnUnmount) {
-          await rmdir(resolvedMountPoint).catch(() => {});
+        // Dedupe concurrent callers onto one attempt; on failure clear
+        // the latch so a later call can retry.
+        if (!unmountInFlight) {
+          unmountInFlight = doUnmount().finally(() => {
+            unmountInFlight = null;
+          });
         }
+        await unmountInFlight;
       },
       mountPoint() {
         return resolvedMountPoint;
@@ -287,7 +357,7 @@ export const make = async (_powers, context, options = {}) => {
       return harden([...handles]);
     },
     help() {
-      return `endo-fs → 9P mounter.\n  mount(fs, mountPoint, options?) -> MountHandle\nOptions: { socketPath, trans='unix', version='9p2000.L', msize=512000, access='any', cache='none', readOnly=false, extraMountOptions, mountProgram, umountProgram, makeMountPoint=true, removeMountPointOnUnmount=false }.\nmount(2) needs CAP_SYS_ADMIN — pass mountProgram:['sudo','mount'] or set NINEP_SUDO=1 when the daemon is unprivileged.\nEvery live mount is unmounted when this caplet is cancelled.`;
+      return `endo-fs → 9P mounter.\n  mount(fs, mountPoint, options?) -> MountHandle\nOptions: { socketPath, trans='unix', version='9p2000.L', msize=131072, access='any', cache='none', readOnly=false, extraMountOptions, mountProgram, umountProgram, makeMountPoint=true, removeMountPointOnUnmount=false, lazyUnmount=false }.\nmount(2) needs CAP_SYS_ADMIN — pass mountProgram:['sudo','mount'] or set NINEP_SUDO=1 when the daemon is unprivileged.\nunmount() leaves the bridge up if umount fails (EBUSY) so the mount never outlives its transport; pass lazyUnmount (or NINEP_LAZY_UMOUNT=1) to force-detach a busy mount on teardown.\nEvery live mount is unmounted when this caplet is cancelled.`;
     },
   });
 };

--- a/packages/9p-server/mount-caplet.js
+++ b/packages/9p-server/mount-caplet.js
@@ -49,6 +49,7 @@ import { makeError, q, X } from '@endo/errors';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { mkdir, rmdir } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
 import os from 'node:os';
 import nodePath from 'node:path';
 import process from 'node:process';
@@ -83,6 +84,68 @@ const defaultSocketDir = env =>
   env.XDG_RUNTIME_DIR || env.NINEP_SOCKET_DIR || os.tmpdir();
 
 /**
+ * Mount options whose value is load-bearing for confinement: `trans`
+ * pins the kernel mount to *this* bridge socket, `version` pins the
+ * dialect, and `access` governs the uid model. A caller must not be
+ * able to override them via `extraMountOptions` (which is appended last
+ * and would win under v9fs's last-key-wins parsing) — e.g.
+ * `extraMountOptions: 'trans=tcp,port=…'` would redirect the privileged
+ * mount to an attacker-chosen 9P server. So we reject those keys.
+ */
+const PINNED_MOUNT_OPTION_KEYS = harden(['trans', 'version', 'access']);
+
+const baseName = s => {
+  const t = String(s);
+  return t.slice(t.lastIndexOf('/') + 1);
+};
+
+/**
+ * Reject `extraMountOptions` that try to override a pinned key.
+ *
+ * @param {unknown} extra
+ */
+const assertExtraMountOptions = extra => {
+  if (extra === undefined || extra === '') return;
+  if (typeof extra !== 'string') {
+    throw makeError(
+      X`extraMountOptions must be a string, got ${q(typeof extra)}`,
+    );
+  }
+  for (const part of extra.split(',')) {
+    const key = part.split('=')[0].trim();
+    if (PINNED_MOUNT_OPTION_KEYS.includes(key)) {
+      throw makeError(
+        X`extraMountOptions may not set the pinned option ${q(key)} (it carries the mount's transport/confinement); got ${q(extra)}`,
+      );
+    }
+  }
+};
+
+/**
+ * Footgun guard (not a security boundary — the mounter cap is held only
+ * by trusted callers): a caller-supplied `mount`/`umount` program vector
+ * must actually invoke the expected command, so a typo like
+ * `umountProgram: ['rm']` fails loudly instead of `rm`-ing the mount
+ * point. The trailing element is the binary the fixed `9p` argv is
+ * appended to; only its basename is checked, so a privilege-helper
+ * prefix with flags (`['sudo', '-u', 'svc', 'mount']`) is preserved.
+ *
+ * @param {string[]} program
+ * @param {string} expectedCommand  `'mount'` | `'umount'`
+ * @param {string} label
+ */
+const assertProgram = (program, expectedCommand, label) => {
+  if (!Array.isArray(program) || program.length === 0) {
+    throw makeError(X`${label} must be a non-empty array of strings`);
+  }
+  if (baseName(program[program.length - 1]) !== expectedCommand) {
+    throw makeError(
+      X`${label} must invoke ${q(expectedCommand)}; got ${q(String(program[program.length - 1]))}`,
+    );
+  }
+};
+
+/**
  * Build the comma-separated `-o` value for `mount -t 9p`.
  *
  * @param {Record<string, unknown>} options
@@ -108,6 +171,7 @@ const buildMountOptionString = options => {
     `cache=${cache}`,
   ];
   if (readOnly) parts.push('ro');
+  assertExtraMountOptions(extraMountOptions);
   if (extraMountOptions) parts.push(String(extraMountOptions));
   return parts.join(',');
 };
@@ -198,6 +262,28 @@ export const makeFsMounter = ({
     );
   }
 
+  // mount/umount programs are OPERATOR configuration (env), never a
+  // per-call option. The mounter cap is handed to an otherwise-untrusted
+  // party whose only granted authority is "mount any files"; letting the
+  // caller choose the program would be arbitrary privileged execution
+  // (e.g. `umountProgram: ['rm']` → `rm -- <mountPoint>`). `NINEP_SUDO`
+  // routes through sudo; `NINEP_MOUNT_PROGRAM` / `NINEP_UMOUNT_PROGRAM`
+  // (whitespace-separated) let the operator name a custom helper.
+  const sudo = env.NINEP_SUDO === '1';
+  const splitProgram = v => v.trim().split(/\s+/).filter(Boolean);
+  const mountProgram = env.NINEP_MOUNT_PROGRAM
+    ? splitProgram(env.NINEP_MOUNT_PROGRAM)
+    : sudo
+      ? ['sudo', 'mount']
+      : ['mount'];
+  const umountProgram = env.NINEP_UMOUNT_PROGRAM
+    ? splitProgram(env.NINEP_UMOUNT_PROGRAM)
+    : sudo
+      ? ['sudo', 'umount']
+      : ['umount'];
+  assertProgram(mountProgram, 'mount', 'NINEP_MOUNT_PROGRAM');
+  assertProgram(umountProgram, 'umount', 'NINEP_UMOUNT_PROGRAM');
+
   /**
    * @param {ERef<any>} fs - endo-fs `Filesystem` capability to project.
    * @param {string} mountPoint - host path to mount onto.
@@ -227,20 +313,20 @@ export const makeFsMounter = ({
         ? opts.socketPath
         : nodePath.join(
             defaultSocketDir(env),
-            `endo-9p-${process.pid}-${mountCounter}-${Date.now()}.sock`,
+            // Random suffix so the path isn't predictable: the UDS
+            // carries the full authority of the projected FS cap, and on
+            // the `os.tmpdir()` fallback (world-writable) a guessable
+            // name would let a local user pre-position and connect.
+            `endo-9p-${process.pid}-${mountCounter}-${randomBytes(9).toString('hex')}.sock`,
           );
 
-    const sudo = env.NINEP_SUDO === '1';
-    const mountProgram = Array.isArray(opts.mountProgram)
-      ? opts.mountProgram.map(String)
-      : sudo
-        ? ['sudo', 'mount']
-        : ['mount'];
-    const umountProgram = Array.isArray(opts.umountProgram)
-      ? opts.umountProgram.map(String)
-      : sudo
-        ? ['sudo', 'umount']
-        : ['umount'];
+    // The program is operator config, not a caller option (see above);
+    // reject a caller that tries to choose it.
+    if (opts.mountProgram !== undefined || opts.umountProgram !== undefined) {
+      throw makeError(
+        X`mountProgram/umountProgram are operator configuration (NINEP_SUDO / NINEP_MOUNT_PROGRAM env), not a per-call option`,
+      );
+    }
     const removeMountPointOnUnmount = opts.removeMountPointOnUnmount === true;
     // Lazy detach (`umount -l`) so an unattended teardown can release a
     // busy mount instead of leaving a live mount over a dead bridge
@@ -393,7 +479,7 @@ export const makeFsMounter = ({
       return harden([...handles]);
     },
     help() {
-      return `endo-fs → 9P mounter.\n  mount(fs, mountPoint, options?) -> MountHandle\nOptions: { socketPath, trans='unix', version='9p2000.L', msize=131072, access='any', cache='none', readOnly=false, extraMountOptions, mountProgram, umountProgram, makeMountPoint=true, removeMountPointOnUnmount=false, lazyUnmount=false }.\nmount(2) needs CAP_SYS_ADMIN — pass mountProgram:['sudo','mount'] or set NINEP_SUDO=1 when the daemon is unprivileged.\nunmount() leaves the bridge up if umount fails (EBUSY) so the mount never outlives its transport; pass lazyUnmount (or NINEP_LAZY_UMOUNT=1) to force-detach a busy mount on teardown.\nEvery live mount is unmounted when this caplet is cancelled.`;
+      return `endo-fs → 9P mounter.\n  mount(fs, mountPoint, options?) -> MountHandle\nCaller options: { socketPath, msize=131072, cache='none', readOnly=false, extraMountOptions, makeMountPoint=true, removeMountPointOnUnmount=false, lazyUnmount=false }.\nThe trans/version/access options are pinned (extraMountOptions may not override them); the mount/umount program is operator config, not a caller option.\nmount(2) needs CAP_SYS_ADMIN — the operator sets NINEP_SUDO=1 (or NINEP_MOUNT_PROGRAM/NINEP_UMOUNT_PROGRAM) when the daemon is unprivileged.\nunmount() leaves the bridge up if umount fails (EBUSY) so the mount never outlives its transport; lazyUnmount (or NINEP_LAZY_UMOUNT=1) force-detaches a busy mount on teardown.\nEvery live mount is unmounted when this caplet is cancelled.`;
     },
   });
 };

--- a/packages/9p-server/mount-caplet.js
+++ b/packages/9p-server/mount-caplet.js
@@ -308,17 +308,30 @@ export const makeFsMounter = ({
 
     mountCounter += 1;
     const resolvedMountPoint = nodePath.resolve(mountPoint);
-    const socketPath =
-      typeof opts.socketPath === 'string'
-        ? opts.socketPath
-        : nodePath.join(
-            defaultSocketDir(env),
-            // Random suffix so the path isn't predictable: the UDS
-            // carries the full authority of the projected FS cap, and on
-            // the `os.tmpdir()` fallback (world-writable) a guessable
-            // name would let a local user pre-position and connect.
-            `endo-9p-${process.pid}-${mountCounter}-${randomBytes(9).toString('hex')}.sock`,
-          );
+    // The UDS path is internal plumbing, not a free-form caller input:
+    // the bridge `unlink()`s it before binding, so an arbitrary
+    // caller-chosen path would be an arbitrary-delete primitive with the
+    // daemon's authority. A caller may still pin a name, but only inside
+    // the socket directory; otherwise we generate a random one (the UDS
+    // carries the projected FS cap's full authority, so on the
+    // world-writable `os.tmpdir()` fallback an unpredictable name keeps a
+    // local user from pre-positioning and connecting).
+    const socketDir = defaultSocketDir(env);
+    let socketPath;
+    if (typeof opts.socketPath === 'string') {
+      socketPath = nodePath.resolve(opts.socketPath);
+      const rel = nodePath.relative(socketDir, socketPath);
+      if (rel === '' || rel.startsWith('..') || nodePath.isAbsolute(rel)) {
+        throw makeError(
+          X`socketPath must be inside the socket directory ${q(socketDir)}; got ${q(opts.socketPath)}`,
+        );
+      }
+    } else {
+      socketPath = nodePath.join(
+        socketDir,
+        `endo-9p-${process.pid}-${mountCounter}-${randomBytes(9).toString('hex')}.sock`,
+      );
+    }
 
     // The program is operator config, not a caller option (see above);
     // reject a caller that tries to choose it.

--- a/packages/9p-server/mount-caplet.js
+++ b/packages/9p-server/mount-caplet.js
@@ -136,21 +136,27 @@ const resolveCancelled = async context => {
 };
 
 /**
- * `make-unconfined` entry point.
+ * Build the mounter exo from injected effects.  `make()` wires the real
+ * Node bindings (`execFile`, `fs.mkdir`/`rmdir`, `makeFsBridge9p`);
+ * tests inject fakes so the privileged `mount(2)` path can be exercised
+ * without root or a real kernel.
  *
- * @param {unknown} _powers - guest powers (unused; mounting uses the
- *   worker's ambient Node authority, which is what `--UNCONFINED`
- *   grants).
- * @param {Promise<any> | any} context - daemon cancellation context.
- * @param {{ env?: Record<string, string> }} [options]
+ * @param {object} deps
+ * @param {Record<string, string>} [deps.env] - caplet env (e.g. NINEP_SUDO).
+ * @param {Promise<never> | null} [deps.cancelledP] - settles on caplet teardown.
+ * @param {(file: string, args: string[]) => Promise<unknown>} deps.runProgram - `execFile`-shaped runner.
+ * @param {(path: string, opts: { recursive: boolean }) => Promise<unknown>} deps.makeDir
+ * @param {(path: string) => Promise<unknown>} deps.removeDir
+ * @param {(opts: { fs: ERef<any>, socketPath: string, cancelled?: Promise<unknown> }) => any} deps.makeBridge
  */
-export const make = async (_powers, context, options = {}) => {
-  const env = options.env ?? {};
-
-  // Cancellation context → unmount-everything trigger.  `whenCancelled`
-  // rejects on teardown, so wire both settlement paths to the sweeper.
-  const cancelledP = await resolveCancelled(context);
-
+export const makeFsMounter = ({
+  env = {},
+  cancelledP = null,
+  runProgram,
+  makeDir,
+  removeDir,
+  makeBridge,
+}) => {
   /** @type {Set<{ unmount: () => Promise<void> }>} */
   const handles = new Set();
 
@@ -244,13 +250,13 @@ export const make = async (_powers, context, options = {}) => {
 
     // 1. Ensure the mount point exists (unless told not to).
     if (opts.makeMountPoint !== false) {
-      await mkdir(resolvedMountPoint, { recursive: true });
+      await makeDir(resolvedMountPoint, { recursive: true });
     }
 
     // 2. Serve the FS cap on the per-mount UDS.  Thread the caplet's
     //    cancellation in so in-flight 9P dispatchers short-circuit on
     //    teardown rather than blocking on the socket-close cascade.
-    const bridge = makeFsBridge9p({
+    const bridge = makeBridge({
       fs,
       socketPath,
       ...(cancelledP ? { cancelled: cancelledP } : {}),
@@ -277,7 +283,7 @@ export const make = async (_powers, context, options = {}) => {
       resolvedMountPoint,
     ];
     try {
-      await execFileP(mountBin, mountArgv);
+      await runProgram(mountBin, mountArgv);
     } catch (cause) {
       // Don't leak a listening socket if the mount itself failed.
       await E(bridge)
@@ -309,7 +315,7 @@ export const make = async (_powers, context, options = {}) => {
         resolvedMountPoint,
       ];
       try {
-        await execFileP(umountBin, umountArgv);
+        await runProgram(umountBin, umountArgv);
       } catch (cause) {
         const reason = /** @type {Error} */ (cause).message;
         const stderr = /** @type {{ stderr?: string }} */ (cause).stderr || '';
@@ -323,7 +329,7 @@ export const make = async (_powers, context, options = {}) => {
         .stop()
         .catch(() => {});
       if (removeMountPointOnUnmount) {
-        await rmdir(resolvedMountPoint).catch(() => {});
+        await removeDir(resolvedMountPoint).catch(() => {});
       }
     };
 
@@ -361,6 +367,29 @@ export const make = async (_powers, context, options = {}) => {
     help() {
       return `endo-fs → 9P mounter.\n  mount(fs, mountPoint, options?) -> MountHandle\nOptions: { socketPath, trans='unix', version='9p2000.L', msize=131072, access='any', cache='none', readOnly=false, extraMountOptions, mountProgram, umountProgram, makeMountPoint=true, removeMountPointOnUnmount=false, lazyUnmount=false }.\nmount(2) needs CAP_SYS_ADMIN — pass mountProgram:['sudo','mount'] or set NINEP_SUDO=1 when the daemon is unprivileged.\nunmount() leaves the bridge up if umount fails (EBUSY) so the mount never outlives its transport; pass lazyUnmount (or NINEP_LAZY_UMOUNT=1) to force-detach a busy mount on teardown.\nEvery live mount is unmounted when this caplet is cancelled.`;
     },
+  });
+};
+harden(makeFsMounter);
+
+/**
+ * `make-unconfined` entry point.  Resolves the daemon cancellation
+ * context and wires the real Node effects into {@link makeFsMounter}.
+ *
+ * @param {unknown} _powers - guest powers (unused; mounting uses the
+ *   worker's ambient Node authority, which is what `--UNCONFINED`
+ *   grants).
+ * @param {Promise<any> | any} context - daemon cancellation context.
+ * @param {{ env?: Record<string, string> }} [options]
+ */
+export const make = async (_powers, context, options = {}) => {
+  const cancelledP = await resolveCancelled(context);
+  return makeFsMounter({
+    env: options.env ?? {},
+    cancelledP,
+    runProgram: execFileP,
+    makeDir: mkdir,
+    removeDir: rmdir,
+    makeBridge: makeFsBridge9p,
   });
 };
 harden(make);

--- a/packages/9p-server/mount-caplet.js
+++ b/packages/9p-server/mount-caplet.js
@@ -9,7 +9,7 @@
  *
  * ```sh
  * endo make-unconfined packages/9p-server/mount-caplet.js \
- *   --name fs-mounter --powers @none
+ *   --name fs-mounter --powers \@none
  * # then, from a caplet/REPL that holds both `fs-mounter` and an
  * # endo-fs `Filesystem` cap named `my-fs`:
  * #   const h = await E(fsMounter).mount(myFs, '/mnt/endo', {});
@@ -41,7 +41,7 @@
  * @module
  */
 
-import { E } from '@endo/far';
+import { E } from '@endo/eventual-send';
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';
 import { makeError, q, X } from '@endo/errors';
@@ -51,6 +51,7 @@ import { promisify } from 'node:util';
 import { mkdir, rmdir } from 'node:fs/promises';
 import os from 'node:os';
 import nodePath from 'node:path';
+import process from 'node:process';
 
 import { makeFsBridge9p } from './src/fs-bridge.js';
 
@@ -90,7 +91,7 @@ const buildMountOptionString = options => {
   const {
     trans = 'unix',
     version = '9p2000.L',
-    msize = 512000,
+    msize = 512_000,
     access = 'any',
     cache = 'none',
     readOnly = false,

--- a/packages/9p-server/mount-caplet.js
+++ b/packages/9p-server/mount-caplet.js
@@ -1,0 +1,293 @@
+// @ts-check
+
+/**
+ * Unconfined caplet: mount an `@endo/platform/fs/extended` `Filesystem`
+ * capability (possibly a remote CapTP presence) into the host Linux
+ * kernel via 9P2000.L.
+ *
+ * Run it with, e.g.:
+ *
+ * ```sh
+ * endo make-unconfined packages/9p-server/mount-caplet.js \
+ *   --name fs-mounter --powers @none
+ * # then, from a caplet/REPL that holds both `fs-mounter` and an
+ * # endo-fs `Filesystem` cap named `my-fs`:
+ * #   const h = await E(fsMounter).mount(myFs, '/mnt/endo', {});
+ * #   …
+ * #   await E(h).unmount();           // or let teardown do it
+ * ```
+ *
+ * `make()` returns a *mounter* exo.  Each `mount(fs, mountPoint,
+ * options)` call:
+ *   1. stands up a `makeFsBridge9p` 9P server on a per-mount Unix
+ *      domain socket,
+ *   2. shells out to `mount -t 9p -o trans=unix,version=9p2000.L,…`
+ *      to attach the socket to `mountPoint`,
+ *   3. returns a `MountHandle` exo whose `unmount()` reverses both
+ *      steps.
+ *
+ * **Teardown.** The caplet wires the daemon's cancellation context
+ * (`context.whenCancelled()`): when the caplet formula is cancelled
+ * (worker terminated, formula removed, daemon shutdown) every live
+ * mount is `umount`ed and its bridge stopped on a best-effort basis.
+ *
+ * **Privilege.** `mount(2)` / `umount(2)` need `CAP_SYS_ADMIN`.  The
+ * daemon worker is rarely root, so by default this will fail with a
+ * permission error unless the daemon runs privileged.  Supply
+ * `options.mountProgram` / `options.umountProgram` (e.g.
+ * `['sudo', 'mount']`) — or set `NINEP_SUDO=1` in the caplet's env —
+ * to route through a privilege helper.
+ *
+ * @module
+ */
+
+import { E } from '@endo/far';
+import { makeExo } from '@endo/exo';
+import { M } from '@endo/patterns';
+import { makeError, q, X } from '@endo/errors';
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdir, rmdir } from 'node:fs/promises';
+import os from 'node:os';
+import nodePath from 'node:path';
+
+import { makeFsBridge9p } from './src/fs-bridge.js';
+
+/** @import { ERef } from '@endo/eventual-send' */
+
+const execFileP = promisify(execFile);
+
+const MountHandleInterface = M.interface('Fs9pMountHandle', {
+  unmount: M.call().returns(M.promise()),
+  mountPoint: M.call().returns(M.string()),
+  socketPath: M.call().returns(M.string()),
+  help: M.call().returns(M.string()),
+});
+
+const MounterInterface = M.interface('Fs9pMounter', {
+  mount: M.call(M.any(), M.string()).optional(M.any()).returns(M.promise()),
+  list: M.call().returns(M.array()),
+  help: M.call().returns(M.string()),
+});
+
+/**
+ * Pick a default directory for the per-mount UDS.  Prefer the XDG
+ * runtime dir (tmpfs, 0700, per-user) so the socket — which carries
+ * the *full authority* of the projected FS cap — is not world-visible.
+ *
+ * @param {Record<string, string>} env
+ */
+const defaultSocketDir = env =>
+  env.XDG_RUNTIME_DIR || env.NINEP_SOCKET_DIR || os.tmpdir();
+
+/**
+ * Build the comma-separated `-o` value for `mount -t 9p`.
+ *
+ * @param {Record<string, unknown>} options
+ */
+const buildMountOptionString = options => {
+  const {
+    trans = 'unix',
+    version = '9p2000.L',
+    msize = 512000,
+    access = 'any',
+    cache = 'none',
+    readOnly = false,
+    extraMountOptions = '',
+  } = options;
+  const parts = [
+    `trans=${trans}`,
+    `version=${version}`,
+    `msize=${msize}`,
+    `access=${access}`,
+    `cache=${cache}`,
+  ];
+  if (readOnly) parts.push('ro');
+  if (extraMountOptions) parts.push(String(extraMountOptions));
+  return parts.join(',');
+};
+
+/**
+ * Resolve the caplet's cancellation promise from whatever shape the
+ * daemon handed us as `context`.  Mirrors the tolerant resolution in
+ * `packages/lal/agent.js` and `packages/fae/agent.js`: a context
+ * presence exposes `whenCancelled()`; an in-process context exposes a
+ * `cancelled` promise; `null`/absent means "no teardown signal".
+ *
+ * @param {Promise<any> | any} context
+ * @returns {Promise<Promise<never> | null>}
+ */
+const resolveCancelled = async context => {
+  if (!context) return null;
+  const resolved = await context;
+  if (!resolved) return null;
+  if (typeof resolved.whenCancelled === 'function') {
+    return E(resolved).whenCancelled();
+  }
+  if (resolved.cancelled) {
+    return resolved.cancelled;
+  }
+  return null;
+};
+
+/**
+ * `make-unconfined` entry point.
+ *
+ * @param {unknown} _powers - guest powers (unused; mounting uses the
+ *   worker's ambient Node authority, which is what `--UNCONFINED`
+ *   grants).
+ * @param {Promise<any> | any} context - daemon cancellation context.
+ * @param {{ env?: Record<string, string> }} [options]
+ */
+export const make = async (_powers, context, options = {}) => {
+  const env = options.env ?? {};
+
+  // Cancellation context → unmount-everything trigger.  `whenCancelled`
+  // rejects on teardown, so wire both settlement paths to the sweeper.
+  const cancelledP = await resolveCancelled(context);
+
+  /** @type {Set<{ unmount: () => Promise<void> }>} */
+  const handles = new Set();
+
+  const unmountAll = async () => {
+    await Promise.all(
+      [...handles].map(handle =>
+        handle.unmount().catch(err => {
+          // Best-effort during teardown — surface but don't reject.
+          // eslint-disable-next-line no-console
+          console.error('[9p mount-caplet] teardown unmount failed', err);
+        }),
+      ),
+    );
+  };
+
+  if (cancelledP) {
+    // The cancelled promise is reject-only; attach to both arms so a
+    // future resolve-style trigger still sweeps.
+    Promise.resolve(cancelledP).then(unmountAll, unmountAll);
+  }
+
+  /**
+   * @param {ERef<any>} fs - endo-fs `Filesystem` capability to project.
+   * @param {string} mountPoint - host path to mount onto.
+   * @param {Record<string, unknown>} [mountOptions]
+   */
+  const mount = async (fs, mountPoint, mountOptions = {}) => {
+    const resolvedMountPoint = nodePath.resolve(mountPoint);
+    const socketPath =
+      typeof mountOptions.socketPath === 'string'
+        ? mountOptions.socketPath
+        : nodePath.join(
+            defaultSocketDir(env),
+            `endo-9p-${process.pid}-${handles.size}-${Date.now()}.sock`,
+          );
+
+    const sudo = env.NINEP_SUDO === '1';
+    const mountProgram = Array.isArray(mountOptions.mountProgram)
+      ? mountOptions.mountProgram.map(String)
+      : sudo
+        ? ['sudo', 'mount']
+        : ['mount'];
+    const umountProgram = Array.isArray(mountOptions.umountProgram)
+      ? mountOptions.umountProgram.map(String)
+      : sudo
+        ? ['sudo', 'umount']
+        : ['umount'];
+    const removeMountPointOnUnmount =
+      mountOptions.removeMountPointOnUnmount === true;
+
+    // 1. Ensure the mount point exists (unless told not to).
+    if (mountOptions.makeMountPoint !== false) {
+      await mkdir(resolvedMountPoint, { recursive: true });
+    }
+
+    // 2. Serve the FS cap on the per-mount UDS.  Thread the caplet's
+    //    cancellation in so in-flight 9P dispatchers short-circuit on
+    //    teardown rather than blocking on the socket-close cascade.
+    const bridge = makeFsBridge9p({
+      fs,
+      socketPath,
+      ...(cancelledP ? { cancelled: cancelledP } : {}),
+    });
+    await E(bridge).start();
+
+    // 3. Attach the socket to the kernel.  `trans=unix` makes v9fs's
+    //    fd transport connect to the UDS named by the mount "device"
+    //    (the socket path).  `version=9p2000.L` is mandatory — the
+    //    bridge only speaks the .L dialect.
+    const optionString = buildMountOptionString(mountOptions);
+    const [mountBin, ...mountPre] = mountProgram;
+    const mountArgv = [
+      ...mountPre,
+      '-t',
+      '9p',
+      '-o',
+      optionString,
+      socketPath,
+      resolvedMountPoint,
+    ];
+    try {
+      await execFileP(mountBin, mountArgv);
+    } catch (cause) {
+      // Don't leak a listening socket if the mount itself failed.
+      await E(bridge)
+        .stop()
+        .catch(() => {});
+      const reason = /** @type {Error} */ (cause).message;
+      const stderr = /** @type {{ stderr?: string }} */ (cause).stderr || '';
+      throw makeError(
+        X`9p mount of ${q(socketPath)} onto ${q(resolvedMountPoint)} failed: ${q(reason)} ${q(stderr)}`,
+      );
+    }
+
+    let unmounted = false;
+    const handle = makeExo('Fs9pMountHandle', MountHandleInterface, {
+      async unmount() {
+        if (unmounted) return;
+        unmounted = true;
+        handles.delete(handle);
+        // Detach the kernel mount first so no process is mid-syscall
+        // against the bridge when we tear the socket down.
+        const [umountBin, ...umountPre] = umountProgram;
+        await execFileP(umountBin, [...umountPre, resolvedMountPoint]).catch(
+          err => {
+            // eslint-disable-next-line no-console
+            console.error(
+              `[9p mount-caplet] umount ${resolvedMountPoint} failed`,
+              err,
+            );
+          },
+        );
+        await E(bridge)
+          .stop()
+          .catch(() => {});
+        if (removeMountPointOnUnmount) {
+          await rmdir(resolvedMountPoint).catch(() => {});
+        }
+      },
+      mountPoint() {
+        return resolvedMountPoint;
+      },
+      socketPath() {
+        return socketPath;
+      },
+      help() {
+        return `9P2000.L mount of an endo-fs Filesystem.\n  mountPoint: ${resolvedMountPoint}\n  socket:     ${socketPath}\n  options:    ${optionString}\nCall unmount() to detach and stop the bridge; the caplet also unmounts on teardown.`;
+      },
+    });
+    handles.add(handle);
+    return handle;
+  };
+
+  return makeExo('Fs9pMounter', MounterInterface, {
+    mount,
+    list() {
+      return harden([...handles]);
+    },
+    help() {
+      return `endo-fs → 9P mounter.\n  mount(fs, mountPoint, options?) -> MountHandle\nOptions: { socketPath, trans='unix', version='9p2000.L', msize=512000, access='any', cache='none', readOnly=false, extraMountOptions, mountProgram, umountProgram, makeMountPoint=true, removeMountPointOnUnmount=false }.\nmount(2) needs CAP_SYS_ADMIN — pass mountProgram:['sudo','mount'] or set NINEP_SUDO=1 when the daemon is unprivileged.\nEvery live mount is unmounted when this caplet is cancelled.`;
+    },
+  });
+};
+harden(make);

--- a/packages/9p-server/mount-caplet.js
+++ b/packages/9p-server/mount-caplet.js
@@ -261,7 +261,20 @@ export const makeFsMounter = ({
       socketPath,
       ...(cancelledP ? { cancelled: cancelledP } : {}),
     });
-    await E(bridge).start();
+    try {
+      await E(bridge).start();
+    } catch (cause) {
+      // start() may have partially set up (created the net.Server,
+      // bound the socket, etc.) before rejecting; stop() so we never
+      // leak a half-open listener / socket file.
+      await E(bridge)
+        .stop()
+        .catch(() => {});
+      const reason = /** @type {Error} */ (cause).message;
+      throw makeError(
+        X`9p bridge failed to start on ${q(socketPath)}: ${q(reason)}`,
+      );
+    }
 
     // 3. Attach the socket to the kernel.  `trans=unix` is the v9fs
     //    transport that connects to a UNIX-domain socket whose path is
@@ -356,6 +369,21 @@ export const makeFsMounter = ({
       },
     });
     handles.add(handle);
+    // Close the mount-vs-teardown race: if cancellation fired while we
+    // were awaiting (makeDir / start / mount), the one-shot teardown
+    // sweep ran before this handle was registered and will never run
+    // again. `handles.add` and this `cancelled` read are synchronous,
+    // so they cannot interleave with the teardown turn (which sets
+    // `cancelled` and snapshots `handles` in one turn) — either it
+    // already ran (we see `cancelled` and unmount here) or it runs
+    // later and sees this handle in the set. `unmount()` is idempotent,
+    // so a double with the sweep is harmless.
+    if (cancelled) {
+      await handle.unmount().catch(() => {});
+      throw makeError(
+        X`mounter cancelled during mount of ${q(resolvedMountPoint)}`,
+      );
+    }
     return handle;
   };
 

--- a/packages/9p-server/src/fs-bridge.js
+++ b/packages/9p-server/src/fs-bridge.js
@@ -104,6 +104,16 @@ export const makeFsBridge9p = ({
       // 0600: the 9P bridge exposes the full authority of the FS
       // capability projected through it. Anyone who can connect can
       // exercise that authority; restrict to the owning UID only.
+      //
+      // There is a small window between `listen()` creating the socket
+      // (at the process umask) and this `chmod`. The atomic fix would be
+      // a restrictive umask across the bind, but `process.umask()` is
+      // unsupported in worker threads (where bridges may run), so we
+      // narrow exposure two other ways instead: callers place the socket
+      // in a private dir (`mount-caplet.js` prefers `XDG_RUNTIME_DIR`,
+      // which is 0700), and the socket name is unpredictable, so a local
+      // user can't pre-position to connect during the window even on the
+      // world-writable `os.tmpdir()` fallback.
       await chmod(socketPath, 0o600);
     },
 

--- a/packages/9p-server/src/server.js
+++ b/packages/9p-server/src/server.js
@@ -58,6 +58,8 @@ const MASK_U64 = (1n << 64n) - 1n;
  *   back to the FS root. Used for `..` walks and the (parent,
  *   name) bookkeeping Tunlinkat / Trenameat need.
  * @property {boolean} open
+ * @property {boolean} [readable]      open mode allows Tread (File)
+ * @property {boolean} [writable]      open mode allows Twrite (File)
  * @property {any} [openFile]          endo-fs OpenFile cap (File open)
  * @property {any} [cursor]            endo-fs Cursor cap (Directory open)
  * @property {Array<{ name: string, qid: any }>} [dirBuffer]
@@ -380,6 +382,10 @@ export const serveConnection = ({
 
     const src = fids.get(fid);
     if (!src) return sendError(tag, ERRNO.EBADF);
+    // 9P forbids walking from a fid already opened for I/O. Enforcing it
+    // is also what stops a `Twalk(fid, fid, …)` from silently
+    // overwriting (and leaking) an open fid's OpenFile / cursor.
+    if (src.open) return sendError(tag, ERRNO.EBADF);
 
     // Build the pipelined chain. `steps[i]` describes the i-th
     // step's resulting cap + qid promise + new ancestry. Caps
@@ -501,6 +507,8 @@ export const serveConnection = ({
         f.dirBuffer = [];
         f.dirBufferDone = false;
         f.open = true;
+        f.readable = true;
+        f.writable = false;
       } else {
         // POSIX-style flag bits: O_RDWR=0o2, O_WRONLY=0o1, O_RDONLY=0o0.
         const oflag = flags & 0o3;
@@ -518,13 +526,18 @@ export const serveConnection = ({
         );
         f.openFile = oh;
         f.open = true;
+        f.readable = wantRead;
+        f.writable = wantWrite;
       }
     } catch (e) {
       return sendError(tag, errnoOf(e));
     }
     const w = makeWriter(13 + 4);
     writeQid(w, qidToWire(f.qid));
-    w.u32(0); // iounit = use msize - 24
+    // iounit: the max bytes the client may Tread/Twrite in one frame.
+    // The onWrite/onRead clamps cap at `msize - header`; advertise that
+    // rather than 0 ("just use msize") so the client sizes I/O to fit.
+    w.u32(Math.max(0, msize - 24));
     send(wrapMessage(T.Rlopen, tag, w.finish()));
     return undefined;
   };
@@ -550,6 +563,10 @@ export const serveConnection = ({
       return sendError(tag, ERRNO.EISDIR);
     }
     if (!f.openFile) return sendError(tag, ERRNO.EBADF);
+    // Reading a fid not opened for read is EBADF (matches read(2) on an
+    // O_WRONLY fd), enforced at the protocol layer rather than relying on
+    // the backend OpenFile to reject it.
+    if (!f.readable) return sendError(tag, ERRNO.EBADF);
     try {
       const reader = await E(f.openFile).read(offset, BigInt(count));
       const chunks = [];
@@ -612,7 +629,10 @@ export const serveConnection = ({
       w.u32(mode);
       w.u32(1000); // uid — base FS has no concept; default for guest mount.
       w.u32(1000); // gid
-      w.u64(1n); // nlink
+      // nlink: directories have >= 2 (`.` plus the parent's entry);
+      // reporting 1 confuses `find`'s link-count traversal optimisation.
+      // The base FS exposes no real link count, so synthesise 2/1.
+      w.u64(isDir ? 2n : 1n); // nlink
       w.u64(0n); // rdev
       w.u64(BigInt(attrs.size ?? 0n));
       w.u64(4096n); // blksize
@@ -698,7 +718,12 @@ export const serveConnection = ({
     while (i < entries.length) {
       const { name, qid } = entries[i];
       const size = offSize(name);
-      if (written + size > count) break;
+      // Always emit at least the first entry at `offset`, even if it
+      // alone exceeds the requested count: returning zero entries would
+      // make the kernel re-request the same cookie forever. (The writer
+      // grows as needed; under the negotiated msize floor a single entry
+      // always fits anyway.)
+      if (written > 0 && written + size > count) break;
       writeQid(w, qidToWire(qid));
       w.u64(BigInt(i + 1)); // next offset cookie
       w.u8(qid.type === 'directory' ? 4 : 8); // DT_DIR | DT_REG
@@ -742,9 +767,12 @@ export const serveConnection = ({
   const onLcreate = async (/** @type {number} */ tag, r) => {
     const fid = r.u32();
     const name = r.str();
-    r.u32(); // flags
+    const flags = r.u32();
     r.u32(); // mode
     r.u32(); // gid
+    const oflag = flags & 0o3;
+    const newReadable = oflag === 0 || oflag === 0o2;
+    const newWritable = oflag === 0o1 || oflag === 0o2;
     const f = fids.get(fid);
     if (!f) return sendError(tag, ERRNO.EBADF);
     if (f.qid.type !== 'directory') return sendError(tag, ERRNO.ENOTDIR);
@@ -773,10 +801,12 @@ export const serveConnection = ({
         ancestry: newAncestry,
         open: true,
         openFile: oh,
+        readable: newReadable,
+        writable: newWritable,
       });
       const w = makeWriter(17);
       writeQid(w, qidToWire(childQid));
-      w.u32(0);
+      w.u32(Math.max(0, msize - 24)); // iounit (see onLopen)
       send(wrapMessage(T.Rlcreate, tag, w.finish()));
     } catch (e) {
       return sendError(tag, errnoOf(e));
@@ -806,6 +836,9 @@ export const serveConnection = ({
     if (!f || !f.open) return sendError(tag, ERRNO.EBADF);
     if (f.qid.type === 'directory') return sendError(tag, ERRNO.EISDIR);
     if (!f.openFile) return sendError(tag, ERRNO.EBADF);
+    // Writing a fid not opened for write is EBADF (matches write(2) on an
+    // O_RDONLY fd).
+    if (!f.writable) return sendError(tag, ERRNO.EBADF);
     try {
       const writer = await E(f.openFile).write(offset);
       // `buffer: 1` lets us push the one chunk this Twrite carries

--- a/packages/9p-server/src/server.js
+++ b/packages/9p-server/src/server.js
@@ -749,18 +749,20 @@ export const serveConnection = ({
     if (!f) return sendError(tag, ERRNO.EBADF);
     if (f.qid.type !== 'directory') return sendError(tag, ERRNO.ENOTDIR);
     try {
-      // Pipeline create + lookup + getQid into one CapTP batch.
-      // create returns an OpenFile (we keep it on the fid);
-      // lookup returns the File cap (so we can take its qid);
-      // getQid runs against the lookup-result promise. All three
-      // CTP_CALLs reach the wire before any reply.
-      const ohP = E(f.cap).create(name, harden({}));
+      // create() makes the new directory entry and returns an OpenFile
+      // we keep on the fid. Await it before looking the child up:
+      // dispatching lookup(name) concurrently in the same batch races
+      // backends whose create writes the entry only after an await
+      // (e.g. node-fs), so the same-turn lookup can ENOENT even though
+      // the file was created — the in-memory backend registers entries
+      // eagerly, which is why this only surfaced on a disk-backed
+      // mount. Once create resolves the entry exists, so lookup +
+      // getQid still pipeline into one further round-trip.
+      const oh = await E(f.cap).create(name, harden({}));
       const childCapP = E(f.cap).lookup(name);
-      const childQidP = E(childCapP).getQid();
-      const [oh, childCap, childQid] = await Promise.all([
-        ohP,
+      const [childCap, childQid] = await Promise.all([
         childCapP,
-        childQidP,
+        E(childCapP).getQid(),
       ]);
       // Replace fid: 9P semantics put newly-created file at the
       // original fid. Ancestry extends.

--- a/packages/9p-server/test/mount-caplet.test.js
+++ b/packages/9p-server/test/mount-caplet.test.js
@@ -11,9 +11,17 @@
 import '@endo/init/debug.js';
 
 import test from 'ava';
+import os from 'node:os';
+import nodePath from 'node:path';
 import { E, Far } from '@endo/far';
 
 import { makeFsMounter } from '../mount-caplet.js';
+
+// A caller-supplied socketPath must live inside the socket directory
+// (defaults to os.tmpdir() when XDG_RUNTIME_DIR is unset), so build the
+// test paths there rather than hard-coding `/tmp`.
+const SOCK = nodePath.join(os.tmpdir(), 's.sock');
+const SOCK2 = nodePath.join(os.tmpdir(), 's2.sock');
 
 const fakeFs = () => Far('FakeFs', {});
 
@@ -69,12 +77,12 @@ test('mount builds the 9P mount argv, makes the dir, and starts the bridge', asy
   const h = await E(mounter).mount(
     fakeFs(),
     '/mnt/x',
-    harden({ socketPath: '/tmp/s.sock' }),
+    harden({ socketPath: SOCK }),
   );
 
   t.deepEqual(calls.makeDir[0], { p: '/mnt/x', o: { recursive: true } });
   t.is(calls.bridges.length, 1);
-  t.is(calls.bridges[0].socketPath, '/tmp/s.sock');
+  t.is(calls.bridges[0].socketPath, SOCK);
   t.is(calls.bridges[0].started, 1);
 
   t.is(calls.run.length, 1);
@@ -93,11 +101,11 @@ test('mount builds the 9P mount argv, makes the dir, and starts the bridge', asy
   }
   // `--` terminates options so a dash-leading path can't be a flag.
   t.is(argv[4], '--');
-  t.is(argv[5], '/tmp/s.sock');
+  t.is(argv[5], SOCK);
   t.is(argv[6], '/mnt/x');
 
   t.is(await E(h).mountPoint(), '/mnt/x');
-  t.is(await E(h).socketPath(), '/tmp/s.sock');
+  t.is(await E(h).socketPath(), SOCK);
   t.is((await E(mounter).list()).length, 1);
 });
 
@@ -107,7 +115,7 @@ test('readOnly, msize override, and extraMountOptions reach the -o string', asyn
     fakeFs(),
     '/mnt/x',
     harden({
-      socketPath: '/tmp/s.sock',
+      socketPath: SOCK,
       readOnly: true,
       msize: 65_536,
       extraMountOptions: 'cache=loose',
@@ -124,7 +132,7 @@ test('NINEP_SUDO routes mount/umount through sudo', async t => {
   const h = await E(mounter).mount(
     fakeFs(),
     '/mnt/x',
-    harden({ socketPath: '/tmp/s.sock' }),
+    harden({ socketPath: SOCK }),
   );
   t.is(calls.run[0].bin, 'sudo');
   t.is(calls.run[0].argv[0], 'mount');
@@ -142,7 +150,7 @@ test('extraMountOptions cannot override the pinned trans option', async t => {
       fakeFs(),
       '/mnt/x',
       harden({
-        socketPath: '/tmp/s.sock',
+        socketPath: SOCK,
         extraMountOptions: 'trans=tcp,port=564',
       }),
     ),
@@ -156,9 +164,21 @@ test('caller cannot choose the mount/umount program', async t => {
     E(mounter).mount(
       fakeFs(),
       '/mnt/x',
-      harden({ socketPath: '/tmp/s.sock', umountProgram: ['rm'] }),
+      harden({ socketPath: SOCK, umountProgram: ['rm'] }),
     ),
     { message: /operator configuration/ },
+  );
+});
+
+test('a socketPath outside the socket directory is rejected', async t => {
+  const { mounter } = makeHarness();
+  await t.throwsAsync(
+    E(mounter).mount(
+      fakeFs(),
+      '/mnt/x',
+      harden({ socketPath: '/etc/evil.sock' }),
+    ),
+    { message: /must be inside the socket directory/ },
   );
 });
 
@@ -169,11 +189,7 @@ test('NINEP_MOUNT_PROGRAM lets the operator set a custom helper', async t => {
       NINEP_UMOUNT_PROGRAM: 'sudo umount',
     },
   });
-  await E(mounter).mount(
-    fakeFs(),
-    '/mnt/x',
-    harden({ socketPath: '/tmp/s.sock' }),
-  );
+  await E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: SOCK }));
   t.is(calls.run[0].bin, 'sudo');
   t.deepEqual(calls.run[0].argv.slice(0, 3), ['-u', 'svc', 'mount']);
 });
@@ -205,7 +221,7 @@ test('a failed mount stops the bridge and leaks no handle', async t => {
         : Promise.resolve(),
   });
   await t.throwsAsync(
-    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: '/tmp/s.sock' })),
+    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: SOCK })),
     { message: /9p mount of .* failed/ },
   );
   t.is(calls.bridges[0].stopped, 1);
@@ -237,7 +253,7 @@ test('a failed bridge.start() is cleaned up and leaks no handle', async t => {
     makeBridge,
   });
   await t.throwsAsync(
-    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: '/tmp/s.sock' })),
+    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: SOCK })),
     { message: /bridge failed to start/ },
   );
   t.is(calls.bridges[0].stopped, 1, 'bridge stopped after start() failure');
@@ -264,7 +280,7 @@ test('cancellation during an in-flight mount unmounts it (no orphan)', async t =
     },
   });
   await t.throwsAsync(
-    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: '/tmp/s.sock' })),
+    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: SOCK })),
     { message: /cancelled during mount/ },
   );
   t.truthy(
@@ -280,7 +296,7 @@ test('unmount detaches with `umount -- <mp>`, stops the bridge, drops the handle
   const h = await E(mounter).mount(
     fakeFs(),
     '/mnt/x',
-    harden({ socketPath: '/tmp/s.sock' }),
+    harden({ socketPath: SOCK }),
   );
   await E(h).unmount();
   const umount = calls.run.find(c => c.bin === 'umount');
@@ -307,7 +323,7 @@ test('a failed umount (EBUSY) keeps the bridge up and the handle, and is retryab
   const h = await E(mounter).mount(
     fakeFs(),
     '/mnt/x',
-    harden({ socketPath: '/tmp/s.sock' }),
+    harden({ socketPath: SOCK }),
   );
   await t.throwsAsync(E(h).unmount(), { message: /busy/ });
   // The mount must not outlive its transport: bridge still up, handle retained.
@@ -324,7 +340,7 @@ test('lazyUnmount adds -l to the umount argv', async t => {
   const h = await E(mounter).mount(
     fakeFs(),
     '/mnt/x',
-    harden({ socketPath: '/tmp/s.sock', lazyUnmount: true }),
+    harden({ socketPath: SOCK, lazyUnmount: true }),
   );
   await E(h).unmount();
   const umount = calls.run.find(c => c.bin === 'umount');
@@ -345,11 +361,7 @@ test('cancellation unmounts live mounts and refuses new ones', async t => {
   });
   cancelledP.catch(() => {});
   const { mounter, calls } = makeHarness({ cancelledP });
-  await E(mounter).mount(
-    fakeFs(),
-    '/mnt/x',
-    harden({ socketPath: '/tmp/s.sock' }),
-  );
+  await E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: SOCK }));
 
   rejectCancelled(new Error('teardown'));
   await flush();
@@ -359,11 +371,7 @@ test('cancellation unmounts live mounts and refuses new ones', async t => {
   t.is((await E(mounter).list()).length, 0);
 
   await t.throwsAsync(
-    E(mounter).mount(
-      fakeFs(),
-      '/mnt/y',
-      harden({ socketPath: '/tmp/s2.sock' }),
-    ),
+    E(mounter).mount(fakeFs(), '/mnt/y', harden({ socketPath: SOCK2 })),
     { message: /cancelled/ },
   );
 });

--- a/packages/9p-server/test/mount-caplet.test.js
+++ b/packages/9p-server/test/mount-caplet.test.js
@@ -1,0 +1,248 @@
+// @ts-nocheck
+/* global setTimeout */
+
+/**
+ * Unit tests for the mount caplet's mounter logic, exercised through
+ * the injectable `makeFsMounter({ runProgram, makeDir, removeDir,
+ * makeBridge })` seam so the privileged `mount(2)` path runs with fakes
+ * — no root, no real kernel, no real 9P bridge.
+ */
+
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import { E, Far } from '@endo/far';
+
+import { makeFsMounter } from '../mount-caplet.js';
+
+const fakeFs = () => Far('FakeFs', {});
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 10));
+
+/**
+ * @param {object} [opts]
+ * @param {Record<string, string>} [opts.env]
+ * @param {Promise<never>} [opts.cancelledP]
+ * @param {(bin: string, argv: string[], nth: number) => Promise<unknown>} [opts.runBehavior]
+ */
+const makeHarness = (opts = {}) => {
+  const calls = { run: [], makeDir: [], removeDir: [], bridges: [] };
+  const runBehavior =
+    opts.runBehavior ?? (() => Promise.resolve({ stdout: '', stderr: '' }));
+  const runProgram = (bin, argv) => {
+    calls.run.push({ bin, argv });
+    return runBehavior(bin, argv, calls.run.length);
+  };
+  const makeDir = (p, o) => {
+    calls.makeDir.push({ p, o });
+    return Promise.resolve();
+  };
+  const removeDir = p => {
+    calls.removeDir.push(p);
+    return Promise.resolve();
+  };
+  const makeBridge = ({ fs, socketPath, cancelled }) => {
+    const rec = { fs, socketPath, cancelled, started: 0, stopped: 0 };
+    calls.bridges.push(rec);
+    return Far('FakeBridge', {
+      async start() {
+        rec.started += 1;
+      },
+      async stop() {
+        rec.stopped += 1;
+      },
+    });
+  };
+  const mounter = makeFsMounter({
+    env: opts.env ?? {},
+    cancelledP: opts.cancelledP ?? null,
+    runProgram,
+    makeDir,
+    removeDir,
+    makeBridge,
+  });
+  return { mounter, calls };
+};
+
+test('mount builds the 9P mount argv, makes the dir, and starts the bridge', async t => {
+  const { mounter, calls } = makeHarness();
+  const h = await E(mounter).mount(
+    fakeFs(),
+    '/mnt/x',
+    harden({ socketPath: '/tmp/s.sock' }),
+  );
+
+  t.deepEqual(calls.makeDir[0], { p: '/mnt/x', o: { recursive: true } });
+  t.is(calls.bridges.length, 1);
+  t.is(calls.bridges[0].socketPath, '/tmp/s.sock');
+  t.is(calls.bridges[0].started, 1);
+
+  t.is(calls.run.length, 1);
+  t.is(calls.run[0].bin, 'mount');
+  const argv = calls.run[0].argv;
+  t.deepEqual(argv.slice(0, 3), ['-t', '9p', '-o']);
+  const optionString = argv[3];
+  for (const part of [
+    'trans=unix',
+    'version=9p2000.L',
+    'msize=131072',
+    'access=any',
+    'cache=none',
+  ]) {
+    t.true(optionString.includes(part), `option string has ${part}`);
+  }
+  // `--` terminates options so a dash-leading path can't be a flag.
+  t.is(argv[4], '--');
+  t.is(argv[5], '/tmp/s.sock');
+  t.is(argv[6], '/mnt/x');
+
+  t.is(await E(h).mountPoint(), '/mnt/x');
+  t.is(await E(h).socketPath(), '/tmp/s.sock');
+  t.is((await E(mounter).list()).length, 1);
+});
+
+test('readOnly, msize override, and extraMountOptions reach the -o string', async t => {
+  const { mounter, calls } = makeHarness();
+  await E(mounter).mount(
+    fakeFs(),
+    '/mnt/x',
+    harden({
+      socketPath: '/tmp/s.sock',
+      readOnly: true,
+      msize: 65_536,
+      extraMountOptions: 'cache=loose',
+    }),
+  );
+  const optionString = calls.run[0].argv[3];
+  t.true(optionString.includes('msize=65536'));
+  t.true(optionString.split(',').includes('ro'));
+  t.true(optionString.includes('cache=loose'));
+});
+
+test('NINEP_SUDO routes mount/umount through sudo', async t => {
+  const { mounter, calls } = makeHarness({ env: { NINEP_SUDO: '1' } });
+  const h = await E(mounter).mount(
+    fakeFs(),
+    '/mnt/x',
+    harden({ socketPath: '/tmp/s.sock' }),
+  );
+  t.is(calls.run[0].bin, 'sudo');
+  t.is(calls.run[0].argv[0], 'mount');
+  await E(h).unmount();
+  const umount = calls.run.find(
+    c => c.bin === 'sudo' && c.argv[0] === 'umount',
+  );
+  t.truthy(umount);
+});
+
+test('a failed mount stops the bridge and leaks no handle', async t => {
+  const { mounter, calls } = makeHarness({
+    runBehavior: bin =>
+      bin === 'mount'
+        ? Promise.reject(
+            Object.assign(new Error('mount: permission denied'), {
+              stderr: 'only root',
+            }),
+          )
+        : Promise.resolve(),
+  });
+  await t.throwsAsync(
+    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: '/tmp/s.sock' })),
+    { message: /9p mount of .* failed/ },
+  );
+  t.is(calls.bridges[0].stopped, 1);
+  t.is((await E(mounter).list()).length, 0);
+});
+
+test('unmount detaches with `umount -- <mp>`, stops the bridge, drops the handle', async t => {
+  const { mounter, calls } = makeHarness();
+  const h = await E(mounter).mount(
+    fakeFs(),
+    '/mnt/x',
+    harden({ socketPath: '/tmp/s.sock' }),
+  );
+  await E(h).unmount();
+  const umount = calls.run.find(c => c.bin === 'umount');
+  t.deepEqual(umount.argv, ['--', '/mnt/x']);
+  t.is(calls.bridges[0].stopped, 1);
+  t.is((await E(mounter).list()).length, 0);
+});
+
+test('a failed umount (EBUSY) keeps the bridge up and the handle, and is retryable', async t => {
+  let umountAttempts = 0;
+  const { mounter, calls } = makeHarness({
+    runBehavior: bin => {
+      if (bin === 'umount') {
+        umountAttempts += 1;
+        if (umountAttempts === 1) {
+          return Promise.reject(
+            Object.assign(new Error('target is busy'), { stderr: 'EBUSY' }),
+          );
+        }
+      }
+      return Promise.resolve();
+    },
+  });
+  const h = await E(mounter).mount(
+    fakeFs(),
+    '/mnt/x',
+    harden({ socketPath: '/tmp/s.sock' }),
+  );
+  await t.throwsAsync(E(h).unmount(), { message: /busy/ });
+  // The mount must not outlive its transport: bridge still up, handle retained.
+  t.is(calls.bridges[0].stopped, 0);
+  t.is((await E(mounter).list()).length, 1);
+  // Retry succeeds.
+  await E(h).unmount();
+  t.is(calls.bridges[0].stopped, 1);
+  t.is((await E(mounter).list()).length, 0);
+});
+
+test('lazyUnmount adds -l to the umount argv', async t => {
+  const { mounter, calls } = makeHarness();
+  const h = await E(mounter).mount(
+    fakeFs(),
+    '/mnt/x',
+    harden({ socketPath: '/tmp/s.sock', lazyUnmount: true }),
+  );
+  await E(h).unmount();
+  const umount = calls.run.find(c => c.bin === 'umount');
+  t.deepEqual(umount.argv, ['-l', '--', '/mnt/x']);
+});
+
+test('default socket paths are distinct across concurrent-ish mounts', async t => {
+  const { mounter } = makeHarness();
+  const h1 = await E(mounter).mount(fakeFs(), '/mnt/a', harden({}));
+  const h2 = await E(mounter).mount(fakeFs(), '/mnt/b', harden({}));
+  t.not(await E(h1).socketPath(), await E(h2).socketPath());
+});
+
+test('cancellation unmounts live mounts and refuses new ones', async t => {
+  let rejectCancelled;
+  const cancelledP = new Promise((_resolve, reject) => {
+    rejectCancelled = reject;
+  });
+  cancelledP.catch(() => {});
+  const { mounter, calls } = makeHarness({ cancelledP });
+  await E(mounter).mount(
+    fakeFs(),
+    '/mnt/x',
+    harden({ socketPath: '/tmp/s.sock' }),
+  );
+
+  rejectCancelled(new Error('teardown'));
+  await flush();
+
+  t.truthy(calls.run.find(c => c.bin === 'umount'));
+  t.is(calls.bridges[0].stopped, 1);
+  t.is((await E(mounter).list()).length, 0);
+
+  await t.throwsAsync(
+    E(mounter).mount(
+      fakeFs(),
+      '/mnt/y',
+      harden({ socketPath: '/tmp/s2.sock' }),
+    ),
+    { message: /cancelled/ },
+  );
+});

--- a/packages/9p-server/test/mount-caplet.test.js
+++ b/packages/9p-server/test/mount-caplet.test.js
@@ -135,6 +135,64 @@ test('NINEP_SUDO routes mount/umount through sudo', async t => {
   t.truthy(umount);
 });
 
+test('extraMountOptions cannot override the pinned trans option', async t => {
+  const { mounter } = makeHarness();
+  await t.throwsAsync(
+    E(mounter).mount(
+      fakeFs(),
+      '/mnt/x',
+      harden({
+        socketPath: '/tmp/s.sock',
+        extraMountOptions: 'trans=tcp,port=564',
+      }),
+    ),
+    { message: /may not set the pinned option .*trans/ },
+  );
+});
+
+test('caller cannot choose the mount/umount program', async t => {
+  const { mounter } = makeHarness();
+  await t.throwsAsync(
+    E(mounter).mount(
+      fakeFs(),
+      '/mnt/x',
+      harden({ socketPath: '/tmp/s.sock', umountProgram: ['rm'] }),
+    ),
+    { message: /operator configuration/ },
+  );
+});
+
+test('NINEP_MOUNT_PROGRAM lets the operator set a custom helper', async t => {
+  const { mounter, calls } = makeHarness({
+    env: {
+      NINEP_MOUNT_PROGRAM: 'sudo -u svc mount',
+      NINEP_UMOUNT_PROGRAM: 'sudo umount',
+    },
+  });
+  await E(mounter).mount(
+    fakeFs(),
+    '/mnt/x',
+    harden({ socketPath: '/tmp/s.sock' }),
+  );
+  t.is(calls.run[0].bin, 'sudo');
+  t.deepEqual(calls.run[0].argv.slice(0, 3), ['-u', 'svc', 'mount']);
+});
+
+test('a NINEP_MOUNT_PROGRAM that does not run mount is rejected at construction', t => {
+  t.throws(
+    () =>
+      makeFsMounter({
+        env: { NINEP_MOUNT_PROGRAM: 'rm -rf' },
+        runProgram: () => Promise.resolve(),
+        makeDir: () => Promise.resolve(),
+        removeDir: () => Promise.resolve(),
+        makeBridge: () =>
+          Far('B', { start: async () => {}, stop: async () => {} }),
+      }),
+    { message: /must invoke .*mount/ },
+  );
+});
+
 test('a failed mount stops the bridge and leaks no handle', async t => {
   const { mounter, calls } = makeHarness({
     runBehavior: bin =>

--- a/packages/9p-server/test/mount-caplet.test.js
+++ b/packages/9p-server/test/mount-caplet.test.js
@@ -154,6 +154,69 @@ test('a failed mount stops the bridge and leaks no handle', async t => {
   t.is((await E(mounter).list()).length, 0);
 });
 
+test('a failed bridge.start() is cleaned up and leaks no handle', async t => {
+  const calls = { run: [], bridges: [] };
+  const makeBridge = ({ fs, socketPath }) => {
+    const rec = { fs, socketPath, started: 0, stopped: 0 };
+    calls.bridges.push(rec);
+    return Far('FakeBridge', {
+      async start() {
+        rec.started += 1;
+        throw new Error('EADDRINUSE: socket already in use');
+      },
+      async stop() {
+        rec.stopped += 1;
+      },
+    });
+  };
+  const mounter = makeFsMounter({
+    runProgram: (bin, argv) => {
+      calls.run.push({ bin, argv });
+      return Promise.resolve();
+    },
+    makeDir: () => Promise.resolve(),
+    removeDir: () => Promise.resolve(),
+    makeBridge,
+  });
+  await t.throwsAsync(
+    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: '/tmp/s.sock' })),
+    { message: /bridge failed to start/ },
+  );
+  t.is(calls.bridges[0].stopped, 1, 'bridge stopped after start() failure');
+  t.is(calls.run.length, 0, 'mount never attempted');
+  t.is((await E(mounter).list()).length, 0, 'no handle leaked');
+});
+
+test('cancellation during an in-flight mount unmounts it (no orphan)', async t => {
+  let rejectCancelled;
+  const cancelledP = new Promise((_resolve, reject) => {
+    rejectCancelled = reject;
+  });
+  cancelledP.catch(() => {});
+  // Fire teardown *during* the mount shell-out and let its sweep run
+  // before mount() resumes — the deterministic version of the
+  // "settle between the last await and handles.add" race.
+  const { mounter, calls } = makeHarness({
+    cancelledP,
+    runBehavior: async bin => {
+      if (bin === 'mount') {
+        rejectCancelled(new Error('teardown'));
+        await flush();
+      }
+    },
+  });
+  await t.throwsAsync(
+    E(mounter).mount(fakeFs(), '/mnt/x', harden({ socketPath: '/tmp/s.sock' })),
+    { message: /cancelled during mount/ },
+  );
+  t.truthy(
+    calls.run.find(c => c.bin === 'umount'),
+    'the mount was unmounted',
+  );
+  t.is(calls.bridges[0].stopped, 1, 'bridge stopped');
+  t.is((await E(mounter).list()).length, 0, 'no orphan handle');
+});
+
 test('unmount detaches with `umount -- <mp>`, stops the bridge, drops the handle', async t => {
   const { mounter, calls } = makeHarness();
   const h = await E(mounter).mount(

--- a/packages/9p-server/test/server.test.js
+++ b/packages/9p-server/test/server.test.js
@@ -18,7 +18,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { mkdtemp, rm } from 'node:fs/promises';
 
-import { E } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
@@ -94,6 +94,37 @@ const setupNodeFsBridge = async t => {
   t.teardown(() => E(bridge).stop());
 
   return { fs, rootDir, socketPath };
+};
+
+/**
+ * A minimal `Filesystem` whose `Directory.create()` makes the new entry
+ * visible to `lookup()` only *after* its own promise resolves — exactly
+ * how node-fs behaves (the backend writes the dir entry after an internal
+ * await). This makes the Tlcreate create-vs-lookup race *deterministic*:
+ * a server that dispatches `lookup(name)` concurrently with `create(name)`
+ * sees ENOENT, while one that awaits `create` first sees the entry. Only
+ * the surface the Tattach → Twalk(clone) → Tlcreate path touches is
+ * implemented.
+ */
+const makeRaceFs = () => {
+  /** @type {Map<string, any>} */
+  const entries = new Map();
+  const dirQid = { type: 'directory', pathId: 0n, version: 0n };
+  const fileQid = { type: 'file', pathId: 7n, version: 0n };
+  const root = Far('RaceDir', {
+    getQid: () => dirQid,
+    async create(_name) {
+      await null; // entry is written only after this resolves
+      entries.set(_name, Far('RaceFile', { getQid: () => fileQid }));
+      return Far('RaceOpenFile', { close: async () => {} });
+    },
+    async lookup(name) {
+      const child = entries.get(name);
+      if (!child) throw Error('ENOENT: not found');
+      return child;
+    },
+  });
+  return Far('RaceFilesystem', { root: () => root });
 };
 
 /**
@@ -536,6 +567,31 @@ test.serial(
       existsSync(path.join(rootDir, 'newfile.txt')),
       'file exists on disk',
     );
+  },
+);
+
+test.serial(
+  'Tlcreate awaits create before lookup (deterministic race regression)',
+  async t => {
+    // Unlike the node-fs test above (which leans on real disk timing),
+    // makeRaceFs exposes the new entry only after create() resolves, so
+    // the race is deterministic on every machine: with the fix (await
+    // create, then lookup) this is Rlcreate; reverting to a concurrent
+    // create+lookup batch yields ENOENT here every time.
+    const fs = makeRaceFs();
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'claude-9p-race-'));
+    t.teardown(() => rm(dir, { recursive: true, force: true }));
+    const socketPath = path.join(dir, '9p.sock');
+    const bridge = makeFsBridge9p({ fs, socketPath });
+    await E(bridge).start();
+    t.teardown(() => E(bridge).stop());
+
+    const c = await setupClient(t, socketPath);
+    await negotiate(c);
+    await attach(c, 1);
+    await walk(c, 1, 2, []); // clone root to fid 2
+    const create = await tlcreate(c, 2, 'newfile.txt');
+    t.is(create.type, T.Rlcreate);
   },
 );
 

--- a/packages/9p-server/test/server.test.js
+++ b/packages/9p-server/test/server.test.js
@@ -21,7 +21,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { E } from '@endo/far';
 import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 
 import { makeInMemoryFilesystem } from '@endo/platform/fs/extended/in-memory.js';
 import { makeNodeFilesystem } from '@endo/platform/fs/extended/node-fs.js';
@@ -285,6 +285,33 @@ const tunlinkat = async (c, dfid, name) => {
   return c.recv();
 };
 
+const trenameat = async (c, oldDirFid, oldName, newDirFid, newName) => {
+  const w = makeWriter();
+  w.u32(oldDirFid);
+  w.str(oldName);
+  w.u32(newDirFid);
+  w.str(newName);
+  c.send(T.Trenameat, 12, w.finish());
+  return c.recv();
+};
+
+// Tsetattr with only ATTR_SIZE set — i.e. ftruncate(fid, size).
+const tsetattrSize = async (c, fid, size) => {
+  const w = makeWriter();
+  w.u32(fid);
+  w.u32(0x8); // valid = ATTR_SIZE
+  w.u32(0); // mode
+  w.u32(0); // uid
+  w.u32(0); // gid
+  w.u64(size);
+  w.u64(0n); // atime_sec
+  w.u64(0n); // atime_nsec
+  w.u64(0n); // mtime_sec
+  w.u64(0n); // mtime_nsec
+  c.send(T.Tsetattr, 13, w.finish());
+  return c.recv();
+};
+
 test('Tversion negotiates 9P2000.L', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
@@ -436,6 +463,112 @@ test('Tlcreate on a disk-backed (node-fs) FS creates without ENOENT (regression)
   const create = await tlcreate(c, 2, 'newfile.txt');
   t.is(create.type, T.Rlcreate, 'Tlcreate must return Rlcreate, not Rlerror');
   t.true(existsSync(path.join(rootDir, 'newfile.txt')), 'file exists on disk');
+});
+
+// The in-memory backing registers mutations eagerly and is the only one
+// the rest of this file exercises; the Tlcreate race showed that hides
+// real-backend bugs. This block re-runs the mutating ops against a
+// disk-backed (node-fs) Filesystem to catch sibling regressions.
+
+test('node-fs: Tlcreate + Twrite + reopen + Tread round-trips on disk', async t => {
+  const { rootDir, socketPath } = await setupNodeFsBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, []); // clone root to fid 2
+  t.is((await tlcreate(c, 2, 'f.txt')).type, T.Rlcreate);
+  t.is((await twrite(c, 2, 0n, Buffer.from('on disk'))).type, T.Rwrite);
+  // Reopen via a fresh walk from root so we read through a new fid.
+  t.is((await walk(c, 1, 3, ['f.txt'])).type, T.Rwalk);
+  t.is((await lopen(c, 3, 0)).type, T.Rlopen);
+  const rd = await tread(c, 3, 0n, 4096);
+  t.is(rd.type, T.Rread);
+  const r = makeReader(rd.payload);
+  t.is(r.take(r.u32()).toString('utf8'), 'on disk');
+  t.is(readFileSync(path.join(rootDir, 'f.txt'), 'utf8'), 'on disk');
+});
+
+test('node-fs: Tmkdir creates a directory reachable by Twalk', async t => {
+  const { rootDir, socketPath } = await setupNodeFsBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  const mk = await tmkdir(c, 1, 'd');
+  t.is(mk.type, T.Rmkdir);
+  const w = await walk(c, 1, 2, ['d']);
+  t.is(w.type, T.Rwalk);
+  const r = makeReader(w.payload);
+  t.is(r.u16(), 1);
+  t.is(readQid(r).type, QT.DIR);
+  t.true(existsSync(path.join(rootDir, 'd')));
+});
+
+test('node-fs: Trenameat moves a file', async t => {
+  const { rootDir, socketPath } = await setupNodeFsBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, []);
+  t.is((await tlcreate(c, 2, 'old.txt')).type, T.Rlcreate);
+  t.is((await trenameat(c, 1, 'old.txt', 1, 'new.txt')).type, T.Rrenameat);
+  t.is((await walk(c, 1, 3, ['new.txt'])).type, T.Rwalk);
+  t.is((await walk(c, 1, 4, ['old.txt'])).type, T.Rlerror);
+  t.false(existsSync(path.join(rootDir, 'old.txt')));
+  t.true(existsSync(path.join(rootDir, 'new.txt')));
+});
+
+test('node-fs: Tunlinkat removes a file', async t => {
+  const { rootDir, socketPath } = await setupNodeFsBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, []);
+  t.is((await tlcreate(c, 2, 'doomed.txt')).type, T.Rlcreate);
+  t.is((await tunlinkat(c, 1, 'doomed.txt')).type, T.Runlinkat);
+  const w = await walk(c, 1, 3, ['doomed.txt']);
+  t.is(w.type, T.Rlerror);
+  t.is(makeReader(w.payload).u32(), ERRNO.ENOENT);
+  t.false(existsSync(path.join(rootDir, 'doomed.txt')));
+});
+
+test('node-fs: Tsetattr truncates a file (ftruncate)', async t => {
+  const { rootDir, socketPath } = await setupNodeFsBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, []);
+  t.is((await tlcreate(c, 2, 'trunc.txt')).type, T.Rlcreate);
+  t.is((await twrite(c, 2, 0n, Buffer.from('hello world'))).type, T.Rwrite);
+  t.is((await tsetattrSize(c, 2, 5n)).type, T.Rsetattr);
+  const ga = await tgetattr(c, 2);
+  t.is(ga.type, T.Rgetattr);
+  t.is(readFileSync(path.join(rootDir, 'trunc.txt'), 'utf8'), 'hello');
+});
+
+test('node-fs: Treaddir lists entries from disk', async t => {
+  const { rootDir, socketPath } = await setupNodeFsBridge(t);
+  // Seed the directory on disk (node-fs reads the backing live) so
+  // readdir reflects real backing content, not just bytes written
+  // through the bridge.
+  writeFileSync(path.join(rootDir, 'alpha.txt'), 'a');
+  mkdirSync(path.join(rootDir, 'beta'));
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  t.is((await lopen(c, 1, 0)).type, T.Rlopen);
+  const rep = await treaddir(c, 1, 0n, 4096);
+  t.is(rep.type, T.Rreaddir);
+  const r = makeReader(rep.payload);
+  r.u32(); // total bytes
+  const names = new Set();
+  while (r.remaining() > 0) {
+    readQid(r);
+    r.u64();
+    r.u8();
+    names.add(r.str());
+  }
+  t.true(names.has('alpha.txt'));
+  t.true(names.has('beta'));
 });
 
 test('Tmkdir + Twalk + Tunlinkat lifecycle', async t => {

--- a/packages/9p-server/test/server.test.js
+++ b/packages/9p-server/test/server.test.js
@@ -21,7 +21,10 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { E } from '@endo/far';
 import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
 
+import { existsSync } from 'node:fs';
+
 import { makeInMemoryFilesystem } from '@endo/platform/fs/extended/in-memory.js';
+import { makeNodeFilesystem } from '@endo/platform/fs/extended/node-fs.js';
 
 import { makeFsBridge9p } from '../src/fs-bridge.js';
 import {
@@ -67,6 +70,30 @@ const setupBridge = async t => {
   t.teardown(() => E(bridge).stop());
 
   return { fs, socketPath };
+};
+
+/**
+ * Serve a real disk-backed (node-fs) Filesystem on a fresh UDS. The
+ * in-memory backing registers new entries eagerly, which masks the
+ * Tlcreate create-vs-lookup race; node-fs writes the entry after an
+ * await, so it exercises the real-mount path.
+ *
+ * @param {import('ava').ExecutionContext<any>} t
+ */
+const setupNodeFsBridge = async t => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'claude-9p-nodefs-'));
+  t.teardown(() => rm(rootDir, { recursive: true, force: true }));
+  const fs = makeNodeFilesystem({ rootPath: rootDir });
+
+  const sockDir = await mkdtemp(path.join(os.tmpdir(), 'claude-9p-sock-'));
+  t.teardown(() => rm(sockDir, { recursive: true, force: true }));
+  const socketPath = path.join(sockDir, '9p.sock');
+
+  const bridge = makeFsBridge9p({ fs, socketPath });
+  await E(bridge).start();
+  t.teardown(() => E(bridge).stop());
+
+  return { fs, rootDir, socketPath };
 };
 
 /**
@@ -391,6 +418,24 @@ test('Tlcreate + Twrite + Tread round-trips writes', async t => {
   const r = makeReader(readRep.payload);
   const count = r.u32();
   t.is(r.take(count).toString('utf8'), 'written via 9P');
+});
+
+test('Tlcreate on a disk-backed (node-fs) FS creates without ENOENT (regression)', async t => {
+  // `echo x > newfile.txt` on a real mount is O_CREAT|O_WRONLY|O_TRUNC
+  // on a missing path → a single Tlcreate. Before the onLcreate fix,
+  // the same-batch lookup(name) raced create(name) on node-fs (whose
+  // create writes the entry after an await), so the server returned
+  // Rlerror(ENOENT) even though the 0-byte file landed on disk. The
+  // in-memory backend masks this, so the regression test must use
+  // node-fs.
+  const { rootDir, socketPath } = await setupNodeFsBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, []); // clone root to fid 2
+  const create = await tlcreate(c, 2, 'newfile.txt');
+  t.is(create.type, T.Rlcreate, 'Tlcreate must return Rlcreate, not Rlerror');
+  t.true(existsSync(path.join(rootDir, 'newfile.txt')), 'file exists on disk');
 });
 
 test('Tmkdir + Twalk + Tunlinkat lifecycle', async t => {

--- a/packages/9p-server/test/server.test.js
+++ b/packages/9p-server/test/server.test.js
@@ -312,7 +312,7 @@ const tsetattrSize = async (c, fid, size) => {
   return c.recv();
 };
 
-test('Tversion negotiates 9P2000.L', async t => {
+test.serial('Tversion negotiates 9P2000.L', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   const { msize, version } = await negotiate(c);
@@ -320,7 +320,7 @@ test('Tversion negotiates 9P2000.L', async t => {
   t.true(msize >= 4096);
 });
 
-test('Tattach returns the root qid', async t => {
+test.serial('Tattach returns the root qid', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -328,7 +328,7 @@ test('Tattach returns the root qid', async t => {
   t.is(qid.type, QT.DIR);
 });
 
-test('Twalk to /greet.txt yields a file qid', async t => {
+test.serial('Twalk to /greet.txt yields a file qid', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -341,7 +341,7 @@ test('Twalk to /greet.txt yields a file qid', async t => {
   t.is(qid.type, QT.FILE);
 });
 
-test('Twalk + Tlopen + Tread round-trips file content', async t => {
+test.serial('Twalk + Tlopen + Tread round-trips file content', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -357,7 +357,7 @@ test('Twalk + Tlopen + Tread round-trips file content', async t => {
   t.is(bytes.toString('utf8'), 'hello');
 });
 
-test('Twrite to a read-only fid is EBADF', async t => {
+test.serial('Twrite to a read-only fid is EBADF', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -369,7 +369,7 @@ test('Twrite to a read-only fid is EBADF', async t => {
   t.is(makeReader(wr.payload).u32(), ERRNO.EBADF);
 });
 
-test('Tread from a write-only fid is EBADF', async t => {
+test.serial('Tread from a write-only fid is EBADF', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -381,7 +381,7 @@ test('Tread from a write-only fid is EBADF', async t => {
   t.is(makeReader(rd.payload).u32(), ERRNO.EBADF);
 });
 
-test('Twalk from an open fid is rejected (EBADF)', async t => {
+test.serial('Twalk from an open fid is rejected (EBADF)', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -393,7 +393,7 @@ test('Twalk from an open fid is rejected (EBADF)', async t => {
   t.is(makeReader(wrep.payload).u32(), ERRNO.EBADF);
 });
 
-test('Tlopen advertises a nonzero iounit (msize - 24)', async t => {
+test.serial('Tlopen advertises a nonzero iounit (msize - 24)', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   const { msize } = await negotiate(c);
@@ -406,7 +406,7 @@ test('Tlopen advertises a nonzero iounit (msize - 24)', async t => {
   t.is(r.u32(), msize - 24);
 });
 
-test('Tgetattr reports nlink >= 2 for a directory', async t => {
+test.serial('Tgetattr reports nlink >= 2 for a directory', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -422,7 +422,7 @@ test('Tgetattr reports nlink >= 2 for a directory', async t => {
   t.is(r.u64(), 2n); // nlink
 });
 
-test('Twalk pipelined chain walks /sub/inner.txt', async t => {
+test.serial('Twalk pipelined chain walks /sub/inner.txt', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -437,7 +437,7 @@ test('Twalk pipelined chain walks /sub/inner.txt', async t => {
   t.is(q2.type, QT.FILE);
 });
 
-test('Twalk to a missing name returns ENOENT', async t => {
+test.serial('Twalk to a missing name returns ENOENT', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -448,26 +448,29 @@ test('Twalk to a missing name returns ENOENT', async t => {
   t.is(r.u32(), ERRNO.ENOENT);
 });
 
-test('Twalk partial success: ["sub", "missing"] returns one qid + no newfid', async t => {
-  const { socketPath } = await setupBridge(t);
-  const c = await setupClient(t, socketPath);
-  await negotiate(c);
-  await attach(c, 1);
-  const rep = await walk(c, 1, 2, ['sub', 'missing']);
-  t.is(rep.type, T.Rwalk);
-  const r = makeReader(rep.payload);
-  t.is(r.u16(), 1);
-  const q1 = readQid(r);
-  t.is(q1.type, QT.DIR);
-  // newfid=2 should NOT have been set; a subsequent Tgetattr on it
-  // is EBADF.
-  const ga = await tgetattr(c, 2);
-  t.is(ga.type, T.Rlerror);
-  const rr = makeReader(ga.payload);
-  t.is(rr.u32(), ERRNO.EBADF);
-});
+test.serial(
+  'Twalk partial success: ["sub", "missing"] returns one qid + no newfid',
+  async t => {
+    const { socketPath } = await setupBridge(t);
+    const c = await setupClient(t, socketPath);
+    await negotiate(c);
+    await attach(c, 1);
+    const rep = await walk(c, 1, 2, ['sub', 'missing']);
+    t.is(rep.type, T.Rwalk);
+    const r = makeReader(rep.payload);
+    t.is(r.u16(), 1);
+    const q1 = readQid(r);
+    t.is(q1.type, QT.DIR);
+    // newfid=2 should NOT have been set; a subsequent Tgetattr on it
+    // is EBADF.
+    const ga = await tgetattr(c, 2);
+    t.is(ga.type, T.Rlerror);
+    const rr = makeReader(ga.payload);
+    t.is(rr.u32(), ERRNO.EBADF);
+  },
+);
 
-test('Treaddir yields entries', async t => {
+test.serial('Treaddir yields entries', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -491,7 +494,7 @@ test('Treaddir yields entries', async t => {
   t.true(names.has('sub'));
 });
 
-test('Tlcreate + Twrite + Tread round-trips writes', async t => {
+test.serial('Tlcreate + Twrite + Tread round-trips writes', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -512,63 +515,75 @@ test('Tlcreate + Twrite + Tread round-trips writes', async t => {
   t.is(r.take(count).toString('utf8'), 'written via 9P');
 });
 
-test('Tlcreate on a disk-backed (node-fs) FS creates without ENOENT (regression)', async t => {
-  // `echo x > newfile.txt` on a real mount is O_CREAT|O_WRONLY|O_TRUNC
-  // on a missing path → a single Tlcreate. Before the onLcreate fix,
-  // the same-batch lookup(name) raced create(name) on node-fs (whose
-  // create writes the entry after an await), so the server returned
-  // Rlerror(ENOENT) even though the 0-byte file landed on disk. The
-  // in-memory backend masks this, so the regression test must use
-  // node-fs.
-  const { rootDir, socketPath } = await setupNodeFsBridge(t);
-  const c = await setupClient(t, socketPath);
-  await negotiate(c);
-  await attach(c, 1);
-  await walk(c, 1, 2, []); // clone root to fid 2
-  const create = await tlcreate(c, 2, 'newfile.txt');
-  t.is(create.type, T.Rlcreate, 'Tlcreate must return Rlcreate, not Rlerror');
-  t.true(existsSync(path.join(rootDir, 'newfile.txt')), 'file exists on disk');
-});
+test.serial(
+  'Tlcreate on a disk-backed (node-fs) FS creates without ENOENT (regression)',
+  async t => {
+    // `echo x > newfile.txt` on a real mount is O_CREAT|O_WRONLY|O_TRUNC
+    // on a missing path → a single Tlcreate. Before the onLcreate fix,
+    // the same-batch lookup(name) raced create(name) on node-fs (whose
+    // create writes the entry after an await), so the server returned
+    // Rlerror(ENOENT) even though the 0-byte file landed on disk. The
+    // in-memory backend masks this, so the regression test must use
+    // node-fs.
+    const { rootDir, socketPath } = await setupNodeFsBridge(t);
+    const c = await setupClient(t, socketPath);
+    await negotiate(c);
+    await attach(c, 1);
+    await walk(c, 1, 2, []); // clone root to fid 2
+    const create = await tlcreate(c, 2, 'newfile.txt');
+    t.is(create.type, T.Rlcreate, 'Tlcreate must return Rlcreate, not Rlerror');
+    t.true(
+      existsSync(path.join(rootDir, 'newfile.txt')),
+      'file exists on disk',
+    );
+  },
+);
 
 // The in-memory backing registers mutations eagerly and is the only one
 // the rest of this file exercises; the Tlcreate race showed that hides
 // real-backend bugs. This block re-runs the mutating ops against a
 // disk-backed (node-fs) Filesystem to catch sibling regressions.
 
-test('node-fs: Tlcreate + Twrite + reopen + Tread round-trips on disk', async t => {
-  const { rootDir, socketPath } = await setupNodeFsBridge(t);
-  const c = await setupClient(t, socketPath);
-  await negotiate(c);
-  await attach(c, 1);
-  await walk(c, 1, 2, []); // clone root to fid 2
-  t.is((await tlcreate(c, 2, 'f.txt')).type, T.Rlcreate);
-  t.is((await twrite(c, 2, 0n, Buffer.from('on disk'))).type, T.Rwrite);
-  // Reopen via a fresh walk from root so we read through a new fid.
-  t.is((await walk(c, 1, 3, ['f.txt'])).type, T.Rwalk);
-  t.is((await lopen(c, 3, 0)).type, T.Rlopen);
-  const rd = await tread(c, 3, 0n, 4096);
-  t.is(rd.type, T.Rread);
-  const r = makeReader(rd.payload);
-  t.is(r.take(r.u32()).toString('utf8'), 'on disk');
-  t.is(readFileSync(path.join(rootDir, 'f.txt'), 'utf8'), 'on disk');
-});
+test.serial(
+  'node-fs: Tlcreate + Twrite + reopen + Tread round-trips on disk',
+  async t => {
+    const { rootDir, socketPath } = await setupNodeFsBridge(t);
+    const c = await setupClient(t, socketPath);
+    await negotiate(c);
+    await attach(c, 1);
+    await walk(c, 1, 2, []); // clone root to fid 2
+    t.is((await tlcreate(c, 2, 'f.txt')).type, T.Rlcreate);
+    t.is((await twrite(c, 2, 0n, Buffer.from('on disk'))).type, T.Rwrite);
+    // Reopen via a fresh walk from root so we read through a new fid.
+    t.is((await walk(c, 1, 3, ['f.txt'])).type, T.Rwalk);
+    t.is((await lopen(c, 3, 0)).type, T.Rlopen);
+    const rd = await tread(c, 3, 0n, 4096);
+    t.is(rd.type, T.Rread);
+    const r = makeReader(rd.payload);
+    t.is(r.take(r.u32()).toString('utf8'), 'on disk');
+    t.is(readFileSync(path.join(rootDir, 'f.txt'), 'utf8'), 'on disk');
+  },
+);
 
-test('node-fs: Tmkdir creates a directory reachable by Twalk', async t => {
-  const { rootDir, socketPath } = await setupNodeFsBridge(t);
-  const c = await setupClient(t, socketPath);
-  await negotiate(c);
-  await attach(c, 1);
-  const mk = await tmkdir(c, 1, 'd');
-  t.is(mk.type, T.Rmkdir);
-  const w = await walk(c, 1, 2, ['d']);
-  t.is(w.type, T.Rwalk);
-  const r = makeReader(w.payload);
-  t.is(r.u16(), 1);
-  t.is(readQid(r).type, QT.DIR);
-  t.true(existsSync(path.join(rootDir, 'd')));
-});
+test.serial(
+  'node-fs: Tmkdir creates a directory reachable by Twalk',
+  async t => {
+    const { rootDir, socketPath } = await setupNodeFsBridge(t);
+    const c = await setupClient(t, socketPath);
+    await negotiate(c);
+    await attach(c, 1);
+    const mk = await tmkdir(c, 1, 'd');
+    t.is(mk.type, T.Rmkdir);
+    const w = await walk(c, 1, 2, ['d']);
+    t.is(w.type, T.Rwalk);
+    const r = makeReader(w.payload);
+    t.is(r.u16(), 1);
+    t.is(readQid(r).type, QT.DIR);
+    t.true(existsSync(path.join(rootDir, 'd')));
+  },
+);
 
-test('node-fs: Trenameat moves a file', async t => {
+test.serial('node-fs: Trenameat moves a file', async t => {
   const { rootDir, socketPath } = await setupNodeFsBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -582,7 +597,7 @@ test('node-fs: Trenameat moves a file', async t => {
   t.true(existsSync(path.join(rootDir, 'new.txt')));
 });
 
-test('node-fs: Tunlinkat removes a file', async t => {
+test.serial('node-fs: Tunlinkat removes a file', async t => {
   const { rootDir, socketPath } = await setupNodeFsBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -596,7 +611,7 @@ test('node-fs: Tunlinkat removes a file', async t => {
   t.false(existsSync(path.join(rootDir, 'doomed.txt')));
 });
 
-test('node-fs: Tsetattr truncates a file (ftruncate)', async t => {
+test.serial('node-fs: Tsetattr truncates a file (ftruncate)', async t => {
   const { rootDir, socketPath } = await setupNodeFsBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -610,7 +625,7 @@ test('node-fs: Tsetattr truncates a file (ftruncate)', async t => {
   t.is(readFileSync(path.join(rootDir, 'trunc.txt'), 'utf8'), 'hello');
 });
 
-test('node-fs: Treaddir lists entries from disk', async t => {
+test.serial('node-fs: Treaddir lists entries from disk', async t => {
   const { rootDir, socketPath } = await setupNodeFsBridge(t);
   // Seed the directory on disk (node-fs reads the backing live) so
   // readdir reflects real backing content, not just bytes written
@@ -636,7 +651,7 @@ test('node-fs: Treaddir lists entries from disk', async t => {
   t.true(names.has('beta'));
 });
 
-test('Tmkdir + Twalk + Tunlinkat lifecycle', async t => {
+test.serial('Tmkdir + Twalk + Tunlinkat lifecycle', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -656,7 +671,7 @@ test('Tmkdir + Twalk + Tunlinkat lifecycle', async t => {
   t.is(r.u32(), ERRNO.ENOENT);
 });
 
-test('Tgetattr returns file size + reasonable mode bits', async t => {
+test.serial('Tgetattr returns file size + reasonable mode bits', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -676,7 +691,7 @@ test('Tgetattr returns file size + reasonable mode bits', async t => {
   t.is(size, 5n); // "hello"
 });
 
-test('Tclunk frees a fid; subsequent ops EBADF', async t => {
+test.serial('Tclunk frees a fid; subsequent ops EBADF', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -689,7 +704,7 @@ test('Tclunk frees a fid; subsequent ops EBADF', async t => {
   t.is(r.u32(), ERRNO.EBADF);
 });
 
-test('Twalk with `..` from root stays at root', async t => {
+test.serial('Twalk with `..` from root stays at root', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);
@@ -702,7 +717,7 @@ test('Twalk with `..` from root stays at root', async t => {
   t.is(q.type, QT.DIR);
 });
 
-test('Twalk with `..` from sub returns to root', async t => {
+test.serial('Twalk with `..` from sub returns to root', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);
   await negotiate(c);

--- a/packages/9p-server/test/server.test.js
+++ b/packages/9p-server/test/server.test.js
@@ -357,6 +357,71 @@ test('Twalk + Tlopen + Tread round-trips file content', async t => {
   t.is(bytes.toString('utf8'), 'hello');
 });
 
+test('Twrite to a read-only fid is EBADF', async t => {
+  const { socketPath } = await setupBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, ['greet.txt']);
+  await lopen(c, 2, 0); // O_RDONLY
+  const wr = await twrite(c, 2, 0n, Buffer.from('nope'));
+  t.is(wr.type, T.Rlerror);
+  t.is(makeReader(wr.payload).u32(), ERRNO.EBADF);
+});
+
+test('Tread from a write-only fid is EBADF', async t => {
+  const { socketPath } = await setupBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, ['greet.txt']);
+  await lopen(c, 2, 1); // O_WRONLY
+  const rd = await tread(c, 2, 0n, 16);
+  t.is(rd.type, T.Rlerror);
+  t.is(makeReader(rd.payload).u32(), ERRNO.EBADF);
+});
+
+test('Twalk from an open fid is rejected (EBADF)', async t => {
+  const { socketPath } = await setupBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, ['sub']); // fid 2 = /sub (directory)
+  await lopen(c, 2, 0); // open it
+  const wrep = await walk(c, 2, 3, ['inner.txt']); // walk from the open fid
+  t.is(wrep.type, T.Rlerror);
+  t.is(makeReader(wrep.payload).u32(), ERRNO.EBADF);
+});
+
+test('Tlopen advertises a nonzero iounit (msize - 24)', async t => {
+  const { socketPath } = await setupBridge(t);
+  const c = await setupClient(t, socketPath);
+  const { msize } = await negotiate(c);
+  await attach(c, 1);
+  await walk(c, 1, 2, ['greet.txt']);
+  const open = await lopen(c, 2, 0);
+  t.is(open.type, T.Rlopen);
+  const r = makeReader(open.payload);
+  readQid(r); // qid (13 bytes)
+  t.is(r.u32(), msize - 24);
+});
+
+test('Tgetattr reports nlink >= 2 for a directory', async t => {
+  const { socketPath } = await setupBridge(t);
+  const c = await setupClient(t, socketPath);
+  await negotiate(c);
+  await attach(c, 1); // root directory, fid 1
+  const ga = await tgetattr(c, 1);
+  t.is(ga.type, T.Rgetattr);
+  const r = makeReader(ga.payload);
+  r.u64(); // valid mask
+  readQid(r); // qid
+  r.u32(); // mode
+  r.u32(); // uid
+  r.u32(); // gid
+  t.is(r.u64(), 2n); // nlink
+});
+
 test('Twalk pipelined chain walks /sub/inner.txt', async t => {
   const { socketPath } = await setupBridge(t);
   const c = await setupClient(t, socketPath);

--- a/packages/daemon/src/networks/setup-tcp.js
+++ b/packages/daemon/src/networks/setup-tcp.js
@@ -1,0 +1,33 @@
+// @ts-check
+// Usage (installs the tcp-netstring network at NETS/tcp):
+//   endo run --UNCONFINED packages/daemon/src/networks/setup-tcp.js \
+//     --powers @agent -E ENDO_TCP_LISTEN=127.0.0.1:9100
+//
+// Requires --powers @agent because the script calls makeUnconfined()
+// and storeValue(). The tcp-netstring service reads its listen address
+// from the agent pet name `tcp-listen-addr`, so we store it first.
+
+import { E } from '@endo/eventual-send';
+
+const tcpSpecifier = new URL('tcp-netstring.js', import.meta.url).href;
+
+/**
+ * @param {import("@endo/eventual-send").ERef<any>} powers - HOST/@agent powers.
+ * @param {object} [_context]
+ * @param {object} [options]
+ * @param {Record<string, string>} [options.env]
+ */
+export const main = async (powers, _context, { env = {} } = {}) => {
+  const listen = env.ENDO_TCP_LISTEN || '127.0.0.1:0';
+  await E(powers).storeValue(listen, 'tcp-listen-addr');
+
+  await E(powers).makeUnconfined(undefined, tcpSpecifier, {
+    powersName: '@agent',
+    resultName: 'network-service-tcp',
+  });
+
+  await E(powers).move(['network-service-tcp'], ['@nets', 'tcp']);
+
+  return `tcp network installed at @nets/tcp (listen ${listen})`;
+};
+harden(main);

--- a/packages/daemon/src/networks/setup-tcp.js
+++ b/packages/daemon/src/networks/setup-tcp.js
@@ -19,6 +19,16 @@ const tcpSpecifier = new URL('tcp-netstring.js', import.meta.url).href;
  */
 export const main = async (powers, _context, { env = {} } = {}) => {
   const listen = env.ENDO_TCP_LISTEN || '127.0.0.1:0';
+  // Warn loudly if this binds the CapTP greeter beyond loopback: it
+  // exposes the daemon's peer-attachment surface to the network, and an
+  // empty host (e.g. `:9100`) silently binds 0.0.0.0.
+  const host = listen.slice(0, listen.lastIndexOf(':'));
+  if (host === '' || host === '0.0.0.0' || host === '::' || host === '*') {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[setup-tcp] WARNING: ENDO_TCP_LISTEN=${listen} binds the CapTP greeter on all interfaces (${host || '0.0.0.0'}); the daemon's peer-attach surface is network-exposed. Use a loopback or specific address unless that is intended.`,
+    );
+  }
   await E(powers).storeValue(listen, 'tcp-listen-addr');
 
   await E(powers).makeUnconfined(undefined, tcpSpecifier, {


### PR DESCRIPTION
Closes: (no issue referenced)

## Description

Adds `packages/9p-server/mount-caplet.js`, an unconfined caplet that projects an `@endo/platform/fs/extended` `Filesystem` capability into the host Linux kernel via 9P2000.L protocol.

The caplet exports a `make()` function that returns a mounter exo with the following capabilities:

- **`mount(fs, mountPoint, options?)`**: Stands up a per-mount 9P server on a Unix domain socket, attaches it to the kernel via `mount -t 9p`, and returns a `MountHandle` for lifecycle management.
- **`list()`**: Returns all active mount handles.
- **`help()`**: Provides usage documentation.

Each `MountHandle` exo offers:
- **`unmount()`**: Detaches the kernel mount and stops the 9P bridge.
- **`mountPoint()`**: Returns the resolved mount path.
- **`socketPath()`**: Returns the UDS path.
- **`help()`**: Describes the mount configuration.

### Key Features

- **Automatic teardown**: Wires the daemon's cancellation context to unmount all live mounts on caplet cancellation (worker termination, formula removal, daemon shutdown).
- **Privilege handling**: Supports `mountProgram`/`umountProgram` options and `NINEP_SUDO=1` environment variable to route mount/umount through privilege helpers (e.g., `sudo`) when the daemon lacks `CAP_SYS_ADMIN`.
- **Socket security**: Prefers `XDG_RUNTIME_DIR` for per-mount UDS placement to avoid world-visible sockets carrying full FS authority.
- **Configurable mount options**: Supports `trans`, `version`, `msize`, `access`, `cache`, `readOnly`, `extraMountOptions`, `socketPath`, `makeMountPoint`, and `removeMountPointOnUnmount`.
- **Error handling**: Graceful cleanup on mount failure; best-effort unmount during teardown with diagnostic logging.

### Security Considerations

This caplet bridges a capability-based FS interface into the kernel's 9P mount system. The UDS socket carries the full authority of the projected `Filesystem` capability and should not be world-visible; the code defaults to `XDG_RUNTIME_DIR` (0700, per-user tmpfs) for socket placement. Mount/unmount operations require `CAP_SYS_ADMIN`; unprivileged daemons must use a privilege helper. The caplet is unconfined and uses the worker's ambient Node authority for filesystem operations.

### Documentation Considerations

Users should be aware that:
- The daemon must run with `CAP_SYS_ADMIN` or route mount/umount through a privilege helper.
- Socket paths are sensitive and should not be world-readable.
- All mounts are automatically unmounted when the caplet is cancelled.
- The 9P bridge only speaks the 9p2000.L dialect.

### Testing Considerations

The caplet includes comprehensive JSDoc with usage examples. Integration testing would involve:
- Mounting an endo-fs `Filesystem` cap and verifying kernel-level access via the mount point.
- Verifying unmount on explicit `unmount()` call and on caplet cancellation.
- Testing privilege escalation via `mountProgram`/`umountProgram` and `NINEP_SUDO`.
- Verifying socket placement in `XDG_RUNTIME_DIR` and permission isolation.

### Compatibility Considerations

This is a new caplet with no impact on existing code or deployments.

### Upgrade Considerations

N/A — new feature.

https://claude.ai/code/session_01QoZTf5E8v8itvA97mk7HtY