### PR TITLE
fix(chat): de-flake forum.test.js and sweep component tests off fixed-tick waits

### DIFF
--- a/packages/chat/designs/preact-confinement-migration.md
+++ b/packages/chat/designs/preact-confinement-migration.md
@@ -639,8 +639,16 @@ they are deliberate timing devices rather than settle-waits:
   setter is wired by an unobservable mount effect (`heat-bar`, `command-selector`,
   `inline-define`, `inventory-component`, …): there is no DOM signal proving the
   setter is wired, and the subsequent per-assertion `waitFor` already absorbs the
-  render race. Where a re-arm was possible (`message-picker.test.js`) the warmup
-  was removed by re-issuing `enable()` inside the poll instead.
+  render race. Where the component instead **buffers** host-pushed state until
+  its mount effect flushes it (`controller.pendingState`), the warmup is
+  unnecessary and was removed outright — the two `petname-*-autocomplete-confined`
+  tests now rely on that buffer plus each test's own `waitFor`. Where a re-arm
+  was possible (`message-picker.test.js`) the warmup was removed by re-issuing
+  `enable()` inside the poll instead. `token-autocomplete-confined.test.js` keeps
+  a deliberate settle because its name list loads from an async `followNameChanges`
+  stream that is not re-filtered when names arrive (no buffer, no observable).
+  The misleading `await waitFor(() => true, { timeout })` no-ops that fronted
+  these warmups were deleted.
 
 While sweeping, `channel-thread.test.js` and `outliner-enter-key.test.js` also
 gained component disposal in `afterEach` (the same teardown-leak class as

--- a/packages/chat/designs/preact-confinement-migration.md
+++ b/packages/chat/designs/preact-confinement-migration.md
@@ -602,6 +602,20 @@ Fixed so far (the flakes actually observed in CI):
 - `inline-command-form.test.js` — the 19 tests were serialized; they shared
   `document.body` with a global `afterEach` wipe, so parallel runs let one
   test's teardown clear another's DOM mid-assertion.
+- `forum.test.js` — not a fixed-tick race (the assertions already poll with
+  `waitFor`) but a teardown leak. The flake surfaced two ways across identical
+  runs: the `a root message renders as a forum node` / dispose assertions
+  failing, and the run reporting "N uncaught exceptions". Both traced to the
+  test's detached `.catch` **re-throwing** the consumer-loop rejection — an
+  unhandled rejection AVA then attributes to whichever test is running — and to
+  the mounted component never being disposed, so its parked `for await` loop,
+  its reader prefetch, and the initial-batch `setTimeout` leaked across tests
+  and could fire against a torn-down DOM. Fixed by (a) dropping the re-throw
+  (the `.catch` only logs; tests assert on observable DOM/spy state), (b)
+  disposing every mounted component in `afterEach` before the shared DOM is
+  cleared, and (c) hardening `forumComponent`'s `dispose()` to cancel the
+  pending batch timer, with a `disposed` guard in the batch-render callbacks so
+  an already-queued timer cannot render post-dispose.
 
 Deferred: a sweep of the remaining fixed-tick waits (~277 `await tick(ms)` calls
 across ~42 component test files). This is preventive — those tests are not

--- a/packages/chat/designs/preact-confinement-migration.md
+++ b/packages/chat/designs/preact-confinement-migration.md
@@ -81,12 +81,12 @@ Audited against the current tree. These view modules still build their UI with
 `document.createElement` / `.innerHTML` / `addEventListener` and have **not**
 been converted to confined Preact:
 
-| Module | Lines | Role |
-| --- | --- | --- |
-| outliner-component | 3003 | `outliner` viewMode body — held for the decompose-into-contract approach |
-| spaces-gutter | 971 | left space gutter — **⊘ deferred** (the floot imperative-Space PR edits it, +41/-5) |
-| heat-simulation | 225 | heat animation; still imperative but host-node-bridged by the converted `channel-header` (not a primary target) |
-| inventory-graph (pkg) | ~ | `@endo/space-inventory-graph/src/graph.js` SVG view — needs the renderer's `allowedTags`/`allowedAttrs` SVG extension first |
+| Module                | Lines | Role                                                                                                                        |
+| --------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------- |
+| outliner-component    | 3003  | `outliner` viewMode body — held for the decompose-into-contract approach                                                    |
+| spaces-gutter         | 971   | left space gutter — **⊘ deferred** (the floot imperative-Space PR edits it, +41/-5)                                         |
+| heat-simulation       | 225   | heat animation; still imperative but host-node-bridged by the converted `channel-header` (not a primary target)             |
+| inventory-graph (pkg) | ~     | `@endo/space-inventory-graph/src/graph.js` SVG view — needs the renderer's `allowedTags`/`allowedAttrs` SVG extension first |
 
 Newly **done** (confined Preact, verified + tests, mount signatures unchanged so
 `chat.js` was untouched): **forum**, **value-component**, **channel-component**
@@ -105,10 +105,10 @@ forced to convert to Preact during the rebase, two files are **deliberately left
 imperative** until that PR lands — they are the only conflict surface for an
 "add an imperative Space" change:
 
-| Module | Lines | Why frozen |
-| --- | --- | --- |
-| chat.js | 1846 | the space-mode dispatch (`if (mode === 'x') return xComponent(...)`); stays the imperative trusted root that calls `renderConfined` on the Preact bodies |
-| add-space-modal | 1979 | the creatable-space-type registration (scheme-picker entry) |
+| Module          | Lines | Why frozen                                                                                                                                               |
+| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| chat.js         | 1846  | the space-mode dispatch (`if (mode === 'x') return xComponent(...)`); stays the imperative trusted root that calls `renderConfined` on the Preact bodies |
+| add-space-modal | 1979  | the creatable-space-type registration (scheme-picker entry)                                                                                              |
 
 Converting a body/chrome view **in place** never edits these (same mount
 signature in, same API out), so all other conversions can proceed without
@@ -124,7 +124,7 @@ chat wrapper; they are **in scope**, just tracked in their own package:
   that package. The chat wrapper just resolves powers and delegates.
 
 Also still DOM but **not** view-migration targets (render helpers consumed via
-`.innerHTML`; the plan migrates their *callers* to vnodes, not these): the
+`.innerHTML`; the plan migrates their _callers_ to vnodes, not these): the
 string-returning `value-render` / `markdown-render` / `markdown-preview`, and the
 `channel-utils` / `react-utils` state logic. Preact-vnode replacements already
 exist for the inbox path (`markdown-vnodes`, `value-vnodes`).
@@ -271,53 +271,53 @@ chat.js make()                      root orchestrator (plain DOM)
 Each entry lists the other UI/render modules a module imports.
 `(none)` means it is a graph leaf.
 
-| Module | Composes |
-| --- | --- |
-| spaces-gutter | add-space-modal, edit-space-modal |
-| add-space-modal | icon-selector, scheme-picker, petname-paths-autocomplete, spaces-gutter |
-| edit-space-modal | icon-selector, scheme-picker, spaces-gutter |
-| inventory-component | (none) |
-| channel-header | heat-engine, heat-simulation |
-| channel-component | channel-utils, markdown-render, monaco-wrapper, profile-popup, react-utils, time-formatters |
-| channel-utils | markdown-render, monaco-wrapper, profile-popup, time-formatters |
-| chat-bar-component | blob-viewer, command-executor, command-registry, command-selector, debugger-panel, define-form, endow-modal, eval-form, form-builder, help-modal, inline-command-form, message-picker, send-form |
-| inbox-component | chime, markdown-render, monaco-wrapper, time-formatters, value-render |
-| command-executor | browser-tree |
-| command-selector | command-registry |
-| define-form | monaco-wrapper |
-| endow-modal | petname-path-autocomplete |
-| eval-form | monaco-wrapper, petname-path-autocomplete |
-| form-builder | petname-path-autocomplete |
-| help-modal | command-registry |
-| inline-command-form | command-registry, inline-define, inline-eval, petname-path-autocomplete, petname-paths-autocomplete, token-autocomplete |
-| send-form | composite-heat-engine, heat-bar, heat-engine, token-autocomplete |
-| blob-viewer | language-detect, markdown-preview, monaco-wrapper |
-| heat-simulation | heat-engine |
-| heat-bar | heat-engine |
-| value-component | language-detect, markdown-preview, monaco-wrapper, value-render |
-| value-render | time-formatters |
-| scheme-picker | spaces-gutter |
-| share-modal | channel-utils |
-| counter-proposal-form | monaco-wrapper, petname-path-autocomplete |
-| inline-eval | petname-path-autocomplete |
-| markdown-preview | monaco-wrapper |
-| profile-popup | (none) |
-| message-picker | (none) |
-| icon-selector | (none) |
-| inline-define | (none) |
-| debugger-panel | (none) |
-| command-registry | (none) |
-| react-utils | (none) |
-| heat-engine | (none) |
-| markdown-render | (none) |
-| monaco-wrapper | (none) |
-| time-formatters | (none) |
-| chime | (none) |
-| token-autocomplete | (none) |
-| petname-path-autocomplete | (none) |
-| petname-paths-autocomplete | (none) |
-| language-detect | (none) |
-| message-parse | (none) |
+| Module                     | Composes                                                                                                                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| spaces-gutter              | add-space-modal, edit-space-modal                                                                                                                                                                |
+| add-space-modal            | icon-selector, scheme-picker, petname-paths-autocomplete, spaces-gutter                                                                                                                          |
+| edit-space-modal           | icon-selector, scheme-picker, spaces-gutter                                                                                                                                                      |
+| inventory-component        | (none)                                                                                                                                                                                           |
+| channel-header             | heat-engine, heat-simulation                                                                                                                                                                     |
+| channel-component          | channel-utils, markdown-render, monaco-wrapper, profile-popup, react-utils, time-formatters                                                                                                      |
+| channel-utils              | markdown-render, monaco-wrapper, profile-popup, time-formatters                                                                                                                                  |
+| chat-bar-component         | blob-viewer, command-executor, command-registry, command-selector, debugger-panel, define-form, endow-modal, eval-form, form-builder, help-modal, inline-command-form, message-picker, send-form |
+| inbox-component            | chime, markdown-render, monaco-wrapper, time-formatters, value-render                                                                                                                            |
+| command-executor           | browser-tree                                                                                                                                                                                     |
+| command-selector           | command-registry                                                                                                                                                                                 |
+| define-form                | monaco-wrapper                                                                                                                                                                                   |
+| endow-modal                | petname-path-autocomplete                                                                                                                                                                        |
+| eval-form                  | monaco-wrapper, petname-path-autocomplete                                                                                                                                                        |
+| form-builder               | petname-path-autocomplete                                                                                                                                                                        |
+| help-modal                 | command-registry                                                                                                                                                                                 |
+| inline-command-form        | command-registry, inline-define, inline-eval, petname-path-autocomplete, petname-paths-autocomplete, token-autocomplete                                                                          |
+| send-form                  | composite-heat-engine, heat-bar, heat-engine, token-autocomplete                                                                                                                                 |
+| blob-viewer                | language-detect, markdown-preview, monaco-wrapper                                                                                                                                                |
+| heat-simulation            | heat-engine                                                                                                                                                                                      |
+| heat-bar                   | heat-engine                                                                                                                                                                                      |
+| value-component            | language-detect, markdown-preview, monaco-wrapper, value-render                                                                                                                                  |
+| value-render               | time-formatters                                                                                                                                                                                  |
+| scheme-picker              | spaces-gutter                                                                                                                                                                                    |
+| share-modal                | channel-utils                                                                                                                                                                                    |
+| counter-proposal-form      | monaco-wrapper, petname-path-autocomplete                                                                                                                                                        |
+| inline-eval                | petname-path-autocomplete                                                                                                                                                                        |
+| markdown-preview           | monaco-wrapper                                                                                                                                                                                   |
+| profile-popup              | (none)                                                                                                                                                                                           |
+| message-picker             | (none)                                                                                                                                                                                           |
+| icon-selector              | (none)                                                                                                                                                                                           |
+| inline-define              | (none)                                                                                                                                                                                           |
+| debugger-panel             | (none)                                                                                                                                                                                           |
+| command-registry           | (none)                                                                                                                                                                                           |
+| react-utils                | (none)                                                                                                                                                                                           |
+| heat-engine                | (none)                                                                                                                                                                                           |
+| markdown-render            | (none)                                                                                                                                                                                           |
+| monaco-wrapper             | (none)                                                                                                                                                                                           |
+| time-formatters            | (none)                                                                                                                                                                                           |
+| chime                      | (none)                                                                                                                                                                                           |
+| token-autocomplete         | (none)                                                                                                                                                                                           |
+| petname-path-autocomplete  | (none)                                                                                                                                                                                           |
+| petname-paths-autocomplete | (none)                                                                                                                                                                                           |
+| language-detect            | (none)                                                                                                                                                                                           |
+| message-parse              | (none)                                                                                                                                                                                           |
 
 ## Not migration targets
 
@@ -344,69 +344,69 @@ for the incoming imperative-Space PR — see "Deferred" above)
 
 ### Tier 1 — leaf views, pure DOM, no `E()`/powers (do first)
 
-| Component | Lines | Reached from | Status | Notes |
-| --- | --- | --- | --- | --- |
-| icon-selector | 81 | add/edit-space modals | ☑ | Done — reusable `IconSelector` confined Preact component |
-| profile-popup | 153 | channel-component | ☑ | Done — confined Preact component |
-| message-picker | 154 | chat-bar | ☑ | Done — confined Preact component |
-| command-selector | 239 | chat-bar | ☑ | Done — confined Preact component |
-| heat-bar | 250 | send-form | ☑ | Done — confined Preact component |
-| inline-define | 358 | inline-command-form | ☑ | Done — confined Preact component |
+| Component        | Lines | Reached from          | Status | Notes                                                    |
+| ---------------- | ----- | --------------------- | ------ | -------------------------------------------------------- |
+| icon-selector    | 81    | add/edit-space modals | ☑      | Done — reusable `IconSelector` confined Preact component |
+| profile-popup    | 153   | channel-component     | ☑      | Done — confined Preact component                         |
+| message-picker   | 154   | chat-bar              | ☑      | Done — confined Preact component                         |
+| command-selector | 239   | chat-bar              | ☑      | Done — confined Preact component                         |
+| heat-bar         | 250   | send-form             | ☑      | Done — confined Preact component                         |
+| inline-define    | 358   | inline-command-form   | ☑      | Done — confined Preact component                         |
 
 ### Tier 2 — leaves, but large or input-stateful (defer)
 
-| Component | Lines | Status | Notes |
-| --- | --- | --- | --- |
-| debugger-panel | 688 | ☑ | Done — confined Preact, on-demand panel |
-| inventory-component | 1267 | ☑ | Done — `InventoryList` + `InventoryItem`; see below |
-| token-autocomplete | — | ☑ | Done — confined dropdown |
-| petname-path-autocomplete | — | ☑ | Done — confined dropdown (pendingState bridge) |
-| petname-paths-autocomplete | — | ☑ | Done — confined dropdown (pendingState bridge) |
+| Component                  | Lines | Status | Notes                                               |
+| -------------------------- | ----- | ------ | --------------------------------------------------- |
+| debugger-panel             | 688   | ☑      | Done — confined Preact, on-demand panel             |
+| inventory-component        | 1267  | ☑      | Done — `InventoryList` + `InventoryItem`; see below |
+| token-autocomplete         | —     | ☑      | Done — confined dropdown                            |
+| petname-path-autocomplete  | —     | ☑      | Done — confined dropdown (pendingState bridge)      |
+| petname-paths-autocomplete | —     | ☑      | Done — confined dropdown (pendingState bridge)      |
 
 ### Channel list (left the inventory)
 
-| Component | Status | Notes |
-| --- | --- | --- |
-| channel-list | ☑ | Done — standalone Preact component (`channel-list.js`), own CSS (`channel.css`); reorder over `SafeDataTransfer`. Creation moved to the New Space modal. |
+| Component    | Status | Notes                                                                                                                                                    |
+| ------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| channel-list | ☑      | Done — standalone Preact component (`channel-list.js`), own CSS (`channel.css`); reorder over `SafeDataTransfer`. Creation moved to the New Space modal. |
 
 ### Tier 3 — composites (after their children)
 
