### PR TITLE
[seg] isolated hang probe: preact-container vitest+chromium on Node 22 vs 24

### DIFF
--- a/.github/workflows/hang-probe.yml
+++ b/.github/workflows/hang-probe.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   preact-container-isolated:
     name: preact-container-isolated

--- a/.github/workflows/hang-probe.yml
+++ b/.github/workflows/hang-probe.yml
@@ -1,0 +1,61 @@
+name: hang-probe
+
+# Throwaway diagnostic for the Node-24 CI test hang (see
+# designs/node24-test-hang-investigation.md). Runs ONLY
+# @endo/preact-container's real test (vitest browser mode + Playwright
+# Chromium) in isolation on Node 22 vs 24, bounded by `timeout`, and dumps any
+# leftover browser/vitest process. vitest output is redirected to a file so a
+# leaked Chromium holds THAT fd (harmless) rather than the step's stdout pipe —
+# otherwise the step itself would hang and we could never read the result.
+# Not for merge.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  preact-container-isolated:
+    name: preact-container-isolated
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - run: corepack enable
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run preact-container test in isolation; detect leaked browser
+        run: |
+          set +e
+          echo "node: $(node --version)"
+          start=$(date +%s)
+          # Redirect vitest output to a file: a leaked Chromium then holds the
+          # file fd, not this step's stdout, so the step can still conclude.
+          timeout -s KILL 240 yarn workspace @endo/preact-container run test \
+            >/tmp/v.out 2>&1
+          code=$?
+          echo "=== preact-container test exit=$code  wall=$(( $(date +%s) - start ))s ==="
+          echo "    (124/137 => vitest itself did not exit = HANG reproduced)"
+          echo "=== last 40 lines of vitest output ==="
+          tail -40 /tmp/v.out || true
+          echo "=== leftover browser / vitest / playwright processes (leak if any) ==="
+          ps -eo pid,ppid,etimes,comm,args \
+            | grep -iE 'chrom|headless|vitest|playwright' \
+            | grep -v grep || echo "  none"
+          echo "=== probe done (step concludes regardless of leak) ==="

--- a/packages/preact-container/package.json
+++ b/packages/preact-container/package.json
@@ -50,7 +50,7 @@
     "@vitest/browser": "^4.1.9",
     "@vitest/browser-playwright": "^4.1.9",
     "eslint": "catalog:dev",
-    "playwright": "1.56.1",
+    "playwright": "^1.60.0",
     "preact": "^10.29.2",
     "ses": "workspace:^",
     "vite": "^8.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,7 +2446,7 @@ __metadata:
     "@vitest/browser": "npm:^4.1.9"
     "@vitest/browser-playwright": "npm:^4.1.9"
     eslint: "catalog:dev"
-    playwright: "npm:1.56.1"
+    playwright: "npm:^1.60.0"
     preact: "npm:^10.29.2"
     ses: "workspace:^"
     vite: "npm:^8.0.16"
@@ -14677,15 +14677,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.56.1":
-  version: 1.56.1
-  resolution: "playwright-core@npm:1.56.1"
-  bin:
-    playwright-core: cli.js
-  checksum: 10c0/ffd40142b99c68678b387445d5b42f1fee4ab0b65d983058c37f342e5629f9cdbdac0506ea80a0dfd41a8f9f13345bad54e9a8c35826ef66dc765f4eb3db8da7
-  languageName: node
-  linkType: hard
-
 "playwright-core@npm:1.59.1":
   version: 1.59.1
   resolution: "playwright-core@npm:1.59.1"
@@ -14695,18 +14686,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright@npm:1.56.1":
-  version: 1.56.1
-  resolution: "playwright@npm:1.56.1"
-  dependencies:
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.56.1"
-  dependenciesMeta:
-    fsevents:
-      optional: true
+"playwright-core@npm:1.61.0":
+  version: 1.61.0
+  resolution: "playwright-core@npm:1.61.0"
   bin:
-    playwright: cli.js
-  checksum: 10c0/8e9965aede86df0f4722063385748498977b219630a40a10d1b82b8bd8d4d4e9b6b65ecbfa024331a30800163161aca292fb6dd7446c531a1ad25f4155625ab4
+    playwright-core: cli.js
+  checksum: 10c0/64cbf5e9f4ad81cbb005d59417e96435e324a6e3801f1c79b36850ad99f6bb90853c4b569a32c49b9eca1e07925bbb2a5a864babdba2178c3c395e0c589d5941
   languageName: node
   linkType: hard
 
@@ -14722,6 +14707,21 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/dfe38396e616e5c4f98825ce90037bb96e477c5a2bd9258a24854f8ce72a8a41427b19098863866f85aa0216e70287dd537c4438d761aca93995e31ae099c533
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.60.0":
+  version: 1.61.0
+  resolution: "playwright@npm:1.61.0"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.61.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/079dceebe8b745fa6062a3af928024d0c508177fbf15d61dba09ba173f277465ad3746fdc1b31788ade65428f4d3f92fc8083b44c07381b088721eaa2ea06513
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Diagnostic complete — root cause confirmed and fix landed on #471.

The Node-24 CI hang is upstream Playwright bug microsoft/playwright#41000: `playwright install chromium` hangs extracting Chromium on Node 24.16.0. This isolated probe proved it on `@endo/preact-container` (vitest browser mode):

- playwright 1.56.1 on Node 24.16.0: install hangs at 100% download, killed at 240s.
- playwright 1.61.0 on Node 24.16.0: Chromium installs, 147 browser tests pass in ~2s.
- Node 22: unaffected throughout.

Fix (`playwright` → `^1.60.0`) applied on PR #471. Closing this throwaway probe.