### PR TITLE
feat(daemon): compose caplets over un-named powers — by-reference `powers` + `retainUntil`

### DIFF
--- a/.changeset/daemon-powers-by-reference.md
+++ b/.changeset/daemon-powers-by-reference.md
@@ -1,0 +1,17 @@
+---
+'@endo/daemon': minor
+---
+
+New: `makeUnconfined`, `makeArchive`, and `makeFromTree` accept caplet powers by
+capability reference via `MakeCapletOptions.powers` (mutually exclusive with
+`powersName`). A per-session powers cap can now be composed directly, without
+minting a host pet name and removing it again afterward.
+
+New: `evaluate` accepts an optional trailing `retainUntil` promise. When the
+result is un-named (no `resultName`), its transient root is held until
+`retainUntil` settles instead of being dropped as soon as the value resolves —
+the ephemeral-root sibling of `resultName`. This lets a caller keep an
+un-named (e.g. inline-evaluated) result alive long enough to compose it by
+reference, for example as the `powers` of a `makeUnconfined` call. Default
+behaviour is unchanged: an un-named `evaluate` with no `retainUntil` is still
+ephemeral.

--- a/.changeset/daemon-powers-by-reference.md
+++ b/.changeset/daemon-powers-by-reference.md
@@ -7,11 +7,11 @@ capability reference via `MakeCapletOptions.powers` (mutually exclusive with
 `powersName`). A per-session powers cap can now be composed directly, without
 minting a host pet name and removing it again afterward.
 