-| Component | Status | Notes |
-| --- | --- | --- |
-| inbox-component | ☑ | Done — the 1:1 recipient-filtered view; confined Preact in three stages (shell + 5 message types, markdown-vnodes + token chips, value-vnodes). Monaco colorize of code fences deferred. |
-| edit-space-modal | ☑ | Done — confined Preact + reusable `IconSelector` (Batch B stage 1); scheme picker still host-embedded |
-| send-form | ☑ | Done — reply-context bar confined; composes heat-bar ☑ + token-autocomplete ☑ as host-node controllers |
-| help-modal | ☑ | Done — confined Preact leaf modal |
-| share-modal | ☑ | Done — confined Preact leaf modal |
-| scheme-picker | ☑ | Done — confined; keeps the `#scheme-picker-slot` embedding contract |
-| inline-eval | ☑ | Done — confined; endowment rows compose autocomplete as host-node controllers |
-| endow-modal | ☑ | Done — confined; definition-slot autocompletes host-embedded |
-| form-builder | ☑ | Done — confined; recipient autocomplete host-embedded |
-| inline-command-form | ☑ | Done — composite; confines its chrome, composes its converted children as host-node controllers |
-| define-form | ☑ | Done — first Monaco-embedding form; established the host-node editor pattern + the Monaco test stub |
-| eval-form / blob-viewer / counter-proposal-form | ☑ | Done — Monaco forms on define-form's host-node editor pattern; blob-viewer moved its markdown preview to `markdownToVnodes` |
-| microblog | ☑ | Done — `microblog` viewMode body; confined Preact via `renderConfined`, `markdownToVnodes` bodies, host-node-bridged author/react chips |
-| value-component | ☑ | Done — value content via `valueToVnodes`, blob preview as a confined `BlobContent`; modal chrome stays host DOM |
-| chat-bar-component | ☑ | Done (view regions) — modeline + command popover confined; the rest is irreducible imperative orchestration over shared `#messages` DOM |
-| channel-component | ☑ | Done — Dan's body; host-node-controller pattern for `react-utils`/`channel-utils`/`profile-popup`; +sync-reply follow-up |
-| channel-header | ☑ | Done — menu/invite/members/attenuator confined; host-node-bridges the imperative `heat-simulation` |
-| forum | ☑ | Done — `forum` viewMode body; same pattern as microblog (a first attempt that only landed a test was reverted, then redone for real) |
-| spaces-gutter | ⊘ | **Deferred** — the floot imperative-Space PR edits it (+41/-5); frozen imperative alongside chat.js + add-space-modal until that PR lands |
-| outliner | ☐ | ~3003 lines — largest body; needs the file-explorer-style decompose-into-contract approach, not a one-shot |
-| add-space-modal | ⊘ | **Deferred** — frozen imperative for the incoming imperative-Space PR (space-type registration); resume after it lands |
-| chat.js (root orchestrator) | ⊘ | **Deferred** — frozen imperative for the incoming imperative-Space PR (space-mode dispatch); stays the trusted root that calls `renderConfined` |
+| Component                                       | Status | Notes                                                                                                                                                                                    |
+| ----------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| inbox-component                                 | ☑      | Done — the 1:1 recipient-filtered view; confined Preact in three stages (shell + 5 message types, markdown-vnodes + token chips, value-vnodes). Monaco colorize of code fences deferred. |
+| edit-space-modal                                | ☑      | Done — confined Preact + reusable `IconSelector` (Batch B stage 1); scheme picker still host-embedded                                                                                    |
+| send-form                                       | ☑      | Done — reply-context bar confined; composes heat-bar ☑ + token-autocomplete ☑ as host-node controllers                                                                                   |
+| help-modal                                      | ☑      | Done — confined Preact leaf modal                                                                                                                                                        |
+| share-modal                                     | ☑      | Done — confined Preact leaf modal                                                                                                                                                        |
+| scheme-picker                                   | ☑      | Done — confined; keeps the `#scheme-picker-slot` embedding contract                                                                                                                      |
+| inline-eval                                     | ☑      | Done — confined; endowment rows compose autocomplete as host-node controllers                                                                                                            |
+| endow-modal                                     | ☑      | Done — confined; definition-slot autocompletes host-embedded                                                                                                                             |
+| form-builder                                    | ☑      | Done — confined; recipient autocomplete host-embedded                                                                                                                                    |
+| inline-command-form                             | ☑      | Done — composite; confines its chrome, composes its converted children as host-node controllers                                                                                          |
+| define-form                                     | ☑      | Done — first Monaco-embedding form; established the host-node editor pattern + the Monaco test stub                                                                                      |
+| eval-form / blob-viewer / counter-proposal-form | ☑      | Done — Monaco forms on define-form's host-node editor pattern; blob-viewer moved its markdown preview to `markdownToVnodes`                                                              |
+| microblog                                       | ☑      | Done — `microblog` viewMode body; confined Preact via `renderConfined`, `markdownToVnodes` bodies, host-node-bridged author/react chips                                                  |
+| value-component                                 | ☑      | Done — value content via `valueToVnodes`, blob preview as a confined `BlobContent`; modal chrome stays host DOM                                                                          |
+| chat-bar-component                              | ☑      | Done (view regions) — modeline + command popover confined; the rest is irreducible imperative orchestration over shared `#messages` DOM                                                  |
+| channel-component                               | ☑      | Done — Dan's body; host-node-controller pattern for `react-utils`/`channel-utils`/`profile-popup`; +sync-reply follow-up                                                                 |
+| channel-header                                  | ☑      | Done — menu/invite/members/attenuator confined; host-node-bridges the imperative `heat-simulation`                                                                                       |
+| forum                                           | ☑      | Done — `forum` viewMode body; same pattern as microblog (a first attempt that only landed a test was reverted, then redone for real)                                                     |
+| spaces-gutter                                   | ⊘      | **Deferred** — the floot imperative-Space PR edits it (+41/-5); frozen imperative alongside chat.js + add-space-modal until that PR lands                                                |
+| outliner                                        | ☐      | ~3003 lines — largest body; needs the file-explorer-style decompose-into-contract approach, not a one-shot                                                                               |
+| add-space-modal                                 | ⊘      | **Deferred** — frozen imperative for the incoming imperative-Space PR (space-type registration); resume after it lands                                                                   |
+| chat.js (root orchestrator)                     | ⊘      | **Deferred** — frozen imperative for the incoming imperative-Space PR (space-mode dispatch); stays the trusted root that calls `renderConfined`                                          |
 
 ### Whylip Space (separate `@endo/space-whylip` package)
 
-| Component | Status | Notes |
-| --- | --- | --- |
-| whylip package | ☑ | Done — ported React 19 + JSX → Preact `h()` (no JSX). The package emits pure components (`WhylipApp`, no rendering), and chat's `whylip-component.js` mounts it through the **confined** renderer, so `SceneCanvas`'s untrusted model HTML is sanitized by `renderConfined`. |
+| Component      | Status | Notes                                                                                                                                                                                                                                                                        |
+| -------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| whylip package | ☑      | Done — ported React 19 + JSX → Preact `h()` (no JSX). The package emits pure components (`WhylipApp`, no rendering), and chat's `whylip-component.js` mounts it through the **confined** renderer, so `SceneCanvas`'s untrusted model HTML is sanitized by `renderConfined`. |
 
 ### File Explorer Space (separate `@endo/space-file-explorer` package)
 
-| Component | Status | Notes |
-| --- | --- | --- |
-| space-file-explorer | ☑ | Done — confined Preact: `FileExplorerApp` + the `useFileExplorer` store hook + view components (Toolbar, Columns/Tree/EntryRow, Viewer, Status, Dialog, Inventory). `file-explorer-component.js` mounts it through `renderConfined`; the imperative `file-explorer.js` (~2827 lines) was removed. Same mount signature, so `chat.js` is untouched. |
+| Component           | Status | Notes                                                                                                                                                                                                                                                                                                                                              |
+| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| space-file-explorer | ☑      | Done — confined Preact: `FileExplorerApp` + the `useFileExplorer` store hook + view components (Toolbar, Columns/Tree/EntryRow, Viewer, Status, Dialog, Inventory). `file-explorer-component.js` mounts it through `renderConfined`; the imperative `file-explorer.js` (~2827 lines) was removed. Same mount signature, so `chat.js` is untouched. |
 
 ## Recommended next migration
 
@@ -461,15 +461,15 @@ Line numbers below are anchors at time of writing, not contracts.
 
 ### Current responsibilities (one function does all of this)
 
-| Region | Lines | Responsibility |
-| --- | --- | --- |
-| `makeStaticNameIterator`, `makeStaticTreePowers` | 66, 103 | Adapt a static `ReadableTree.list()` snapshot to the live `followNameChanges()` streaming interface |
-| `CONVERSABLE_TYPES` / `NON_EXPANDABLE_TYPES` / `HUB_TYPES` | 38–60 | Formula-type classification (selectable, expandable, drop-accepting) |
-| `inventoryComponent` shell + `for await` consumer | 142–178, 1252–1266 | Subscribe to name changes, maintain the `$names` map, mount/cleanup rows, recurse into subtrees |
-| Channel-mode header + `showNewForm` / `showJoinForm` | 178–410 | "Channels" title, New-channel and Join-channel inline forms |
-| `dropTargetPath` / `clearAllDropTargets` / `showDropMenu` | 412–518 | Tree drag-and-drop: link/move an item between directories; the "Link here / Move here" menu |
-| `createItem` | 519–1097 | The recursive pet-name **row** — wrapper, disclosure, name, type badge, action buttons, children, row-level drag-and-drop, channel menu, bookmarks |
-| Channel-list reordering | 1099–1250 | List-level drag reorder with a drop indicator; persists via `onChannelReorder` |
+| Region                                                     | Lines              | Responsibility                                                                                                                                     |
+| ---------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `makeStaticNameIterator`, `makeStaticTreePowers`           | 66, 103            | Adapt a static `ReadableTree.list()` snapshot to the live `followNameChanges()` streaming interface                                                |
+| `CONVERSABLE_TYPES` / `NON_EXPANDABLE_TYPES` / `HUB_TYPES` | 38–60              | Formula-type classification (selectable, expandable, drop-accepting)                                                                               |
+| `inventoryComponent` shell + `for await` consumer          | 142–178, 1252–1266 | Subscribe to name changes, maintain the `$names` map, mount/cleanup rows, recurse into subtrees                                                    |
+| Channel-mode header + `showNewForm` / `showJoinForm`       | 178–410            | "Channels" title, New-channel and Join-channel inline forms                                                                                        |
+| `dropTargetPath` / `clearAllDropTargets` / `showDropMenu`  | 412–518            | Tree drag-and-drop: link/move an item between directories; the "Link here / Move here" menu                                                        |
+| `createItem`                                               | 519–1097           | The recursive pet-name **row** — wrapper, disclosure, name, type badge, action buttons, children, row-level drag-and-drop, channel menu, bookmarks |
+| Channel-list reordering                                    | 1099–1250          | List-level drag reorder with a drop indicator; persists via `onChannelReorder`                                                                     |
 
 ### Proposed subcomponents
 
@@ -504,7 +504,7 @@ are not part of the inventory migration.
   plus the remove context menu.
 - Channel reordering already lives in `inventory/dnd.js` (`makeChannelReorder`).
 - A shared **PopupMenu** in `components/` should fall out of `ChannelItemMenu`
-  + `DropMenu`.
+  - `DropMenu`.
 
 ### Extract as framework-agnostic factories (behavior, not views)
 
@@ -534,15 +534,15 @@ functions the factory and any future hook both call.
 
 Applying the two-phase rule to the pieces above:
 
-| Piece | Treatment |
-| --- | --- |
-| `inventory-tree-source` (static/live adapter + type rules) | Phase 1 — extract now |
-| `makeItemDragDrop` (row drag source/target, `acceptsDrop`, drop-target paths) | Phase 1 — extract now |
-| `makeChannelReorder` (list reorder + indicator) | Phase 1 — extract now |
-| controller↔row prop/callback boundary | Phase 1 — define now |
-| `ItemLabel`, `ItemActions`, `DropMenu` | Convert-in-place |
-| `ItemDisclosure` | Convert-in-place |
-| `PetItem`, `InventoryList` shell | Convert-in-place |
+| Piece                                                                                                               | Treatment                                               |
+| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `inventory-tree-source` (static/live adapter + type rules)                                                          | Phase 1 — extract now                                   |
+| `makeItemDragDrop` (row drag source/target, `acceptsDrop`, drop-target paths)                                       | Phase 1 — extract now                                   |
+| `makeChannelReorder` (list reorder + indicator)                                                                     | Phase 1 — extract now                                   |
+| controller↔row prop/callback boundary                                                                               | Phase 1 — define now                                    |
+| `ItemLabel`, `ItemActions`, `DropMenu`                                                                              | Convert-in-place                                        |
+| `ItemDisclosure`                                                                                                    | Convert-in-place                                        |
+| `PetItem`, `InventoryList` shell                                                                                    | Convert-in-place                                        |
 | channel sidebar (`NewChannelForm` / `JoinChannelForm`, `BookmarkItem` / `BookmarkList`, `ChannelItemMenu`, reorder) | Split to `channel-sidebar.js`; separate later migration |
 
 ### Migration order for the inventory bar
@@ -561,6 +561,7 @@ Steps 1 are Phase-1 refactors (no Preact); steps 2–5 convert markup in place.
    `InventoryList` was converted (step 5) the drag-and-drop was reimplemented as
    Preact event handlers over `SafeDataTransfer`, so `inventory/dnd.js` and the
    `test/inventory-dnd` probe were deleted.
+
 2. Migrate the leaf views to `h()` components rendered through
    `renderConfined`:
    - `DropMenu` (inventory/drop-menu.js). ☑ done — the first Preact `h()`
@@ -617,10 +618,33 @@ Fixed so far (the flakes actually observed in CI):
   pending batch timer, with a `disposed` guard in the batch-render callbacks so
   an already-queued timer cannot render post-dispose.
 
