### PR TITLE
fix(eslint): make ignore set independent of working directory

### DIFF
--- a/packages/base64/.eslintignore
+++ b/packages/base64/.eslintignore
@@ -1,2 +1,0 @@
-dist
-types

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -64,6 +64,10 @@
   "eslintConfig": {
     "extends": [
       "plugin:@endo/internal"
+    ],
+    "ignorePatterns": [
+      "dist",
+      "types"
     ]
   },
   "ava": {

--- a/packages/captp/.eslintignore
+++ b/packages/captp/.eslintignore
@@ -1,2 +1,0 @@
-/dist/
-/scripts/

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -78,6 +78,10 @@
   "eslintConfig": {
     "extends": [
       "plugin:@endo/internal"
+    ],
+    "ignorePatterns": [
+      "/dist/",
+      "/scripts/"
     ]
   },
   "typeCoverage": {

--- a/packages/eslint-plugin/lib/configs/internal.js
+++ b/packages/eslint-plugin/lib/configs/internal.js
@@ -85,16 +85,44 @@ module.exports = {
     },
     ...dynamicConfig.overrides,
   ],
+  // Ignore patterns that must apply to package sources belong here, in the
+  // shared config, rather than in a `.eslintignore` file. ESLint only loads
+  // the `.eslintignore` adjacent to its working directory, so a root
+  // `.eslintignore` is honored when CI runs `eslint .` from the repo root but
+  // is invisible when a contributor runs `yarn lint` inside a single package
+  // (and a per-package `.eslintignore` is the reverse: honored locally,
+  // ignored by the root run). That split makes local lint pass while CI fails,
+  // or vice-versa. Config `ignorePatterns` are resolved per-file regardless of
+  // the working directory, so root and single-package lint runs agree on the
+  // ignore set. `**/`-prefixed globs keep matching independent of the directory
+  // ESLint is invoked from.
+  //
+  // The repo-root `.eslintignore` is still required for paths that live outside
+  // any package (e.g. `rust/`, `api-docs/`, `browser-test/`): the root
+  // package.json sets `root: true` with no `extends`, so files there never see
+  // this config. Keep the two lists in agreement for those root-level paths.
   ignorePatterns: [
     '**/output/**',
-    'bundles/**',
-    'coverage/**',
-    'dist/**',
+    '**/bundles/**',
+    '**/coverage/**',
+    '**/build/**',
+    '**/dist/**',
+    '**/api-docs/**',
+    '**/browser-test/**',
+    '**/*.json',
     '**/*.d.ts*',
     '**/*.d.cts*',
     '**/*.d.mts*',
-    'tmp/**',
-    'test262/**',
+    // `*.types.d.*` files are hand-authored and must stay linted; re-include
+    // them after the broad `*.d.*` ignore above.
+    '!**/*.types.d.ts',
+    '!**/*.types.d.cts',
+    '!**/*.types.d.mts',
+    // `*.types.js` confuses typescript-eslint; ignore until the eslint/tseslint
+    // upgrade that fixes it.
+    '**/*.types.js',
+    '**/tmp/**',
+    '**/test262/**',
     'ava*.config.js',
   ],
 };