-New: `evaluate` accepts an optional trailing `retainUntil` promise. When the
-result is un-named (no `resultName`), its transient root is held until
-`retainUntil` settles instead of being dropped as soon as the value resolves —
-the ephemeral-root sibling of `resultName`. This lets a caller keep an
-un-named (e.g. inline-evaluated) result alive long enough to compose it by
-reference, for example as the `powers` of a `makeUnconfined` call. Default
-behaviour is unchanged: an un-named `evaluate` with no `retainUntil` is still
-ephemeral.
+New: `evaluate` accepts an optional trailing `retainUntil` promise. The result
+is held as a transient root until `retainUntil` settles instead of being
+dropped as soon as the value resolves — the ephemeral-root sibling of
+`resultName`. This lets a caller keep a result (typically an un-named,
+inline-evaluated one) alive long enough to compose it by reference, for example
+as the `powers` of a `makeUnconfined` call. `retainUntil` is honored even when
+`resultName` is also supplied. Default behaviour is unchanged: an un-named
+`evaluate` with no `retainUntil` is still ephemeral.

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -274,6 +274,8 @@ export const makeGuestMaker = ({
       if (resultName === undefined) {
         return retainUnnamed(id, value, retainUntil);
       }
+      // A named result is durably rooted by its pet-name edge, so any
+      // `retainUntil` is redundant and intentionally ignored on this branch.
       return value;
     };
 

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -14,6 +14,7 @@ import {
 } from './pet-name.js';
 import { makeDeferredTasks } from './deferred-tasks.js';
 import { idFromLocator } from './locator.js';
+import { makeRetainUnnamed } from './retain-unnamed.js';
 
 /** @import { Context, DaemonCore, DeferredTasks, EndoGuest, EvalDeferredTaskParams, FormulaIdentifier, MakeDirectoryNode, MakeMailbox, MarshalDeferredTaskParams, Name, NameOrPath, NamePath, NodeNumber, NamesOrPaths, Provide, ReadableBlobDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
 import { GuestInterface } from './interfaces.js';
@@ -206,12 +207,15 @@ export const makeGuestMaker = ({
      * @param {NameOrPath} [resultName]
      * @returns {Promise<unknown>}
      */
+    const retainUnnamed = makeRetainUnnamed(unpinTransient);
+
     const evaluate = async (
       workerName,
       source,
       codeNames,
       petNamesOrPaths,
       resultName,
+      retainUntil,
     ) => {
       if (workerName !== undefined) {
         assertName(workerName);
@@ -268,11 +272,7 @@ export const makeGuestMaker = ({
         resultName === undefined ? pinTransient : undefined,
       );
       if (resultName === undefined) {
-        try {
-          return await value;
-        } finally {
-          await unpinTransient(id);
-        }
+        return retainUnnamed(id, value, retainUntil);
       }
       return value;
     };

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -269,13 +269,18 @@ export const makeGuestMaker = ({
         endowmentFormulaIdsOrPaths,
         tasks,
         workerId,
-        resultName === undefined ? pinTransient : undefined,
+        // Pin the result whenever it is un-named or whenever the caller
+        // supplied `retainUntil` (an explicit request to hold it); a named
+        // result is otherwise durably rooted by its pet-name edge.
+        resultName === undefined || retainUntil !== undefined
+          ? pinTransient
+          : undefined,
       );
-      if (resultName === undefined) {
+      if (resultName === undefined || retainUntil !== undefined) {
+        // `retainUnnamed` drops the pin once `retainUntil` settles, or
+        // immediately when there is no `retainUntil` (the ephemeral case).
         return retainUnnamed(id, value, retainUntil);
       }
-      // A named result is durably rooted by its pet-name edge, so any
-      // `retainUntil` is redundant and intentionally ignored on this branch.
       return value;
     };
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -712,7 +712,8 @@ export const makeHostMaker = ({
      */
     const prepareMakeCaplet = (workerName, options = {}) => {
       const {
-        powersName = '@none',
+        powersName,
+        powers,
         resultName,
         env = {},
         workerTrustedShims,
@@ -720,7 +721,11 @@ export const makeHostMaker = ({
       if (workerName !== undefined) {
         assertName(workerName);
       }
-      assertPowersName(powersName);
+      if (powers !== undefined && powersName !== undefined) {
+        throw makeError(
+          X`Specify either "powers" (by capability reference) or "powersName", not both`,
+        );
+      }
 
       /** @type {DeferredTasks<MakeCapletDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
@@ -730,15 +735,38 @@ export const makeHostMaker = ({
         tasks.push,
       );
 
-      const powersId = /** @type {FormulaIdentifier | undefined} */ (
-        petStore.identifyLocal(/** @type {Name} */ (powersName))
-      );
-      if (powersId === undefined) {
-        assertPetName(powersName);
-        const powersPetName = powersName;
-        tasks.push(identifiers => {
-          return petStore.storeIdentifier(powersPetName, identifiers.powersId);
-        });
+      /** @type {FormulaIdentifier | undefined} */
+      let powersId;
+      if (powers !== undefined) {
+        // Powers supplied by reference: resolve the capability to the
+        // formula id it was minted from (the same identity map
+        // `provideHostPath` uses). The caplet formula then depends on that
+        // id directly, so the powers needs no pet name — it stays reachable
+        // for exactly the caplet's lifetime and is collected with it. This
+        // mirrors how the daemon already accepts a *named* powers id, only
+        // the id comes from the cap's identity rather than the pet store.
+        powersId = getIdForRef(powers);
+        if (powersId === undefined) {
+          throw makeError(
+            X`"powers" must be a capability minted by this daemon`,
+          );
+        }
+      } else {
+        const resolvedPowersName = powersName ?? '@none';
+        assertPowersName(resolvedPowersName);
+        powersId = /** @type {FormulaIdentifier | undefined} */ (
+          petStore.identifyLocal(/** @type {Name} */ (resolvedPowersName))
+        );
+        if (powersId === undefined) {
+          assertPetName(resolvedPowersName);
+          const powersPetName = resolvedPowersName;
+          tasks.push(identifiers => {
+            return petStore.storeIdentifier(
+              powersPetName,
+              identifiers.powersId,
+            );
+          });
+        }
       }
 
       if (resultName !== undefined) {

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -700,6 +700,8 @@ export const makeHostMaker = ({
         // concurrent collection can't reclaim it.
         return retainUnnamed(id, value, retainUntil);
       }
+      // A named result is durably rooted by its pet-name edge, so any
+      // `retainUntil` is redundant and intentionally ignored on this branch.
       return value;
     };
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -36,6 +36,7 @@ import { toHex, fromHex } from './hex.js';
 import { makePetSitter } from './pet-sitter.js';
 
 import { makeDeferredTasks } from './deferred-tasks.js';
+import { makeRetainUnnamed } from './retain-unnamed.js';
 
 import { HostInterface } from './interfaces.js';
 import { hostHelp, makeHelp } from './help-text.js';
@@ -623,12 +624,15 @@ export const makeHostMaker = ({
      * @param {(string | string[])[]} petNamePaths
      * @param {NameOrPath | undefined} resultName
      */
+    const retainUnnamed = makeRetainUnnamed(unpinTransient);
+
     const evaluate = async (
       workerName,
       source,
       codeNames,
       petNamePaths,
       resultName,
+      retainUntil,
     ) => {
       if (workerName !== undefined) {
         assertName(workerName);
@@ -692,15 +696,9 @@ export const makeHostMaker = ({
         workerLabel,
       );
       if (resultName === undefined) {
-        // Ephemeral eval: the formula was pinned inside formulateEval
-        // (inside the lock) so concurrent collection can't reclaim it.
-        // Unpin after the value resolves and drain any resulting
-        // collection cleanup (worker termination, etc.).
-        try {
-          return await value;
-        } finally {
-          await unpinTransient(id);
-        }
+        // The formula was pinned inside formulateEval (inside the lock) so
+        // concurrent collection can't reclaim it.
+        return retainUnnamed(id, value, retainUntil);
       }
       return value;
     };

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -685,6 +685,11 @@ export const makeHostMaker = ({
         );
       }
 
+      // Pin the result as a transient root whenever it is un-named (so it
+      // survives formulation against concurrent collection) or whenever the
+      // caller supplied `retainUntil` (an explicit request to hold it). A
+      // named result is otherwise durably rooted by its pet-name edge.
+      const pinResult = resultName === undefined || retainUntil !== undefined;
       const { id, value } = await formulateEval(
         hostId,
         source,
@@ -692,16 +697,16 @@ export const makeHostMaker = ({
         endowmentFormulaIdsOrPaths,
         tasks,
         workerId,
-        resultName === undefined ? pinTransient : undefined,
+        pinResult ? pinTransient : undefined,
         workerLabel,
       );
-      if (resultName === undefined) {
+      if (pinResult) {
         // The formula was pinned inside formulateEval (inside the lock) so
-        // concurrent collection can't reclaim it.
+        // concurrent collection can't reclaim it. `retainUnnamed` drops the
+        // pin once `retainUntil` settles, or immediately when there is no
+        // `retainUntil` (the ephemeral un-named case).
         return retainUnnamed(id, value, retainUntil);
       }
-      // A named result is durably rooted by its pet-name edge, so any
-      // `retainUntil` is redundant and intentionally ignored on this branch.
       return value;
     };
 

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -43,6 +43,12 @@ const MakeCapletOptionsShape = M.splitRecord(
   {},
   {
     powersName: NameShape,
+    // Alternative to `powersName`: supply the powers by capability
+    // reference. The daemon resolves the cap to its formula id, so the
+    // caller need never give it a pet name (and the resulting caplet keeps
+    // it reachable for its own lifetime). Mutually exclusive with
+    // `powersName`.
+    powers: M.remotable('Powers'),
     resultName: NameOrPathShape,
     env: EnvShape,
     workerTrustedShims: M.arrayOf(M.string()),

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -56,14 +56,18 @@ const MakeCapletOptionsShape = M.splitRecord(
 );
 
 // Shared method guard for evaluate (used by both Host and Guest)
-// Both execute directly in a worker, differing only in namespace
+// Both execute directly in a worker, differing only in namespace.
+// Trailing optionals: `resultName` (durably roots the result by pet name)
+// and `retainUntil` (a promise that keeps an *un-named* result alive — a
+// transient root — until it settles; the ephemeral-root sibling of
+// `resultName`).
 const EvaluateMethodGuard = M.call(
   M.or(NameShape, M.undefined()),
   M.string(),
   M.arrayOf(M.string()),
   NamesOrPathsShape,
 )
-  .optional(NameOrPathShape)
+  .optional(M.or(NameOrPathShape, M.undefined()), M.promise())
   .returns(M.promise());
 
 // #region Interfaces

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -58,9 +58,9 @@ const MakeCapletOptionsShape = M.splitRecord(
 // Shared method guard for evaluate (used by both Host and Guest)
 // Both execute directly in a worker, differing only in namespace.
 // Trailing optionals: `resultName` (durably roots the result by pet name)
-// and `retainUntil` (a promise that keeps an *un-named* result alive — a
-// transient root — until it settles; the ephemeral-root sibling of
-// `resultName`).
+// and `retainUntil` (a promise that keeps the result alive — a transient
+// root — until it settles; the ephemeral-root sibling of `resultName`,
+// honored even alongside it, and most useful for an un-named result).
 const EvaluateMethodGuard = M.call(
   M.or(NameShape, M.undefined()),
   M.string(),

--- a/packages/daemon/src/retain-unnamed.js
+++ b/packages/daemon/src/retain-unnamed.js
@@ -1,0 +1,52 @@
+// @ts-check
+
+/**
+ * Retention policy for an un-named formula returned by `evaluate` (the
+ * formula is already pinned as a transient root inside `formulateEval`).
+ *
+ * Without `retainUntil` the result is **ephemeral**: the transient pin is
+ * released as soon as the value resolves, which triggers collection (an
+ * un-named result with no other root is reclaimed immediately). This keeps
+ * one-shot evaluations (e.g. `endo eval expr`) from leaking a formula.
+ *
+ * With `retainUntil` the transient pin is **held until the caller's promise
+ * settles** (resolve or reject) — the ephemeral-root sibling of
+ * `resultName`. This lets a caller hold an un-named result long enough to
+ * compose it by reference (e.g. pass an eval'd powers exo as `powers` to
+ * `makeUnconfined`), after which a durable dependency edge roots it and the
+ * caller settles the promise to drop the transient pin. The retention is
+ * in-memory, so it is lost on daemon restart — which is harmless, because
+ * by then any durable edge that captured the result has been persisted.
+ *
+ * @param {(id: import('./types.js').FormulaIdentifier) => void} unpinTransient
+ * @returns {(
+ *   id: import('./types.js').FormulaIdentifier,
+ *   value: unknown,
+ *   retainUntil: Promise<unknown> | undefined,
+ * ) => Promise<unknown>}
+ */
+export const makeRetainUnnamed =
+  unpinTransient => async (id, value, retainUntil) => {
+    let resolved;
+    try {
+      resolved = await value;
+    } catch (error) {
+      // The evaluation itself failed — release the pin rather than leak it.
+      unpinTransient(id);
+      throw error;
+    }
+    if (retainUntil === undefined) {
+      // Ephemeral: drop the pin now (this triggers collection).
+      unpinTransient(id);
+    } else {
+      // Hold the pin until the caller's retention promise settles, either
+      // way. A remote promise rejects when its connection drops, so the
+      // pin is also released if the holder disconnects.
+      Promise.resolve(retainUntil).then(
+        () => unpinTransient(id),
+        () => unpinTransient(id),
+      );
+    }
+    return resolved;
+  };
+harden(makeRetainUnnamed);

--- a/packages/daemon/src/retain-unnamed.js
+++ b/packages/daemon/src/retain-unnamed.js
@@ -1,22 +1,27 @@
 // @ts-check
 
 /**
- * Retention policy for an un-named formula returned by `evaluate` (the
- * formula is already pinned as a transient root inside `formulateEval`).
+ * Retention policy for a formula returned by `evaluate` that has been pinned
+ * as a transient root inside `formulateEval`.
  *
  * Without `retainUntil` the result is **ephemeral**: the transient pin is
  * released as soon as the value resolves, which triggers collection (an
  * un-named result with no other root is reclaimed immediately). This keeps
  * one-shot evaluations (e.g. `endo eval expr`) from leaking a formula.
+ * (`evaluate` only pins, and so only routes through this policy, an un-named
+ * result in the no-`retainUntil` case.)
  *
  * With `retainUntil` the transient pin is **held until the caller's promise
  * settles** (resolve or reject) — the ephemeral-root sibling of
- * `resultName`. This lets a caller hold an un-named result long enough to
- * compose it by reference (e.g. pass an eval'd powers exo as `powers` to
+ * `resultName`. This lets a caller hold a result long enough to compose it
+ * by reference (e.g. pass an eval'd powers exo as `powers` to
  * `makeUnconfined`), after which a durable dependency edge roots it and the
- * caller settles the promise to drop the transient pin. The retention is
- * in-memory, so it is lost on daemon restart — which is harmless, because
- * by then any durable edge that captured the result has been persisted.
+ * caller settles the promise to drop the transient pin. `retainUntil` is
+ * honored regardless of `resultName`: a named result is already durably
+ * rooted by its pet-name edge, but an explicit `retainUntil` is still held
+ * as requested rather than ignored. The retention is in-memory, so it is
+ * lost on daemon restart — which is harmless, because by then any durable
+ * edge that captured the result has been persisted.
  *
  * @param {(id: import('./types.js').FormulaIdentifier) => void} unpinTransient
  * @returns {(

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1345,6 +1345,13 @@ export interface EndoGuest extends EndoAgent {
     codeNames: Array<string>,
     petNamesOrPaths: Array<string | string[]>,
     resultNameOrPath?: string | string[],
+    /**
+     * When `resultNameOrPath` is omitted, keep the un-named result alive
+     * (as a transient root) until this promise settles, so it can be
+     * composed by reference before collection. The ephemeral-root sibling
+     * of `resultNameOrPath`; in-memory only (lost on daemon restart).
+     */
+    retainUntil?: Promise<unknown>,
   ): Promise<unknown>;
   define(
     source: string,
@@ -1482,6 +1489,12 @@ export interface EndoHost extends EndoAgent {
     codeNames: Array<string>,
     petNamesOrPaths: Array<string | string[]>,
     resultName?: string | string[],
+    /**
+     * When `resultName` is omitted, keep the un-named result alive (as a
+     * transient root) until this promise settles, so it can be composed by
+     * reference before collection. In-memory only (lost on daemon restart).
+     */
+    retainUntil?: Promise<unknown>,
   ): Promise<unknown>;
   makeUnconfined(
     workerName: string | undefined,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1256,6 +1256,14 @@ export type MakeHostOrGuestOptions = {
 
 export type MakeCapletOptions = {
   powersName?: string;
+  /**
+   * Powers supplied by capability reference instead of by pet name. The
+   * daemon resolves the cap to its formula id; mutually exclusive with
+   * `powersName`. Lets a caller compose a caplet over an un-named powers
+   * cap (e.g. an `evaluate` result), which is then rooted only by the
+   * caplet that depends on it.
+   */
+  powers?: unknown;
   resultName?: string | string[];
   env?: Record<string, string>;
   workerTrustedShims?: string[];

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1346,10 +1346,12 @@ export interface EndoGuest extends EndoAgent {
     petNamesOrPaths: Array<string | string[]>,
     resultNameOrPath?: string | string[],
     /**
-     * When `resultNameOrPath` is omitted, keep the un-named result alive
-     * (as a transient root) until this promise settles, so it can be
-     * composed by reference before collection. The ephemeral-root sibling
-     * of `resultNameOrPath`; in-memory only (lost on daemon restart).
+     * Keep the result alive (as a transient root) until this promise
+     * settles, so it can be composed by reference before collection. The
+     * ephemeral-root sibling of `resultNameOrPath`, and honored even when
+     * `resultNameOrPath` is also supplied; in-memory only (lost on daemon
+     * restart). Most useful for an un-named result, which is otherwise
+     * collected as soon as it resolves.
      */
     retainUntil?: Promise<unknown>,
   ): Promise<unknown>;
@@ -1490,9 +1492,11 @@ export interface EndoHost extends EndoAgent {
     petNamesOrPaths: Array<string | string[]>,
     resultName?: string | string[],
     /**
-     * When `resultName` is omitted, keep the un-named result alive (as a
-     * transient root) until this promise settles, so it can be composed by
-     * reference before collection. In-memory only (lost on daemon restart).
+     * Keep the result alive (as a transient root) until this promise
+     * settles, so it can be composed by reference before collection.
+     * Honored even when `resultName` is also supplied; in-memory only (lost
+     * on daemon restart). Most useful for an un-named result, which is
+     * otherwise collected as soon as it resolves.
      */
     retainUntil?: Promise<unknown>,
   ): Promise<unknown>;

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -1024,6 +1024,79 @@ testNeedsNodeWorker(
 );
 
 testNeedsNodeWorker(
+  'an already-settled retainUntil releases the pin (result not composable)',
+  async t => {
+    const { host } = await prepareHost(t);
+    // retainUntil resolved before the call returns: the unpin fires on the
+    // next microtask, so by the time the (CapTP-round-tripped) result is in
+    // hand the formula has already been collected — i.e. equivalent to no
+    // retainUntil. Pins the pre-settled boundary.
+    const powers = await E(host).evaluate(
+      '@main',
+      `Far('Pingable', { ping: () => 'pong' })`,
+      [],
+      [],
+      undefined,
+      Promise.resolve('done'),
+    );
+    await t.throwsAsync(
+      E(host).makeUnconfined('@main', powersPingPath, { powers }),
+      { message: /minted by this daemon/ },
+    );
+  },
+);
+
+testNeedsNodeWorker(
+  'a rejected retainUntil resolves evaluate normally and releases the pin',
+  async t => {
+    const { host } = await prepareHost(t);
+    // A rejected retention promise must not reject `evaluate` (the rejection
+    // only drives the unpin) and must still release the pin (no leak).
+    const rejected = Promise.reject(new Error('retention aborted'));
+    rejected.catch(() => {}); // we hand the rejection to the daemon, not Node
+    const powers = await E(host).evaluate(
+      '@main',
+      `Far('Pingable', { ping: () => 'pong' })`,
+      [],
+      [],
+      undefined,
+      rejected,
+    );
+    // evaluate resolved to the value despite the rejected retainUntil...
+    t.truthy(powers);
+    // ...and the pin was released, so the result is no longer composable.
+    await t.throwsAsync(
+      E(host).makeUnconfined('@main', powersPingPath, { powers }),
+      { message: /minted by this daemon/ },
+    );
+  },
+);
+
+testNeedsNodeWorker(
+  'guest evaluate threads retainUntil and keeps an un-named result alive',
+  async t => {
+    const { host } = await prepareHost(t);
+    const guest = await E(host).provideGuest('guest');
+    await E(host).provideWorker(['worker']);
+
+    const release = makePromiseKit();
+    // Guest path (guest.js) routes through the same makeRetainUnnamed policy.
+    const result = await E(guest).evaluate(
+      'worker',
+      `Far('Pingable', { ping: () => 'guest-pong' })`,
+      [],
+      [],
+      undefined,
+      release.promise,
+    );
+    // Retained while the promise is pending: the un-named result is still
+    // live, so a method call on it resolves.
+    t.is(await E(result).ping(), 'guest-pong');
+    release.resolve();
+  },
+);
+
+testNeedsNodeWorker(
   'move moves value, between different caplet name hubs',
   async t => {
     const { host } = await prepareHost(t);

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -969,6 +969,61 @@ testNeedsNodeWorker(
 );
 
 testNeedsNodeWorker(
+  'evaluate retainUntil keeps an un-named result composable by reference',
+  async t => {
+    const { host } = await prepareHost(t);
+    const release = makePromiseKit();
+
+    // The @endo/claude-sandbox factory's shape: build a powers cap from
+    // inline source + endowments, keep it alive un-named via retainUntil,
+    // hand it to makeUnconfined by reference, then release once the
+    // caplet's dependency edge roots it. No pet name is ever involved.
+    const powers = await E(host).evaluate(
+      '@main',
+      `Far('Pingable', { ping: () => 'pong-eval' })`,
+      [],
+      [],
+      undefined, // resultName — un-named
+      release.promise, // retainUntil
+    );
+    const caplet = await E(host).makeUnconfined('@main', powersPingPath, {
+      powers,
+      resultName: 'ping-caplet',
+    });
+    t.is(await E(caplet).pong(), 'pong-eval');
+
+    // Drop the transient pin; the caplet's ['powers', id] edge now roots it.
+    release.resolve();
+
+    const names = await E(host).list();
+    t.deepEqual(
+      names.filter(n => !n.startsWith('@') && n !== 'ping-caplet'),
+      [],
+      `only the caplet is named; saw: ${names.join(', ')}`,
+    );
+  },
+);
+
+testNeedsNodeWorker(
+  'without retainUntil an un-named evaluate result is ephemeral (not composable)',
+  async t => {
+    const { host } = await prepareHost(t);
+    // Default eval: the un-named result is collected as soon as it resolves
+    // (its transient pin is dropped), so it cannot be passed by reference.
+    const powers = await E(host).evaluate(
+      '@main',
+      `Far('Pingable', { ping: () => 'pong' })`,
+      [],
+      [],
+    );
+    await t.throwsAsync(
+      E(host).makeUnconfined('@main', powersPingPath, { powers }),
+      { message: /minted by this daemon/ },
+    );
+  },
+);
+
+testNeedsNodeWorker(
   'move moves value, between different caplet name hubs',
   async t => {
     const { host } = await prepareHost(t);

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -1073,6 +1073,46 @@ testNeedsNodeWorker(
 );
 
 testNeedsNodeWorker(
+  'retainUntil is honored alongside resultName (held until the promise settles)',
+  async t => {
+    const { host } = await prepareHost(t);
+    const release = makePromiseKit();
+
+    // Both a pet name and retainUntil: the pet-name edge roots the result,
+    // but retainUntil is still honored (not ignored) as a transient pin. We
+    // observe this by removing the name while retainUntil is pending — the
+    // transient pin keeps the result composable by reference until release.
+    const powers = await E(host).evaluate(
+      '@main',
+      `Far('Pingable', { ping: () => 'pong-eval' })`,
+      [],
+      [],
+      'retained-powers', // resultName — named
+      release.promise, // retainUntil — still honored
+    );
+    await E(host).remove('retained-powers');
+
+    // The name is gone, but the transient pin from retainUntil keeps the
+    // result alive and daemon-minted, so it composes by reference.
+    const caplet = await E(host).makeUnconfined('@main', powersPingPath, {
+      powers,
+      resultName: 'ping-caplet',
+    });
+    t.is(await E(caplet).pong(), 'pong-eval');
+
+    // Drop the transient pin; the caplet's ['powers', id] edge now roots it.
+    release.resolve();
+
+    const names = await E(host).list();
+    t.deepEqual(
+      names.filter(n => !n.startsWith('@') && n !== 'ping-caplet'),
+      [],
+      `only the caplet is named; saw: ${names.join(', ')}`,
+    );
+  },
+);
+
+testNeedsNodeWorker(
   'guest evaluate threads retainUntil and keeps an un-named result alive',
   async t => {
     const { host } = await prepareHost(t);

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -900,6 +900,74 @@ testNeedsNodeWorker(
   },
 );
 
+const pingablePath = path.join(dirname, 'test', 'pingable.js');
+const powersPingPath = path.join(dirname, 'test', 'powers-ping.js');
+
+testNeedsNodeWorker(
+  'makeUnconfined accepts powers by capability reference (un-named)',
+  async t => {
+    const { host } = await prepareHost(t);
+
+    // Mint a powers cap WITHOUT naming it. An un-named make-unconfined
+    // result is durable and retained by the caller's reference (unlike an
+    // un-named `evaluate`, which is ephemeral — see the README note).
+    const powers = await E(host).makeUnconfined('@main', pingablePath, {
+      powersName: '@none',
+    });
+
+    // Compose a caplet over that cap *by reference* — no pet name involved.
+    const caplet = await E(host).makeUnconfined('@main', powersPingPath, {
+      powers,
+      resultName: 'ping-caplet',
+    });
+
+    // The caplet received exactly that powers cap (it echoed ping()).
+    t.is(await E(caplet).pong(), 'pong-42');
+
+    // The powers cap was never named: the only host pet name created is the
+    // caplet's. (A by-name powers would have added a second entry that the
+    // caller would then have to remove — the "unname trick" this avoids.)
+    const names = await E(host).list();
+    t.deepEqual(
+      names.filter(n => !n.startsWith('@') && n !== 'ping-caplet'),
+      [],
+      `only the caplet is named; saw: ${names.join(', ')}`,
+    );
+  },
+);
+
+testNeedsNodeWorker(
+  'makeUnconfined rejects powers that is not a daemon capability',
+  async t => {
+    const { host } = await prepareHost(t);
+
+    // A remotable the daemon never minted has no formula id.
+    await t.throwsAsync(
+      E(host).makeUnconfined('@main', powersPingPath, {
+        powers: Far('NotADaemonCap', { ping: () => 'nope' }),
+      }),
+      { message: /minted by this daemon/ },
+    );
+  },
+);
+
+testNeedsNodeWorker(
+  'makeUnconfined rejects supplying both powers and powersName',
+  async t => {
+    const { host } = await prepareHost(t);
+    const powers = await E(host).makeUnconfined('@main', pingablePath, {
+      powersName: '@none',
+    });
+    await t.throwsAsync(
+      E(host).makeUnconfined('@main', powersPingPath, {
+        powers,
+        powersName: '@none',
+      }),
+      { message: /either "powers".*or "powersName"/ },
+    );
+  },
+);
+
 testNeedsNodeWorker(
   'move moves value, between different caplet name hubs',
   async t => {

--- a/packages/daemon/test/pingable.js
+++ b/packages/daemon/test/pingable.js
@@ -1,0 +1,15 @@
+// A minimal powers-like caplet for the by-reference `powers` tests: it
+// exposes a single `ping()` so a downstream caplet (see `powers-ping.js`)
+// can prove it was instantiated with *this* capability.
+
+import { makeExo } from '@endo/exo';
+import { M } from '@endo/patterns';
+
+export const make = () =>
+  makeExo(
+    'Pingable',
+    M.interface('Pingable', {}, { defaultGuards: 'passable' }),
+    {
+      ping: () => 'pong-42',
+    },
+  );

--- a/packages/daemon/test/powers-ping.js
+++ b/packages/daemon/test/powers-ping.js
@@ -1,0 +1,23 @@
+// A test fixture for `makeUnconfined`'s by-reference `powers` option.
+//
+// Its `make(powers)` calls a method on whatever powers cap it was
+// instantiated with and re-exports the result, so a test can prove the
+// caplet was wired to a specific powers capability (rather than a fresh
+// guest or a named pet-store entry).
+
+import { E } from '@endo/far';
+import { makeExo } from '@endo/exo';
+import { M } from '@endo/patterns';
+
+export const make = async powers => {
+  const pong = await E(powers).ping();
+  return makeExo(
+    'PowersPing',
+    M.interface('PowersPing', {}, { defaultGuards: 'passable' }),
+    {
+      pong() {
+        return pong;
+      },
+    },
+  );
+};


### PR DESCRIPTION
Two small, additive, complementary changes that together let a caller compose a caplet over a **per-session powers cap with no pet name** — removing the "unname trick".

## Motivation — removing the "unname trick"

`makeUnconfined` only accepted powers **by pet name** (`powersName`), resolved against the host petstore — and a pet name is a GC root. So to give a caplet a powers cap that should live and die *with that caplet*, a caller had to: (1) **name** the powers (a host GC root), (2) `makeUnconfined` against that name, (3) **`remove`** the name again — so the powers ends up rooted *only* by the caplet's dependency edge. That mint → name → use → unname dance mutates the user's namespace just to express "this powers belongs to this caplet", and is a workaround for a **name-centric API over an id-centric core**.

This came out of [`@endo/claude-sandbox` (#486)](https://github.com/endojs/endo-but-for-bots/pull/486), whose factory builds a fresh per-session powers exo for every client and currently does exactly this dance.

## The two halves

**1. `makeUnconfined({ powers })` — supply powers by capability reference** (commit 1). `MakeCapletOptions` gains an optional `powers` field, mutually exclusive with `powersName`. The daemon resolves the cap to its formula id via `getIdForRef` (the same identity map `provideHostPath` uses); the caplet formula depends on that id directly. The internal pipeline is already id-based (`providePowersId` accepts a string id), so this just exposes it at the `EndoHost` boundary. An un-named powers cap is then rooted solely by the caplet's `['powers', id]` edge — it lives exactly as long as the caplet.

**2. `evaluate(..., retainUntil)` — keep an un-named result alive until a promise settles** (commit 2). Needed because an un-named `evaluate` result is otherwise **ephemeral**: the transient root that protects it during formulation is dropped as soon as the value resolves (so one-shot `endo eval expr` doesn't leak), and it's collected before it can be referenced. `retainUntil` holds that transient pin until the caller's promise settles — long enough to hand the result to `makeUnconfined({ powers })`, after which the dependency edge roots it durably and the caller settles the promise.

Together, the factory's pattern becomes name-free:

```js
const release = makePromiseKit();
const powers = await E(host).evaluate(src, codeNames, petNames, undefined, release.promise);
const client = await E(host).makeUnconfined(spec, { powers });
release.resolve(); // caplet edge now roots the powers; drop the transient pin
```

## `retainUntil` is the ephemeral-root sibling of `resultName`

Two ways to root an un-named result, and they slot into the same call sites:

| | root | lifetime | survives restart |
|---|---|---|---|
| `resultName` | pet-name edge | until removed | yes |
| `retainUntil` | transient pin | until promise settles | no (harmless — by restart the durable edge exists) |

Because it's `resultName`'s sibling, it generalises to **anywhere `resultName` is optional**: implemented here on `evaluate` (the factory-critical, canonical ephemeral case). It applies equally to `MakeCapletOptions` (`makeUnconfined`/`makeArchive`/`makeFromTree`), where it would additionally **fix a latent leak** — un-named caplet results today are never pinned and never visited by `maybeCollect`, so they linger uncollected. That generalisation is a natural follow-up; this PR keeps the surface to `evaluate`. A remote `retainUntil` also rejects on disconnect, so the pin is released if the holder goes away.

## Why not a `retain` flag / FinalizationRegistry / implicit local retention

- **No formula method exposes a lifetime/pin option today** — the only lifetime knob is `resultName`; `pin`/`pinTransient` are internal `DaemonCore` primitives. So a boolean `retain` (let alone `pinTransient`) would be novel, mechanism-named surface. A `retainUntil` *promise* instead reuses the daemon's pervasive promise-driven lifecycle idiom (`cancelled` / `whenCancelled` / CapTP disconnect rejection).
- **A daemon FinalizationRegistry** would couple formula lifetime to host-VM GC timing — nondeterministic, against the explicit-reachability design, and discouraged under SES.
- **Implicit local-holder retention** (make a held local reference a keep-alive root, mirroring the cross-gateway retention set that `graph.js` `addRetention`/`removeRetention` + `residence.js` already implement) is the attractive *implicit default*, and remains a good companion follow-up. `retainUntil` is the *explicit* primitive — deterministic and caller-scoped — and is enough to unblock the factory now.

## Changes

- `interfaces.js` — `MakeCapletOptionsShape` gains `powers`; shared `EvaluateMethodGuard` gains the optional `retainUntil` promise.
- `host.js` / `guest.js` — `prepareMakeCaplet` resolves `powers` via `getIdForRef`; `evaluate` threads `retainUntil`.
- `retain-unnamed.js` (new) — `makeRetainUnnamed(unpinTransient)`, the shared hold-until-settled policy.
- `types.d.ts` — `MakeCapletOptions.powers`, `evaluate(..., retainUntil?)`.
- `test/endo.test.js` (+ fixtures `pingable.js`, `powers-ping.js`) — by-reference powers wires through and is never named; an inline-eval'd powers retained via `retainUntil` composes by reference (the factory's shape); error/negative controls (non-daemon cap; `powers`+`powersName`; ephemeral-without-`retainUntil`). Existing ephemeral-eval and `powersName`-path tests still pass.

`yarn lint` (tsc + eslint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYbcKfz463UCabALiTeCCp