-Deferred: a sweep of the remaining fixed-tick waits (~277 `await tick(ms)` calls
-across ~42 component test files). This is preventive — those tests are not
-currently failing — and a blanket conversion is wide, risky churn, so it is held
-until a focused pass.
+**Done — the full sweep landed.** Every component test under
+[`test/component`](../test/component) that used a fixed `await tick(ms)` to wait
+for a render/async update before an assertion now polls the asserted condition
+with `waitFor(predicate)` instead. The conversion is condition-driven: each
+former settle-wait now polls exactly what the following assertion checks (the
+rendered node/class, the spy-call count, the controller flag), so the assertion
+can never run before the state it depends on exists.
+
+A small set of `tick` calls is intentionally KEPT, each with a comment, because
+they are deliberate timing devices rather than settle-waits:
+
+- race / async-latency simulations that intentionally interleave work (e.g.
+  `channel-thread.test.js`'s generation-counter and queued-re-render tests),
+- microtask flushes (`await tick(0)` / `await null`) used to let an iterator's
+  `return()` settle before teardown,
+- settle delays that precede a NEGATIVE assertion (asserting something did
+  _not_ render / stays absent), where there is no positive condition to poll,
+- the short `tick(80)` setup warmups in a few files whose confined controller
+  setter is wired by an unobservable mount effect (`heat-bar`, `command-selector`,
+  `inline-define`, `inventory-component`, …): there is no DOM signal proving the
+  setter is wired, and the subsequent per-assertion `waitFor` already absorbs the
+  render race. Where a re-arm was possible (`message-picker.test.js`) the warmup
+  was removed by re-issuing `enable()` inside the poll instead.
+
+While sweeping, `channel-thread.test.js` and `outliner-enter-key.test.js` also
+gained component disposal in `afterEach` (the same teardown-leak class as
+`forum.test.js` above).
 
 ### `inline-eval.test.js` skipped on Node 24 and macOS (partly diagnosed)
 
@@ -659,7 +683,7 @@ steps: bisect which test/resource accumulates (active-handle dump via
 the file so per-worker accumulation stays under the threshold.
 
 The `waitFor` helper now bounds the poll with a generous wall-clock ceiling
-(`Date.now` survives this package's lockdown options), so the *non-stall*
+(`Date.now` survives this package's lockdown options), so the _non-stall_
 flavor of this hang — a render that never completes while timers still fire —
 fails fast with a pointed error instead of wedging CI until AVA's global
 timeout. The ceiling is generous (20s, ~100× a real flush) so it never
@@ -832,12 +856,12 @@ drag-highlight sweep.
 
 ### Severity roll-up
 
-| Package | HIGH | MED | LOW |
-| --- | --- | --- | --- |
-| chat | 1 (add-space-modal, unmigrated) | 6 | ~10 |
-| space-file-explorer | 0 | 3 | 4 |
-| space-peers | 0 | 2 | 3 |
-| space-whylip | 1 (stream cancel) | 3 | 4 |
+| Package             | HIGH                            | MED | LOW |
+| ------------------- | ------------------------------- | --- | --- |
+| chat                | 1 (add-space-modal, unmigrated) | 6   | ~10 |
+| space-file-explorer | 0                               | 3   | 4   |
+| space-peers         | 0                               | 2   | 3   |
+| space-whylip        | 1 (stream cancel)               | 3   | 4   |
 
 Suggested fix order when picked up: (1) the subscription-cancellation class
 across whylip/peers (correctness); (2) the inbox + debugger-panel

--- a/packages/chat/forum-component.js
+++ b/packages/chat/forum-component.js
@@ -895,11 +895,21 @@ export const forumComponent = async (
   let disposed = false;
   /** @type {AsyncIterableIterator<unknown> | null} */
   let activeIterator = null;
+  /**
+   * Batch incoming messages during initial load. Declared here so `dispose`
+   * can cancel a pending initial render that would otherwise fire (and scroll)
+   * against a torn-down container.
+   */
+  let batchTimer = 0;
   /** @type {{ closeThread: () => boolean, dispose: () => void }} */
   const channelAPI = harden({
     closeThread: () => false,
     dispose: () => {
       disposed = true;
+      if (batchTimer) {
+        clearTimeout(batchTimer);
+        batchTimer = 0;
+      }
       if (activeIterator) {
         activeIterator.return();
       }
@@ -931,14 +941,12 @@ export const forumComponent = async (
   });
   activeIterator = messageIterator;
 
-  /** Batch incoming messages during initial load. */
-  let batchTimer = 0;
-
   // Schedule an initial render after the first batch arrives.
   batchTimer = setTimeout(() => {
+    batchTimer = 0;
+    if (disposed) return;
     rerender();
     $parent.scrollTo(0, $parent.scrollHeight);
-    batchTimer = 0;
   }, 200);
 
   for await (const message of messageIterator) {
@@ -1006,9 +1014,10 @@ export const forumComponent = async (
     if (batchTimer) {
       clearTimeout(batchTimer);
       batchTimer = setTimeout(() => {
+        batchTimer = 0;
+        if (disposed) return;
         rerender();
         $parent.scrollTo(0, $parent.scrollHeight);
-        batchTimer = 0;
       }, 50);
     } else if (isLive()) {
       // After initial load, render incrementally

--- a/packages/chat/profile-popup.js
+++ b/packages/chat/profile-popup.js
@@ -230,7 +230,10 @@ harden(ProfilePopup);
  * the container is empty, matching the original `innerHTML = ''` teardown.
  *
  * @param {object} props
- * @param {{ setState?: (s: { data: ProfilePopupData | null }) => void }} props.controller
+ * @param {{
+ *   setState?: (s: { data: ProfilePopupData | null }) => void,
+ *   pendingState?: { data: ProfilePopupData | null },
+ * }} props.controller
  */
 const ProfilePopupRoot = ({ controller }) => {
   const [state, setState] = useState(
@@ -239,10 +242,17 @@ const ProfilePopupRoot = ({ controller }) => {
 
   useEffect(() => {
     controller.setState = setState;
+    // Apply any state the host pushed before this effect wired `setState`, so a
+    // show()/hide() that lands before mount is not silently dropped.
+    if (controller.pendingState !== undefined) {
+      setState(controller.pendingState);
+    }
     return () => {
       if (controller.setState === setState) delete controller.setState;
     };
-  }, [controller]);
+    // Mount-only: keying on `controller` re-runs this effect every render under
+    // confinement (the sanitizer reissues the prop identity).
+  }, []);
 
   if (!state.data) {
     return null;
@@ -265,7 +275,12 @@ export const createProfilePopup = $container => {
   // Mutable bridge to the root component's state setter (populated by the
   // component's effect). Intentionally NOT hardened — the component writes its
   // setter onto it.
-  /** @type {{ setState?: (s: { data: ProfilePopupData | null }) => void }} */
+  /**
+   * @type {{
+   *   setState?: (s: { data: ProfilePopupData | null }) => void,
+   *   pendingState?: { data: ProfilePopupData | null },
+   * }}
+   */
   const controller = {};
 
   // The popup is fixed-position and styled via the existing `.profile-popup-*`
@@ -276,6 +291,7 @@ export const createProfilePopup = $container => {
 
   const hide = () => {
     $container.style.display = 'none';
+    controller.pendingState = { data: null };
     if (controller.setState) {
       controller.setState({ data: null });
     }
@@ -302,17 +318,19 @@ export const createProfilePopup = $container => {
   }) => {
     void anchorElement; // reserved for future anchor-relative positioning
     $container.style.display = 'flex';
+    const next = {
+      data: {
+        proposedName,
+        pedigree,
+        pedigreeMemberIds,
+        nameMap,
+        yourName,
+        onAssignName,
+      },
+    };
+    controller.pendingState = next;
     if (controller.setState) {
-      controller.setState({
-        data: {
-          proposedName,
-          pedigree,
-          pedigreeMemberIds,
-          nameMap,
-          yourName,
-          onAssignName,
-        },
-      });
+      controller.setState(next);
     }
   };
 

--- a/packages/chat/test/component/channel-list.test.js
+++ b/packages/chat/test/component/channel-list.test.js
@@ -3,7 +3,7 @@
 import '@endo/init/debug.js';
 
 import test from 'ava';
-import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
+import { createDOM, waitFor } from '../helpers/dom-setup.js';
 import { makeMockPowers } from '../helpers/mock-powers.js';
 import { channelListComponent } from '../../channel-list.js';
 
@@ -31,8 +31,9 @@ const setupChannels = async (opts = {}) => {
   });
 
   // Let the followNameChanges loop + per-name locate probes + Preact effects
-  // settle. Generous because the first test pays SES/Preact warmup.
-  await tick(80);
+  // settle. Poll for the first channel row to render rather than racing a fixed
+  // delay; every test mounts at least one channel-typed name.
+  await waitFor(() => !!$container.querySelector('.channel-list-row'));
   return { $container, mock, selected, viewModes, api };
 };
 

--- a/packages/chat/test/component/channel-thread.test.js
+++ b/packages/chat/test/component/channel-thread.test.js
@@ -451,7 +451,9 @@ test.serial(
     // Poll for the initial render + queued re-render to finish rather than
     // racing a fixed delay: on a loaded CI runner the queued re-render can land
     // well after any fixed timeout, which is the original flake.
-    await waitFor(() => $parent.querySelectorAll('.thread-message').length >= 3);
+    await waitFor(
+      () => $parent.querySelectorAll('.thread-message').length >= 3,
+    );
 
     const threadMsgs = $parent.querySelectorAll('.thread-message');
     t.is(

--- a/packages/chat/test/component/channel-thread.test.js
+++ b/packages/chat/test/component/channel-thread.test.js
@@ -6,7 +6,7 @@ import '@endo/init/debug.js';
 import test from 'ava';
 import { Far } from '@endo/far';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
-import { createDOM, tick } from '../helpers/dom-setup.js';
+import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
 import { channelComponent } from '../../channel-component.js';
 
 const { document: testDocument, cleanup: cleanupDOM } = createDOM();
@@ -147,17 +147,25 @@ const setup = async ({ memberDelay = 0 } = {}) => {
     onThreadClose: () => threadCloseCallbacks.push(true),
   });
 
-  // Wait for async setup (getProposedName, getMember, followMessages)
-  await tick(50);
+  // Wait for async setup (getProposedName, getMember, followMessages). Poll for
+  // the channel API rather than racing a fixed delay on a loaded CI runner.
+  await waitFor(() => !!$parent.channelAPI);
+
+  // Track how many messages have been pushed so `push` can poll for the
+  // corresponding `.message-wrapper` to appear instead of guessing a delay.
+  let expectedWrappers = 0;
 
   /**
-   * Push a message and wait for it to render.
+   * Push a message and wait for it to render into the chronological list.
    * @param msg
-   * @param ms
    */
-  const push = async (msg, ms = 80) => {
+  const push = async msg => {
+    expectedWrappers += 1;
     pushMessage(msg);
-    await tick(ms);
+    await waitFor(
+      () =>
+        $parent.querySelectorAll('.message-wrapper').length >= expectedWrappers,
+    );
   };
 
   return {
@@ -243,7 +251,11 @@ test.serial('clicking reply count opens thread view', async t => {
   const $badge = $parent.querySelector('.reply-count');
   t.truthy($badge, 'reply count badge should exist');
   $badge.click();
-  await tick(100);
+  await waitFor(
+    () =>
+      $parent.classList.contains('thread-active') &&
+      !!$parent.querySelector('.thread-view'),
+  );
 
   t.true(
     $parent.classList.contains('thread-active'),
@@ -264,7 +276,9 @@ test.serial(
     await push(makeMessage(2, 'Reply', { replyTo: 1 }));
 
     $parent.querySelector('.reply-count').click();
-    await tick(100);
+    await waitFor(
+      () => $parent.querySelectorAll('.thread-message').length >= 2,
+    );
 
     const threadMsgs = $parent.querySelectorAll('.thread-message');
     t.is(threadMsgs.length, 2, 'thread should contain root and reply');
@@ -280,14 +294,14 @@ test.serial('back button closes thread view', async t => {
   await push(makeMessage(2, 'Reply', { replyTo: 1 }));
 
   $parent.querySelector('.reply-count').click();
-  await tick(100);
+  await waitFor(() => !!$parent.querySelector('.thread-back'));
 
   t.true($parent.classList.contains('thread-active'));
 
   const $back = $parent.querySelector('.thread-back');
   t.truthy($back, 'back button should exist');
   $back.click();
-  await tick(50);
+  await waitFor(() => !$parent.classList.contains('thread-active'));
 
   t.false(
     $parent.classList.contains('thread-active'),
@@ -306,14 +320,14 @@ test.serial('Channel breadcrumb closes thread view', async t => {
   await push(makeMessage(2, 'Reply', { replyTo: 1 }));
 
   $parent.querySelector('.reply-count').click();
-  await tick(100);
+  await waitFor(() => $parent.querySelectorAll('.thread-crumb').length > 0);
 
   const crumbs = $parent.querySelectorAll('.thread-crumb');
   // First crumb should be "Channel"
   const $channelCrumb = crumbs[0];
   t.is($channelCrumb.textContent, 'Channel');
   $channelCrumb.click();
-  await tick(50);
+  await waitFor(() => !$parent.classList.contains('thread-active'));
 
   t.false($parent.classList.contains('thread-active'));
   t.falsy($parent.querySelector('.thread-view'));
@@ -327,14 +341,14 @@ test.serial('new reply appears in thread view (live update)', async t => {
 
   // Open thread view
   $parent.querySelector('.reply-count').click();
-  await tick(100);
+  await waitFor(() => $parent.querySelectorAll('.thread-message').length >= 2);
 
   let threadMsgs = $parent.querySelectorAll('.thread-message');
   t.is(threadMsgs.length, 2);
 
   // Push a new reply while thread is open
   await push(makeMessage(3, 'Reply 2', { replyTo: 1 }));
-  await tick(100);
+  await waitFor(() => $parent.querySelectorAll('.thread-message').length >= 3);
 
   threadMsgs = $parent.querySelectorAll('.thread-message');
   t.is(threadMsgs.length, 3, 'new reply should appear in thread view');
@@ -348,11 +362,11 @@ test.serial('nested reply in thread view (live update)', async t => {
 
   // Open thread view
   $parent.querySelector('.reply-count').click();
-  await tick(100);
+  await waitFor(() => $parent.querySelectorAll('.thread-message').length >= 2);
 
   // Push a reply to the reply (depth 2) while thread is open
   await push(makeMessage(3, 'Reply to reply', { replyTo: 2 }));
-  await tick(100);
+  await waitFor(() => $parent.querySelectorAll('.thread-message').length >= 3);
 
   const threadMsgs = $parent.querySelectorAll('.thread-message');
   t.is(threadMsgs.length, 3, 'nested reply should appear in thread view');
@@ -366,7 +380,7 @@ test.serial('thread view shows breadcrumb with thread number', async t => {
   await push(makeMessage(2, 'Reply', { replyTo: 1 }));
 
   $parent.querySelector('.reply-count').click();
-  await tick(100);
+  await waitFor(() => $parent.querySelectorAll('.thread-crumb').length >= 2);
 
   const crumbs = $parent.querySelectorAll('.thread-crumb');
   t.true(crumbs.length >= 2, 'should have Channel and Thread crumbs');
@@ -432,10 +446,12 @@ test.serial(
     // Without the re-render queue this reply would be lost because the
     // message loop's showThreadView call hits the threadViewRendering guard.
     await tick(5);
-    await push(makeMessage(3, 'Reply 2', { replyTo: 1 }), 10);
+    await push(makeMessage(3, 'Reply 2', { replyTo: 1 }));
 
-    // Wait long enough for the initial render + queued re-render to finish.
-    await tick(400);
+    // Poll for the initial render + queued re-render to finish rather than
+    // racing a fixed delay: on a loaded CI runner the queued re-render can land
+    // well after any fixed timeout, which is the original flake.
+    await waitFor(() => $parent.querySelectorAll('.thread-message').length >= 3);
 
     const threadMsgs = $parent.querySelectorAll('.thread-message');
     t.is(
@@ -455,7 +471,7 @@ test.serial('onThreadOpen fires when thread view opens', async t => {
   await push(makeMessage(2, 'Reply', { replyTo: 1 }));
 
   $parent.querySelector('.reply-count').click();
-  await tick(100);
+  await waitFor(() => threadOpenCallbacks.length >= 1);
 
   t.is(threadOpenCallbacks.length, 1, 'onThreadOpen should be called once');
   t.is(threadOpenCallbacks[0].number, '1');
@@ -469,12 +485,12 @@ test.serial('onThreadClose fires when back button closes thread', async t => {
   await push(makeMessage(2, 'Reply', { replyTo: 1 }));
 
   $parent.querySelector('.reply-count').click();
-  await tick(100);
+  await waitFor(() => !!$parent.querySelector('.thread-back'));
 
   t.is(threadCloseCallbacks.length, 0, 'onThreadClose not called yet');
 
   $parent.querySelector('.thread-back').click();
-  await tick(50);
+  await waitFor(() => threadCloseCallbacks.length >= 1);
 
   t.is(threadCloseCallbacks.length, 1, 'onThreadClose should be called once');
 });
@@ -486,11 +502,11 @@ test.serial('onThreadClose fires when Escape closes thread', async t => {
   await push(makeMessage(2, 'Reply', { replyTo: 1 }));
 
   $parent.querySelector('.reply-count').click();
-  await tick(100);
+  await waitFor(() => $parent.classList.contains('thread-active'));
 
   const ev = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
   testDocument.dispatchEvent(ev);
-  await tick(50);
+  await waitFor(() => threadCloseCallbacks.length >= 1);
 
   t.is(threadCloseCallbacks.length, 1, 'onThreadClose should fire on Escape');
 });
@@ -504,11 +520,11 @@ test.serial(
     await push(makeMessage(2, 'Reply', { replyTo: 1 }));
 
     $parent.querySelector('.reply-count').click();
-    await tick(100);
+    await waitFor(() => $parent.querySelectorAll('.thread-crumb').length > 0);
 
     const crumbs = $parent.querySelectorAll('.thread-crumb');
     crumbs[0].click(); // "Channel" crumb
-    await tick(50);
+    await waitFor(() => threadCloseCallbacks.length >= 1);
 
     t.is(
       threadCloseCallbacks.length,
@@ -536,7 +552,11 @@ test.serial(
     t.is(indicators.length, 2, 'should have two reply indicators');
     // Click the indicator on message 3 (the deepest one)
     indicators[1].click();
-    await tick(100);
+    await waitFor(
+      () =>
+        $parent.classList.contains('thread-active') &&
+        $parent.querySelectorAll('.thread-message').length >= 3,
+    );
 
     t.true(
       $parent.classList.contains('thread-active'),
@@ -579,7 +599,7 @@ test.serial(
     const badges = $parent.querySelectorAll('.reply-count');
     t.is(badges.length, 2, 'should have two reply count badges');
     badges[0].click();
-    await tick(100);
+    await waitFor(() => $parent.classList.contains('thread-active'));
 
     t.true(
       $parent.classList.contains('thread-active'),
@@ -591,7 +611,7 @@ test.serial(
     // This should close the thread and keep us in the channel.
     const closed = $parent.channelAPI.closeThread();
     t.true(closed, 'closeThread() should return true when thread was active');
-    await tick(50);
+    await waitFor(() => threadCloseCallbacks.length >= 1);
 
     t.false(
       $parent.classList.contains('thread-active'),
@@ -607,7 +627,11 @@ test.serial(
     const newBadges = $parent.querySelectorAll('.reply-count');
     t.true(newBadges.length >= 2, 'reply count badges should still exist');
     newBadges[1].click();
-    await tick(100);
+    await waitFor(
+      () =>
+        $parent.classList.contains('thread-active') &&
+        !!$parent.querySelector('.thread-back'),
+    );
 
     t.true(
       $parent.classList.contains('thread-active'),
@@ -620,7 +644,7 @@ test.serial(
 
     // Close the second thread via its own back button
     $parent.querySelector('.thread-back').click();
-    await tick(50);
+    await waitFor(() => threadCloseCallbacks.length >= 2);
 
     t.false(
       $parent.classList.contains('thread-active'),
@@ -640,7 +664,7 @@ test.serial(
 
     // Open thread
     $parent.querySelector('.reply-count').click();
-    await tick(100);
+    await waitFor(() => $parent.classList.contains('thread-active'));
 
     t.true($parent.classList.contains('thread-active'));
 

--- a/packages/chat/test/component/channel-thread.test.js
+++ b/packages/chat/test/component/channel-thread.test.js
@@ -153,6 +153,9 @@ const setup = async ({ memberDelay = 0 } = {}) => {
 
   // Track how many messages have been pushed so `push` can poll for the
   // corresponding `.message-wrapper` to appear instead of guessing a delay.
+  // Assumes each pushed message is visible in the active view (true for every
+  // test here): the count is global, so pushing a message that isn't rendered
+  // in the currently-open thread would never reach `expectedWrappers`.
   let expectedWrappers = 0;
 
   /**

--- a/packages/chat/test/component/channel.test.js
+++ b/packages/chat/test/component/channel.test.js
@@ -208,14 +208,17 @@ const setup = async () => {
 
   const api = $parent.channelAPI;
 
+  // Track pushed messages so `push` can poll for the message to render into the
+  // chronological list (one `.message-wrapper` per message) rather than racing a
+  // fixed inter-push delay.
+  let expectedWrappers = 0;
   const push = async msg => {
+    expectedWrappers += 1;
     pushMessage(msg);
-    // Kept as a deliberate inter-push settle: this shared helper can't know
-    // which message a given test pushed, so there is no single positive
-    // condition to poll here. Each test does its own `waitFor` on the concrete
-    // rendered result after pushing, which is the race-robust wait; this small
-    // gap only orders sequential pushes so the stream applies them in turn.
-    await tick(60);
+    await waitFor(
+      () =>
+        $parent.querySelectorAll('.message-wrapper').length >= expectedWrappers,
+    );
   };
 
   return {

--- a/packages/chat/test/component/channel.test.js
+++ b/packages/chat/test/component/channel.test.js
@@ -210,7 +210,11 @@ const setup = async () => {
 
   const push = async msg => {
     pushMessage(msg);
-    // Wait for the re-render to land.
+    // Kept as a deliberate inter-push settle: this shared helper can't know
+    // which message a given test pushed, so there is no single positive
+    // condition to poll here. Each test does its own `waitFor` on the concrete
+    // rendered result after pushing, which is the race-robust wait; this small
+    // gap only orders sequential pushes so the stream applies them in turn.
     await tick(60);
   };
 

--- a/packages/chat/test/component/chat-bar.test.js
+++ b/packages/chat/test/component/chat-bar.test.js
@@ -137,12 +137,14 @@ const setupChatBar = async (overrides = {}) => {
 
   const api = chatBarComponent($parent, powers, options);
 
-  // Let the confined mounts' effects (which wire the modeline controller's
-  // setter) settle. Generous because the first test pays SES/Preact warmup.
-  await tick(80);
-
   const $chatBar = $parent.querySelector('#chat-bar');
   const $modeline = $parent.querySelector('#chat-modeline');
+
+  // Let the confined mounts' effects (which wire the modeline controller's
+  // setter) settle. The modeline paints its default hints on initial render, so
+  // their presence is a reliable signal the confined mounts are wired.
+  await waitFor(() => $modeline.querySelectorAll('.modeline-hint').length > 0);
+
   const $popover = $parent.querySelector('#chat-command-popover');
   const $menuButton = $parent.querySelector('#chat-menu-button');
 
@@ -284,7 +286,7 @@ test.serial(
     t.truthy($row, 'a /mkdir row is available');
 
     $row.click();
-    await tick(40);
+    await waitFor(() => !ctx.$popover.classList.contains('visible'));
 
     // The host hides the popover after selection (clears .visible).
     t.false(
@@ -326,7 +328,9 @@ test.serial('dispose unmounts the confined modeline mount', async t => {
   );
 
   ctx.api.dispose();
-  await tick(20);
+  await waitFor(
+    () => ctx.$modeline.querySelectorAll('.modeline-hint').length === 0,
+  );
 
   // unmount() tears the confined tree down, leaving no hint spans behind.
   t.is(

--- a/packages/chat/test/component/command-selector.test.js
+++ b/packages/chat/test/component/command-selector.test.js
@@ -72,7 +72,7 @@ test.serial('filter narrows the command list', async t => {
   const { $menu, selector } = await setupSelector();
 
   selector.show();
-  await tick(20);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length > 0);
   const totalCount = $menu.querySelectorAll('.token-menu-item').length;
 
   selector.filter('mk');
@@ -104,7 +104,7 @@ test.serial('filter with no matches shows the empty state', async t => {
   const { $menu, selector } = await setupSelector();
 
   selector.show();
-  await tick(20);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length > 0);
 
   selector.filter('zzzznotacommand');
   await waitFor(() => $menu.querySelector('.token-menu-empty'));
@@ -150,7 +150,7 @@ test.serial(
     });
 
     selector.show();
-    await tick(20);
+    await waitFor(() => $menu.querySelectorAll('.token-menu-item').length > 0);
 
     const firstName = selector.getSelected();
 
@@ -196,7 +196,7 @@ test.serial(
     const { $menu, selector, selected } = await setupSelector();
 
     selector.show();
-    await tick(20);
+    await waitFor(() => $menu.querySelectorAll('.token-menu-item').length > 0);
 
     selector.selectNext();
     await waitFor(() => selector.getSelected());
@@ -228,7 +228,7 @@ test.serial('selectFirst and selectLast jump to the ends', async t => {
   const { selector } = await setupSelector();
 
   selector.show();
-  await tick(20);
+  await waitFor(() => !!selector.getSelected());
   const firstName = selector.getSelected();
 
   selector.selectLast();
@@ -247,7 +247,7 @@ test.serial('clicking a row selects that command and closes', async t => {
   const { $menu, selector, selected } = await setupSelector();
 
   selector.show();
-  await tick(20);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length >= 3);
 
   const $items = $menu.querySelectorAll('.token-menu-item');
   const $target = $items[2];

--- a/packages/chat/test/component/counter-proposal-form.test.js
+++ b/packages/chat/test/component/counter-proposal-form.test.js
@@ -360,6 +360,8 @@ test.serial(
     const $codeName = $container.querySelector('.eval-codename');
     $codeName.value = 'orphan';
     $codeName.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
+    // Settle the code-name update into form state between interactions; no
+    // positive condition to poll until the submit drives the validation error.
     await tick(20);
 
     $container

--- a/packages/chat/test/component/debugger-panel.test.js
+++ b/packages/chat/test/component/debugger-panel.test.js
@@ -199,6 +199,8 @@ test.serial('console eval calls evaluate and shows the result', async t => {
   const $input = $container.querySelector('.debugger-console-input');
   $input.value = '1 + 1';
   $input.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
+  // Settle the input update between interactions so the Enter handler reads it;
+  // no positive condition to poll until the keydown drives evaluate.
   await tick(10);
 
   $input.dispatchEvent(
@@ -231,6 +233,9 @@ test.serial('adding a breakpoint sends setBreakpoint and lists it', async t => {
   $path.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
   $line.value = '7';
   $line.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
+  // Settle the path/line input updates between interactions so the add handler
+  // reads them; no positive condition to poll until the click drives
+  // setBreakpoint.
   await tick(10);
 
   $container.querySelector('.debugger-bp-add').click();

--- a/packages/chat/test/component/define-form.test.js
+++ b/packages/chat/test/component/define-form.test.js
@@ -180,7 +180,7 @@ test.serial('add-slot renders a controlled slot row', async t => {
   $codeName.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
   $label.value = 'a foo';
   $label.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
-  await tick(20);
+  await waitFor(() => form.isDirty());
 
   t.true(form.isDirty(), 'editing a slot marks the form dirty');
 });
@@ -210,7 +210,9 @@ test.serial('submit invokes onSubmit with the editor value', async t => {
   $codeName.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
   $label.value = 'a power';
   $label.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
-  await tick(20);
+  // Ensure the slot edits have registered into form state before submitting, so
+  // the completed slot is carried through.
+  await waitFor(() => form.isDirty());
 
   // Submit via the Define button.
   $container

--- a/packages/chat/test/component/edit-space-modal.test.js
+++ b/packages/chat/test/component/edit-space-modal.test.js
@@ -204,6 +204,8 @@ test.serial('save invokes onSubmit with the edited form data', async t => {
   const $name = $container.querySelector('#edit-space-name');
   $name.value = 'Workspace';
   $name.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
+  // Settle the name update into form state between interactions; no positive
+  // condition to poll here (the next icon click has its own waitFor).
   await tick(20);
 
   // Pick a different emoji icon (the first option).
@@ -252,6 +254,8 @@ test.serial('empty name blocks submit with a validation error', async t => {
   const $name = $container.querySelector('#edit-space-name');
   $name.value = '   ';
   $name.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
+  // Settle the (whitespace) name update into form state between interactions; no
+  // positive condition to poll until the submit drives the validation error.
   await tick(20);
 
   const $form = $container.querySelector('.add-space-form');

--- a/packages/chat/test/component/eval-form.test.js
+++ b/packages/chat/test/component/eval-form.test.js
@@ -217,7 +217,7 @@ test.serial(
     // Controlled code-name input updates form state.
     $codeName.value = 'foo';
     $codeName.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
-    await tick(20);
+    await waitFor(() => form.isDirty());
 
     t.true(form.isDirty(), 'editing an endowment marks the form dirty');
   },
@@ -254,7 +254,7 @@ test.serial('submit invokes onSubmit with the editor value', async t => {
   const $resultName = $container.querySelector('#eval-result-name');
   $resultName.value = 'my-result';
   $resultName.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
-  await tick(20);
+  await waitFor(() => form.isDirty());
 
   // Submit via the Evaluate button.
   $container
@@ -349,7 +349,7 @@ test.serial(
     const $codeName = $container.querySelector('.eval-codename');
     $codeName.value = 'orphan';
     $codeName.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
-    await tick(20);
+    await waitFor(() => form.isDirty());
 
     $container
       .querySelector('.eval-submit')

--- a/packages/chat/test/component/form-builder.test.js
+++ b/packages/chat/test/component/form-builder.test.js
@@ -135,6 +135,8 @@ test.serial(
 
     // Clicking submit with empty recipient shows an error and does not call onSubmit.
     $container.querySelector('.form-builder-submit').click();
+    // Settle before a NEGATIVE assertion (onSubmit must NOT fire); no positive
+    // condition to poll.
     await tick(30);
     t.is(submits.length, 0, 'onSubmit not called while invalid');
   },
@@ -175,6 +177,8 @@ test.serial(
     $description.dispatchEvent(
       new globalThis.Event('input', { bubbles: true }),
     );
+    // Settle the description input update between interactions; no positive DOM
+    // condition to poll yet (the field row is added by the next click).
     await tick(20);
 
     // Add a field and fill its name + label.
@@ -239,7 +243,7 @@ test.serial('close button resets, hides, and calls onClose', async t => {
   const $description = $container.querySelector('.form-builder-description');
   $description.value = 'something';
   $description.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
-  await tick(20);
+  await waitFor(() => builder.isDirty());
   t.true(builder.isDirty(), 'dirty after typing');
 
   $container.querySelector('.form-builder-close').click();

--- a/packages/chat/test/component/form-request-inbox.test.js
+++ b/packages/chat/test/component/form-request-inbox.test.js
@@ -7,7 +7,7 @@ import test from 'ava';
 import { Far } from '@endo/far';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 import { makePromiseKit } from '@endo/promise-kit';
-import { createDOM, waitFor } from '../helpers/dom-setup.js';
+import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
 import { inboxComponent } from '../../inbox-component.js';
 
 const { document: testDocument } = createDOM();
@@ -179,11 +179,12 @@ test.serial('form renders fields and Submit calls submit()', async t => {
   inputs[0].dispatchEvent(new globalThis.Event('input', { bubbles: true }));
   inputs[1].value = 'Portland';
   inputs[1].dispatchEvent(new globalThis.Event('input', { bubbles: true }));
-  // The inputs are controlled, so wait for the re-render to reflect both typed
-  // values before submitting (they would reset to state otherwise).
-  await waitFor(
-    () => inputs[0].value === 'green' && inputs[1].value === 'Portland',
-  );
+  // Deliberate flush, not a settle-poll: the submit handler reads the typed
+  // values out of component state (`values`), but a controlled input shows the
+  // same string whether or not that state has committed, so there is no DOM
+  // condition to poll. Let the onInput-triggered re-render commit both values
+  // into the handler's closure before clicking Submit.
+  await tick(10);
 
   // Click Submit
   const $submit = $parent.querySelector('.form-request-submit');

--- a/packages/chat/test/component/form-request-inbox.test.js
+++ b/packages/chat/test/component/form-request-inbox.test.js
@@ -7,7 +7,7 @@ import test from 'ava';
 import { Far } from '@endo/far';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 import { makePromiseKit } from '@endo/promise-kit';
-import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
+import { createDOM, waitFor } from '../helpers/dom-setup.js';
 import { inboxComponent } from '../../inbox-component.js';
 
 const { document: testDocument } = createDOM();
@@ -179,7 +179,11 @@ test.serial('form renders fields and Submit calls submit()', async t => {
   inputs[0].dispatchEvent(new globalThis.Event('input', { bubbles: true }));
   inputs[1].value = 'Portland';
   inputs[1].dispatchEvent(new globalThis.Event('input', { bubbles: true }));
-  await tick(10);
+  // The inputs are controlled, so wait for the re-render to reflect both typed
+  // values before submitting (they would reset to state otherwise).
+  await waitFor(
+    () => inputs[0].value === 'green' && inputs[1].value === 'Portland',
+  );
 
   // Click Submit
   const $submit = $parent.querySelector('.form-request-submit');

--- a/packages/chat/test/component/forum.test.js
+++ b/packages/chat/test/component/forum.test.js
@@ -139,6 +139,14 @@ const makeMessage = (number, text, opts = {}) => ({
 });
 
 /**
+ * Disposers for components mounted by `setup`, drained in `afterEach` so each
+ * test's consumer loop and timers stop before the shared DOM is torn down.
+ *
+ * @type {Array<() => void>}
+ */
+const mountedDisposals = [];
+
+/**
  * Mount the forum exactly as chat.js does:
  * channelViewFn($messages, $anchor, channelRef, { ...options }).
  */
@@ -190,8 +198,21 @@ const setup = async () => {
       forkCallbacks.push({ chain, preview });
     },
   }).catch(err => {
+    // Surface the failure as a diagnostic, but never re-throw it. Re-throwing
+    // inside this detached `.catch` turns a (possibly post-teardown) consumer
+    // rejection into an *unhandled* rejection that AVA attributes to whichever
+    // test happens to be running — the original cross-test CI flake that showed
+    // up as "N uncaught exceptions". Tests assert on observable DOM/spy state,
+    // not on this promise.
     console.error('forumComponent error:', err);
-    throw err;
+  });
+
+  // Ensure the component is disposed at end of test even if the body returns
+  // early: a parked `for await` loop, its prefetch, and the initial-batch timer
+  // otherwise leak across tests and fire against a torn-down DOM.
+  mountedDisposals.push(() => {
+    const api = /** @type {any} */ ($parent).channelAPI;
+    if (api) api.dispose();
   });
 
   // Wait for async createChannelState + mount insertion.
@@ -215,7 +236,17 @@ const setup = async () => {
   };
 };
 
-test.afterEach(() => {
+test.afterEach(async () => {
+  // Dispose every component mounted this test so its `for await` consumer loop,
+  // its reader prefetch, and any pending batch timer stop before the DOM is
+  // detached. Disposing first, then letting the iterator's `return()` and any
+  // in-flight microtasks settle, prevents a stray post-teardown render or
+  // rejection from leaking into a later test.
+  while (mountedDisposals.length > 0) {
+    const dispose = /** @type {() => void} */ (mountedDisposals.pop());
+    dispose();
+  }
+  await tick(0);
   testDocument.body.innerHTML = '';
 });
 

--- a/packages/chat/test/component/forum.test.js
+++ b/packages/chat/test/component/forum.test.js
@@ -220,7 +220,11 @@ const setup = async () => {
 
   const push = async msg => {
     pushMessage(msg);
-    // Wait past the debounce for the re-render to land.
+    // Deliberate wait past the 50ms feed debounce: this generic helper can't
+    // poll a per-message node because modifier messages (edits/deletions) fold
+    // into an existing node instead of rendering their own, so there is no
+    // single positive selector valid for every caller. Each test does its own
+    // `waitFor` on the concrete rendered result afterward.
     await tick(120);
   };
 

--- a/packages/chat/test/component/forum.test.js
+++ b/packages/chat/test/component/forum.test.js
@@ -220,12 +220,6 @@ const setup = async () => {
 
   const push = async msg => {
     pushMessage(msg);
-    // Deliberate wait past the 50ms feed debounce: this generic helper can't
-    // poll a per-message node because modifier messages (edits/deletions) fold
-    // into an existing node instead of rendering their own, so there is no
-    // single positive selector valid for every caller. Each test does its own
-    // `waitFor` on the concrete rendered result afterward.
-    await tick(120);
   };
 
   return {
@@ -337,7 +331,10 @@ test.serial('edit-type replies do not render as nodes', async t => {
   await push(makeMessage(0, 'Original'));
   await push(makeMessage(1, 'Edited text', { replyTo: 0, replyType: 'edit' }));
 
-  await waitFor(() => !!$parent.querySelector('.forum-node'));
+  // Gate on the edit actually being applied (it adds an "edited by" marker to
+  // the target node) so the count assertion can't run before the edit is
+  // processed — the edit must fold into node 0, not spawn a second node.
+  await waitFor(() => !!$parent.querySelector('.forum-edited-by'));
   const $nodes = $parent.querySelectorAll('.forum-node');
   t.is($nodes.length, 1, 'edit should not create a second tree node');
 });

--- a/packages/chat/test/component/heat-bar.test.js
+++ b/packages/chat/test/component/heat-bar.test.js
@@ -28,8 +28,12 @@ const setupBar = async () => {
 
   const bar = createHeatBar($container, $sendButton);
 
-  // Let the root component's mount effect (which wires the controller setter)
-  // settle. Generous because the first test pays SES/Preact warmup.
+  // Kept as a deliberate settle for controller wiring: `bar.update()` fires the
+  // view setter exactly once and silently no-ops until the root's mount EFFECT
+  // installs `controller.setView`. That setter isn't observable from the test
+  // (the `.heat-bar` node renders a frame earlier, before the effect runs), so
+  // there is no DOM condition to poll that proves `update()` will take effect.
+  // The per-test `waitFor` after each `.update()` covers the render race itself.
   await tick(80);
   return { $container, $sibling, $sendButton, bar };
 };

--- a/packages/chat/test/component/inbox-shell.test.js
+++ b/packages/chat/test/component/inbox-shell.test.js
@@ -224,6 +224,8 @@ test.serial(
     await waitFor(
       () => $parent.querySelectorAll('.message-envelope').length >= 1,
     );
+    // Settle before a NEGATIVE assertion: give the filtered-out message its
+    // chance to (wrongly) render before we assert exactly one renders.
     await tick(50);
 
     const envelopes = $parent.querySelectorAll('.message-envelope');
@@ -274,10 +276,12 @@ test.serial(
     t.truthy($input, 'pet-name input renders');
     $input.value = 'my-grant';
     $input.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
+    // Settle the input update between interactions; no positive condition to
+    // poll until the resolve click drives powers.resolve.
     await tick(10);
 
     $resolve.click();
-    await tick(20);
+    await waitFor(() => calls.some(c => c.method === 'resolve'));
 
     const resolveCall = calls.find(c => c.method === 'resolve');
     t.truthy(resolveCall, 'resolve was called');

--- a/packages/chat/test/component/inline-command-form.test.js
+++ b/packages/chat/test/component/inline-command-form.test.js
@@ -430,6 +430,8 @@ test.serial('immediate commands render no fields', async t => {
   });
 
   form.setCommand('exit'); // immediate command with no fields
+  // Settle before a NEGATIVE assertion: an immediate command must render no
+  // fields, so there is no positive condition to poll.
   await tick(30);
 
   const fields = $container.querySelectorAll('.inline-field');
@@ -522,7 +524,7 @@ test.serial('dispose tears everything down without leaking', async t => {
   await waitFor(() => !!$container.querySelector('.petname-input'));
 
   form.dispose();
-  await tick(30);
+  await waitFor(() => !$container.querySelector('.inline-command-form'));
 
   // The confined mount and all field nodes are gone from the container.
   t.falsy($container.querySelector('.inline-command-form'));

--- a/packages/chat/test/component/inline-define.test.js
+++ b/packages/chat/test/component/inline-define.test.js
@@ -30,7 +30,10 @@ const setupDefine = async (overrides = {}) => {
   });
 
   // Let the root component's mount effect (which wires the controller) settle.
+  // The controller-wiring effect has no DOM signal to poll, so this stays a
+  // fixed settle; wait for the source input to render before returning.
   await tick(80);
+  await waitFor(() => !!$container.querySelector('.inline-eval-input'));
   return { $container, api, events };
 };
 
@@ -110,14 +113,14 @@ test.serial('slot codeName and label feed getData', async t => {
 
   const $source = $container.querySelector('.inline-eval-input');
   fireInput($source, '@');
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.inline-eval-petname'));
 
   const $codeName = $container.querySelector('.inline-eval-petname');
   fireInput($codeName, 'foo');
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.inline-eval-codename'));
   const $label = $container.querySelector('.inline-eval-codename');
   fireInput($label, 'a foo thing');
-  await tick(20);
+  await waitFor(() => $label.value === 'a foo thing');
 
   // Source still needs a value to be valid.
   const $source2 = $container.querySelector('.inline-eval-input');
@@ -139,7 +142,7 @@ test.serial('Enter on the source submits parsed data', async t => {
 
   const $source = $container.querySelector('.inline-eval-input');
   fireInput($source, 'doThing()');
-  await tick(20);
+  await waitFor(() => api.isValid());
   fireKeyDown($source, 'Enter');
   await waitFor(() => events.submit.length === 1);
 
@@ -154,6 +157,8 @@ test.serial('Enter on empty source does not submit', async t => {
 
   const $source = $container.querySelector('.inline-eval-input');
   fireKeyDown($source, 'Enter');
+  // Settle delay before a negative assertion (no submit should occur); there is
+  // no positive condition to poll for.
   await tick(20);
 
   t.is(events.submit.length, 0, 'no submit on empty source');
@@ -166,7 +171,7 @@ test.serial('Cmd-Enter expands with a cursor position', async t => {
 
   const $source = $container.querySelector('.inline-eval-input');
   fireInput($source, 'expr');
-  await tick(20);
+  await waitFor(() => api.isValid());
   fireKeyDown($source, 'Enter', { metaKey: true });
   await waitFor(() => events.expand.length === 1);
 
@@ -259,7 +264,7 @@ test.serial('setDisabled disables the source and slot inputs', async t => {
   const { $container, api } = await setupDefine();
 
   api.setData({ source: 'x', slots: [{ codeName: 'a', label: 'l' }] });
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.inline-eval-petname'));
 
   api.setDisabled(true);
   await waitFor(
@@ -288,10 +293,10 @@ test.serial('label defaults to codeName when blank', async t => {
 
   const $source = $container.querySelector('.inline-eval-input');
   fireInput($source, '@');
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.inline-eval-petname'));
   const $codeName = $container.querySelector('.inline-eval-petname');
   fireInput($codeName, 'bar');
-  await tick(20);
+  await waitFor(() => $codeName.value === 'bar');
   const $source2 = $container.querySelector('.inline-eval-input');
   fireInput($source2, 'bar');
   await waitFor(() => api.getData().slots.length === 1);
@@ -306,7 +311,7 @@ test.serial('dispose unmounts the view', async t => {
 
   const $source = $container.querySelector('.inline-eval-input');
   fireInput($source, 'x');
-  await tick(20);
+  await waitFor(() => api.isValid());
 
   api.dispose();
   await waitFor(() => !$container.querySelector('.inline-eval-input'));

--- a/packages/chat/test/component/inline-eval.test.js
+++ b/packages/chat/test/component/inline-eval.test.js
@@ -113,6 +113,9 @@ const setupEval = async (overrides = {}) => {
   });
 
   // Let the source Root's mount effect (which wires the controller) settle.
+  // Kept as a deliberate warmup: although the Root buffers pendingState, the
+  // endowment-row confined sub-mounts have delicate first-flush timing (see the
+  // design doc) and removing this settle makes the file time out.
   await waitFor(() => !!$container.querySelector('.inline-eval-input'));
   await tick(40);
   return { $container, api, events };

--- a/packages/chat/test/component/inline-eval.test.js
+++ b/packages/chat/test/component/inline-eval.test.js
@@ -195,7 +195,7 @@ evalTest(
 
     const $source = $container.querySelector('.inline-eval-input');
     fireInput($source, '1 + 1');
-    await tick(40);
+    await waitFor(() => api.isValid());
 
     t.deepEqual(
       api.getData(),
@@ -224,11 +224,11 @@ evalTest('an endowment feeds the submitted data', async t => {
 
   const $petName = $container.querySelector('.inline-eval-petname');
   fireInput($petName, 'alice');
-  await tick(40);
+  await waitFor(() => $petName.value === 'alice');
 
   const $source2 = $container.querySelector('.inline-eval-input');
   fireInput($source2, 'alice');
-  await tick(40);
+  await waitFor(() => api.isValid());
 
   fireKeyDown($source2, 'Enter');
   await waitFor(() => events.submit.length === 1);
@@ -251,7 +251,7 @@ evalTest('Cmd-Enter expands with a cursor position', async t => {
 
   const $source = $container.querySelector('.inline-eval-input');
   fireInput($source, 'expr');
-  await tick(40);
+  await waitFor(() => api.isValid());
   fireKeyDown($source, 'Enter', { metaKey: true });
   await waitFor(() => events.expand.length === 1);
 
@@ -403,10 +403,10 @@ evalTest('dispose unmounts the view', async t => {
 
   const $source = $container.querySelector('.inline-eval-input');
   fireInput($source, 'x');
-  await tick(40);
+  await waitFor(() => api.isValid());
 
   api.dispose();
-  await tick(40);
+  await waitFor(() => !$container.querySelector('.inline-eval-input'));
 
   t.falsy(
     $container.querySelector('.inline-eval-input'),

--- a/packages/chat/test/component/inventory-component.test.js
+++ b/packages/chat/test/component/inventory-component.test.js
@@ -174,9 +174,9 @@ test.serial('hub-typed rows accept drop; leaf-typed rows do not', async t => {
     locators,
   });
 
-  // locate() runs asynchronously after each item is added; give it a beat
-  // beyond the initial render tick to settle.
-  await tick(80);
+  // locate() runs asynchronously after each item is added; wait for both type
+  // badges to resolve so the rows are typed before the drag interaction.
+  await waitFor(() => $list.querySelectorAll('.pet-type-badge').length === 2);
 
   const $inboxRow = /** @type {HTMLElement} */ (
     $list.querySelector('.pet-item-wrapper:nth-child(1) .pet-item-row')
@@ -215,6 +215,8 @@ test.serial('hub-typed rows accept drop; leaf-typed rows do not', async t => {
   );
 
   $noteRow.dispatchEvent(makeDragoverEvent());
+  // Settle delay before a negative assertion (the leaf row must NOT highlight);
+  // there is no positive condition to poll for.
   await tick(10);
   t.false(
     $noteRow.classList.contains('drop-target'),
@@ -303,7 +305,8 @@ test.serial(
       names: ['inbox'],
       locators: new Map([['inbox', 'endo://?type=directory&number=1']]),
     });
-    await tick(80);
+    // Wait for the locate probe to resolve so the row is typed as a directory.
+    await waitFor(() => !!$list.querySelector('.pet-type-badge'));
 
     const $row = /** @type {HTMLElement} */ (
       $list.querySelector('.pet-item-row')
@@ -385,7 +388,9 @@ test.serial(
         ['dest', 'endo://?type=directory&number=2'],
       ]),
     });
-    await tick(80);
+    // Wait for both locate probes to resolve so both rows are typed as
+    // directories (drop targets) before the drag interaction.
+    await waitFor(() => $list.querySelectorAll('.pet-type-badge').length === 2);
 
     const $destRow = /** @type {HTMLElement} */ (
       $list.querySelector('.pet-item-wrapper:nth-child(2) .pet-item-row')
@@ -445,7 +450,9 @@ test.serial(
         ['dest', 'endo://?type=directory&number=2'],
       ]),
     });
-    await tick(80);
+    // Wait for both locate probes to resolve so both rows are typed as
+    // directories (drop targets) before the drag interaction.
+    await waitFor(() => $list.querySelectorAll('.pet-type-badge').length === 2);
 
     const $destRow = /** @type {HTMLElement} */ (
       $list.querySelector('.pet-item-wrapper:nth-child(2) .pet-item-row')
@@ -502,7 +509,8 @@ test.serial(
       names: ['inbox'],
       locators: new Map([['inbox', 'endo://?type=directory&number=1']]),
     });
-    await tick(80);
+    // Wait for the locate probe to resolve so the row is typed as a directory.
+    await waitFor(() => !!$list.querySelector('.pet-type-badge'));
 
     const $row = /** @type {HTMLElement} */ (
       $list.querySelector('.pet-item-row')

--- a/packages/chat/test/component/inventory-component.test.js
+++ b/packages/chat/test/component/inventory-component.test.js
@@ -215,9 +215,10 @@ test.serial('hub-typed rows accept drop; leaf-typed rows do not', async t => {
   );
 
   $noteRow.dispatchEvent(makeDragoverEvent());
-  // Settle delay before a negative assertion (the leaf row must NOT highlight);
-  // there is no positive condition to poll for.
-  await tick(10);
+  // The readable-blob leaf's onDragOver early-returns (acceptsDrop is false), so
+  // dispatching dragover changes no leaf state and schedules no re-render —
+  // assert synchronously. A poll for the class's absence would pass vacuously on
+  // the first tick without proving the leaf was actually left unhighlighted.
   t.false(
     $noteRow.classList.contains('drop-target'),
     'readable-blob row does not accept drop',

--- a/packages/chat/test/component/message-picker.test.js
+++ b/packages/chat/test/component/message-picker.test.js
@@ -3,7 +3,7 @@
 import '@endo/init/debug.js';
 
 import test from 'ava';
-import { createDOM, tick } from '../helpers/dom-setup.js';
+import { createDOM, waitFor } from '../helpers/dom-setup.js';
 import { createMessagePicker } from '../../message-picker.js';
 
 const { document: testDocument } = createDOM();
@@ -53,9 +53,6 @@ const setupPicker = async () => {
     onSelect: n => selected.push(n),
   });
 
-  // Let the root component's mount effect (which wires the controller setter)
-  // settle. Generous because the first test pays SES/Preact warmup.
-  await tick(80);
   return { $messagesContainer, picker, selected };
 };
 
@@ -78,21 +75,33 @@ const keydown = key => {
   );
 };
 
-// Enable the picker and wait until its overlay has rendered its items, which is
-// when the overlay element (and its onKeyDown handler) exists. Avoids racing
-// the first synthetic keystroke against the async enable -> setState -> render
-// sequence.
+// The number of rendered overlay items for the picker under test.
+const overlayItemCount = () => {
+  const $overlay = getOverlay();
+  return $overlay
+    ? $overlay.querySelectorAll('.message-picker-item').length
+    : 0;
+};
+
+// Enable the picker and wait until its overlay has rendered its items. The
+// root's mount effect wires the controller setter asynchronously, so a single
+// `enable()` can land first and no-op (`syncOverlay` bails without a setter,
+// and a second `enable()` is guarded out by `isActive`). Re-arm with
+// disable/enable each poll until the overlay actually populates — robust on a
+// loaded runner without racing a fixed warmup delay.
 const enableAndWait = async picker => {
-  picker.enable();
-  await null;
-  for (let i = 0; i < 20; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
-    await tick(10);
-    const $overlay = getOverlay();
-    if ($overlay && $overlay.querySelectorAll('.message-picker-item').length) {
-      return;
-    }
-  }
+  await waitFor(() => {
+    if (overlayItemCount() > 0) return true;
+    if (picker.isActive()) picker.disable();
+    picker.enable();
+    return false;
+  });
+};
+
+// Whether the overlay item at `index` currently carries the keyboard highlight.
+const itemHighlighted = index => {
+  const $items = getOverlay().querySelectorAll('.message-picker-item');
+  return !!$items[index] && $items[index].classList.contains('highlighted');
 };
 
 test.serial('enable decorates host messages and renders overlay', async t => {
@@ -121,15 +130,17 @@ test.serial(
     await enableAndWait(picker);
 
     // Default highlight is the first row (#1). Arrow down twice -> #3, up -> #2.
+    // Poll the rendered highlight between keystrokes so each keydown reads the
+    // settled selectedIndex rather than racing the previous render.
     keydown('ArrowDown');
-    await tick(10);
+    await waitFor(() => itemHighlighted(1));
     keydown('ArrowDown');
-    await tick(10);
+    await waitFor(() => itemHighlighted(2));
     keydown('ArrowUp');
-    await tick(10);
+    await waitFor(() => itemHighlighted(1));
 
     keydown('Enter');
-    await tick(20);
+    await waitFor(() => selected.length >= 1);
 
     t.deepEqual(selected, [2], 'onSelect fired with the navigated message');
     t.is(picker.getSelected(), 2, 'selected number tracked');
@@ -145,7 +156,7 @@ test.serial('clicking an overlay item fires onSelect', async t => {
 
   const $items = getOverlay().querySelectorAll('.message-picker-item');
   $items[2].click();
-  await tick(20);
+  await waitFor(() => selected.length >= 1);
 
   t.deepEqual(selected, [3], 'onSelect fired with the clicked message');
 
@@ -159,7 +170,7 @@ test.serial('Escape closes the picker', async t => {
   t.truthy(getOverlay(), 'overlay rendered');
 
   keydown('Escape');
-  await tick(20);
+  await waitFor(() => !picker.isActive());
 
   t.false(picker.isActive(), 'picker disabled by Escape');
   t.is(getOverlay().style.display, 'none', 'overlay hidden');
@@ -183,7 +194,11 @@ test.serial(
     await enableAndWait(picker);
 
     picker.setSelected(2);
-    await tick(20);
+    await waitFor(() =>
+      $messagesContainer
+        .querySelectorAll('.message')[1]
+        .classList.contains('highlighted'),
+    );
     t.is(picker.getSelected(), 2, 'selected number recorded');
 
     const $messages = $messagesContainer.querySelectorAll('.message');
@@ -193,7 +208,7 @@ test.serial(
     );
 
     picker.disable();
-    await tick(20);
+    await waitFor(() => !picker.isActive());
 
     t.false(picker.isActive(), 'picker inactive after disable');
     t.is(getOverlay().style.display, 'none', 'overlay hidden after disable');

--- a/packages/chat/test/component/microblog.test.js
+++ b/packages/chat/test/component/microblog.test.js
@@ -198,7 +198,11 @@ const setup = async () => {
 
   const push = async msg => {
     pushMessage(msg);
-    // Wait past the 150ms debounce for the re-render to land.
+    // Kept as a deliberate timing device: the feed coalesces messages behind a
+    // 150ms debounce, so this waits past that window for the re-render to land.
+    // This shared helper can't know what a given test pushed (bios become the
+    // header, replies/edits fold into an existing post rather than adding one),
+    // so there is no single positive count/selector to poll generically.
     await tick(220);
   };
 

--- a/packages/chat/test/component/outliner-enter-key.test.js
+++ b/packages/chat/test/component/outliner-enter-key.test.js
@@ -6,7 +6,7 @@ import '@endo/init/debug.js';
 import test from 'ava';
 import { Far } from '@endo/far';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
-import { createDOM, waitFor } from '../helpers/dom-setup.js';
+import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
 
 import { outlinerComponent } from '../../outliner-component.js';
 
@@ -302,7 +302,9 @@ test.afterEach(async () => {
     const dispose = /** @type {() => void} */ (mountedDisposals.pop());
     dispose();
   }
-  await null;
+  // Let the iterator's return() and pending timers settle (macrotask) before
+  // detaching the DOM, matching forum.test.js.
+  await tick(0);
   testDocument.body.innerHTML = '';
 });
 

--- a/packages/chat/test/component/outliner-enter-key.test.js
+++ b/packages/chat/test/component/outliner-enter-key.test.js
@@ -285,9 +285,7 @@ const setup = async () => {
       pushMessage(msg);
     }
     await waitFor(() =>
-      msgs.every(
-        msg => !!$parent.querySelector(`[data-key="${msg.number}"]`),
-      ),
+      msgs.every(msg => !!$parent.querySelector(`[data-key="${msg.number}"]`)),
     );
   };
 
@@ -415,7 +413,9 @@ test.serial(
     await waitFor(() => {
       const $m1 = $parent.querySelector('[data-key="1"]');
       const $children = $m1 && directChild($m1, 'outliner-children');
-      return !!$children && directChildren($children, 'outliner-draft').length === 1;
+      return (
+        !!$children && directChildren($children, 'outliner-draft').length === 1
+      );
     });
 
     restoreSelection();

--- a/packages/chat/test/component/outliner-enter-key.test.js
+++ b/packages/chat/test/component/outliner-enter-key.test.js
@@ -1,13 +1,12 @@
 // @ts-nocheck - Component test with happy-dom
 /* global globalThis */
-/* eslint-disable no-await-in-loop */
 
 import '@endo/init/debug.js';
 
 import test from 'ava';
 import { Far } from '@endo/far';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
-import { createDOM, tick } from '../helpers/dom-setup.js';
+import { createDOM, waitFor } from '../helpers/dom-setup.js';
 
 import { outlinerComponent } from '../../outliner-component.js';
 
@@ -214,6 +213,13 @@ const directChildren = (parent, className) => {
 };
 
 /**
+ * Disposers for components mounted by `setup`, drained in `afterEach`.
+ *
+ * @type {Array<() => void>}
+ */
+const mountedDisposals = [];
+
+/**
  * Set up a fresh outliner component for testing.
  * Returns helpers for pushing messages and inspecting the DOM.
  */
@@ -256,23 +262,33 @@ const setup = async () => {
     onBookmark: undefined,
   });
 
-  // Wait for async setup (getProposedName, getMember, followMessages)
-  await tick(50);
+  // Wait for async setup (getProposedName, getMember, followMessages) by polling
+  // for the control API rather than racing a fixed delay on a loaded CI runner.
+  await waitFor(() => !!$parent.channelAPI);
+
+  // Dispose the component after the test so its `for await` consumer loop and
+  // timers stop before the shared DOM is torn down.
+  mountedDisposals.push(() => {
+    const api = /** @type {any} */ ($parent).channelAPI;
+    if (api) api.dispose();
+  });
 
   /**
-   * Push messages and wait for them to render.
-   * Pushes all messages rapidly, then waits for the batch render.
+   * Push messages and wait for them all to render as committed nodes. Polling
+   * the rendered `[data-key]` nodes is robust against the batch debounce, where
+   * a fixed delay races the render on a loaded runner.
    *
    * @param {unknown[]} msgs
    */
   const pushAll = async msgs => {
     for (const msg of msgs) {
       pushMessage(msg);
-      // Small tick to allow for-await-of to consume each message
-      await tick(10);
     }
-    // Wait for batch timer (50ms) + rendering
-    await tick(300);
+    await waitFor(() =>
+      msgs.every(
+        msg => !!$parent.querySelector(`[data-key="${msg.number}"]`),
+      ),
+    );
   };
 
   return {
@@ -283,7 +299,12 @@ const setup = async () => {
   };
 };
 
-test.afterEach(() => {
+test.afterEach(async () => {
+  while (mountedDisposals.length > 0) {
+    const dispose = /** @type {() => void} */ (mountedDisposals.pop());
+    dispose();
+  }
+  await null;
   testDocument.body.innerHTML = '';
 });
 
@@ -323,8 +344,12 @@ test.serial(
     });
     $msg2Text.dispatchEvent(enterEvent);
 
-    // Wait for requestAnimationFrame to fire
-    await tick(50);
+    // Poll for the draft to be inserted (it appears via requestAnimationFrame)
+    // rather than racing a fixed delay.
+    await waitFor(() => {
+      const $children = directChild($msg2Node, 'outliner-children');
+      return !!$children && !!directChild($children, 'outliner-draft');
+    });
 
     restoreSelection();
 
@@ -386,7 +411,12 @@ test.serial(
     });
     $msg2Text.dispatchEvent(enterEvent);
 
-    await tick(50);
+    // Poll for the sibling draft to land in message 1's children.
+    await waitFor(() => {
+      const $m1 = $parent.querySelector('[data-key="1"]');
+      const $children = $m1 && directChild($m1, 'outliner-children');
+      return !!$children && directChildren($children, 'outliner-draft').length === 1;
+    });
 
     restoreSelection();
 
@@ -436,7 +466,11 @@ test.serial(
     });
     $msg1Text.dispatchEvent(enterEvent);
 
-    await tick(50);
+    // Poll for the child draft to land in the root's children.
+    await waitFor(() => {
+      const $children = directChild($msg1Node, 'outliner-children');
+      return !!$children && !!directChild($children, 'outliner-draft');
+    });
 
     restoreSelection();
 

--- a/packages/chat/test/component/peers.test.js
+++ b/packages/chat/test/component/peers.test.js
@@ -120,7 +120,7 @@ test.serial('peers view renders through the confined tree', async t => {
 
   // Teardown unmounts the confined tree AND removes the mount node.
   cleanup();
-  await tick(20);
+  await waitFor(() => $parent.querySelector('.peers-container') === null);
   t.is(
     $parent.querySelector('.peers-container'),
     null,

--- a/packages/chat/test/component/petname-path-autocomplete-confined.test.js
+++ b/packages/chat/test/component/petname-path-autocomplete-confined.test.js
@@ -67,11 +67,10 @@ const setup = async names => {
   $input.addEventListener('input', () => selected.push($input.value));
 
   const api = petNamePathAutocomplete($input, $menu, { E, powers });
-  // Let the confined Root's effect wire the controller's state setter before
-  // the test drives input (the effect flush is deferred through rAF, so this
-  // matches token-autocomplete's setup of waiting past the first flush).
-  await waitFor(() => true, { timeout: 50 });
-  await tick(60);
+  // No warmup needed: the confined Root buffers any state the host pushes
+  // before its mount effect wires the setter (controller.pendingState, flushed
+  // on mount), so the first input a test dispatches is never dropped. Each test
+  // then polls for the rendered suggestions with waitFor.
   return { $input, $menu, api, selected };
 };
 
@@ -110,12 +109,10 @@ test.serial('keyboard Down then Enter selects the suggestion', async t => {
   $input.value = 'al';
   $input.dispatchEvent(new globalThis.Event('input', { bubbles: true }));
   await waitFor(() => $menu.querySelectorAll('.token-menu-item').length >= 2);
-  // Let any pending async updateSuggestions settle so it doesn't reset the
-  // highlight after the keypress below.
-  await tick(30);
 
-  // Suggestions render in sorted order: ['alfred', 'alice']. The first row is
-  // highlighted initially (selectedIndex 0).
+  // Suggestions render in sorted order: ['alfred', 'alice']. Poll for the
+  // initial highlight to land on the first row, which also confirms the async
+  // updateSuggestions has settled before we drive the keyboard below.
   await waitFor(() => {
     const sel = $menu.querySelector('.token-menu-item.selected');
     return sel && sel.textContent === 'alfred';

--- a/packages/chat/test/component/petname-path-autocomplete.test.js
+++ b/packages/chat/test/component/petname-path-autocomplete.test.js
@@ -4,7 +4,7 @@ import '@endo/init/debug.js';
 
 import test from 'ava';
 import { E } from '@endo/far';
-import { createDOM, tick } from '../helpers/dom-setup.js';
+import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
 import { makeMockPowers } from '../helpers/mock-powers.js';
 import { petNamePathAutocomplete } from '../../petname-path-autocomplete.js';
 
@@ -107,7 +107,7 @@ test('menu shows on input when there are matching names', async t => {
 
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => api.isMenuVisible());
 
   t.true(api.isMenuVisible());
   t.true($menu.classList.contains('visible'));
@@ -124,7 +124,7 @@ test('menu shows suggestions filtered by input', async t => {
 
   $input.value = 'al';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length >= 2);
 
   const items = $menu.querySelectorAll('.token-menu-item');
   t.is(items.length, 2); // alice and alfred
@@ -142,13 +142,13 @@ test('menu hides when input is empty', async t => {
   // First show menu
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => api.isMenuVisible());
   t.true(api.isMenuVisible());
 
   // Then clear
   $input.value = '';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !api.isMenuVisible());
 
   t.false(api.isMenuVisible());
 
@@ -164,7 +164,7 @@ test('dispose hides menu', async t => {
 
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => api.isMenuVisible());
   t.true(api.isMenuVisible());
 
   api.dispose();
@@ -181,13 +181,13 @@ test('keyboard Escape hides menu', async t => {
 
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => api.isMenuVisible());
   t.true(api.isMenuVisible());
 
   $input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
   );
-  await tick(10);
+  await waitFor(() => !api.isMenuVisible());
 
   t.false(api.isMenuVisible());
 
@@ -203,7 +203,7 @@ test('keyboard ArrowDown navigates to next suggestion', async t => {
 
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(100);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length >= 1);
 
   // Get initial selection
   const items = $menu.querySelectorAll('.token-menu-item');
@@ -215,7 +215,7 @@ test('keyboard ArrowDown navigates to next suggestion', async t => {
   $input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
   );
-  await tick(20);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item.selected'));
 
   selected = $menu.querySelector('.token-menu-item.selected');
   // Should either move to next item or wrap around
@@ -233,19 +233,22 @@ test('keyboard ArrowUp navigates to previous suggestion', async t => {
 
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(100);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item.selected'));
 
   // Go down first
   $input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
   );
+  // Small gap to let the down-navigation selection update before navigating up.
   await tick(20);
 
   // Go up
   $input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }),
   );
-  await tick(20);
+  await waitFor(
+    () => !!$menu.querySelector('.token-menu-item.selected')?.textContent,
+  );
 
   const afterUp = $menu.querySelector('.token-menu-item.selected')?.textContent;
 
@@ -264,7 +267,7 @@ test('Tab selects suggestion and updates input', async t => {
 
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(100);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item.selected'));
 
   // Get the currently selected suggestion
   const selected = $menu.querySelector('.token-menu-item.selected');
@@ -273,7 +276,7 @@ test('Tab selects suggestion and updates input', async t => {
   $input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
   );
-  await tick(50);
+  await waitFor(() => $input.value === expectedValue);
 
   // Input should now have the selected value
   t.is($input.value, expectedValue);
@@ -290,12 +293,12 @@ test('Enter selects suggestion', async t => {
 
   $input.value = 'b';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item.selected'));
 
   $input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
   );
-  await tick(10);
+  await waitFor(() => $input.value === 'bob');
 
   t.is($input.value, 'bob');
 
@@ -311,7 +314,7 @@ test('menu shows hint text', async t => {
 
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-hint'));
 
   const hint = $menu.querySelector('.token-menu-hint');
   t.truthy(hint);
@@ -334,7 +337,7 @@ test('handles path with dots - fetches from nested directory', async t => {
 
   $input.value = 'dir.';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => api.isMenuVisible());
 
   // Should show nested items
   const items = $menu.querySelectorAll('.token-menu-item');
@@ -352,7 +355,7 @@ test('shows "No matches" when no suggestions', async t => {
 
   $input.value = 'xyz';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-empty'));
 
   const empty = $menu.querySelector('.token-menu-empty');
   t.truthy(empty);
@@ -370,7 +373,7 @@ test('menu wraps around when navigating past end', async t => {
 
   $input.value = 'a';
   $input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(100);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item.selected'));
 
   const items = $menu.querySelectorAll('.token-menu-item');
   const itemCount = items.length;
@@ -385,7 +388,11 @@ test('menu wraps around when navigating past end', async t => {
       new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
     );
   }
-  await tick(10);
+  await waitFor(
+    () =>
+      $menu.querySelector('.token-menu-item.selected')?.textContent ===
+      firstName,
+  );
 
   const afterWrap = $menu.querySelector('.token-menu-item.selected');
   // After wrapping, should be back at first item

--- a/packages/chat/test/component/petname-path-autocomplete.test.js
+++ b/packages/chat/test/component/petname-path-autocomplete.test.js
@@ -235,11 +235,13 @@ test('keyboard ArrowUp navigates to previous suggestion', async t => {
   $input.dispatchEvent(new Event('input', { bubbles: true }));
   await waitFor(() => !!$menu.querySelector('.token-menu-item.selected'));
 
-  // Go down first
+  // Go down first. Only 'alice' matches the 'a' prefix (filter is
+  // `startsWith`), so there is a single suggestion and ArrowDown does not move
+  // the selection — there is no transition to poll, so this stays a small
+  // deliberate gap sequencing the two keydowns.
   $input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
   );
-  // Small gap to let the down-navigation selection update before navigating up.
   await tick(20);
 
   // Go up

--- a/packages/chat/test/component/petname-paths-autocomplete-confined.test.js
+++ b/packages/chat/test/component/petname-paths-autocomplete-confined.test.js
@@ -62,12 +62,10 @@ const setup = async names => {
 
   const { powers } = makeMockPowers({ names });
   const api = petNamePathsAutocomplete($container, $menu, { E, powers });
-  // Let the confined Root's effect wire the controller's state setter before
-  // the test drives input (the effect flush is deferred through rAF, so this
-  // matches the sibling autocomplete tests' setup of waiting past the first
-  // flush).
-  await waitFor(() => true, { timeout: 50 });
-  await tick(60);
+  // No warmup needed: the confined Root buffers any state the host pushes
+  // before its mount effect wires the setter (controller.pendingState, flushed
+  // on mount), so the first input a test dispatches is never dropped. Each test
+  // then polls for the rendered suggestions with waitFor.
 
   const $input = /** @type {HTMLInputElement} */ (
     $container.querySelector('input.chip-input')
@@ -112,12 +110,10 @@ test.serial('keyboard Down then Space selects the suggestion', async t => {
 
   $input.dispatchEvent(new globalThis.Event('focus', { bubbles: true }));
   await waitFor(() => $menu.querySelectorAll('.token-menu-item').length >= 2);
-  // Let any pending async updateSuggestions settle so it doesn't reset the
-  // highlight after the keypress below.
-  await tick(30);
 
-  // Suggestions render in sorted order: ['alice', 'bob']. The first row is
-  // highlighted initially (selectedIndex 0).
+  // Suggestions render in sorted order: ['alice', 'bob']. Poll for the initial
+  // highlight to land on the first row, which also confirms the async
+  // updateSuggestions has settled before we drive the keyboard below.
   await waitFor(() => {
     const sel = $menu.querySelector('.token-menu-item.selected');
     return sel && sel.textContent === 'alice';

--- a/packages/chat/test/component/petname-paths-autocomplete.test.js
+++ b/packages/chat/test/component/petname-paths-autocomplete.test.js
@@ -4,7 +4,7 @@ import '@endo/init/debug.js';
 
 import test from 'ava';
 import { E } from '@endo/far';
-import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
+import { createDOM, waitFor } from '../helpers/dom-setup.js';
 import { makeMockPowers } from '../helpers/mock-powers.js';
 import { petNamePathsAutocomplete } from '../../petname-paths-autocomplete.js';
 
@@ -147,7 +147,7 @@ test('menu shows on focus', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => api.isMenuVisible());
 
   t.true(api.isMenuVisible());
 
@@ -165,7 +165,7 @@ test('dispose hides menu', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => api.isMenuVisible());
   t.true(api.isMenuVisible());
 
   api.dispose();
@@ -202,7 +202,7 @@ test('clicking remove button removes chip', async t => {
 
   const firstRemove = $container.querySelector('.path-chip-remove');
   /** @type {HTMLElement} */ (firstRemove).click();
-  await tick(10);
+  await waitFor(() => $container.querySelectorAll('.path-chip').length === 1);
 
   t.deepEqual(api.getValue(), ['bob']);
   t.is($container.querySelectorAll('.path-chip').length, 1);
@@ -227,7 +227,7 @@ test('Backspace on empty input removes last chip', async t => {
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
   );
-  await tick(10);
+  await waitFor(() => $container.querySelectorAll('.path-chip').length === 1);
 
   t.deepEqual(api.getValue(), ['alice']);
   t.is($container.querySelectorAll('.path-chip').length, 1);
@@ -246,13 +246,13 @@ test('Escape hides menu', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => api.isMenuVisible());
   t.true(api.isMenuVisible());
 
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
   );
-  await tick(10);
+  await waitFor(() => !api.isMenuVisible());
 
   t.false(api.isMenuVisible());
 
@@ -306,13 +306,13 @@ test('Space creates chip and starts new path', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item.selected'));
 
   // Select first suggestion (alice) with Space
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: ' ', bubbles: true }),
   );
-  await tick(50);
+  await waitFor(() => $container.querySelectorAll('.path-chip').length === 1);
 
   const chips = $container.querySelectorAll('.path-chip');
   t.is(chips.length, 1);
@@ -334,12 +334,12 @@ test('Tab completes suggestion in input', async t => {
   );
   input.value = 'a';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item.selected'));
 
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
   );
-  await tick(10);
+  await waitFor(() => input.value === 'alice');
 
   t.is(input.value, 'alice');
   // No chip created yet - Tab just completes
@@ -383,7 +383,7 @@ test('onChange callback is called when value changes', async t => {
   );
   input.value = 'test';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  await tick(10);
+  await waitFor(() => changeCount > 0);
 
   t.true(changeCount > 0);
 
@@ -412,7 +412,7 @@ test('onSubmit callback is called on Enter', async t => {
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
   );
-  await tick(10);
+  await waitFor(() => submitted);
 
   t.true(submitted);
 
@@ -430,7 +430,7 @@ test('menu shows hint text', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-hint'));
 
   const hint = $menu.querySelector('.token-menu-hint');
   t.truthy(hint);
@@ -503,7 +503,7 @@ test('finalizeOnSelect: selecting does not show more suggestions', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item'));
 
   t.true(api.isMenuVisible());
 
@@ -512,7 +512,7 @@ test('finalizeOnSelect: selecting does not show more suggestions', async t => {
   menuItem?.dispatchEvent(
     new testWindow.MouseEvent('mousedown', { bubbles: true }),
   );
-  await tick(50);
+  await waitFor(() => !api.isMenuVisible());
 
   // Menu should be hidden (not showing more suggestions)
   t.false(api.isMenuVisible());
@@ -565,8 +565,8 @@ test('Shift+Tab goes back to edit previous chip', async t => {
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }),
   );
-  // updateSuggestions is async, wait longer
-  await tick(100);
+  // updateSuggestions is async; poll for the nested children to render.
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length === 2);
 
   // Chip should be removed and path should be in input with trailing slash
   t.is($container.querySelectorAll('.path-chip').length, 0);
@@ -596,7 +596,7 @@ test('finalizeOnSelect: hint shows Shift+Tab instead of Space', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-hint'));
 
   const hint = $menu.querySelector('.token-menu-hint');
   t.truthy(hint);
@@ -618,7 +618,7 @@ test('clicking menu item creates chip (modal usage pattern)', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(50);
+  await waitFor(() => !!$menu.querySelector('.token-menu-item'));
 
   // Click on the first menu item (use mousedown since that's what triggers selection)
   const menuItem = $menu.querySelector('.token-menu-item');
@@ -626,7 +626,7 @@ test('clicking menu item creates chip (modal usage pattern)', async t => {
   menuItem?.dispatchEvent(
     new testWindow.MouseEvent('mousedown', { bubbles: true }),
   );
-  await tick(50);
+  await waitFor(() => $container.querySelectorAll('.path-chip').length === 1);
 
   // Clicking now creates a chip (uses 'space' mode)
   const chips = $container.querySelectorAll('.path-chip');
@@ -676,7 +676,7 @@ test('setValue with path then focus shows nested suggestions', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(100);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length === 2);
 
   // Should show children of @agent
   t.true(api.isMenuVisible(), 'Menu should be visible');
@@ -728,7 +728,7 @@ test('clicking nested suggestion extends chip path', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(100);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length === 2);
 
   // Menu should show children of @agent
   t.true(api.isMenuVisible(), 'Menu should be visible');
@@ -739,7 +739,7 @@ test('clicking nested suggestion extends chip path', async t => {
   menuItems[0].dispatchEvent(
     new testWindow.MouseEvent('mousedown', { bubbles: true }),
   );
-  await tick(50);
+  await waitFor(() => api.getValue()[0] === '@agent/child1');
 
   // Should have extended the @agent chip to @agent/child1
   const chips = $container.querySelectorAll('.path-chip');
@@ -787,7 +787,11 @@ test('ArrowDown works after setValue with existing chip', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(100);
+  await waitFor(
+    () =>
+      $menu.querySelector('.token-menu-item.selected')?.textContent ===
+      'option1',
+  );
 
   // Verify initial selection
   let selected = $menu.querySelector('.token-menu-item.selected');
@@ -797,7 +801,11 @@ test('ArrowDown works after setValue with existing chip', async t => {
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
   );
-  await tick(10);
+  await waitFor(
+    () =>
+      $menu.querySelector('.token-menu-item.selected')?.textContent ===
+      'option2',
+  );
 
   selected = $menu.querySelector('.token-menu-item.selected');
   t.is(selected?.textContent, 'option2');
@@ -806,7 +814,11 @@ test('ArrowDown works after setValue with existing chip', async t => {
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
   );
-  await tick(10);
+  await waitFor(
+    () =>
+      $menu.querySelector('.token-menu-item.selected')?.textContent ===
+      'option3',
+  );
 
   selected = $menu.querySelector('.token-menu-item.selected');
   t.is(selected?.textContent, 'option3');
@@ -851,13 +863,17 @@ test('Space on nested suggestion extends the chip path', async t => {
     $container.querySelector('input.chip-input')
   );
   input.dispatchEvent(new Event('focus', { bubbles: true }));
-  await tick(100);
+  await waitFor(
+    () =>
+      $menu.querySelector('.token-menu-item.selected')?.textContent ===
+      'child1',
+  );
 
   // Press Space to select 'child1' - should extend @agent chip to @agent/child1
   input.dispatchEvent(
     new KeyboardEvent('keydown', { key: ' ', bubbles: true }),
   );
-  await tick(50);
+  await waitFor(() => api.getValue()[0] === '@agent/child1');
 
   // Should now have one chip with extended path
   const chips = $container.querySelectorAll('.path-chip');

--- a/packages/chat/test/component/profile-popup.test.js
+++ b/packages/chat/test/component/profile-popup.test.js
@@ -18,11 +18,9 @@ const setupPopup = async () => {
 
   const popup = createProfilePopup($container);
 
-  // Let the root component's mount effect (which wires the controller setter)
-  // settle. Generous because the first test pays SES/Preact warmup. Kept as a
-  // fixed tick: show() silently no-ops until the mount effect wires the setter,
-  // and there is no observable readiness signal to poll before the first show().
-  await tick(80);
+  // No warmup needed: the Root buffers show()/hide() pushed before its mount
+  // effect wires the setter (controller.pendingState, flushed on mount), so the
+  // first show() is never dropped. Each test polls for the popup with waitFor.
   return { $container, popup };
 };
 

--- a/packages/chat/test/component/profile-popup.test.js
+++ b/packages/chat/test/component/profile-popup.test.js
@@ -131,7 +131,11 @@ test.serial('Save button fires onAssignName with the typed name', async t => {
 
   const $save = $container.querySelector('.profile-save-btn');
   $save.click();
-  await waitFor(() => assigned.length >= 1);
+  // Save fires onAssignName then onClose; the popup removal re-renders
+  // asynchronously, so gate on both the callback and the popup being gone.
+  await waitFor(
+    () => assigned.length >= 1 && !$container.querySelector('.profile-popup'),
+  );
 
   t.deepEqual(assigned, ['Ally'], 'onAssignName called with trimmed name');
   t.falsy(

--- a/packages/chat/test/component/profile-popup.test.js
+++ b/packages/chat/test/component/profile-popup.test.js
@@ -3,7 +3,7 @@
 import '@endo/init/debug.js';
 
 import test from 'ava';
-import { createDOM, tick } from '../helpers/dom-setup.js';
+import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
 import { createProfilePopup } from '../../profile-popup.js';
 
 const { document: testDocument } = createDOM();
@@ -19,7 +19,9 @@ const setupPopup = async () => {
   const popup = createProfilePopup($container);
 
   // Let the root component's mount effect (which wires the controller setter)
-  // settle. Generous because the first test pays SES/Preact warmup.
+  // settle. Generous because the first test pays SES/Preact warmup. Kept as a
+  // fixed tick: show() silently no-ops until the mount effect wires the setter,
+  // and there is no observable readiness signal to poll before the first show().
   await tick(80);
   return { $container, popup };
 };
@@ -45,7 +47,7 @@ test.serial('show renders the popup with the proposed name', async t => {
   const { args } = makeShowArgs();
 
   popup.show(args);
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.profile-popup'));
 
   const $popup = $container.querySelector('.profile-popup');
   t.truthy($popup, 'popup card rendered');
@@ -65,7 +67,7 @@ test.serial('pedigree renders assigned and proposed names', async t => {
   const { args } = makeShowArgs();
 
   popup.show(args);
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.pedigree-chain'));
 
   const $chain = $container.querySelector('.pedigree-chain');
   t.truthy($chain, 'invitation chain rendered');
@@ -85,7 +87,7 @@ test.serial('empty pedigree renders the channel-creator marker', async t => {
   const { args } = makeShowArgs({ pedigree: [], pedigreeMemberIds: [] });
 
   popup.show(args);
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.pedigree-creator'));
 
   const $creator = $container.querySelector('.pedigree-creator');
   t.truthy($creator, 'creator marker rendered');
@@ -99,11 +101,11 @@ test.serial('hide removes the popup and hides the container', async t => {
   const { args } = makeShowArgs();
 
   popup.show(args);
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.profile-popup'));
   t.truthy($container.querySelector('.profile-popup'), 'popup shown');
 
   popup.hide();
-  await tick(20);
+  await waitFor(() => !$container.querySelector('.profile-popup'));
   t.falsy(
     $container.querySelector('.profile-popup'),
     'popup removed after hide',
@@ -116,17 +118,20 @@ test.serial('Save button fires onAssignName with the typed name', async t => {
   const { args, assigned } = makeShowArgs();
 
   popup.show(args);
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.profile-assign-name'));
 
   const $input = $container.querySelector('.profile-assign-name');
   t.truthy($input, 'assign-name input rendered');
   $input.value = 'Ally';
   $input.dispatchEvent(new testDocument.defaultView.Event('input'));
+  // Let the input's onInput handler propagate the typed value into component
+  // state before the save reads it; this microtask flush has no observable DOM
+  // signal of its own.
   await tick(10);
 
   const $save = $container.querySelector('.profile-save-btn');
   $save.click();
-  await tick(20);
+  await waitFor(() => assigned.length >= 1);
 
   t.deepEqual(assigned, ['Ally'], 'onAssignName called with trimmed name');
   t.falsy(
@@ -140,12 +145,12 @@ test.serial('clicking the backdrop closes the popup', async t => {
   const { args, assigned } = makeShowArgs();
 
   popup.show(args);
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.profile-popup-backdrop'));
 
   const $backdrop = $container.querySelector('.profile-popup-backdrop');
   t.truthy($backdrop, 'backdrop rendered');
   $backdrop.click();
-  await tick(20);
+  await waitFor(() => !$container.querySelector('.profile-popup'));
 
   t.falsy(
     $container.querySelector('.profile-popup'),
@@ -159,7 +164,7 @@ test.serial('Escape closes the popup', async t => {
   const { args, assigned } = makeShowArgs();
 
   popup.show(args);
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.profile-assign-name'));
 
   // Escape is handled declaratively by a wrapper's onKeyDown (the keydown
   // bubbles up from the autofocused input), not a document-level listener.
@@ -171,7 +176,7 @@ test.serial('Escape closes the popup', async t => {
       bubbles: true,
     }),
   );
-  await tick(20);
+  await waitFor(() => !$container.querySelector('.profile-popup'));
 
   t.falsy(
     $container.querySelector('.profile-popup'),
@@ -187,12 +192,12 @@ test.serial('close button closes the popup', async t => {
   const { args } = makeShowArgs();
 
   popup.show(args);
-  await tick(20);
+  await waitFor(() => !!$container.querySelector('.profile-popup-close'));
 
   const $close = $container.querySelector('.profile-popup-close');
   t.truthy($close, 'close button rendered');
   $close.click();
-  await tick(20);
+  await waitFor(() => !$container.querySelector('.profile-popup'));
 
   t.falsy(
     $container.querySelector('.profile-popup'),

--- a/packages/chat/test/component/send-form.test.js
+++ b/packages/chat/test/component/send-form.test.js
@@ -206,7 +206,7 @@ test.serial(
     });
 
     typeText(ctx.$input, 'hello world');
-    await tick(20);
+    await waitFor(() => ctx.component.getState().hasText);
 
     // Submit via the send button (handleSend → E(powers).send).
     ctx.$sendButton.click();
@@ -241,7 +241,7 @@ test.serial(
     const ctx = setup({ getChannelRef: () => channelRef });
 
     typeText(ctx.$input, 'channel hello');
-    await tick(20);
+    await waitFor(() => ctx.component.getState().hasText);
 
     ctx.$sendButton.click();
     await waitFor(() => posts.length > 0);
@@ -259,7 +259,7 @@ test.serial('state changes notify callback', async t => {
   t.is(ctx.stateChanges.length, 0);
 
   typeText(ctx.$input, 'h');
-  await tick(10);
+  await waitFor(() => ctx.stateChanges.length > 0);
 
   t.true(ctx.stateChanges.length > 0);
   const lastState = ctx.stateChanges[ctx.stateChanges.length - 1];
@@ -272,13 +272,13 @@ test.serial('clear resets state', async t => {
   const ctx = setup();
 
   typeText(ctx.$input, 'hello');
-  await tick(10);
+  await waitFor(() => ctx.component.getState().hasText);
 
   let state = ctx.component.getState();
   t.true(state.hasText);
 
   ctx.component.clear();
-  await tick(10);
+  await waitFor(() => ctx.component.getState().isEmpty);
 
   state = ctx.component.getState();
   t.true(state.isEmpty);
@@ -303,6 +303,8 @@ test.serial(
     t.true(before > 0);
 
     ctx.component.dispose();
+    // Settle delay before a negative assertion (the bar should be gone); there
+    // is no positive condition to poll for.
     await tick(20);
 
     t.falsy(
@@ -379,6 +381,9 @@ test.serial(
       lockoutDurationMs: 5000,
       postLockoutPct: 50,
     });
+    // Deliberate settle to let the post-dispose init continuation run, before a
+    // negative assertion that NO rAF loop started; there is no positive
+    // condition to poll for.
     await tick(50);
 
     t.is(rafAfterDispose, 0, 'no heat engine / rAF loop started after dispose');

--- a/packages/chat/test/component/spaces-gutter-home.test.js
+++ b/packages/chat/test/component/spaces-gutter-home.test.js
@@ -371,9 +371,13 @@ test.serial(
     t.true($icons.length > 0, 'icon options rendered');
     // Click the first icon option (🧙)
     $icons[0].click();
-    // Let the icon-selection state update flush before submitting; the selected
-    // icon is reflected in the store call we assert on below.
-    await tick(10);
+    // Poll for the click to commit the selection (the chosen wizard icon gains
+    // the `selected` class) before submitting, rather than a fixed delay.
+    await waitFor(() =>
+      $editModalContainer
+        .querySelector('.icon-option.selected')
+        ?.textContent.includes('🧙'),
+    );
 
     // Submit the form
     const $form = $editModalContainer.querySelector('.add-space-form');

--- a/packages/chat/test/component/spaces-gutter-home.test.js
+++ b/packages/chat/test/component/spaces-gutter-home.test.js
@@ -7,7 +7,7 @@ import harden from '@endo/harden';
 import { Far } from '@endo/far';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 import { makePromiseKit } from '@endo/promise-kit';
-import { createDOM, tick } from '../helpers/dom-setup.js';
+import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
 
 const { document: testDocument } = createDOM();
 
@@ -169,6 +169,23 @@ const setupGutter = async (opts = {}) => {
 
   const { powers, calls, storedValues } = makeSpacesPowers(opts);
 
+  // Identify the spaces the watcher will surface from pre-stored config so the
+  // wait below covers them, not just the always-present home item: a regular
+  // space (id != '0') renders its own item; a stored 'spaces/0' overrides the
+  // home icon.
+  const regularSpaceIds = [];
+  let homeIconOverride;
+  for (const [key, value] of storedValues.entries()) {
+    if (key.startsWith('spaces/')) {
+      const id = key.slice('spaces/'.length);
+      if (id === '0') {
+        homeIconOverride = /** @type {{ icon?: string }} */ (value)?.icon;
+      } else {
+        regularSpaceIds.push(id);
+      }
+    }
+  }
+
   const navigated = [];
   const { createSpacesGutter } = await import('../../spaces-gutter.js');
 
@@ -180,8 +197,26 @@ const setupGutter = async (opts = {}) => {
     onNavigate: path => navigated.push([...path]),
   });
 
-  // Wait for refresh + watcher to settle
-  await tick(50);
+  // Wait for refresh + watcher to settle: poll for the observable results of the
+  // initial refresh (home item, each stored regular space, and any stored home
+  // icon override) rather than guessing a fixed delay.
+  await waitFor(() => {
+    if (!$container.querySelector('.space-item.home')) return false;
+    for (const id of regularSpaceIds) {
+      if (!$container.querySelector(`.space-item[data-space-id="${id}"]`)) {
+        return false;
+      }
+    }
+    if (homeIconOverride !== undefined) {
+      const $homeIcon = $container.querySelector(
+        '.space-item.home .space-icon',
+      );
+      if (!$homeIcon || $homeIcon.textContent !== homeIconOverride) {
+        return false;
+      }
+    }
+    return true;
+  });
 
   // The edit modals render into their own overlay container, inserted by the
   // gutter immediately after $modalContainer, so the add-space modal's
@@ -290,7 +325,7 @@ test.serial(
     const $edit = $container.querySelector('[data-action="edit"]');
     $edit.click();
 
-    await tick(20);
+    await waitFor(() => !!$editModalContainer.querySelector('.icon-selector'));
 
     // Name field should NOT exist
     const $nameInput = $editModalContainer.querySelector('#edit-space-name');
@@ -327,20 +362,31 @@ test.serial(
     // Click Edit
     const $edit = $container.querySelector('[data-action="edit"]');
     $edit.click();
-    await tick(20);
+    await waitFor(
+      () => $editModalContainer.querySelectorAll('.icon-option').length > 0,
+    );
 
     // Click a different emoji icon (e.g., the wizard 🧙)
     const $icons = $editModalContainer.querySelectorAll('.icon-option');
     t.true($icons.length > 0, 'icon options rendered');
     // Click the first icon option (🧙)
     $icons[0].click();
+    // Let the icon-selection state update flush before submitting; the selected
+    // icon is reflected in the store call we assert on below.
     await tick(10);
 
     // Submit the form
     const $form = $editModalContainer.querySelector('.add-space-form');
     t.truthy($form, 'form exists');
     $form.dispatchEvent(new Event('submit', { bubbles: true }));
-    await tick(50);
+    await waitFor(() =>
+      calls.some(
+        c =>
+          c.method === 'storeValue' &&
+          c.args[1][0] === 'spaces' &&
+          c.args[1][1] === '0',
+      ),
+    );
 
     // Check that storeValue was called with ['spaces', '1']
     const storeCalls = calls.filter(c => c.method === 'storeValue');
@@ -424,7 +470,7 @@ test.serial(
 
     const $edit = $container.querySelector('[data-action="edit"]');
     $edit.click();
-    await tick(20);
+    await waitFor(() => !!$editModalContainer.querySelector('.add-space-form'));
 
     // The edit form renders in its own container, untouched by the add-space
     // modal's innerHTML write.

--- a/packages/chat/test/component/spaces-gutter-home.test.js
+++ b/packages/chat/test/component/spaces-gutter-home.test.js
@@ -400,7 +400,14 @@ test.serial(
     t.deepEqual(storedConfig.profilePath, [], 'profilePath is enforced as []');
     t.is(storedConfig.icon, '🧙', 'icon was changed');
 
-    // Verify the rendered home icon updated
+    // The icon repaints only after the store await resolves and re-render runs,
+    // a step after the storeValue call above — poll the rendered icon itself
+    // rather than racing that re-render.
+    await waitFor(
+      () =>
+        $container.querySelector('.space-item.home .space-icon')
+          ?.textContent === '🧙',
+    );
     const $homeIcon = $container.querySelector('.space-item.home .space-icon');
     t.is($homeIcon.textContent, '🧙', 'rendered icon reflects new value');
   },

--- a/packages/chat/test/component/spaces-gutter-home.test.js
+++ b/packages/chat/test/component/spaces-gutter-home.test.js
@@ -7,7 +7,7 @@ import harden from '@endo/harden';
 import { Far } from '@endo/far';
 import { readerFromIterator } from '@endo/exo-stream/reader-from-iterator.js';
 import { makePromiseKit } from '@endo/promise-kit';
-import { createDOM, tick, waitFor } from '../helpers/dom-setup.js';
+import { createDOM, waitFor } from '../helpers/dom-setup.js';
 
 const { document: testDocument } = createDOM();
 

--- a/packages/chat/test/component/token-autocomplete-confined.test.js
+++ b/packages/chat/test/component/token-autocomplete-confined.test.js
@@ -124,8 +124,10 @@ const setup = async (names = ['alice', 'bob', 'charlie']) => {
     powers,
   });
 
-  // Let followNameChanges populate the pet-name list.
-  await waitFor(() => true, { timeout: 50 });
+  // Deliberate settle (not a poll): wait for the async followNameChanges stream
+  // to populate the pet-name list before typing. There is no DOM-observable
+  // signal for it, and the component does not re-filter an already-typed query
+  // when names arrive later, so a typed-then-poll approach would race.
   await tick(50);
 
   $input.focus();

--- a/packages/chat/test/component/token-autocomplete.test.js
+++ b/packages/chat/test/component/token-autocomplete.test.js
@@ -6,7 +6,12 @@ import test from 'ava';
 import { E } from '@endo/far';
 import { iterateReader } from '@endo/exo-stream/iterate-reader.js';
 import { makeMockPowers } from '../helpers/mock-powers.js';
-import { createDOM, createInputElements, tick } from '../helpers/dom-setup.js';
+import {
+  createDOM,
+  createInputElements,
+  tick,
+  waitFor,
+} from '../helpers/dom-setup.js';
 import { tokenAutocompleteComponent } from '../../token-autocomplete.js';
 
 const { document: testDocument, window: testWindow } = createDOM();
@@ -106,7 +111,9 @@ const setup = async (names = ['alice', 'bob', 'charlie']) => {
     powers,
   });
 
-  // Let followNameChanges populate the pet names list
+  // Let followNameChanges populate the pet names list. Kept as a fixed tick:
+  // the populated list has no observable signal until a token is typed, so there
+  // is nothing to poll for at setup time.
   await tick(50);
 
   // Focus and set initial cursor
@@ -128,7 +135,7 @@ const setup = async (names = ['alice', 'bob', 'charlie']) => {
 test.serial('typing @ opens autocomplete menu', async t => {
   const { $input, $menu } = await setup();
   typeInto($input, '@');
-  await tick(10);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length === 3);
 
   t.true($menu.classList.contains('visible'), 'menu should be visible');
   const items = $menu.querySelectorAll('.token-menu-item');
@@ -138,12 +145,12 @@ test.serial('typing @ opens autocomplete menu', async t => {
 test.serial('Escape closes menu and leaves literal @', async t => {
   const { $input, $menu } = await setup();
   typeInto($input, '@');
-  await tick(10);
+  await waitFor(() => $menu.classList.contains('visible'));
 
   t.true($menu.classList.contains('visible'), 'menu opens');
 
   press($input, 'Escape');
-  await tick(10);
+  await waitFor(() => !$menu.classList.contains('visible'));
 
   t.false($menu.classList.contains('visible'), 'menu closes');
   // The literal @ should remain in the input
@@ -159,7 +166,9 @@ test.serial(
 
     // Type @ to open menu
     typeInto($input, '@');
-    await tick(10);
+    await waitFor(
+      () => $menu.querySelectorAll('.token-menu-item').length === 4,
+    );
 
     t.true($menu.classList.contains('visible'), 'menu visible after first @');
     let items = $menu.querySelectorAll('.token-menu-item');
@@ -167,7 +176,9 @@ test.serial(
 
     // Type second @ — should filter to @-prefixed names
     typeInto($input, '@');
-    await tick(10);
+    await waitFor(
+      () => $menu.querySelectorAll('.token-menu-item').length === 2,
+    );
 
     t.true(
       $menu.classList.contains('visible'),
@@ -195,7 +206,7 @@ test.serial('typing @@s filters to special names matching @s', async t => {
   typeInto($input, '@');
   typeInto($input, '@');
   typeInto($input, 's');
-  await tick(10);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length === 1);
 
   t.true($menu.classList.contains('visible'), 'menu visible');
   const items = $menu.querySelectorAll('.token-menu-item');
@@ -210,7 +221,7 @@ test.serial('@-prefixed names match when typed without @@', async t => {
   typeInto($input, '@');
   typeInto($input, 's');
   typeInto($input, 'e');
-  await tick(10);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length === 1);
 
   t.true($menu.classList.contains('visible'), 'menu visible');
   const items = $menu.querySelectorAll('.token-menu-item');
@@ -224,7 +235,7 @@ test.serial('@-prefixed names do not get double @ prefix in menu', async t => {
   const { $input, $menu } = await setup(['@self', 'alice']);
 
   typeInto($input, '@');
-  await tick(10);
+  await waitFor(() => $menu.querySelectorAll('.token-menu-item').length === 2);
 
   const items = $menu.querySelectorAll('.token-menu-item');
   t.is(items.length, 2, 'both names shown');

--- a/packages/chat/test/component/whylip.test.js
+++ b/packages/chat/test/component/whylip.test.js
@@ -75,7 +75,7 @@ test.serial('whylip panels render through the confined tree', async t => {
 
   // Teardown unmounts the confined tree AND removes the mount node.
   cleanup();
-  await tick(20);
+  await waitFor(() => $parent.querySelector('.whylip-layout') === null);
   t.is(
     $parent.querySelector('.whylip-layout'),
     null,


### PR DESCRIPTION
## Why

The Preact rewrite of Chat introduced an intermittent CI failure in `packages/chat/test/component/forum.test.js`. Across identical runs it surfaced two ways: the `a root message renders as a forum node` / dispose assertions failing, and the run reporting **"N uncaught exceptions"**.

Root cause was a **teardown leak**, not a fixed-tick render race (the forum assertions already poll with `waitFor`):

- The test's detached `.catch(err => { throw err })` **re-threw** the consumer-loop rejection, turning it into an *unhandled* rejection that AVA attributes to whichever test happens to be running — hence the random, cross-test "uncaught exceptions".
- The mounted component was **never disposed**, so its parked `for await` loop, its reader prefetch, and the initial-batch `setTimeout` leaked across tests and could fire against a torn-down DOM.

## What

**forum de-flake**
- `forum.test.js`: stop re-throwing in the detached `.catch` (it only logs; tests assert on observable DOM/spy state); dispose every mounted component in `afterEach` before the shared DOM is cleared, letting the iterator's `return()` settle first.
- `forum-component.js`: harden `dispose()` to cancel the pending batch timer, with a `disposed` guard in the batch-render callbacks so an already-queued timer cannot render post-dispose.

**fixed-tick sweep** (follow-up commits)
- Continue moving the component tests off fixed `await tick(ms)` waits — which race the async confined render on a loaded runner — toward `waitFor(predicate)` polling of the actual asserted condition. Deliberate timing gaps (race simulations, microtask flushes) are kept.

## Verification

- 6× stress runs of `forum.test.js` — clean, zero uncaught exceptions.
- Full chat suite green.
- ESLint 0 errors; tsc unchanged vs. baseline; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BggjhfWE5KxPAZ5XxBkWQU)_