### PR TITLE
feat(daemon,cli): normalize directory-path acceptance across the agent/host/guest surface

### DIFF
--- a/packages/cli/src/commands/accept.js
+++ b/packages/cli/src/commands/accept.js
@@ -2,6 +2,7 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
 const fromAsync = async iterable => {
   const all = [];
@@ -16,6 +17,8 @@ export const accept = async ({ guestName, agentNames }) => {
   process.stdin.setEncoding('utf-8');
   const invitationLocator = (await fromAsync(process.stdin)).join('').trim();
   return withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    await E(agent).accept(invitationLocator.trim(), guestName);
+    // A slash-delimited guest name nests the accepted guest inside a
+    // directory; the parent directory must already exist.
+    await E(agent).accept(invitationLocator.trim(), parsePetNamePath(guestName));
   });
 };

--- a/packages/cli/src/commands/accept.js
+++ b/packages/cli/src/commands/accept.js
@@ -19,6 +19,9 @@ export const accept = async ({ guestName, agentNames }) => {
   return withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
     // A slash-delimited guest name nests the accepted guest inside a
     // directory; the parent directory must already exist.
-    await E(agent).accept(invitationLocator.trim(), parsePetNamePath(guestName));
+    await E(agent).accept(
+      invitationLocator.trim(),
+      parsePetNamePath(guestName),
+    );
   });
 };