--- a/packages/eventual-send/.eslintignore
+++ b/packages/eventual-send/.eslintignore
@@ -1,5 +1,0 @@
-# dist
-dist
-node_modules
-.git
-.cache

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -62,6 +62,12 @@
   "eslintConfig": {
     "extends": [
       "plugin:@endo/internal"
+    ],
+    "ignorePatterns": [
+      "dist",
+      "node_modules",
+      ".git",
+      ".cache"
     ]
   },
   "publishConfig": {

--- a/packages/marshal/.eslintignore
+++ b/packages/marshal/.eslintignore
@@ -1,2 +1,0 @@
-/dist
-/src/bundles/

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -81,6 +81,10 @@
   "eslintConfig": {
     "extends": [
       "plugin:@endo/internal"
+    ],
+    "ignorePatterns": [
+      "/dist",
+      "/src/bundles/"
     ]
   },
   "publishConfig": {

--- a/packages/module-source/.eslintignore
+++ b/packages/module-source/.eslintignore
@@ -1,2 +1,0 @@
-fixtures
-src/external.types.js

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -113,7 +113,8 @@
       }
     ],
     "ignorePatterns": [
-      "test/fixtures/"
+      "test/fixtures/",
+      "src/external.types.js"
     ]
   },
   "sesAvaConfigs": {

--- a/packages/nat/.eslintignore
+++ b/packages/nat/.eslintignore
@@ -1,2 +1,0 @@
-/dist
-/integration-test

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -69,6 +69,10 @@
   "eslintConfig": {
     "extends": [
       "plugin:@endo/internal"
+    ],
+    "ignorePatterns": [
+      "/dist",
+      "/integration-test"
     ]
   }
 }

--- a/packages/pass-style/.eslintignore
+++ b/packages/pass-style/.eslintignore
@@ -1,2 +1,0 @@
-# typescript-eslint errors on this because it has no typecheck information, because tsc produced it for the `types.d.ts` instead
-/src/types.js

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -74,6 +74,9 @@
   "eslintConfig": {
     "extends": [
       "plugin:@endo/internal"
+    ],
+    "ignorePatterns": [
+      "/src/types.js"
     ]
   },
   "sesAvaConfigs": {


### PR DESCRIPTION
## Problem

Global (CI) lint and single-package lint disagreed on which files to lint, so a change could pass `yarn lint` inside a package yet fail CI (or vice-versa).

The cause: ESLint v8 (`.eslintrc` mode) loads **only the `.eslintignore` next to its working directory** — it does not merge ignore files up the tree the way it merges configs. The repo had ignore patterns split across:

- a **root** `.eslintignore`, honored only when CI runs `eslint .` from the repo root, and
- **per-package** `.eslintignore` files (`nat`, `base64`, `eventual-send`, `captp`, `pass-style`, `marshal`, `module-source`), honored only when running `eslint` from inside that package.

So the two runs ignored different file sets. Demonstrated with `eslint.isPathIgnored`:

```
packages/pass-style/src/types.js
  from repo root (CI):  ignored = false  → CI lints it
  from inside package:  ignored = true   → local lint skips it
```

That is exactly the **local pass / CI fail** symptom (driven by per-package `.eslintignore`), with the mirror case (**local fail / CI pass**) coming from the root file's package-agnostic patterns not applying to single-package runs.

## Fix

Move ignore configuration into ESLint `ignorePatterns`, which **is** resolved per-file regardless of the working directory, so root and single-package runs agree:

- Convert every per-package `.eslintignore` into `ignorePatterns` on that package's `eslintConfig` and delete the files. (`module-source` already used `ignorePatterns`; its `.eslintignore` entries are folded in.)
- Mirror the package-agnostic root patterns (`build`, `api-docs`, `browser-test`, `*.json`, `*.types.js`, and the `*.types.d.*` re-includes) into the shared `@endo/internal` config using `**/`-prefixed globs so they match from any cwd.
- Keep the root `.eslintignore` for paths **outside** any package (`rust/`, `api-docs/`, `browser-test/`), which never see the shared config because the root `package.json` is `root: true` with no `extends`.

## Verification

- Automated sweep comparing `isPathIgnored` from the repo root vs. each package's own cwd across all 7 changed packages + `daemon`: **0 mismatches**.
- Edge cases match current CI behavior: `*.types.d.ts` stays linted, `*.types.js` stays ignored, regular sources stay linted, daemon `.d.ts` stays ignored.
- Real `eslint` on `base64` from both root and package cwd → identical output (0 errors, 2 pre-existing warnings). Changed files pass prettier and `node --check`.

> Note: `pass-style`'s `.eslintignore` carried an explanatory comment that JSON can't preserve; its rationale now lives in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013GyUURj2Nh5XZPLhCfAmJ8)_