--- a/packages/cli/src/commands/eval.js
+++ b/packages/cli/src/commands/eval.js
@@ -31,7 +31,10 @@ export const evalCommand = async ({
     const petNames = pairs.map(pair => parsePetNamePath(pair[1]));
 
     const result = await E(agent).evaluate(
-      workerName,
+      // A slash-delimited worker name references a worker nested in a
+      // directory; the parent directory must already exist (as with
+      // `mkdir`, `store`, and `mv`).
+      parseOptionalPetNamePath(workerName),
       source,
       codeNames,
       petNames,

--- a/packages/cli/src/commands/invite.js
+++ b/packages/cli/src/commands/invite.js
@@ -2,10 +2,13 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
 export const invite = async ({ guestName, agentNames }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    const invitation = await E(agent).invite(guestName);
+    // A slash-delimited guest name nests the invitation (and the
+    // redeemed guest) inside a directory; the parent must already exist.
+    const invitation = await E(agent).invite(parsePetNamePath(guestName));
     const locator = await E(invitation).locate();
     console.log(locator);
   });

--- a/packages/cli/src/commands/make.js
+++ b/packages/cli/src/commands/make.js
@@ -73,11 +73,16 @@ export const makeCommand = async ({
     archiveReaderRef = bytesReaderFromIterator([archiveBytes]);
   }
 
+  // A slash-delimited archive name references (or stores) the source
+  // archive nested in a directory; the parent directory must already
+  // exist (as with `mkdir`, `store`, and `mv`).
+  const archivePath = parseOptionalPetNamePath(archiveName);
+
   await withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
     await null;
     // Prepare an archive, with the given name.
     if (archiveReaderRef !== undefined) {
-      await E(agent).storeBlob(archiveReaderRef, archiveName);
+      await E(agent).storeBlob(archiveReaderRef, archivePath);
     }
 
     // A slash-delimited worker name references a worker nested in a
@@ -96,7 +101,7 @@ export const makeCommand = async ({
         { powersName: powersPath, resultName: resultPath, env },
       );
     } else {
-      resultP = E(agent).makeArchive(workerPath, archiveName, {
+      resultP = E(agent).makeArchive(workerPath, archivePath, {
         powersName: powersPath,
         resultName: resultPath,
         env,

--- a/packages/cli/src/commands/make.js
+++ b/packages/cli/src/commands/make.js
@@ -80,18 +80,23 @@ export const makeCommand = async ({
       await E(agent).storeBlob(archiveReaderRef, archiveName);
     }
 
+    // A slash-delimited worker name references a worker nested in a
+    // directory; the parent directory must already exist (as with
+    // `mkdir`, `store`, and `mv`).
+    const workerPath = parseOptionalPetNamePath(workerName);
+
     let resultP;
     if (importPath !== undefined) {
       // makeUnconfined is unconditionally Node-scoped; default to
       // the host's @node worker when no other worker is named.
-      const unconfinedWorkerName = workerName ?? '@node';
+      const unconfinedWorkerName = workerPath ?? '@node';
       resultP = E(agent).makeUnconfined(
         unconfinedWorkerName,
         url.pathToFileURL(path.resolve(importPath)).href,
         { powersName: powersPath, resultName: resultPath, env },
       );
     } else {
-      resultP = E(agent).makeArchive(workerName, archiveName, {
+      resultP = E(agent).makeArchive(workerPath, archiveName, {
         powersName: powersPath,
         resultName: resultPath,
         env,

--- a/packages/cli/src/commands/make.js
+++ b/packages/cli/src/commands/make.js
@@ -46,6 +46,10 @@ export const makeCommand = async ({
   }
 
   const resultPath = parseOptionalPetNamePath(resultName);
+  // A slash-delimited powers name references powers nested in a
+  // directory; the parent directory must already exist (as with
+  // `mkdir`, `store`, and `mv`).
+  const powersPath = parseOptionalPetNamePath(powersName);
 
   /** @type {PassableBytesReader | undefined} */
   let archiveReaderRef;
@@ -84,11 +88,11 @@ export const makeCommand = async ({
       resultP = E(agent).makeUnconfined(
         unconfinedWorkerName,
         url.pathToFileURL(path.resolve(importPath)).href,
-        { powersName, resultName: resultPath, env },
+        { powersName: powersPath, resultName: resultPath, env },
       );
     } else {
       resultP = E(agent).makeArchive(workerName, archiveName, {
-        powersName,
+        powersName: powersPath,
         resultName: resultPath,
         env,
       });

--- a/packages/cli/src/commands/mkguest.js
+++ b/packages/cli/src/commands/mkguest.js
@@ -2,6 +2,7 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath, parseOptionalPetNamePath } from '../pet-name.js';
 
 export const mkguest = async ({
   handleName,
@@ -10,9 +11,12 @@ export const mkguest = async ({
   introducedNames,
 }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    const newGuest = await E(agent).provideGuest(handleName, {
+    // A slash-delimited handle or agent name nests the guest inside a
+    // directory; the parent directory must already exist (as with
+    // `mkdir`, `store`, and `mv`).
+    const newGuest = await E(agent).provideGuest(parsePetNamePath(handleName), {
       introducedNames,
-      agentName,
+      agentName: parseOptionalPetNamePath(agentName),
     });
     console.log(newGuest);
   });

--- a/packages/cli/src/commands/mkhost.js
+++ b/packages/cli/src/commands/mkhost.js
@@ -2,6 +2,7 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath, parseOptionalPetNamePath } from '../pet-name.js';
 
 export const mkhost = async ({
   handleName,
@@ -10,9 +11,12 @@ export const mkhost = async ({
   introducedNames,
 }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    const newHost = await E(agent).provideHost(handleName, {
+    // A slash-delimited handle or agent name nests the host inside a
+    // directory; the parent directory must already exist (as with
+    // `mkdir`, `store`, and `mv`).
+    const newHost = await E(agent).provideHost(parsePetNamePath(handleName), {
       introducedNames,
-      agentName,
+      agentName: parseOptionalPetNamePath(agentName),
     });
     console.log(newHost);
   });

--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -94,7 +94,10 @@ export const run = async ({
       } else if (powersName === '@endo') {
         powersP = bootstrap;
       } else {
-        powersP = E(agent).provideGuest(powersName);
+        // A slash-delimited powers name references a guest nested in a
+        // directory; the parent directory must already exist (as with
+        // `mkdir`, `store`, and `mv`).
+        powersP = E(agent).provideGuest(parsePetNamePath(powersName));
       }
 
       if (importPath !== undefined) {

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -3391,7 +3391,7 @@ const makeDaemonCore = async (
         id,
         hostAgentId,
         hostHandleId,
-        /** @type {import('./types.js').PetName} */ (guestName),
+        /** @type {import('./types.js').NameOrPath} */ (guestName),
       ),
     timer: async ({ intervalMs, label: timerLabel }, context) => {
       const interval = Number(intervalMs) || 60_000;
@@ -3933,7 +3933,7 @@ const makeDaemonCore = async (
   /**
    * @param {FormulaIdentifier} hostAgentId
    * @param {FormulaIdentifier} hostHandleId
-   * @param {PetName} guestName
+   * @param {NameOrPath} guestName
    * @param {DeferredTasks<InvitationDeferredTaskParams>} deferredTasks
    */
   const formulateInvitation = async (
@@ -5497,10 +5497,15 @@ const makeDaemonCore = async (
    * @param {FormulaIdentifier} id
    * @param {FormulaIdentifier} hostAgentId
    * @param {FormulaIdentifier} hostHandleId
-   * @param {import('./types.js').PetName} guestName
+   * @param {import('./types.js').NameOrPath} guestName
    */
   const makeInvitation = async (id, hostAgentId, hostHandleId, guestName) => {
     const hostAgent = /** @type {EndoHost} */ (await provide(hostAgentId));
+    // The invitation persists the name (or directory path) the redeemed
+    // guest should be stored under.  The durable mail-delivery name takes
+    // the full path; the pin and label use the leaf pet name.
+    const guestNamePath = namePathFrom(guestName);
+    const guestLeaf = guestNamePath[guestNamePath.length - 1];
 
     const locate = async () => {
       const { node, addresses } = await hostAgent.getPeerInfo();
@@ -5577,7 +5582,7 @@ const makeDaemonCore = async (
         hostAgentId,
         hostHandleId,
         guestTasks,
-        `guest:${guestName}`,
+        `guest:${guestLeaf}`,
       );
 
       // Look up the local guest's handle from its formula so we can
@@ -5589,7 +5594,7 @@ const makeDaemonCore = async (
 
       // Name the guest handle inside @pins so it persists.
       await E(hostAgent).storeIdentifier(
-        /** @type {NamePath} */ (['@pins', `guest-${guestName}`]),
+        /** @type {NamePath} */ (['@pins', `guest-${guestLeaf}`]),
         localGuestFormula.handle,
       );
       await unpinTransient(localGuestFormula.handle);
@@ -5598,10 +5603,7 @@ const makeDaemonCore = async (
       // Use storeLocator so the directory properly internalizes the
       // remote formula identifier for peer resolution.
       const guestHandleLocatorStr = formatLocator(guestHandleId, 'remote');
-      await E(hostAgent).storeLocator(
-        /** @type {NamePath} */ ([guestName]),
-        guestHandleLocatorStr,
-      );
+      await E(hostAgent).storeLocator(guestNamePath, guestHandleLocatorStr);
 
       // Return the remote guest's public key for retention tracking.
       return harden({ guestPublicKey: guestDaemonNode });

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -376,7 +376,9 @@ export const makeDirectoryMaker = ({
 
     /** @type {EndoDirectory['writeText']} */
     const writeText = async (petNameOrPath, content) => {
-      const { namePath } = petNamePathFrom(petNameOrPath);
+      // Coerce for branching only; the store funnels through this
+      // directory's own storeIdentifier, which enforces a pet-name leaf.
+      const namePath = namePathFrom(petNameOrPath);
       if (namePath.length < 2) {
         const bytes = bytesFromText(content);
         const readerRef = bytesReaderFromIterator([bytes]);

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -13,6 +13,7 @@ import {
   assertNames,
   assertPetNamePath,
   namePathFrom,
+  petNamePathFrom,
 } from './pet-name.js';
 import { makeDeferredTasks } from './deferred-tasks.js';
 import { directoryHelp, makeHelp } from './help-text.js';
@@ -311,9 +312,7 @@ export const makeDirectoryMaker = ({
      * @param {string} id
      */
     const storeIdentifier = async (petNamePath, id) => {
-      const { prefixPath, petName } = assertPetNamePath(
-        namePathFrom(petNamePath),
-      );
+      const { prefixPath, petName } = petNamePathFrom(petNamePath);
       await null;
       if (prefixPath.length === 0) {
         await controller.storeIdentifier(petName, id);

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -352,7 +352,6 @@ export const makeDirectoryMaker = ({
     /** @type {EndoDirectory['readText']} */
     const readText = async petNameOrPath => {
       const namePath = namePathFrom(petNameOrPath);
-      assertNamePath(namePath);
       if (namePath.length < 2) {
         const blob = await lookup(namePath);
         return E(/** @type {any} */ (blob)).text();
@@ -364,7 +363,6 @@ export const makeDirectoryMaker = ({
     /** @type {EndoDirectory['maybeReadText']} */
     const maybeReadText = async petNameOrPath => {
       const namePath = namePathFrom(petNameOrPath);
-      assertNamePath(namePath);
       if (namePath.length < 2) {
         const blob = await maybeLookup(namePath);
         if (blob === undefined || blob === null) {
@@ -378,8 +376,7 @@ export const makeDirectoryMaker = ({
 
     /** @type {EndoDirectory['writeText']} */
     const writeText = async (petNameOrPath, content) => {
-      const namePath = namePathFrom(petNameOrPath);
-      assertNamePath(namePath);
+      const { namePath } = petNamePathFrom(petNameOrPath);
       if (namePath.length < 2) {
         const bytes = bytesFromText(content);
         const readerRef = bytesReaderFromIterator([bytes]);

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -9,6 +9,7 @@ import {
   assertNamePath,
   assertPetNamePath,
   namePathFrom,
+  petNamePathFrom,
 } from './pet-name.js';
 import { makeDeferredTasks } from './deferred-tasks.js';
 import { idFromLocator } from './locator.js';
@@ -303,7 +304,7 @@ export const makeGuestMaker = ({
       if (petName === undefined) {
         throw new TypeError('storeBlob requires a pet name');
       }
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
 
       /** @type {DeferredTasks<ReadableBlobDeferredTaskParams>} */
       const tasks = makeDeferredTasks();

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -6,7 +6,6 @@ import { q } from '@endo/errors';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 import { makePetSitter } from './pet-sitter.js';
 import {
-  assertNamePath,
   assertPetNamePath,
   namePathFrom,
   petNamePathFrom,
@@ -220,9 +219,6 @@ export const makeGuestMaker = ({
       petNamesOrPaths,
       resultName,
     ) => {
-      if (workerName !== undefined) {
-        assertNamePath(namePathFrom(workerName));
-      }
       if (!Array.isArray(codeNames)) {
         throw new Error('Evaluator requires an array of code names');
       }
@@ -230,10 +226,6 @@ export const makeGuestMaker = ({
         if (typeof codeName !== 'string') {
           throw new Error(`Invalid endowment name: ${q(codeName)}`);
         }
-      }
-      if (resultName !== undefined) {
-        const resultNamePath = namePathFrom(resultName);
-        assertNamePath(resultNamePath);
       }
       if (petNamesOrPaths.length !== codeNames.length) {
         throw new Error('Evaluator requires one pet name for each code name');
@@ -259,7 +251,7 @@ export const makeGuestMaker = ({
       });
 
       if (resultName !== undefined) {
-        const resultNamePath = namePathFrom(resultName);
+        const { namePath: resultNamePath } = petNamePathFrom(resultName);
         tasks.push(identifiers =>
           E(directory).storeIdentifier(resultNamePath, identifiers.evalId),
         );
@@ -318,8 +310,7 @@ export const makeGuestMaker = ({
 
     /** @type {EndoGuest['storeValue']} */
     const storeValue = async (value, petName) => {
-      const namePath = namePathFrom(petName);
-      assertNamePath(namePath);
+      const { namePath } = petNamePathFrom(petName);
       /** @type {DeferredTasks<MarshalDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       tasks.push(identifiers =>

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -6,9 +6,7 @@ import { q } from '@endo/errors';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 import { makePetSitter } from './pet-sitter.js';
 import {
-  assertName,
   assertNamePath,
-  assertPetName,
   assertPetNamePath,
   namePathFrom,
 } from './pet-name.js';
@@ -177,22 +175,28 @@ export const makeGuestMaker = ({
     } = mailbox;
 
     /**
-     * @param {Name | undefined} workerName
+     * @param {NameOrPath | undefined} workerName
      * @param {DeferredTasks<WorkerDeferredTaskParams>['push']} deferTask
      */
-    const prepareWorkerFormulation = (workerName, deferTask) => {
+    const prepareWorkerFormulation = async (workerName, deferTask) => {
       if (workerName === undefined) {
         return undefined;
       }
+      const workerNamePath = namePathFrom(workerName);
+      // A single segment resolves against the guest's own pet store; a
+      // path resolves through the directory.
       const workerId = /** @type {FormulaIdentifier | undefined} */ (
-        specialStore.identifyLocal(workerName)
+        workerNamePath.length === 1
+          ? specialStore.identifyLocal(workerNamePath[0])
+          : await E(directory).identify(...workerNamePath)
       );
       if (workerId === undefined) {
-        assertPetName(workerName);
-        const petName = workerName;
-        deferTask(identifiers => {
-          return specialStore.storeIdentifier(petName, identifiers.workerId);
-        });
+        const { namePath, petName } = assertPetNamePath(workerNamePath);
+        deferTask(identifiers =>
+          namePath.length === 1
+            ? specialStore.storeIdentifier(petName, identifiers.workerId)
+            : E(directory).storeIdentifier(namePath, identifiers.workerId),
+        );
         return undefined;
       }
       return workerId;
@@ -201,7 +205,7 @@ export const makeGuestMaker = ({
     /**
      * Evaluate code directly in a worker, constrained only by reachable
      * capabilities in the guest's namespace.
-     * @param {Name | undefined} workerName
+     * @param {NameOrPath | undefined} workerName
      * @param {string} source
      * @param {Array<string>} codeNames
      * @param {NamesOrPaths} petNamesOrPaths
@@ -216,7 +220,7 @@ export const makeGuestMaker = ({
       resultName,
     ) => {
       if (workerName !== undefined) {
-        assertName(workerName);
+        assertNamePath(namePathFrom(workerName));
       }
       if (!Array.isArray(codeNames)) {
         throw new Error('Evaluator requires an array of code names');
@@ -237,7 +241,7 @@ export const makeGuestMaker = ({
       /** @type {DeferredTasks<EvalDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
-      const workerId = prepareWorkerFormulation(workerName, tasks.push);
+      const workerId = await prepareWorkerFormulation(workerName, tasks.push);
 
       /** @type {(FormulaIdentifier | NamePath)[]} */
       const endowmentFormulaIdsOrPaths = petNamesOrPaths.map(petNameOrPath => {

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -840,9 +840,13 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['makeArchive']} */
     const makeArchive = async (workerName, archiveName, options) => {
-      const archiveId = petStore.identifyLocal(
-        /** @type {Name} */ (archiveName),
-      );
+      // A single segment resolves against the agent's own pet store; a
+      // path resolves the source archive through the directory.
+      const archiveNamePath = namePathFrom(archiveName);
+      const archiveId =
+        archiveNamePath.length === 1
+          ? petStore.identifyLocal(/** @type {Name} */ (archiveNamePath[0]))
+          : await E(directory).identify(...archiveNamePath);
       if (archiveId === undefined) {
         throw new TypeError(`Unknown pet name for archive: ${q(archiveName)}`);
       }

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -936,10 +936,12 @@ export const makeHostMaker = ({
      * surface exposes only the mount capability.
      *
      * @param {string | string[]} treeName
-     * @param {string} scratchPetName
+     * @param {NameOrPath} scratchPetName
      */
     const stageTreeInternal = async (treeName, scratchPetName) => {
-      assertPetName(scratchPetName);
+      // provideScratchMount validates the scratch name/path and stores it
+      // through the directory, so a path nests the scratch mount.
+      const scratchNamePath = namePathFrom(scratchPetName);
       const treeNamePath = namePathFrom(/** @type {NameOrPath} */ (treeName));
       assertNamePath(treeNamePath);
       // Use identify + provide instead of a lookup chain to keep the
@@ -966,11 +968,11 @@ export const makeHostMaker = ({
         const msg = String((err && /** @type {any} */ (err).message) || err);
         if (!msg.includes('not yet implemented')) throw err;
       }
-      const scratchMount = await provideScratchMount(scratchPetName);
+      const scratchMount = await provideScratchMount(scratchNamePath);
       await materializeTree(sourceForWalk, scratchMount, []);
       // Resolve the scratch mount's identifier after it's been stored
       // by the deferred pet-store task inside provideScratchMount.
-      const scratchId = await E(directory).identify(scratchPetName);
+      const scratchId = await E(directory).identify(...scratchNamePath);
       if (scratchId === undefined) {
         throw new TypeError(
           `Internal error: scratch mount ${q(scratchPetName)} was not stored`,
@@ -984,7 +986,7 @@ export const makeHostMaker = ({
     const stageTree = async (treeName, scratchPetName) => {
       const { scratchMount } = await stageTreeInternal(
         treeName,
-        scratchPetName,
+        /** @type {NameOrPath} */ (scratchPetName),
       );
       return scratchMount;
     };
@@ -1003,7 +1005,10 @@ export const makeHostMaker = ({
       // Scratch mount carries a derived pet name so the caller can
       // observe / cancel it explicitly if desired.
       const scratchPetName = `scratch-${resultLabel}`;
-      const { scratchId } = await stageTreeInternal(treeName, scratchPetName);
+      const { scratchId } = await stageTreeInternal(
+        treeName,
+        /** @type {NameOrPath} */ (scratchPetName),
+      );
       const scratchPath = getScratchMountPath(scratchId);
       const entryPath = `${scratchPath}/${entry}`;
       // Reuse the existing makeUnconfined flow (which already defaults
@@ -1256,20 +1261,24 @@ export const makeHostMaker = ({
     /**
      * Create a timer that fires at a specified interval.
      *
-     * @param {PetName} petName - Pet name to store the timer under
+     * @param {NameOrPath} petName - Pet name or path to store the timer under
      * @param {number} intervalMs - Interval in milliseconds
      * @param {string} [label] - Optional label for the timer
      */
     const makeTimerCmd = async (petName, intervalMs, label) => {
-      assertPetName(petName);
+      const { namePath, petName: timerPetName } = assertPetNamePath(
+        namePathFrom(petName),
+      );
       /** @type {DeferredTasks<{ timerId: import('./types.js').FormulaIdentifier }>} */
       const tasks = makeDeferredTasks();
       tasks.push(identifiers =>
-        petStore.storeIdentifier(petName, identifiers.timerId),
+        namePath.length === 1
+          ? petStore.storeIdentifier(timerPetName, identifiers.timerId)
+          : E(directory).storeIdentifier(namePath, identifiers.timerId),
       );
       const { value } = await formulateTimer(
         Number(intervalMs),
-        label || petName,
+        label || timerPetName,
         tasks,
       );
       return value;
@@ -1277,15 +1286,19 @@ export const makeHostMaker = ({
 
     /**
      * Create a new channel and store it under the given pet name.
-     * @param {PetName} petName - Pet name to store the channel under.
+     * @param {NameOrPath} petName - Pet name or path to store the channel under.
      * @param {string} channelProposedName - Display name for the channel creator.
      */
     const makeChannelCmd = async (petName, channelProposedName) => {
-      assertPetName(petName);
+      const { namePath, petName: channelPetName } = assertPetNamePath(
+        namePathFrom(petName),
+      );
       /** @type {DeferredTasks<ChannelDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       tasks.push(identifiers =>
-        petStore.storeIdentifier(petName, identifiers.channelId),
+        namePath.length === 1
+          ? petStore.storeIdentifier(channelPetName, identifiers.channelId)
+          : E(directory).storeIdentifier(namePath, identifiers.channelId),
       );
       const { value } = await formulateChannel(
         hostId,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -17,7 +17,6 @@ import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 import {
   assertPetName,
   assertPetNamePath,
-  assertNamePath,
   namePathFrom,
   petNamePathFrom,
 } from './pet-name.js';
@@ -572,8 +571,7 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['storeValue']} */
     const storeValue = async (value, petName) => {
-      const namePath = namePathFrom(petName);
-      assertNamePath(namePath);
+      const { namePath } = petNamePathFrom(petName);
       /** @type {DeferredTasks<MarshalDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
@@ -590,7 +588,6 @@ export const makeHostMaker = ({
      */
     const provideWorker = async workerNamePath => {
       const namePath = namePathFrom(workerNamePath);
-      assertNamePath(namePath);
       const workerId = await E(directory).identify(...namePath);
 
       if (workerId !== undefined) {
@@ -655,9 +652,6 @@ export const makeHostMaker = ({
       petNamePaths,
       resultName,
     ) => {
-      if (workerName !== undefined) {
-        assertNamePath(namePathFrom(workerName));
-      }
       if (!Array.isArray(codeNames)) {
         throw new Error('Evaluator requires an array of code names');
       }
@@ -665,10 +659,6 @@ export const makeHostMaker = ({
         if (typeof codeName !== 'string') {
           throw new Error(`Invalid endowment name: ${q(codeName)}`);
         }
-      }
-      if (resultName !== undefined) {
-        const resultNamePath = namePathFrom(resultName);
-        assertNamePath(resultNamePath);
       }
       if (petNamePaths.length !== codeNames.length) {
         throw new Error('Evaluator requires one pet name for each code name');
@@ -698,7 +688,7 @@ export const makeHostMaker = ({
       });
 
       if (resultName !== undefined) {
-        const resultNamePath = namePathFrom(resultName);
+        const { namePath: resultNamePath } = petNamePathFrom(resultName);
         tasks.push(identifiers =>
           E(directory).storeIdentifier(resultNamePath, identifiers.evalId),
         );
@@ -740,9 +730,6 @@ export const makeHostMaker = ({
         env = {},
         workerTrustedShims,
       } = options;
-      if (workerName !== undefined) {
-        assertNamePath(namePathFrom(workerName));
-      }
       assertPowersNameOrPath(powersName);
       const powersNamePath = namePathFrom(powersName);
 
@@ -948,7 +935,6 @@ export const makeHostMaker = ({
       // through the directory, so a path nests the scratch mount.
       const scratchNamePath = namePathFrom(scratchPetName);
       const treeNamePath = namePathFrom(/** @type {NameOrPath} */ (treeName));
-      assertNamePath(treeNamePath);
       // Use identify + provide instead of a lookup chain to keep the
       // source invariant (so Mount sub-node wrapping doesn't confuse
       // the materialise walk).
@@ -1035,7 +1021,6 @@ export const makeHostMaker = ({
     /** @type {EndoHost['makeFromTree']} */
     const makeFromTree = async (workerName, treeName, options) => {
       const namePath = namePathFrom(treeName);
-      assertNamePath(namePath);
       const treeId = await E(directory).identify(...namePath);
       if (treeId === undefined) {
         throw new TypeError(`Unknown pet name for tree: ${q(treeName)}`);
@@ -1199,7 +1184,7 @@ export const makeHostMaker = ({
     /** @type {EndoHost['provideHost']} */
     const provideHost = async (petName, opts) => {
       if (petName !== undefined) {
-        assertNamePath(namePathFrom(petName));
+        petNamePathFrom(petName);
       }
       const normalizedOpts = normalizeHostOrGuestOptions(opts);
       const { value } = await makeChildHost(
@@ -1253,7 +1238,7 @@ export const makeHostMaker = ({
     /** @type {EndoHost['provideGuest']} */
     const provideGuest = async (petName, opts) => {
       if (petName !== undefined) {
-        assertNamePath(namePathFrom(petName));
+        petNamePathFrom(petName);
       }
       const normalizedOpts = normalizeHostOrGuestOptions(opts);
       const { value } = await makeGuest(
@@ -1513,8 +1498,7 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['adoptFromLocator']} */
     const adoptFromLocator = async (locator, petNameOrPath) => {
-      const namePath = namePathFrom(petNameOrPath);
-      assertNamePath(namePath);
+      const { namePath } = petNamePathFrom(petNameOrPath);
       const url = new URL(locator);
       const nodeNumber = url.hostname;
       assertNodeNumber(nodeNumber);
@@ -1607,9 +1591,6 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['endow']} */
     const endow = async (messageNumber, bindings, workerName, resultName) => {
-      if (workerName !== undefined) {
-        assertNamePath(namePathFrom(workerName));
-      }
       const { source, slots, guestHandleId } =
         mailbox.getDefineRequest(messageNumber);
 
@@ -1648,7 +1629,7 @@ export const makeHostMaker = ({
       );
 
       if (resultName !== undefined) {
-        const resultNamePath = namePathFrom(resultName);
+        const { namePath: resultNamePath } = petNamePathFrom(resultName);
         tasks.push(identifiers =>
           E(directory).storeIdentifier(resultNamePath, identifiers.evalId),
         );

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -1310,10 +1310,12 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {PetName} guestName
+     * @param {NameOrPath} guestName
      */
     const invite = async guestName => {
-      assertPetName(guestName);
+      const { namePath, petName: guestPetName } = assertPetNamePath(
+        namePathFrom(guestName),
+      );
       // We must immediately retain a formula under guestName so that we
       // preserve the invitation across restarts, but we must replace the
       // guestName with the handle of the guest that accepts the invitation.
@@ -1322,10 +1324,14 @@ export const makeHostMaker = ({
       // Overwriting the guestName must cancel the pending invitation (consume
       // once) so that the invitation can no longer modify the petStore entry
       // for the guestName.
+      // A path nests the invitation (and, once redeemed, the guest)
+      // inside a directory; the parent directory must already exist.
       /** @type {DeferredTasks<InvitationDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       tasks.push(identifiers =>
-        petStore.storeIdentifier(guestName, identifiers.invitationId),
+        namePath.length === 1
+          ? petStore.storeIdentifier(guestPetName, identifiers.invitationId)
+          : E(directory).storeIdentifier(namePath, identifiers.invitationId),
       );
       const { value } = await formulateInvitation(
         hostId,
@@ -1338,10 +1344,14 @@ export const makeHostMaker = ({
 
     /**
      * @param {string} invitationLocator
-     * @param {PetName} guestName
+     * @param {NameOrPath} guestName
      */
     const accept = async (invitationLocator, guestName) => {
-      assertPetName(guestName);
+      // A path nests the accepted guest inside a directory; the parent
+      // directory must already exist.
+      const { namePath: guestNamePath, petName: guestLeaf } = assertPetNamePath(
+        namePathFrom(guestName),
+      );
       const url = new URL(invitationLocator);
       const daemonNode = url.hostname;
       const invitationNumber = url.searchParams.get('id');
@@ -1397,7 +1407,9 @@ export const makeHostMaker = ({
       const handleLocator = handleUrl.href;
 
       const invitation = await provide(invitationId, 'invitation');
-      await E(invitation).accept(handleLocator, guestName);
+      // The remote invitation ignores this name (`_hostNameFromGuest`),
+      // so the leaf pet name suffices for the protocol.
+      await E(invitation).accept(handleLocator, guestLeaf);
 
       // Create a local guest with a regular pet store.
       // Pin the guest handle via deferred task to prevent premature
@@ -1409,7 +1421,7 @@ export const makeHostMaker = ({
         hostId,
         handleId,
         guestTasks,
-        `guest:${guestName}`,
+        `guest:${guestLeaf}`,
       );
 
       // Look up the local guest's handle from its formula so we can
@@ -1422,7 +1434,7 @@ export const makeHostMaker = ({
 
       // Store the durable name and release the transient pin.
       await E(directory).storeIdentifier(
-        ['@pins', `guest-${guestName}`],
+        ['@pins', `guest-${guestLeaf}`],
         localGuestFormula.handle,
       );
       await unpinTransient(localGuestFormula.handle);
@@ -1438,7 +1450,7 @@ export const makeHostMaker = ({
         node: /** @type {import('./types.js').NodeNumber} */ (remoteHandleNode),
       });
       const remoteHandleLocator = formatLocator(remoteHandleId, 'handle');
-      await E(directory).storeLocator([guestName], remoteHandleLocator);
+      await E(directory).storeLocator(guestNamePath, remoteHandleLocator);
     };
 
     /** @type {EndoHost['cancel']} */

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -17,7 +17,6 @@ import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 import {
   assertPetName,
   assertPetNamePath,
-  assertName,
   assertNamePath,
   namePathFrom,
 } from './pet-name.js';
@@ -608,31 +607,41 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {Name | undefined} workerName
+     * @param {NameOrPath | undefined} workerName
      * @param {DeferredTasks<WorkerDeferredTaskParams>['push']} deferTask
-     * @returns {{ workerId: FormulaIdentifier | undefined, workerLabel: string | undefined }}
+     * @returns {Promise<{ workerId: FormulaIdentifier | undefined, workerLabel: string | undefined }>}
      */
-    const prepareWorkerFormulation = (workerName, deferTask) => {
+    const prepareWorkerFormulation = async (workerName, deferTask) => {
       if (workerName === undefined) {
         return { workerId: undefined, workerLabel: undefined };
       }
+      const workerNamePath = namePathFrom(workerName);
+      // A single segment resolves against the agent's own pet store
+      // (including special workers like `@main` / `@node`); a path
+      // resolves through the directory, matching provideWorker.
       const workerId = /** @type {FormulaIdentifier | undefined} */ (
-        petStore.identifyLocal(workerName)
+        workerNamePath.length === 1
+          ? petStore.identifyLocal(workerNamePath[0])
+          : await E(directory).identify(...workerNamePath)
       );
       if (workerId === undefined) {
-        assertPetName(workerName);
-        const petName = workerName;
-        deferTask(identifiers => {
-          return petStore.storeIdentifier(petName, identifiers.workerId);
-        });
+        const { namePath, petName } = assertPetNamePath(workerNamePath);
+        deferTask(identifiers =>
+          namePath.length === 1
+            ? petStore.storeIdentifier(petName, identifiers.workerId)
+            : E(directory).storeIdentifier(namePath, identifiers.workerId),
+        );
         return { workerId: undefined, workerLabel: petName };
       }
-      return { workerId, workerLabel: /** @type {string} */ (workerName) };
+      return {
+        workerId,
+        workerLabel: workerNamePath[workerNamePath.length - 1],
+      };
     };
 
     /**
      * Evaluate code directly in a worker.
-     * @param {Name | undefined} workerName
+     * @param {NameOrPath | undefined} workerName
      * @param {string} source
      * @param {Array<string>} codeNames
      * @param {(string | string[])[]} petNamePaths
@@ -646,7 +655,7 @@ export const makeHostMaker = ({
       resultName,
     ) => {
       if (workerName !== undefined) {
-        assertName(workerName);
+        assertNamePath(namePathFrom(workerName));
       }
       if (!Array.isArray(codeNames)) {
         throw new Error('Evaluator requires an array of code names');
@@ -667,10 +676,8 @@ export const makeHostMaker = ({
       /** @type {DeferredTasks<EvalDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
-      const { workerId, workerLabel: explicitLabel } = prepareWorkerFormulation(
-        workerName,
-        tasks.push,
-      );
+      const { workerId, workerLabel: explicitLabel } =
+        await prepareWorkerFormulation(workerName, tasks.push);
       const workerLabel =
         explicitLabel ??
         (resultName !== undefined ? `eval:${resultName}` : 'eval');
@@ -722,7 +729,7 @@ export const makeHostMaker = ({
 
     /**
      * Helper function for makeUnconfined and makeArchive.
-     * @param {Name | undefined} workerName
+     * @param {NameOrPath | undefined} workerName
      * @param {MakeCapletOptions} [options]
      */
     const prepareMakeCaplet = async (workerName, options = {}) => {
@@ -733,7 +740,7 @@ export const makeHostMaker = ({
         workerTrustedShims,
       } = options;
       if (workerName !== undefined) {
-        assertName(workerName);
+        assertNamePath(namePathFrom(workerName));
       }
       assertPowersNameOrPath(powersName);
       const powersNamePath = namePathFrom(powersName);
@@ -741,7 +748,7 @@ export const makeHostMaker = ({
       /** @type {DeferredTasks<MakeCapletDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
-      const { workerId, workerLabel } = prepareWorkerFormulation(
+      const { workerId, workerLabel } = await prepareWorkerFormulation(
         workerName,
         tasks.push,
       );
@@ -806,7 +813,7 @@ export const makeHostMaker = ({
         env,
         workerTrustedShims,
       } = await prepareMakeCaplet(
-        /** @type {Name | undefined} */ (effectiveWorkerName),
+        /** @type {NameOrPath | undefined} */ (effectiveWorkerName),
         options,
       );
       const workerLabel =
@@ -848,7 +855,7 @@ export const makeHostMaker = ({
         env,
         workerTrustedShims,
       } = await prepareMakeCaplet(
-        /** @type {Name | undefined} */ (workerName),
+        /** @type {NameOrPath | undefined} */ (workerName),
         options,
       );
       const workerLabel =
@@ -1032,7 +1039,7 @@ export const makeHostMaker = ({
         env,
         workerTrustedShims,
       } = await prepareMakeCaplet(
-        /** @type {Name | undefined} */ (workerName),
+        /** @type {NameOrPath | undefined} */ (workerName),
         options,
       );
       const workerLabel =
@@ -1578,7 +1585,7 @@ export const makeHostMaker = ({
     /** @type {EndoHost['endow']} */
     const endow = async (messageNumber, bindings, workerName, resultName) => {
       if (workerName !== undefined) {
-        assertName(workerName);
+        assertNamePath(namePathFrom(workerName));
       }
       const { source, slots, guestHandleId } =
         mailbox.getDefineRequest(messageNumber);
@@ -1612,7 +1619,10 @@ export const makeHostMaker = ({
 
       /** @type {DeferredTasks<EvalDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
-      const { workerId } = prepareWorkerFormulation(workerName, tasks.push);
+      const { workerId } = await prepareWorkerFormulation(
+        /** @type {NameOrPath | undefined} */ (workerName),
+        tasks.push,
+      );
 
       if (resultName !== undefined) {
         const resultNamePath = namePathFrom(resultName);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -19,6 +19,7 @@ import {
   assertPetNamePath,
   assertNamePath,
   namePathFrom,
+  petNamePathFrom,
 } from './pet-name.js';
 import {
   assertFormulaNumber,
@@ -257,7 +258,7 @@ export const makeHostMaker = ({
      * @param {NameOrPath} petName
      */
     const storeBlob = async (readerRef, petName) => {
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
 
       /** @type {DeferredTasks<ReadableBlobDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
@@ -275,7 +276,7 @@ export const makeHostMaker = ({
      * @param {NameOrPath} petName
      */
     const storeTree = async (remoteTree, petName) => {
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
 
       /** @type {DeferredTasks<ReadableTreeDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
@@ -297,7 +298,7 @@ export const makeHostMaker = ({
      */
     const provideMount = async (mountPath, petName, options = {}) => {
       const { readOnly = false } = options;
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
 
       /** @type {DeferredTasks<MountDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
@@ -360,7 +361,7 @@ export const makeHostMaker = ({
      */
     const provideScratchMount = async (petName, options = {}) => {
       const { readOnly = false } = options;
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
 
       /** @type {DeferredTasks<ScratchMountDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
@@ -389,7 +390,7 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['provideGit']} */
     const provideGit = async (mountCap, petName) => {
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
       const mountId = getIdForRef(mountCap);
       if (mountId === undefined) {
         throw makeError(
@@ -409,7 +410,7 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['provideBearerCredential']} */
     const provideBearerCredential = async (petName, options) => {
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
       if (!options || typeof options !== 'object') {
         throw makeError(
           X`provideBearerCredential: options must include audience and token`,
@@ -441,7 +442,7 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['provideBasicCredential']} */
     const provideBasicCredential = async (petName, options) => {
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
       if (!options || typeof options !== 'object') {
         throw makeError(
           X`provideBasicCredential: options must include audience, username, and password`,
@@ -501,7 +502,7 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['provideGitRemote']} */
     const provideGitRemote = async (gitCap, petName, opts) => {
-      const { namePath } = assertPetNamePath(namePathFrom(petName));
+      const { namePath } = petNamePathFrom(petName);
       const gitId = getIdForRef(gitCap);
       if (gitId === undefined) {
         throw makeError(
@@ -1132,7 +1133,7 @@ export const makeHostMaker = ({
       const tasks = makeDeferredTasks();
       if (handleName !== undefined) {
         const { namePath: handlePath, petName: handlePetName } =
-          assertPetNamePath(namePathFrom(handleName));
+          petNamePathFrom(handleName);
         tasks.push(identifiers =>
           handlePath.length === 1
             ? petStore.storeIdentifier(handlePetName, identifiers.handleId)
@@ -1141,7 +1142,7 @@ export const makeHostMaker = ({
       }
       if (agentName !== undefined) {
         const { namePath: agentPath, petName: agentPetName } =
-          assertPetNamePath(namePathFrom(agentName));
+          petNamePathFrom(agentName);
         tasks.push(identifiers =>
           agentPath.length === 1
             ? petStore.storeIdentifier(agentPetName, identifiers.agentId)
@@ -1270,9 +1271,7 @@ export const makeHostMaker = ({
      * @param {string} [label] - Optional label for the timer
      */
     const makeTimerCmd = async (petName, intervalMs, label) => {
-      const { namePath, petName: timerPetName } = assertPetNamePath(
-        namePathFrom(petName),
-      );
+      const { namePath, petName: timerPetName } = petNamePathFrom(petName);
       /** @type {DeferredTasks<{ timerId: import('./types.js').FormulaIdentifier }>} */
       const tasks = makeDeferredTasks();
       tasks.push(identifiers =>
@@ -1294,9 +1293,7 @@ export const makeHostMaker = ({
      * @param {string} channelProposedName - Display name for the channel creator.
      */
     const makeChannelCmd = async (petName, channelProposedName) => {
-      const { namePath, petName: channelPetName } = assertPetNamePath(
-        namePathFrom(petName),
-      );
+      const { namePath, petName: channelPetName } = petNamePathFrom(petName);
       /** @type {DeferredTasks<ChannelDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       tasks.push(identifiers =>
@@ -1317,9 +1314,7 @@ export const makeHostMaker = ({
      * @param {NameOrPath} guestName
      */
     const invite = async guestName => {
-      const { namePath, petName: guestPetName } = assertPetNamePath(
-        namePathFrom(guestName),
-      );
+      const { namePath, petName: guestPetName } = petNamePathFrom(guestName);
       // We must immediately retain a formula under guestName so that we
       // preserve the invitation across restarts, but we must replace the
       // guestName with the handle of the guest that accepts the invitation.
@@ -1353,9 +1348,8 @@ export const makeHostMaker = ({
     const accept = async (invitationLocator, guestName) => {
       // A path nests the accepted guest inside a directory; the parent
       // directory must already exist.
-      const { namePath: guestNamePath, petName: guestLeaf } = assertPetNamePath(
-        namePathFrom(guestName),
-      );
+      const { namePath: guestNamePath, petName: guestLeaf } =
+        petNamePathFrom(guestName);
       const url = new URL(invitationLocator);
       const daemonNode = url.hostname;
       const invitationNumber = url.searchParams.get('id');

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -50,12 +50,27 @@ const assertPowersName = name => {
 };
 
 /**
+ * Validate a powers name or directory path.  A single segment must be a
+ * special powers name (`@none` / `@agent` / `@endo`) or a pet name; a
+ * multi-segment path is validated as a name path by {@link namePathFrom},
+ * letting a caller reference powers that live inside a directory rather
+ * than at the agent's top level.
+ * @param {string | string[]} nameOrPath
+ */
+const assertPowersNameOrPath = nameOrPath => {
+  const namePath = namePathFrom(nameOrPath);
+  if (namePath.length === 1) {
+    assertPowersName(namePath[0]);
+  }
+};
+
+/**
  * Normalizes host or guest options, providing default values.
  * @param {MakeHostOrGuestOptions | undefined} opts
- * @returns {{ introducedNames: Record<Name, PetName>, agentName?: PetName }}
+ * @returns {{ introducedNames: Record<Name, PetName>, agentName?: NameOrPath }}
  */
 const normalizeHostOrGuestOptions = opts => {
-  const agentName = /** @type {PetName | undefined} */ (opts?.agentName);
+  const agentName = /** @type {NameOrPath | undefined} */ (opts?.agentName);
   return {
     introducedNames: /** @type {Record<Name, PetName>} */ (
       opts?.introducedNames ?? Object.create(null)
@@ -710,7 +725,7 @@ export const makeHostMaker = ({
      * @param {Name | undefined} workerName
      * @param {MakeCapletOptions} [options]
      */
-    const prepareMakeCaplet = (workerName, options = {}) => {
+    const prepareMakeCaplet = async (workerName, options = {}) => {
       const {
         powersName = '@none',
         resultName,
@@ -720,7 +735,8 @@ export const makeHostMaker = ({
       if (workerName !== undefined) {
         assertName(workerName);
       }
-      assertPowersName(powersName);
+      assertPowersNameOrPath(powersName);
+      const powersNamePath = namePathFrom(powersName);
 
       /** @type {DeferredTasks<MakeCapletDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
@@ -730,15 +746,24 @@ export const makeHostMaker = ({
         tasks.push,
       );
 
+      // A single segment resolves against the agent's own pet store
+      // (preserving special-name powers like `@agent`); a path resolves
+      // through the directory so powers can live inside a subdirectory.
       const powersId = /** @type {FormulaIdentifier | undefined} */ (
-        petStore.identifyLocal(/** @type {Name} */ (powersName))
+        powersNamePath.length === 1
+          ? petStore.identifyLocal(/** @type {Name} */ (powersNamePath[0]))
+          : await E(directory).identify(...powersNamePath)
       );
       if (powersId === undefined) {
-        assertPetName(powersName);
-        const powersPetName = powersName;
-        tasks.push(identifiers => {
-          return petStore.storeIdentifier(powersPetName, identifiers.powersId);
-        });
+        const { petName: powersPetName } = assertPetNamePath(powersNamePath);
+        tasks.push(identifiers =>
+          powersNamePath.length === 1
+            ? petStore.storeIdentifier(powersPetName, identifiers.powersId)
+            : E(directory).storeIdentifier(
+                powersNamePath,
+                identifiers.powersId,
+              ),
+        );
       }
 
       if (resultName !== undefined) {
@@ -780,7 +805,7 @@ export const makeHostMaker = ({
         powersId,
         env,
         workerTrustedShims,
-      } = prepareMakeCaplet(
+      } = await prepareMakeCaplet(
         /** @type {Name | undefined} */ (effectiveWorkerName),
         options,
       );
@@ -822,7 +847,7 @@ export const makeHostMaker = ({
         powersId,
         env,
         workerTrustedShims,
-      } = prepareMakeCaplet(
+      } = await prepareMakeCaplet(
         /** @type {Name | undefined} */ (workerName),
         options,
       );
@@ -1006,7 +1031,7 @@ export const makeHostMaker = ({
         powersId,
         env,
         workerTrustedShims,
-      } = prepareMakeCaplet(
+      } = await prepareMakeCaplet(
         /** @type {Name | undefined} */ (workerName),
         options,
       );
@@ -1055,12 +1080,20 @@ export const makeHostMaker = ({
 
     /**
      * @template {'host' | 'guest' | 'agent'} T
-     * @param {Name} [petName] - The agent's potential pet name.
+     * @param {NameOrPath} [nameOrPath] - The agent's potential pet name or
+     * directory path.
      * @param {T} [type]
      */
-    const getNamedAgent = (petName, type) => {
-      if (petName !== undefined) {
-        const id = petStore.identifyLocal(petName);
+    const getNamedAgent = async (nameOrPath, type) => {
+      if (nameOrPath !== undefined) {
+        const namePath = namePathFrom(nameOrPath);
+        // A single segment resolves against the agent's own pet store; a
+        // path resolves through the directory so an agent can be named
+        // (and found again, idempotently) inside a subdirectory.
+        const id =
+          namePath.length === 1
+            ? petStore.identifyLocal(namePath[0])
+            : await E(directory).identify(...namePath);
         if (id !== undefined) {
           const formulaId = /** @type {FormulaIdentifier} */ (id);
           return {
@@ -1073,31 +1106,37 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {PetName} [handleName] - The pet name of the handle.
-     * @param {PetName} [agentName] - The pet name of the agent.
+     * @param {NameOrPath} [handleName] - The pet name or directory path of
+     * the handle.
+     * @param {NameOrPath} [agentName] - The pet name or directory path of
+     * the agent.
      */
     const getDeferredTasksForAgent = (handleName, agentName) => {
       /** @type {DeferredTasks<AgentDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       if (handleName !== undefined) {
-        assertPetName(handleName);
-        const handlePetName = handleName;
-        tasks.push(identifiers => {
-          return petStore.storeIdentifier(handlePetName, identifiers.handleId);
-        });
+        const { namePath: handlePath, petName: handlePetName } =
+          assertPetNamePath(namePathFrom(handleName));
+        tasks.push(identifiers =>
+          handlePath.length === 1
+            ? petStore.storeIdentifier(handlePetName, identifiers.handleId)
+            : E(directory).storeIdentifier(handlePath, identifiers.handleId),
+        );
       }
       if (agentName !== undefined) {
-        assertPetName(agentName);
-        const agentPetName = agentName;
-        tasks.push(identifiers => {
-          return petStore.storeIdentifier(agentPetName, identifiers.agentId);
-        });
+        const { namePath: agentPath, petName: agentPetName } =
+          assertPetNamePath(namePathFrom(agentName));
+        tasks.push(identifiers =>
+          agentPath.length === 1
+            ? petStore.storeIdentifier(agentPetName, identifiers.agentId)
+            : E(directory).storeIdentifier(agentPath, identifiers.agentId),
+        );
       }
       return tasks;
     };
 
     /**
-     * @param {PetName} [petName]
+     * @param {NameOrPath} [petName]
      * @param {MakeHostOrGuestOptions} [opts]
      * @returns {Promise<{id: FormulaIdentifier, value: Promise<EndoHost>}>}
      */
@@ -1105,8 +1144,7 @@ export const makeHostMaker = ({
       petName,
       { introducedNames = Object.create(null), agentName = undefined } = {},
     ) => {
-      let host = getNamedAgent(petName, 'host');
-      await null;
+      let host = await getNamedAgent(petName, 'host');
       if (host === undefined) {
         const hostLabel = agentName
           ? `host:${agentName}`
@@ -1121,7 +1159,7 @@ export const makeHostMaker = ({
             pinsDirectoryId,
             getDeferredTasksForAgent(
               petName,
-              /** @type {PetName | undefined} */ (agentName),
+              /** @type {NameOrPath | undefined} */ (agentName),
             ),
             undefined,
             handleId,
@@ -1144,18 +1182,18 @@ export const makeHostMaker = ({
     /** @type {EndoHost['provideHost']} */
     const provideHost = async (petName, opts) => {
       if (petName !== undefined) {
-        assertName(petName);
+        assertNamePath(namePathFrom(petName));
       }
       const normalizedOpts = normalizeHostOrGuestOptions(opts);
       const { value } = await makeChildHost(
-        /** @type {PetName | undefined} */ (petName),
+        /** @type {NameOrPath | undefined} */ (petName),
         normalizedOpts,
       );
       return value;
     };
 
     /**
-     * @param {PetName} [handleName]
+     * @param {NameOrPath} [handleName]
      * @param {MakeHostOrGuestOptions} [opts]
      * @returns {Promise<{id: FormulaIdentifier, value: Promise<EndoGuest>}>}
      */
@@ -1163,8 +1201,7 @@ export const makeHostMaker = ({
       handleName,
       { introducedNames = Object.create(null), agentName = undefined } = {},
     ) => {
-      let guest = getNamedAgent(handleName, 'guest');
-      await null;
+      let guest = await getNamedAgent(handleName, 'guest');
       if (guest === undefined) {
         const guestLabel = agentName
           ? `guest:${agentName}`
@@ -1178,7 +1215,7 @@ export const makeHostMaker = ({
             handleId,
             getDeferredTasksForAgent(
               handleName,
-              /** @type {PetName | undefined} */ (agentName),
+              /** @type {NameOrPath | undefined} */ (agentName),
             ),
             guestLabel,
           );
@@ -1199,11 +1236,11 @@ export const makeHostMaker = ({
     /** @type {EndoHost['provideGuest']} */
     const provideGuest = async (petName, opts) => {
       if (petName !== undefined) {
-        assertName(petName);
+        assertNamePath(namePathFrom(petName));
       }
       const normalizedOpts = normalizeHostOrGuestOptions(opts);
       const { value } = await makeGuest(
-        /** @type {PetName | undefined} */ (petName),
+        /** @type {NameOrPath | undefined} */ (petName),
         normalizedOpts,
       );
       return value;

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -345,7 +345,7 @@ export const HostInterface = M.interface('EndoHost', {
     .optional(MakeCapletOptionsShape)
     .returns(M.promise()),
   // Make a caplet from a source-only ZIP archive
-  makeArchive: M.call(M.or(NameOrPathShape, M.undefined()), NameShape)
+  makeArchive: M.call(M.or(NameOrPathShape, M.undefined()), NameOrPathShape)
     .optional(MakeCapletOptionsShape)
     .returns(M.promise()),
   // Make a caplet from a ReadableTree or Mount laid out as a

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -391,9 +391,9 @@ export const HostInterface = M.interface('EndoHost', {
   // Adopt a value from a locator with connection hints
   adoptFromLocator: M.call(LocatorShape, NameOrPathShape).returns(M.promise()),
   // Create an invitation
-  invite: M.call(NameShape).returns(M.promise()),
+  invite: M.call(NameOrPathShape).returns(M.promise()),
   // Accept an invitation
-  accept: M.call(LocatorShape, NameShape).returns(M.promise()),
+  accept: M.call(LocatorShape, NameOrPathShape).returns(M.promise()),
   // Reply to a message
   reply: M.call(
     MessageNumberShape,

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -355,7 +355,7 @@ export const HostInterface = M.interface('EndoHost', {
     .optional(MakeCapletOptionsShape)
     .returns(M.promise()),
   // Materialise a readable tree into a new scratch mount.
-  stageTree: M.call(NameOrPathShape, NameShape).returns(M.promise()),
+  stageTree: M.call(NameOrPathShape, NameOrPathShape).returns(M.promise()),
   // Stage a readable tree and run its entry module as an unconfined
   // Node caplet.
   makeUnconfinedFromTree: M.call(
@@ -365,9 +365,9 @@ export const HostInterface = M.interface('EndoHost', {
     .optional(MakeCapletOptionsShape)
     .returns(M.promise()),
   // Create a channel
-  makeChannel: M.call(NameShape, M.string()).returns(M.promise()),
+  makeChannel: M.call(NameOrPathShape, M.string()).returns(M.promise()),
   // Create a timer
-  makeTimer: M.call(NameShape, M.number())
+  makeTimer: M.call(NameOrPathShape, M.number())
     .optional(M.string())
     .returns(M.promise()),
   // Cancel a value

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -44,7 +44,7 @@ const EnvShape = M.recordOf(M.string(), M.string());
 const MakeCapletOptionsShape = M.splitRecord(
   {},
   {
-    powersName: NameShape,
+    powersName: NameOrPathShape,
     resultName: NameOrPathShape,
     env: EnvShape,
     workerTrustedShims: M.arrayOf(M.string()),
@@ -329,9 +329,13 @@ export const HostInterface = M.interface('EndoHost', {
   // able to recover host paths for daemon-minted top-level mounts.
   provideHostPath: M.call(M.any()).returns(M.promise()),
   // Provide a guest
-  provideGuest: M.call().optional(NameShape, M.record()).returns(M.promise()),
+  provideGuest: M.call()
+    .optional(NameOrPathShape, M.record())
+    .returns(M.promise()),
   // Provide a host
-  provideHost: M.call().optional(NameShape, M.record()).returns(M.promise()),
+  provideHost: M.call()
+    .optional(NameOrPathShape, M.record())
+    .returns(M.promise()),
   // Provide a worker
   provideWorker: M.call(NameOrPathShape).returns(M.promise()),
   // Evaluate code directly in a worker

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -12,7 +12,6 @@ import {
   getInfoMethodGuard,
 } from '@endo/platform/fs/lite';
 import {
-  NameShape,
   NamePathShape,
   NameOrPathShape,
   NamesOrPathsShape,

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -54,7 +54,7 @@ const MakeCapletOptionsShape = M.splitRecord(
 // Shared method guard for evaluate (used by both Host and Guest)
 // Both execute directly in a worker, differing only in namespace
 const EvaluateMethodGuard = M.call(
-  M.or(NameShape, M.undefined()),
+  M.or(NameOrPathShape, M.undefined()),
   M.string(),
   M.arrayOf(M.string()),
   NamesOrPathsShape,
@@ -341,17 +341,17 @@ export const HostInterface = M.interface('EndoHost', {
   // Evaluate code directly in a worker
   evaluate: EvaluateMethodGuard,
   // Make an unconfined caplet
-  makeUnconfined: M.call(M.or(NameShape, M.undefined()), M.string())
+  makeUnconfined: M.call(M.or(NameOrPathShape, M.undefined()), M.string())
     .optional(MakeCapletOptionsShape)
     .returns(M.promise()),
   // Make a caplet from a source-only ZIP archive
-  makeArchive: M.call(M.or(NameShape, M.undefined()), NameShape)
+  makeArchive: M.call(M.or(NameOrPathShape, M.undefined()), NameShape)
     .optional(MakeCapletOptionsShape)
     .returns(M.promise()),
   // Make a caplet from a ReadableTree or Mount laid out as a
   // compartment-mapper archive (compartment-map.json at root plus
   // modules at their referenced paths).
-  makeFromTree: M.call(M.or(NameShape, M.undefined()), NameOrPathShape)
+  makeFromTree: M.call(M.or(NameOrPathShape, M.undefined()), NameOrPathShape)
     .optional(MakeCapletOptionsShape)
     .returns(M.promise()),
   // Materialise a readable tree into a new scratch mount.
@@ -359,7 +359,7 @@ export const HostInterface = M.interface('EndoHost', {
   // Stage a readable tree and run its entry module as an unconfined
   // Node caplet.
   makeUnconfinedFromTree: M.call(
-    M.or(NameShape, M.undefined()),
+    M.or(NameOrPathShape, M.undefined()),
     NameOrPathShape,
   )
     .optional(MakeCapletOptionsShape)
@@ -418,7 +418,7 @@ export const HostInterface = M.interface('EndoHost', {
     M.record(), // bindings
   )
     .optional(
-      M.or(NameShape, M.undefined()), // workerName
+      M.or(NameOrPathShape, M.undefined()), // workerName
       NameOrPathShape, // resultName
     )
     .returns(M.promise()),

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -17,8 +17,8 @@ import {
 import {
   assertName,
   assertNames,
-  assertPetNamePath,
   namePathFrom,
+  petNamePathFrom,
 } from './pet-name.js';
 import { makeDeferredTasks } from './deferred-tasks.js';
 import { makeSerialJobs } from './serial-jobs.js';
@@ -1006,8 +1006,7 @@ export const makeMailboxMaker = ({
     /** @type {Mail['adopt']} */
     const adopt = async (messageNumber, edgeName, petNameOrPath) => {
       assertName(edgeName);
-      const petNamePath = namePathFrom(petNameOrPath);
-      assertPetNamePath(petNamePath);
+      const { namePath: petNamePath } = petNamePathFrom(petNameOrPath);
       const normalizedMessageNumber = mustParseBigint(messageNumber, 'message');
       const message = messages.get(normalizedMessageNumber);
       if (message === undefined) {

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -1049,9 +1049,14 @@ export const makeMailboxMaker = ({
     /** @type {Mail['request']} */
     const request = async (toNameOrPath, description, responseName) => {
       const toPath = namePathFrom(toNameOrPath);
+      // The response is stored under responseName, so it is a store
+      // target (pet-name leaf); coerce+validate once and reuse.
+      const responseNamePath =
+        responseName !== undefined
+          ? petNamePathFrom(responseName).namePath
+          : undefined;
       await null;
-      if (responseName !== undefined) {
-        const responseNamePath = namePathFrom(responseName);
+      if (responseNamePath !== undefined) {
         const resolutionId = await E(directory).identify(...responseNamePath);
         if (resolutionId !== undefined) {
           context.thisDiesIfThatDies(
@@ -1093,8 +1098,7 @@ export const makeMailboxMaker = ({
       context.thisDiesIfThatDies(resolutionId);
       const responseP = provide(resolutionId);
 
-      if (responseName !== undefined) {
-        const responseNamePath = namePathFrom(responseName);
+      if (responseNamePath !== undefined) {
         await E(directory).storeIdentifier(responseNamePath, resolutionId);
       }
 

--- a/packages/daemon/src/pet-name.js
+++ b/packages/daemon/src/pet-name.js
@@ -150,3 +150,21 @@ export const namePathFrom = nameOrPath => {
   assertNamePath(path);
   return /** @type {NamePath} */ (path);
 };
+
+/**
+ * Coerces a name or path to a validated **pet-name path**: a name path
+ * whose final segment is a pet name (the others may be any name). This is
+ * the canonical validator for a store target — a place a new value is
+ * named — combining {@link namePathFrom} (coerce + validate each segment)
+ * with {@link assertPetNamePath} (require a pet-name leaf). Returns the
+ * full path, the prefix path (all but the last segment), and the final
+ * pet name.
+ *
+ * Use {@link namePathFrom} instead when the leaf may be a special name
+ * (e.g. resolving an existing `@main` worker or `@agent` powers).
+ *
+ * @param {string | string[]} nameOrPath
+ * @returns {{ namePath: NamePath, prefixPath: NamePath, petName: PetName }}
+ */
+export const petNamePathFrom = nameOrPath =>
+  assertPetNamePath(namePathFrom(nameOrPath));

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1368,7 +1368,7 @@ export interface EndoAgent extends EndoDirectory {
 export interface EndoGuest extends EndoAgent {
   /** Evaluate code directly in a worker, constrained by reachable capabilities. */
   evaluate(
-    workerPetName: string | undefined,
+    workerPetName: string | string[] | undefined,
     source: string,
     codeNames: Array<string>,
     petNamesOrPaths: Array<string | string[]>,
@@ -1505,24 +1505,24 @@ export interface EndoHost extends EndoAgent {
   makeDirectory(petNamePath: string | string[]): Promise<EndoDirectory>;
   provideWorker(petNamePath: string | string[]): Promise<EndoWorker>;
   evaluate(
-    workerPetName: string | undefined,
+    workerPetName: string | string[] | undefined,
     source: string,
     codeNames: Array<string>,
     petNamesOrPaths: Array<string | string[]>,
     resultName?: string | string[],
   ): Promise<unknown>;
   makeUnconfined(
-    workerName: string | undefined,
+    workerName: string | string[] | undefined,
     specifier: string,
     options?: MakeCapletOptions,
   ): Promise<unknown>;
   makeArchive(
-    workerPetName: string | undefined,
+    workerPetName: string | string[] | undefined,
     archiveName: string,
     options?: MakeCapletOptions,
   ): Promise<unknown>;
   makeFromTree(
-    workerPetName: string | undefined,
+    workerPetName: string | string[] | undefined,
     treeName: string | string[],
     options?: MakeCapletOptions,
   ): Promise<unknown>;
@@ -1543,7 +1543,7 @@ export interface EndoHost extends EndoAgent {
    * Supports native Node modules (unlike {@link makeFromTree}).
    */
   makeUnconfinedFromTree(
-    workerPetName: string | undefined,
+    workerPetName: string | string[] | undefined,
     treeName: string | string[],
     options?: MakeCapletOptions & { entry?: string },
   ): Promise<unknown>;
@@ -1573,7 +1573,7 @@ export interface EndoHost extends EndoAgent {
   endow(
     messageNumber: bigint,
     bindings: Record<string, string | string[]>,
-    workerName?: string,
+    workerName?: string | string[],
     resultName?: string | string[],
   ): Promise<void>;
   submit(messageNumber: bigint, values: Record<string, unknown>): Promise<void>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1284,12 +1284,12 @@ export interface EndoMount {
 export interface EndoWorker {}
 
 export type MakeHostOrGuestOptions = {
-  agentName?: string;
+  agentName?: string | string[];
   introducedNames?: Record<string, string>;
 };
 
 export type MakeCapletOptions = {
-  powersName?: string;
+  powersName?: string | string[];
   resultName?: string | string[];
   env?: Record<string, string>;
   workerTrustedShims?: string[];
@@ -1495,11 +1495,11 @@ export interface EndoHost extends EndoAgent {
    */
   provideHostPath(cap: unknown): Promise<string>;
   provideGuest(
-    petName?: string,
+    petName?: string | string[],
     opts?: MakeHostOrGuestOptions,
   ): Promise<EndoGuest>;
   provideHost(
-    petName?: string,
+    petName?: string | string[],
     opts?: MakeHostOrGuestOptions,
   ): Promise<EndoHost>;
   makeDirectory(petNamePath: string | string[]): Promise<EndoDirectory>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -625,7 +625,7 @@ type InvitationFormula = {
   type: 'invitation';
   hostAgent: FormulaIdentifier;
   hostHandle: FormulaIdentifier;
-  guestName: PetName;
+  guestName: NameOrPath;
 };
 
 export type InvitationDeferredTaskParams = {
@@ -1571,8 +1571,11 @@ export interface EndoHost extends EndoAgent {
     locator: string,
     petNameOrPath: string | string[],
   ): Promise<void>;
-  invite(guestName: string): Promise<Invitation>;
-  accept(invitationLocator: string, guestName: string): Promise<void>;
+  invite(guestName: string | string[]): Promise<Invitation>;
+  accept(
+    invitationLocator: string,
+    guestName: string | string[],
+  ): Promise<void>;
   endow(
     messageNumber: bigint,
     bindings: Record<string, string | string[]>,
@@ -2248,7 +2251,7 @@ export interface DaemonCore {
   formulateInvitation: (
     hostAgentId: FormulaIdentifier,
     hostHandleId: FormulaIdentifier,
-    guestName: PetName,
+    guestName: NameOrPath,
     deferredTasks: DeferredTasks<InvitationDeferredTaskParams>,
   ) => FormulateResult<Invitation>;
 

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1534,7 +1534,7 @@ export interface EndoHost extends EndoAgent {
    */
   stageTree(
     treeName: string | string[],
-    scratchPetName: string,
+    scratchPetName: string | string[],
   ): Promise<unknown>;
   /**
    * Stage a readable tree (ReadableTree or Mount) into an internal
@@ -1555,9 +1555,12 @@ export interface EndoHost extends EndoAgent {
   addPeerInfo(peerInfo: PeerInfo): Promise<void>;
   listKnownPeers(): Promise<PeerInfo[]>;
   followPeerChanges(): AsyncGenerator<PetStoreNameChange, undefined, undefined>;
-  makeChannel(petName: string, proposedName: string): Promise<EndoChannel>;
+  makeChannel(
+    petName: string | string[],
+    proposedName: string,
+  ): Promise<EndoChannel>;
   makeTimer(
-    petName: string,
+    petName: string | string[],
     intervalMs: number,
     label?: string,
   ): Promise<unknown>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1518,7 +1518,7 @@ export interface EndoHost extends EndoAgent {
   ): Promise<unknown>;
   makeArchive(
     workerPetName: string | string[] | undefined,
-    archiveName: string,
+    archiveName: string | string[],
     options?: MakeCapletOptions,
   ): Promise<unknown>;
   makeFromTree(

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -2451,6 +2451,40 @@ testNeedsNodeWorker(
   },
 );
 
+testNeedsNodeWorker(
+  'path-named agents and powers reject a missing parent directory',
+  async t => {
+    const { host } = await prepareHost(t);
+
+    // A specified path whose parent directory does not exist is rejected
+    // the same way `makeDirectory` (and the `mkdir` / `store` / `mv` CLI
+    // verbs that build on it) reject one: with "Unknown pet name".  No
+    // intermediate directories are auto-created, so provisioning an agent
+    // or referencing powers at a path follows the same rule as every
+    // other path operation.
+    await t.throwsAsync(E(host).makeDirectory(['nope', 'sub']), {
+      message: /Unknown pet name/,
+    });
+    await t.throwsAsync(E(host).provideGuest(['nope', 'handle']), {
+      message: /Unknown pet name/,
+    });
+    await t.throwsAsync(E(host).provideHost(['nope', 'handle']), {
+      message: /Unknown pet name/,
+    });
+
+    await E(host).provideWorker(['worker']);
+    const counterPath = path.join(dirname, 'test', 'counter.js');
+    const counterLocation = url.pathToFileURL(counterPath).href;
+    await t.throwsAsync(
+      E(host).makeUnconfined('worker', counterLocation, {
+        powersName: ['nope', 'agent'],
+        resultName: 'counter',
+      }),
+      { message: /Unknown pet name/ },
+    );
+  },
+);
+
 testNeedsNodeWorker('cancel because of requested capability', async t => {
   const { host } = await prepareHost(t);
 

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -2485,6 +2485,18 @@ testNeedsNodeWorker(
   },
 );
 
+test('makeTimer and makeChannel accept directory paths', async t => {
+  const { host } = await prepareHost(t);
+  await E(host).makeDirectory('infra');
+
+  await E(host).makeTimer(['infra', 'tick'], 1000);
+  t.true(await E(host).has('infra', 'tick'));
+  t.false(await E(host).has('tick'));
+
+  await E(host).makeChannel(['infra', 'chan'], 'me');
+  t.true(await E(host).has('infra', 'chan'));
+});
+
 testNeedsNodeWorker(
   'evaluate and makeUnconfined accept a worker at a directory path',
   async t => {

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -2378,6 +2378,79 @@ testNeedsNodeWorker('indirect cancellation via caplet', async t => {
   );
 });
 
+testNeedsNodeWorker(
+  'provideGuest and powersName accept directory paths (no move dance)',
+  async t => {
+    const { host } = await prepareHost(t);
+
+    // The factory's controller directory.
+    await E(host).makeDirectory('factory');
+
+    // The guest handle and its agent are born *inside* the directory —
+    // no top-level pet names, no relocate-after-makeUnconfined dance.
+    await E(host).provideGuest(['factory', 'handle'], {
+      agentName: ['factory', 'agent'],
+    });
+
+    // They are reachable by path and absent at the top level.
+    t.true(await E(host).has('factory', 'handle'));
+    t.true(await E(host).has('factory', 'agent'));
+    t.false(await E(host).has('handle'));
+    t.false(await E(host).has('agent'));
+
+    // A value the host will grant when the caplet asks its powers.
+    await E(host).provideWorker(['worker']);
+    await E(host).evaluate(
+      'worker',
+      `
+      makeExo('Answer', M.interface('Answer', {}, { defaultGuards: 'passable' }), {
+        value: () => 42,
+      })
+      `,
+      [],
+      [],
+      ['grant'],
+    );
+
+    // The caplet's powers are supplied *by directory path*, and its
+    // result is stored at a directory path too.
+    const servicePath = path.join(dirname, 'test', 'service.js');
+    const serviceLocation = url.pathToFileURL(servicePath).href;
+    await E(host).makeUnconfined('worker', serviceLocation, {
+      powersName: ['factory', 'agent'],
+      resultName: ['factory', 'service'],
+    });
+
+    // Asking the service routes a request to the host from the
+    // in-directory handle, proving the powers wired to the path-named
+    // agent.  The endowment is supplied by path as well.
+    const iterator = iterateReader(E(host).followMessages());
+    const answer = E(host).evaluate(
+      'worker',
+      'E(service).ask()',
+      ['service'],
+      [['factory', 'service']],
+      ['answer'],
+    );
+    const { value: message } = await iterator.next();
+    const { number, from: fromId } = E.get(message);
+    // `from` is a locator; compare against the in-directory handle's
+    // locator to prove the request came from the path-named handle.
+    t.is(await fromId, await E(host).locate('factory', 'handle'));
+    await E(host).resolve(await number, 'grant');
+    t.is(await E(await answer).value(), 42);
+
+    // Native path idempotency: re-providing the same guest at the same
+    // path resolves to the same agent id — no controller-path keying
+    // workaround required.
+    const agentId = await E(host).identify('factory', 'agent');
+    await E(host).provideGuest(['factory', 'handle'], {
+      agentName: ['factory', 'agent'],
+    });
+    t.is(await E(host).identify('factory', 'agent'), agentId);
+  },
+);
+
 testNeedsNodeWorker('cancel because of requested capability', async t => {
   const { host } = await prepareHost(t);
 

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -2485,6 +2485,45 @@ testNeedsNodeWorker(
   },
 );
 
+testNeedsNodeWorker(
+  'evaluate and makeUnconfined accept a worker at a directory path',
+  async t => {
+    const { host } = await prepareHost(t);
+    await E(host).makeDirectory('workers');
+
+    // provideWorker already accepts a path; reference that same worker
+    // by path from evaluate and makeUnconfined.
+    await E(host).provideWorker(['workers', 'w']);
+    const workerId = await E(host).identify('workers', 'w');
+    t.true(await E(host).has('workers', 'w'));
+
+    t.is(
+      42,
+      await E(host).evaluate(['workers', 'w'], '6 * 7', [], [], ['answer']),
+    );
+    // The worker was reused, not recreated.
+    t.is(await E(host).identify('workers', 'w'), workerId);
+
+    const servicePath = path.join(dirname, 'test', 'service.js');
+    const serviceLocation = url.pathToFileURL(servicePath).href;
+    const service = await E(host).makeUnconfined(
+      ['workers', 'w'],
+      serviceLocation,
+      { powersName: '@none', resultName: ['workers', 'svc'] },
+    );
+    t.truthy(service);
+    t.is(await E(host).identify('workers', 'w'), workerId);
+
+    // A worker named at a path that does not yet exist is created and
+    // stored there (the parent directory must already exist).
+    t.is(
+      3,
+      await E(host).evaluate(['workers', 'w2'], '1 + 2', [], [], ['three']),
+    );
+    t.true(await E(host).has('workers', 'w2'));
+  },
+);
+
 testNeedsNodeWorker('cancel because of requested capability', async t => {
   const { host } = await prepareHost(t);
 

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -2497,6 +2497,15 @@ test('makeTimer and makeChannel accept directory paths', async t => {
   t.true(await E(host).has('infra', 'chan'));
 });
 
+test('invite nests the invitation at a directory path', async t => {
+  const { host } = await prepareHost(t);
+  await E(host).makeDirectory('peers');
+  const invitation = await E(host).invite(['peers', 'bob']);
+  t.truthy(await E(invitation).locate());
+  t.true(await E(host).has('peers', 'bob'));
+  t.false(await E(host).has('bob'));
+});
+
 testNeedsNodeWorker(
   'evaluate and makeUnconfined accept a worker at a directory path',
   async t => {

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -2545,6 +2545,41 @@ testNeedsNodeWorker(
   },
 );
 
+testNeedsNodeWorker(
+  'makeArchive accepts a source archive at a directory path',
+  async t => {
+    const { host } = await prepareHost(t);
+    await E(host).provideWorker(['w1']);
+    await E(host).makeDirectory('archives');
+
+    // Store the source archive blob at a directory path.
+    const servicePath = path.join(
+      dirname,
+      'test',
+      'fixtures',
+      'archive-service',
+    );
+    const moduleLocation = url.pathToFileURL(servicePath).href;
+    const archiveBytes = await makeCompartmentArchive(
+      archiveReadPowers,
+      moduleLocation,
+      { parserForLanguage: sourceParserForLanguage },
+    );
+    const archiveReaderRef = bytesReaderFromIterator([archiveBytes]);
+    await E(host).storeBlob(archiveReaderRef, ['archives', 'svc']);
+    t.true(await E(host).has('archives', 'svc'));
+
+    // makeArchive resolves the source by path and stores its result by
+    // path too.
+    const service = await E(host).makeArchive('w1', ['archives', 'svc'], {
+      powersName: '@none',
+      resultName: ['archives', 's1'],
+    });
+    t.truthy(service);
+    t.true(await E(host).has('archives', 's1'));
+  },
+);
+
 testNeedsNodeWorker('cancel because of requested capability', async t => {
   const { host } = await prepareHost(t);
 

--- a/packages/daemon/test/invite-retention.test.js
+++ b/packages/daemon/test/invite-retention.test.js
@@ -226,6 +226,59 @@ test.serial('invited guest retains values shared through mail', async t => {
 });
 
 test.serial(
+  'invite and accept nest the redeemed guest at a directory path',
+  async t => {
+    const { host: hostA } = await prepareHostWithGcAndNetwork(t);
+    const { host: hostB } = await prepareHostWithGcAndNetwork(t);
+
+    // Parent directories must already exist (no mkdir -p), as with every
+    // other path verb.
+    await E(hostA).makeDirectory('peers');
+    await E(hostB).makeDirectory('friends');
+
+    // A invites a guest nested at peers/bob; B accepts it nested at
+    // friends/alice. This exercises both path-redeem branches: the
+    // invitation formula's accept handler (stores the remote handle on A)
+    // and host.accept (stores the local guest on B).
+    const invitation = await E(hostA).invite(['peers', 'bob']);
+    const invitationLocator = await E(invitation).locate();
+    await E(hostB).accept(invitationLocator, ['friends', 'alice']);
+
+    // On A: the remote handle is named at the invite path, and the local
+    // guest is pinned under the leaf name.
+    t.true(
+      await E(hostA).has('peers', 'bob'),
+      'A named the remote handle at peers/bob',
+    );
+    t.truthy(
+      await E(hostA).identify('@pins', 'guest-bob'),
+      'A pinned guest-bob by leaf',
+    );
+
+    // On B: the remote handle is named at the accept path, and the local
+    // guest is pinned under the leaf name.
+    t.true(
+      await E(hostB).has('friends', 'alice'),
+      'B named the remote handle at friends/alice',
+    );
+    t.truthy(
+      await E(hostB).identify('@pins', 'guest-alice'),
+      'B pinned guest-alice by leaf',
+    );
+
+    // The path-named guest is functional: a value shared from A to the
+    // path-named recipient reaches B's inbox.
+    await E(hostA).evaluate('@main', '"shared-value"', [], [], ['shared']);
+    await E(hostA).send(['peers', 'bob'], ['Here'], ['shared'], ['shared']);
+    const messages = /** @type {unknown[]} */ (await E(hostB).listMessages());
+    t.true(
+      messages.length > 0,
+      'B received a message via the path-named guest',
+    );
+  },
+);
+
+test.serial(
   'deleting invited guest and pin collects guest formulas',
   async t => {
     const { host: hostA, config: configA } =

--- a/packages/daemon/test/pet-name.test.js
+++ b/packages/daemon/test/pet-name.test.js
@@ -15,6 +15,7 @@ import {
   assertNamePath,
   assertPetNamePath,
   namePathFrom,
+  petNamePathFrom,
 } from '../src/pet-name.js';
 
 // --- isValidName ---
@@ -204,4 +205,35 @@ test('namePathFrom passes through array', t => {
 test('namePathFrom validates', t => {
   t.throws(() => namePathFrom(''), { message: /Invalid/ });
   t.throws(() => namePathFrom([]), { message: /Invalid/ });
+});
+
+// --- petNamePathFrom ---
+
+test('petNamePathFrom coerces a string and returns structured result', t => {
+  const result = petNamePathFrom('hello');
+  t.deepEqual(result.namePath, ['hello']);
+  t.deepEqual(result.prefixPath, []);
+  t.is(result.petName, 'hello');
+});
+
+test('petNamePathFrom coerces a path and returns structured result', t => {
+  const result = petNamePathFrom(['a', 'b', 'c']);
+  t.deepEqual(result.namePath, ['a', 'b', 'c']);
+  t.deepEqual(result.prefixPath, ['a', 'b']);
+  t.is(result.petName, 'c');
+});
+
+test('petNamePathFrom allows a special name in the prefix', t => {
+  t.is(petNamePathFrom(['@self', 'child']).petName, 'child');
+});
+
+test('petNamePathFrom rejects a special name leaf', t => {
+  t.throws(() => petNamePathFrom('@self'), { message: /Invalid pet name/ });
+  t.throws(() => petNamePathFrom(['a', '@self']), {
+    message: /Invalid pet name/,
+  });
+});
+
+test('petNamePathFrom rejects an empty path', t => {
+  t.throws(() => petNamePathFrom([]), { message: /Invalid name path/ });
 });


### PR DESCRIPTION
## What this is

`@endo/daemon`'s name-bearing methods were inconsistent about whether a name could be a **directory path** (`['dir', 'leaf']` / `dir/leaf`). The name-hub and mail surface already accepted `NameOrPath` everywhere, and `resultName` did too — but the provisioning verbs resolved or stored their names through the **flat pet store**, so you could create something in a directory and then be unable to reference it (or be forced into a "store at top level, then `move`" dance).

This PR **normalizes path acceptance** across the rest of the surface, then **unifies name validation** behind a single helper. Every path change follows the same shape: the guard accepts `NameOrPathShape`, the body coerces, a **single segment** still resolves/stores through the agent's own pet store (so special names like `@none`/`@agent`/`@main`/`@node` and all single-name behavior are byte-for-byte preserved), and a **path** resolves/stores through the directory.

## Part 1 — path acceptance (commits 1–6)

| Verb(s) | Name made path-capable | CLI |
|---|---|---|
| `provideGuest` / `provideHost` | handle pet name + optional `agentName` | `mkguest` / `mkhost` |
| `powersName` (`MakeCapletOptions`) | caplet powers | `make`/`run --powers` |
| `evaluate`, `makeUnconfined`, `makeArchive`, `makeFromTree`, `makeUnconfinedFromTree`, `endow` | **worker name** (host + guest) | `eval`/`make --worker` |
| `makeTimer`, `makeChannel`, `stageTree` | timer/channel/scratch result | — (daemon-only) |
| `invite` / `accept` | local guest name | `invite` / `accept` |
| `makeArchive` | source archive name | `make --archive` |

Highlights:
- **Removes the born-top-level-then-`move` dance** for factory powers; `provideGuest`'s own existence check is the idempotency key.
- **Worker name** was the standout inconsistency: `provideWorker` already stored workers in the directory, but every consumer resolved the worker through the flat store, so a worker created at a path couldn't be referenced. Now host *and* guest `prepareWorkerFormulation` are path-capable.
- **`invite`/`accept`**: `InvitationFormula.guestName` and the redeemed-guest handler take a `NameOrPath`. The durable mail-delivery name uses the full path; the `@pins` pin and the guest label use the leaf. The name is purely local (the remote ignores it via the unused `_hostNameFromGuest` arg), so the cross-peer protocol is unchanged, and single-name invitations persist exactly as before.

### Non-existing-path behavior (matches every other path verb)

No `mkdir -p`. A path whose **parent directory** doesn't exist is rejected with `"Unknown pet name"` — exactly as `makeDirectory`/`mkdir`, `store`, `mv`, `copy` already do (all funnel through `directory.lookup(prefixPath)`). The new code inherits this on both the store (`storeIdentifier`) and lookup (`identify`) sides. A factory creates its controller directory first; that directory is the natural idempotency anchor.

## Part 2 — one consistent validation pattern (commits 7–9)

Introduces **`petNamePathFrom(nameOrPath)`** in `pet-name.js` — the canonical store-target validator: coerce `string | string[]`, validate every segment, require a **pet-name leaf**, return `{ namePath, prefixPath, petName }`. (Exo method *guards* can only match, not transform, so coercion belongs in the body; this is the one-liner for it.)

Then a single rule, applied across `host.js` / `guest.js` / `directory.js` / `mail.js`:
- **store target** (leaf must be a pet name) → `petNamePathFrom`
- **resolve / lookup** (leaf may be `@main`/`@agent`/etc., or a source tree) → `namePathFrom`, no trailing assert

This removed the redundant `namePathFrom(x)` + `assertNamePath(...)` double-validation everywhere (`namePathFrom` already validates), plus two further internal double-validations (`mail.request` response name, `directory.writeText`). Tightening loose store sites to strict is **behavior-preserving** end-to-end — those stores already funnel through `directory.storeIdentifier` (now `petNamePathFrom`) / `petStore` (`assertValidName`), so a special-name leaf was always rejected; it now fails fast at the method boundary. It also closes a latent bug where `provideGuest('@self')` could resolve the special and return it as a guest.

## The payoff

```js
await E(host).makeDirectory('factory');
await E(host).provideWorker(['factory', 'worker']);
await E(host).provideGuest(['factory', 'handle'], { agentName: ['factory', 'agent'] });
await E(host).makeUnconfined(['factory', 'worker'], spec, {
  powersName: ['factory', 'agent'],
  resultName: ['factory', 'service'],
});
```

No `move`; every name nests cleanly.

## Tests

New daemon tests cover: provideGuest/powersName paths (+ idempotency, no move), missing-parent rejection parity, worker-at-path (eval + makeUnconfined, reuse + on-demand create), makeTimer/makeChannel at a path, invite nested at a path, makeArchive from a path-stored source, `petNamePathFrom` unit tests, and a **two-daemon invite/accept redeem at a directory path** (nests on both sides + a value routed through the path-named guest). Single-name regression suites all pass — caplet cancellation, requested-capability cancel, persist confined/unconfined services + restart, guest evaluate, store/move/copy/read/write/adopt, and the two-daemon invite-retention suite (across-restart + mail-retention).

## Review

Two subagent reviews (validation consistency; path-acceptance correctness) came back clean on substance: resolve-vs-store classification correct at every site, tightening confirmed behavior-preserving, no missing `await`s, guards/types consistent, no array-stringification bugs in invite/accept. Both Low findings they raised were fixed; the cross-peer redeem coverage gap they noted is now closed by the two-daemon path test.

## Verification

- Source is type-clean: zero `src/` errors under tsgo and a clean `tsc --build`. (Heads-up: `yarn lint` currently emits intermittent, non-deterministic tsgo errors in some untouched **test** files — present on the base branch too, unrelated to this PR.)
- eslint clean (0 errors) in `packages/daemon` and `packages/cli`.

## Scope notes

- Daemon-level path *acceptance* + the CLI verbs above. Other surfaces (chat, agent setup helpers) still pass single names and are unaffected.
- `introducedNames` child names remain single pet names (they name into the *guest's* namespace), unchanged.
- The remote invitation-protocol arg (`_hostNameFromGuest`) is unused and stays single — only local storage names became path-capable.
- CLI single-name invitations now persist `['bob']` rather than `'bob'`; benign (normalized on read, and pre-existing string-form formulas still redeem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLE7nD8SKVurA1gz2hrFhn