### PR TITLE
feat(agentry): @endo/agentry execute-only code-mode runtime + git loop

### DIFF
--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -21,9 +21,17 @@
       "types": "./types-index.d.ts",
       "default": "./types-index.js"
     },
+    "./pi": {
+      "types": "./pi.d.ts",
+      "default": "./src/pi.js"
+    },
     "./tool.js": {
       "types": "./tool.d.ts",
       "default": "./src/tool.js"
+    },
+    "./src/pi.js": {
+      "types": "./src/pi.d.ts",
+      "default": "./src/pi.js"
     },
     "./git-tool.js": {
       "types": "./git-tool.d.ts",
@@ -77,6 +85,8 @@
     "@endo/platform": "workspace:^"
   },
   "devDependencies": {
+    "@earendil-works/pi-agent-core": "^0.79.0",
+    "@earendil-works/pi-ai": "^0.79.0",
     "@endo/daemon": "workspace:^",
     "@endo/git": "workspace:^",
     "@endo/init": "workspace:^",
@@ -85,6 +95,18 @@
     "c8": "catalog:dev",
     "eslint": "catalog:dev",
     "typescript": "catalog:dev"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": "^0.79.0",
+    "@earendil-works/pi-ai": "^0.79.0"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-agent-core": {
+      "optional": true
+    },
+    "@earendil-works/pi-ai": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "extends": [

--- a/packages/agent-tools/pi.d.ts
+++ b/packages/agent-tools/pi.d.ts
@@ -1,0 +1,1 @@
+export { toPiAgentTool } from './src/pi.js';

--- a/packages/agent-tools/src/pi.d.ts
+++ b/packages/agent-tools/src/pi.d.ts
@@ -1,0 +1,8 @@
+import type { Tool } from '@earendil-works/pi-ai';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import type { ToolRecord } from './types.js';
+
+export declare const toPiAgentTool: (
+  tool: ToolRecord,
+  options?: { renderToolResult?: (result: unknown) => string },
+) => AgentTool<Tool['parameters']>;

--- a/packages/agent-tools/src/pi.js
+++ b/packages/agent-tools/src/pi.js
@@ -1,0 +1,58 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { Tool } from '@earendil-works/pi-ai' */
+/** @import { AgentTool, AgentToolResult } from '@earendil-works/pi-agent-core' */
+/** @import { ToolRecord } from './types.js' */
+
+/**
+ * Default tool-result renderer: plain strings pass through unchanged; every
+ * other value is `JSON.stringify`-ed. Marshalling-aware callers (e.g.
+ * `@endo/agentry`, which speaks SmallCaps) inject their own renderer through
+ * the `renderToolResult` option so this package carries no marshalling
+ * dependency.
+ *
+ * @param {unknown} result
+ * @returns {string}
+ */
+const defaultRenderToolResult = result =>
+  typeof result === 'string' ? result : JSON.stringify(result);
+
+/**
+ * Bridge a provider-independent {@link ToolRecord} into a pi-agent-core
+ * {@link AgentTool}. The model-facing surface (`name`, `description`,
+ * `parameters`) is copied verbatim; the bridge `invoke`s the record and renders
+ * its completion value to the text the model reads, retaining the raw value as
+ * the tool result's structured `details`.
+ *
+ * The text rendering is injected, not built in: pass `renderToolResult` to
+ * encode results in whatever wire format the caller's transcript expects (the
+ * default is plain-string-passthrough plus `JSON.stringify`). This keeps
+ * `@endo/agent-tools` free of any marshalling dependency while letting a
+ * SmallCaps-speaking caller round-trip BigInts and sigil-prefixed strings.
+ *
+ * @param {ToolRecord} tool
+ * @param {{ renderToolResult?: (result: unknown) => string }} [options]
+ * @returns {AgentTool<Tool['parameters']>}
+ */
+export const toPiAgentTool = (tool, options = {}) => {
+  const { renderToolResult = defaultRenderToolResult } = options;
+  return harden({
+    name: tool.name,
+    label: tool.name,
+    description: tool.description,
+    parameters: /** @type {Tool['parameters']} */ (tool.parameters),
+    execute: async (_toolCallId, params, _signal, _onUpdate) => {
+      const result = await tool.invoke(
+        /** @type {Record<string, unknown>} */ (params ?? {}),
+      );
+      /** @type {AgentToolResult<unknown>} */
+      const toolResult = {
+        content: [{ type: 'text', text: renderToolResult(result) }],
+        details: result,
+      };
+      return toolResult;
+    },
+  });
+};
+harden(toPiAgentTool);

--- a/packages/agent-tools/test/pi.test.js
+++ b/packages/agent-tools/test/pi.test.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+// Establish a SES perimeter (provides the `harden` global).
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+import test from 'ava';
+
+import { makeTool } from '../src/tool.js';
+import { toPiAgentTool } from '../src/pi.js';
+
+/**
+ * @param {unknown} result
+ * @returns {import('../src/types.js').ToolRecord}
+ */
+const toolReturning = result =>
+  makeTool({
+    name: 'echo',
+    description: 'Echo a fixed result.',
+    parameters: harden({
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    }),
+    execute: async () => result,
+  });
+
+test('toPiAgentTool copies the model-facing surface verbatim', t => {
+  const tool = toolReturning('ok');
+  const agentTool = toPiAgentTool(tool);
+  t.is(agentTool.name, 'echo');
+  t.is(agentTool.label, 'echo');
+  t.is(agentTool.description, 'Echo a fixed result.');
+  t.is(agentTool.parameters, tool.parameters);
+});
+
+test('default render passes strings through and JSON-stringifies the rest', async t => {
+  const stringTool = toPiAgentTool(toolReturning('plain text'));
+  const stringResult = await stringTool.execute('id-1', {});
+  t.deepEqual(stringResult.content, [{ type: 'text', text: 'plain text' }]);
+  t.is(stringResult.details, 'plain text');
+
+  const objectTool = toPiAgentTool(toolReturning(harden({ a: 1 })));
+  const objectResult = await objectTool.execute('id-2', {});
+  t.deepEqual(objectResult.content, [{ type: 'text', text: '{"a":1}' }]);
+});
+
+test('the renderToolResult hook controls the rendered text', async t => {
+  const seen = [];
+  const tool = toPiAgentTool(toolReturning(harden({ value: 42 })), {
+    renderToolResult: result => {
+      seen.push(result);
+      return 'RENDERED';
+    },
+  });
+  const result = await tool.execute('id-3', {});
+  t.deepEqual(result.content, [{ type: 'text', text: 'RENDERED' }]);
+  // The raw value is retained as structured details for non-text consumers.
+  t.deepEqual(result.details, { value: 42 });
+  t.deepEqual(seen, [{ value: 42 }]);
+});

--- a/packages/agent-tools/tsconfig.json
+++ b/packages/agent-tools/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.eslint-base.json",
   "compilerOptions": {
     "allowJs": false,
-    "checkJs": false
+    "checkJs": false,
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts"

--- a/packages/agentry/LICENSE
+++ b/packages/agentry/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Endo Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/agentry/README.md
+++ b/packages/agentry/README.md
@@ -1,0 +1,105 @@
+# @endo/agentry
+
+Shared infrastructure for building agentic harnesses across endo packages.
+
+The package is intended to grow as a small library of capabilities that more
+than one agent harness in the monorepo needs.
+Each surface is opt-in via its own subpath export.
+
+## Current surfaces
+
+- `@endo/agentry` (root) — `defineAgent` plus the harness primitives
+  (marshalling, the credential seam, model resolution, and the pi-agent
+  builder).
+- `@endo/agentry/define-agent` — `defineAgent(config)`, which returns a maker
+  function: the powerless definition is the closure, and calling the returned
+  maker with a powers handle is the powered stage.
+- `@endo/agentry/harness` — the code-mode-independent primitives the harness is
+  built from: `toolResultToSmallcaps` + the SmallCaps codec, `makeEnvCredentials`
+  (the single reader of `process.env`), `resolveModel`/`defineModels`, and
+  `makePiAgent`. `@endo/lal` imports these directly.
+- `@endo/agentry/execute` — the execute-only code-mode tool and its presets
+  (`makeCodeModeAgent`, `makeCodeModeGitLoopAgent`), built on `defineAgent`.
+
+## defineAgent
+
+`defineAgent(config)` returns a **maker function**. The powerless definition —
+the resolved model, the system instructions, and the model-facing tool surface —
+is captured in the maker's closure and holds no powers. Calling the maker with a
+powers handle is the powered stage:
+
+```js
+import { defineAgent } from '@endo/agentry';
+
+const makeAgent = defineAgent({
+  model: 'sonnet', // a profile id, or a concrete pi-ai Model
+  instructions: 'You are a helpful agent.',
+  tools: [/* model-facing AgentTools */],
+});
+
+const agent = makeAgent(/* powers? */);
+await agent.prompt('Hello.');
+await agent.waitForIdle();
+```
+
+Config is scoped to `{ model, instructions, tools, endow }`. The `endow` hook
+derives the powered tool surface and credential resolver from the live powers at
+construction time, so the powerless definition never holds a capability.
+Importing `@endo/agentry/harness` performs **no** provider registration as a
+side effect; instead the harness registers pi-ai's built-in providers lazily, on
+first model resolution, so a registry model resolves without any caller-side
+setup:
+
+```js
+import { defineAgent } from '@endo/agentry';
+
+const makeAgent = defineAgent({
+  model: 'anthropic/claude-opus-4-5-20251101',
+});
+```
+
+`actions`/`skills`/`cwd` are deferred.
+
+## Credential seam
+
+`@endo/agentry/harness` exports `makeEnvCredentials`, the harness's single choke
+point for reading secrets. `get(name)` resolves a key out of the ambient process
+environment (the default) or a caller-supplied record. Every consumer resolves
+secrets through `.get()`, so swapping the env-backed provider for a
+capability-scoped secret store is a local change.
+
+## Code mode
+
+Code mode is just an agent whose one tool is `execute`. `makeCodeModeAgent` is
+the code-mode preset of `defineAgent`:
+
+```js
+import { makeCodeModeAgent } from '@endo/agentry/execute';
+
+const { agent } = makeCodeModeAgent({
+  model,
+  powers: { workspace, git, gitMode: 'readOnly' }, // or 'readWrite'
+});
+await agent.prompt('Inspect the current branch.');
+await agent.waitForIdle();
+```
+
+The model-facing tool surface is intentionally one tool:
+`execute({ source, resultName? })`. Workspace and Git operations happen inside
+the Endo Compartment through lexical caps (`workspace`, `git`, and any
+configured named powers). The lexical globals are advertised to the model by
+name and a one-line description only — the model discovers a capability's method
+surface at runtime via `E(cap).__getMethodNames__()` rather than reading a
+checked-in type declaration.
+
+Plain-data completion values returned from `execute` are encoded for the model
+with the SmallCaps marshaller (`@endo/marshal`), so BigInts and other
+non-JSON-native passable values round-trip losslessly. Capability-bearing
+results are not serialized; the agent keeps them live inside the Compartment and
+stores them under a pet name via `resultName` when it needs them across turns.
+
+## Status
+
+This package is private to the endo monorepo. The API is best-effort stable but
+pre-1.0 — breaking changes in this package can land in the same PR as their
+workspace consumers.

--- a/packages/agentry/SECURITY.md
+++ b/packages/agentry/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+The SES package and associated Endo packages are still undergoing development and security review, and all
+users are encouraged to use the latest version available. Security fixes will
+be made for the most recent branch only.
+
+## Coordinated Vulnerability Disclosure of Security Bugs
+
+SES stands for fearless cooperation, and strong security requires strong collaboration with security researchers. If you believe that you have found a security sensitive bug that should not be disclosed until a fix has been made available, we encourage you to report it. To report a bug in HardenedJS, you have several options that include:
+
+* Reporting the issue to the [Agoric HackerOne vulnerability rewards program](https://hackerone.com/agoric).
+
+* Sending an email to security at (@) agoric.com., encrypted or unencrypted. To encrypt, please use  @Warner’s personal GPG key  [A476E2E6 11880C98 5B3C3A39 0386E81B 11CAA07A](http://www.lothar.com/warner-gpg.html)  .
+
+* Sending a message on Keybase to `@agoric_security`, or sharing code and other log files via Keybase’s encrypted file system. ((_keybase_private/agoric_security,$YOURNAME).
+
+* It is important to be able to provide steps that reproduce the issue and demonstrate its impact with a Proof of Concept example in an initial bug report. Before reporting a bug, a reporter may want to have another trusted individual reproduce the issue.
+
+* A bug reporter can expect acknowledgment of a potential vulnerability reported through  [security@agoric.com](mailto:security@agoric.com)  within one business day of submitting a report. If an acknowledgement of an issue is not received within this time frame, especially during a weekend or holiday period, please reach out again. Any issues reported to the HackerOne program will be acknowledged within the time frames posted on the program page.
+	* The bug triage team and Agoric code maintainers are primarily located in the San Francisco Bay Area with business hours in  [Pacific Time](https://www.timeanddate.com/worldclock/usa/san-francisco) .
+
+* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public GitHub issues during the coordination process.
+
+* Once a vulnerability report has been received and triaged:
+	* Agoric code maintainers will confirm whether it is valid, and will provide updates to the reporter on validity of the report.
+	* It may take up to 72 hours for an issue to be validated, especially if reported during holidays or on weekends.
+
+* When the Agoric team has verified an issue, remediation steps and patch release timeline information will be shared with the reporter.
+	* Complexity, severity, impact, and likelihood of exploitation are all vital factors that determine the amount of time required to remediate an issue and distribute a software patch.
+	* If an issue is Critical or High Severity, Agoric code maintainers will release a security advisory to notify impacted parties to prepare for an emergency patch.
+	* While the current industry standard for vulnerability coordination resolution is 90 days, Agoric code maintainers will strive to release a patch as quickly as possible.
+
+When a bug patch is included in a software release, the Agoric code maintainers will:
+	* Confirm the version and date of the software release with the reporter.
+	* Provide information about the security issue that the software release resolves.
+	* Credit the bug reporter for discovery by adding thanks in release notes, securing a CVE designation, or adding the researcher’s name to a Hall of Fame.

--- a/packages/agentry/package.json
+++ b/packages/agentry/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@endo/agentry",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared infrastructure for building agentic harnesses across endo packages",
+  "keywords": [],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/agentry#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/agentry"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.js",
+      "default": "./src/index.js"
+    },
+    "./harness": {
+      "types": "./src/harness/index.js",
+      "default": "./src/harness/index.js"
+    },
+    "./define-agent": {
+      "types": "./src/define-agent.js",
+      "default": "./src/define-agent.js"
+    },
+    "./execute": {
+      "types": "./src/execute/index.js",
+      "default": "./src/execute/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
+    "lint:eslint": "eslint '**/*.js'",
+    "lint:types": "tsc",
+    "prepack": "exit 0",
+    "test": "ava"
+  },
+  "dependencies": {
+    "@earendil-works/pi-agent-core": "^0.79.0",
+    "@earendil-works/pi-ai": "^0.79.0",
+    "@endo/agent-tools": "workspace:^",
+    "@endo/exo-git": "workspace:^",
+    "@endo/far": "workspace:^",
+    "@endo/marshal": "workspace:^",
+    "@endo/pass-style": "workspace:^"
+  },
+  "devDependencies": {
+    "@endo/daemon": "workspace:^",
+    "@endo/exo-stream": "workspace:^",
+    "@endo/git": "workspace:^",
+    "@endo/init": "workspace:^",
+    "@endo/lockdown": "workspace:^",
+    "@endo/platform": "workspace:^",
+    "@endo/ses-ava": "workspace:^",
+    "ava": "catalog:dev",
+    "eslint": "catalog:dev",
+    "typescript": "catalog:dev"
+  },
+  "files": [
+    "./*.d.ts",
+    "./*.js",
+    "./*.map",
+    "LICENSE*",
+    "SECURITY*",
+    "src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "plugin:@endo/internal"
+    ]
+  },
+  "ava": {
+    "files": [
+      "test/**/*.test.*"
+    ],
+    "timeout": "2m"
+  }
+}

--- a/packages/agentry/src/define-agent.js
+++ b/packages/agentry/src/define-agent.js
@@ -3,10 +3,10 @@
 
 /** @import { Message, Model } from '@earendil-works/pi-ai' */
 /** @import { Agent, AgentMessage, AgentTool, StreamFn } from '@earendil-works/pi-agent-core' */
-/** @import { Credentials } from './harness/credentials.js' */
+/** @import { Credentials, GetApiKey } from './harness/credentials.js' */
 /** @import { ThinkingLevel } from './harness/model.js' */
 
-import { makeEnvCredentials } from './harness/credentials.js';
+import { makeApiKeyGetter, makeEnvCredentials } from './harness/credentials.js';
 import { resolveModelProfile } from './harness/model.js';
 import { makePiAgent } from './harness/pi-agent.js';
 
@@ -31,7 +31,7 @@ import { makePiAgent } from './harness/pi-agent.js';
  * @property {AgentMessage[]} [messages]
  * @property {StreamFn} [streamFn]
  * @property {(messages: AgentMessage[]) => Message[] | Promise<Message[]>} [convertToLlm]
- * @property {(provider: string) => Promise<string | undefined> | string | undefined} [getApiKey]
+ * @property {GetApiKey} [getApiKey]
  * @property {ThinkingLevel} [thinkingLevel]
  *
  * @typedef {(options?: AgentMakeOptions) => Agent} AgentMaker A maker function:
@@ -44,7 +44,7 @@ import { makePiAgent } from './harness/pi-agent.js';
  *   string resolved via the harness (`'sonnet'`, `'anthropic/claude-...'`).
  * @property {string} [instructions] The system prompt.
  * @property {AgentTool<any>[]} [tools] The powerless model-facing tool surface.
- * @property {(definition: AgentDefinition, options: AgentMakeOptions) => { tools?: AgentTool<any>[], getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined }} [endow]
+ * @property {(definition: AgentDefinition, options: AgentMakeOptions) => { tools?: AgentTool<any>[], getApiKey?: GetApiKey }} [endow]
  *   A hook the maker calls at construction time to derive the powered tool
  *   surface and credential resolver from the live powers. This is the seam
  *   where a powerless definition is endowed with powers without the powerless
@@ -90,6 +90,25 @@ const resolveConfiguredModel = model => {
 };
 
 /**
+ * Derive a pi-agent-core `getApiKey` hook from a `Credentials` seam. Resolves
+ * `<PROVIDER>_API_KEY` through the seam; for a local-Ollama model it falls back
+ * to the harmless `'ollama'` sentinel pi-ai's openai-completions adaptor
+ * accepts in lieu of a real key (a local-Ollama model masquerades as the
+ * `'openai'` provider, so no real `OPENAI_API_KEY` is expected for it).
+ *
+ * @param {Credentials} credentials
+ * @param {boolean} localOllama
+ * @returns {GetApiKey}
+ */
+const deriveCredentialApiKeyGetter = (credentials, localOllama) => {
+  const getApiKey = makeApiKeyGetter(credentials);
+  if (!localOllama) {
+    return getApiKey;
+  }
+  return provider => getApiKey(provider) ?? 'ollama';
+};
+
+/**
  * Define an agent from configuration alone, returning a **maker function**. The
  * definition (resolved model, instructions, powerless tool surface) is captured
  * in the maker's closure and holds no powers; calling the returned maker with a
@@ -126,7 +145,20 @@ export const defineAgent = (config = {}) => {
     const endowments = endow ? endow(definition, options) : {};
     const builtTools =
       options.tools || endowments.tools || definition.toolSchemas;
-    const getApiKey = options.getApiKey || endowments.getApiKey;
+    // getApiKey precedence: an explicit caller hook wins, then the endow hook's,
+    // then one derived from the supplied (or code-mode default) `credentials`
+    // seam. Without this last fallback a caller that wires only `credentials`
+    // (the advertised seam) would build an agent with no key resolver, and the
+    // default local-Ollama path would throw 'No API key for provider: openai'
+    // because pi-ai's openai-completions adaptor rejects a missing key.
+    const credentialsGetApiKey = options.credentials
+      ? deriveCredentialApiKeyGetter(
+          options.credentials,
+          definition.localOllama,
+        )
+      : undefined;
+    const getApiKey =
+      options.getApiKey || endowments.getApiKey || credentialsGetApiKey;
     return makePiAgent({
       model: definition.model,
       tools: builtTools,

--- a/packages/agentry/src/define-agent.js
+++ b/packages/agentry/src/define-agent.js
@@ -1,0 +1,145 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { Message, Model } from '@earendil-works/pi-ai' */
+/** @import { Agent, AgentMessage, AgentTool, StreamFn } from '@earendil-works/pi-agent-core' */
+/** @import { Credentials } from './harness/credentials.js' */
+/** @import { ThinkingLevel } from './harness/model.js' */
+
+import { makeEnvCredentials } from './harness/credentials.js';
+import { resolveModelProfile } from './harness/model.js';
+import { makePiAgent } from './harness/pi-agent.js';
+
+/**
+ * @typedef {object} AgentDefinition The powerless first stage. Everything
+ *   derivable from configuration alone — the resolved model, the system
+ *   instructions, and the model-facing tool surface — with no powers in hand.
+ * @property {Model<string>} model
+ * @property {boolean} localOllama
+ * @property {string} instructions
+ * @property {AgentTool<any>[]} toolSchemas The model-facing tool surface,
+ *   built from powerless placeholders so a definition can advertise its tools
+ *   before any power is granted.
+ *
+ * @typedef {object} AgentMakeOptions The powered second-stage inputs: the live
+ *   powers handle plus per-construction wiring that only matters once an agent
+ *   is actually built.
+ * @property {unknown} [powers]
+ * @property {Credentials} [credentials]
+ * @property {AgentTool<any>[]} [tools] The powered tool surface (closures bound
+ *   to live powers). Falls back to the definition's powerless `toolSchemas`.
+ * @property {AgentMessage[]} [messages]
+ * @property {StreamFn} [streamFn]
+ * @property {(messages: AgentMessage[]) => Message[] | Promise<Message[]>} [convertToLlm]
+ * @property {(provider: string) => Promise<string | undefined> | string | undefined} [getApiKey]
+ * @property {ThinkingLevel} [thinkingLevel]
+ *
+ * @typedef {(options?: AgentMakeOptions) => Agent} AgentMaker A maker function:
+ *   the powered second stage. Calling it with a powers handle (and optional
+ *   per-construction wiring) builds the live pi-agent-core `Agent`.
+ *
+ * @typedef {object} AgentConfig
+ * @property {Model<string> | string | { provider?: string, model?: string, baseUrl?: string, reasoning?: boolean }} [model]
+ *   A concrete pi-ai `Model`, a model-profile config object, or a bare profile
+ *   string resolved via the harness (`'sonnet'`, `'anthropic/claude-...'`).
+ * @property {string} [instructions] The system prompt.
+ * @property {AgentTool<any>[]} [tools] The powerless model-facing tool surface.
+ * @property {(definition: AgentDefinition, options: AgentMakeOptions) => { tools?: AgentTool<any>[], getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined }} [endow]
+ *   A hook the maker calls at construction time to derive the powered tool
+ *   surface and credential resolver from the live powers. This is the seam
+ *   where a powerless definition is endowed with powers without the powerless
+ *   stage ever holding a capability.
+ */
+
+/**
+ * @param {AgentConfig['model']} model
+ * @returns {{ model: Model<string>, localOllama: boolean }}
+ */
+const resolveConfiguredModel = model => {
+  // A bare string config is the profile-id / "provider/modelId" form the README
+  // documents (`model: 'sonnet'`, `model: 'anthropic/claude-...'`). Route it
+  // through the resolver as the profile's `model` field. Passing the string
+  // straight to `resolveModelProfile` (as the fallthrough below would) reads its
+  // absent `.provider` / `.model` properties as `undefined` and silently falls
+  // back to the default local `ollama/qwen3` profile, dropping the caller's
+  // model choice.
+  if (typeof model === 'string') {
+    return resolveModelProfile({ model });
+  }
+  // NOTE: a concrete pi-ai `Model` is discriminated from a model-profile config
+  // by the presence of all three of `api`, `provider`, and `id`. The
+  // discriminant key is `id` (a concrete `Model` always carries one); the
+  // profile shape declared on `AgentConfig['model']` is
+  // `{ provider?, model?, baseUrl?, reasoning? }` and has no `id`, so the
+  // discriminant is sound for the declared surface. If a future profile-shape
+  // extension adds an `id` key, this duck-type would misread the profile as a
+  // concrete Model — switch to an explicit tag at that point rather than
+  // widening the key set.
+  if (
+    model !== undefined &&
+    typeof model === 'object' &&
+    'api' in model &&
+    'provider' in model &&
+    'id' in model
+  ) {
+    return harden({ model, localOllama: false });
+  }
+  return resolveModelProfile(
+    /** @type {{ provider?: string, model?: string }} */ (model || {}),
+  );
+};
+
+/**
+ * Define an agent from configuration alone, returning a **maker function**. The
+ * definition (resolved model, instructions, powerless tool surface) is captured
+ * in the maker's closure and holds no powers; calling the returned maker with a
+ * powers handle constructs the live agent. The powerless definition is the
+ * closure; the powered stage is calling the returned maker.
+ *
+ * @param {AgentConfig} [config]
+ * @returns {AgentMaker}
+ */
+export const defineAgent = (config = {}) => {
+  const { instructions = '', tools = [], endow } = config;
+  // Model resolution self-registers pi-ai's built-in providers on first use
+  // (see `resolveModelProfile`/`resolveModel`), so a registry model resolves
+  // here without any caller-controlled setup hook.
+  const { model, localOllama } = resolveConfiguredModel(config.model);
+
+  /** @type {AgentDefinition} */
+  const definition = harden({
+    model,
+    localOllama,
+    instructions,
+    toolSchemas: harden([...tools]),
+  });
+
+  /** @type {AgentMaker} */
+  const maker = (options = {}) => {
+    // The endow hook runs on every make, even when `options.tools` is
+    // supplied: the hook contributes BOTH a powered tool surface and a
+    // `getApiKey` credential resolver, and the latter is wanted regardless of
+    // who provides the tools. Tool precedence is then explicit caller tools >
+    // endow tools > powerless `toolSchemas`; when the caller passes `tools`,
+    // `endowments.tools` is intentionally discarded (the hook was still invoked
+    // for its `getApiKey` and for whatever live-power side effect it performs).
+    const endowments = endow ? endow(definition, options) : {};
+    const builtTools =
+      options.tools || endowments.tools || definition.toolSchemas;
+    const getApiKey = options.getApiKey || endowments.getApiKey;
+    return makePiAgent({
+      model: definition.model,
+      tools: builtTools,
+      systemPrompt: definition.instructions,
+      messages: options.messages,
+      streamFn: options.streamFn,
+      convertToLlm: options.convertToLlm,
+      getApiKey,
+      thinkingLevel: options.thinkingLevel,
+    });
+  };
+  return harden(maker);
+};
+harden(defineAgent);
+
+export { makeEnvCredentials };

--- a/packages/agentry/src/execute/compartment.js
+++ b/packages/agentry/src/execute/compartment.js
@@ -1,0 +1,33 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { CodeModeExecute } from './tool.js' */
+
+/**
+ * Build a Compartment-backed execute function. Callers supply every endowment
+ * they want in lexical scope (typically `{ E, workspace, git }` plus stream
+ * helpers). The completion value is returned; when `resultName` is supplied it
+ * is also handed to `storeResult` for out-of-band capability storage.
+ *
+ * @param {object} options
+ * @param {Record<string, unknown>} options.endowments
+ * @param {(value: unknown, resultName: string | string[]) => Promise<void> | void} [options.storeResult]
+ * @returns {CodeModeExecute}
+ */
+export const makeCompartmentExecute = ({ endowments, storeResult }) => {
+  const hardenedEndowments = harden({ ...endowments });
+  return async ({ source, resultName }) => {
+    const compartment = new Compartment(hardenedEndowments);
+    const result = await compartment.evaluate(source);
+    if (resultName !== undefined) {
+      if (storeResult === undefined) {
+        throw new Error(
+          'execute.resultName was supplied but no storeResult callback is configured',
+        );
+      }
+      await storeResult(result, resultName);
+    }
+    return result;
+  };
+};
+harden(makeCompartmentExecute);

--- a/packages/agentry/src/execute/globals.js
+++ b/packages/agentry/src/execute/globals.js
@@ -1,0 +1,99 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { CodeModeGlobal } from './tool.js' */
+
+const IDENTIFIER_RE = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
+
+/**
+ * @param {unknown} value
+ * @returns {value is string | string[]}
+ */
+const isResultName = value =>
+  typeof value === 'string' ||
+  (Array.isArray(value) && value.every(part => typeof part === 'string'));
+
+/**
+ * Normalize a list of code-mode globals: each global must have a JS-identifier
+ * `name`; `petName` defaults to `name`; `description` is carried as-is. Type
+ * declarations are intentionally not part of the prompt surface — the model
+ * introspects a live capability via `E(cap).__getMethodNames__()` rather than
+ * reading a hand-maintained type blob.
+ *
+ * @param {CodeModeGlobal[]} globals
+ * @returns {CodeModeGlobal[]}
+ */
+export const normalizeGlobals = globals =>
+  harden(
+    globals.map(global => {
+      const { name, petName = name, description } = global;
+      if (!IDENTIFIER_RE.test(name)) {
+        throw new Error(
+          `code-mode global name must be a JS identifier: ${name}`,
+        );
+      }
+      if (!isResultName(petName)) {
+        throw new Error(`code-mode global "${name}" has invalid petName`);
+      }
+      return harden({ name, petName, description });
+    }),
+  );
+harden(normalizeGlobals);
+
+/**
+ * Format the lexical globals as a prompt fragment: one `declare const <name>;`
+ * per global, annotated with its one-line description. No type declaration is
+ * emitted — the model discovers a capability's method surface at runtime via
+ * CapTP introspection (`E(name).__getMethodNames__()`).
+ *
+ * @param {CodeModeGlobal[]} globals
+ * @returns {string}
+ */
+export const formatGlobalDeclarations = globals =>
+  globals
+    .map(global => {
+      const description = global.description
+        ? ` // ${global.description.replaceAll('\n', ' ')}`
+        : '';
+      return `declare const ${global.name};${description}`;
+    })
+    .join('\n');
+
+/**
+ * Build the system prompt for the narrow code-mode agent.
+ *
+ * @param {CodeModeGlobal[]} globals
+ * @param {{ preamble?: string }} [options]
+ * @returns {string}
+ */
+export const makeCodeModeSystemPrompt = (globals, options = {}) => {
+  const normalized = normalizeGlobals(globals);
+  const preamble =
+    options.preamble ||
+    'You are codeMode, an Endo code-mode agent. You solve tasks by writing JavaScript and calling the execute tool.';
+  return `${preamble}
+
+You have exactly one tool: execute. Do not call any other tool and do not answer in prose when a tool call can do the work.
+
+The execute tool evaluates JavaScript source in an Endo Compartment. The compartment includes hardened SES globals plus the powers listed below. These powers are already in lexical scope; do not look them up by pet name. Discover a capability's methods at runtime with E(capability).__getMethodNames__().
+
+Use E(capability).method(...) for remotable capabilities. Top-level await is not available, so use an async IIFE when you need multiple awaits or a final awaited result:
+
+\`\`\`js
+(async () => {
+  const value = await E(example).method();
+  return value;
+})()
+\`\`\`
+
+Return the desired value as the source completion value. Use resultName only when the user asks you to store the result for later.
+
+Available powers:
+
+\`\`\`ts
+declare const E;
+${formatGlobalDeclarations(normalized)}
+\`\`\`
+`;
+};
+harden(makeCodeModeSystemPrompt);

--- a/packages/agentry/src/execute/globals.js
+++ b/packages/agentry/src/execute/globals.js
@@ -5,6 +5,13 @@
 
 const IDENTIFIER_RE = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
 
+// `E` is always injected into the code-mode compartment as the eventual-send
+// operator (see `makeCodeModeEndowments` in execute/preset.js and the
+// `declare const E;` line `makeCodeModeSystemPrompt` emits). A global named `E`
+// would collide with it; reject it by name rather than letting the injected `E`
+// silently win at endowment-merge time.
+const RESERVED_GLOBAL_NAMES = harden(['E']);
+
 /**
  * @param {unknown} value
  * @returns {value is string | string[]}
@@ -20,11 +27,21 @@ const isResultName = value =>
  * introspects a live capability via `E(cap).__getMethodNames__()` rather than
  * reading a hand-maintained type blob.
  *
+ * Global names must be unique and must not collide with a reserved binding
+ * (`E`). A duplicate or reserved name is a misconfiguration — the well-known
+ * `workspace` / `git` globals are pushed before `namedPowers` in
+ * `makeCodeModeGlobals`, and the injected `E` is spread first in
+ * `makeCodeModeEndowments`, so a collision would otherwise let the earlier
+ * binding silently win while `formatGlobalDeclarations` emitted a duplicate
+ * `declare const` line into the prompt. Throw instead, so the author learns
+ * their power was shadowed rather than getting a silently powerless binding.
+ *
  * @param {CodeModeGlobal[]} globals
  * @returns {CodeModeGlobal[]}
  */
-export const normalizeGlobals = globals =>
-  harden(
+export const normalizeGlobals = globals => {
+  const seen = new Set();
+  return harden(
     globals.map(global => {
       const { name, petName = name, description } = global;
       if (!IDENTIFIER_RE.test(name)) {
@@ -32,12 +49,22 @@ export const normalizeGlobals = globals =>
           `code-mode global name must be a JS identifier: ${name}`,
         );
       }
+      if (RESERVED_GLOBAL_NAMES.includes(name)) {
+        throw new Error(
+          `code-mode global name "${name}" is reserved and cannot be used`,
+        );
+      }
+      if (seen.has(name)) {
+        throw new Error(`code-mode global name "${name}" is declared twice`);
+      }
+      seen.add(name);
       if (!isResultName(petName)) {
         throw new Error(`code-mode global "${name}" has invalid petName`);
       }
       return harden({ name, petName, description });
     }),
   );
+};
 harden(normalizeGlobals);
 
 /**

--- a/packages/agentry/src/execute/index.js
+++ b/packages/agentry/src/execute/index.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+export { makeExecuteTool, toSmallcapsPiAgentTool } from './tool.js';
+export { makeCompartmentExecute } from './compartment.js';
+export {
+  normalizeGlobals,
+  formatGlobalDeclarations,
+  makeCodeModeSystemPrompt,
+} from './globals.js';
+export { makeCodeModeAgent, makeCodeModeGitLoopAgent } from './preset.js';

--- a/packages/agentry/src/execute/preset.js
+++ b/packages/agentry/src/execute/preset.js
@@ -1,0 +1,285 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { Model } from '@earendil-works/pi-ai' */
+/** @import { Agent, AgentMessage, StreamFn } from '@earendil-works/pi-agent-core' */
+/** @import { Credentials } from '../harness/credentials.js' */
+/** @import { ThinkingLevel } from '../harness/model.js' */
+/** @import { CodeModeExecute, CodeModeGlobal, CodeModePower, PowerHandle, LookupPowers } from './tool.js' */
+
+import { E } from '@endo/far';
+import { isGitReadOnly } from '@endo/exo-git';
+
+import { defineAgent } from '../define-agent.js';
+import { makeEnvCredentials } from '../harness/credentials.js';
+import { makeCompartmentExecute } from './compartment.js';
+import { makeExecuteTool, toSmallcapsPiAgentTool } from './tool.js';
+import { makeCodeModeSystemPrompt, normalizeGlobals } from './globals.js';
+
+const IDENTIFIER_RE = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
+
+/**
+ * @param {string} petName
+ * @param {string} label
+ * @returns {string}
+ */
+const petNameToBindingName = (petName, label) => {
+  if (IDENTIFIER_RE.test(petName)) {
+    return petName;
+  }
+  throw new Error(
+    `code-mode ${label} petName must be a single JS identifier to use as a lexical binding`,
+  );
+};
+
+/**
+ * @param {LookupPowers | undefined} powers
+ * @param {string | string[]} petName
+ * @param {string} label
+ * @returns {Promise<PowerHandle>}
+ */
+const lookupRequiredPower = (powers, petName, label) => {
+  if (powers === undefined || powers === null) {
+    throw new Error(`code-mode ${label} capability requires powers`);
+  }
+  return E(powers).lookup(petName);
+};
+
+/**
+ * @typedef {object} CodeModePowers
+ * @property {CodeModePower} [workspace]
+ * @property {string} [workspacePetName]
+ * @property {CodeModePower} [git]
+ * @property {string} [gitPetName]
+ * @property {'readOnly' | 'readWrite'} [gitMode]
+ * @property {CodeModeGlobal[]} [namedPowers]
+ *
+ * @typedef {object} MakeCodeModeAgentOptions
+ * @property {Model<string>} model
+ * @property {CodeModePowers} [powers]
+ * @property {LookupPowers} [lookupPowers] A live powers handle with
+ *   `lookup(petName)` for resolving capabilities not passed inline.
+ * @property {Credentials} [credentials]
+ * @property {Record<string, unknown>} [endowments]
+ * @property {CodeModeExecute} [execute]
+ * @property {(value: unknown, resultName: string | string[]) => Promise<void> | void} [storeResult]
+ * @property {CodeModeGlobal[]} [globals]
+ * @property {string} [systemPrompt]
+ * @property {string} [preamble]
+ * @property {AgentMessage[]} [messages]
+ * @property {StreamFn} [streamFn]
+ * @property {(provider: string) => Promise<string | undefined> | string | undefined} [getApiKey]
+ * @property {ThinkingLevel} [thinkingLevel]
+ */
+
+/**
+ * Build the lexical globals for a code-mode agent from its configured powers.
+ * Each global carries a name, pet name, and a one-line description; type blobs
+ * are intentionally absent (the model introspects live caps at runtime).
+ *
+ * @param {CodeModePowers} powers
+ * @returns {CodeModeGlobal[]}
+ */
+const makeCodeModeGlobals = (powers = {}) => {
+  /** @type {CodeModeGlobal[]} */
+  const globals = [];
+  if (powers.workspace !== undefined || powers.workspacePetName !== undefined) {
+    const workspacePetName = powers.workspacePetName ?? 'workspace';
+    globals.push({
+      name: petNameToBindingName(workspacePetName, 'workspace'),
+      petName: workspacePetName,
+      description:
+        'Writable @endo/platform/fs/extended Filesystem for the repository.',
+    });
+  }
+  if (powers.git !== undefined || powers.gitPetName !== undefined) {
+    const readOnlyGit = powers.gitMode === 'readOnly';
+    const gitPetName = powers.gitPetName ?? 'git';
+    globals.push({
+      name: petNameToBindingName(gitPetName, 'git'),
+      petName: gitPetName,
+      description: readOnlyGit
+        ? 'Read-only @endo/exo-git Git capability for repository inspection.'
+        : 'Read/write @endo/exo-git Git capability for repository changes.',
+    });
+  }
+  globals.push(...(powers.namedPowers || []));
+  return normalizeGlobals(globals);
+};
+harden(makeCodeModeGlobals);
+
+/**
+ * @param {CodeModePowers} powers
+ * @param {LookupPowers | undefined} lookupPowers
+ * @returns {Record<string, CodeModePower>}
+ */
+const resolveConfiguredPowers = (powers, lookupPowers) => {
+  /** @type {Record<string, CodeModePower>} */
+  const resolved = {};
+  if (powers.workspace !== undefined || powers.workspacePetName !== undefined) {
+    const workspacePetName = powers.workspacePetName ?? 'workspace';
+    const workspaceName = petNameToBindingName(workspacePetName, 'workspace');
+    resolved[workspaceName] =
+      powers.workspace ??
+      lookupRequiredPower(lookupPowers, workspacePetName, 'workspace');
+  }
+  if (powers.git !== undefined || powers.gitPetName !== undefined) {
+    const gitPetName = powers.gitPetName ?? 'git';
+    const gitName = petNameToBindingName(gitPetName, 'git');
+    resolved[gitName] =
+      powers.git ?? lookupRequiredPower(lookupPowers, gitPetName, 'git');
+    if (powers.gitMode === 'readOnly') {
+      const gitReadOnly = isGitReadOnly(resolved[gitName]);
+      if (gitReadOnly === false) {
+        throw new Error(
+          'code-mode gitMode readOnly requires an already read-only Git capability',
+        );
+      }
+    }
+  }
+  return harden(resolved);
+};
+
+/**
+ * @param {CodeModePowers} powers
+ * @param {Record<string, CodeModePower>} resolvedPowers
+ * @param {Record<string, unknown>} baseEndowments
+ * @param {LookupPowers | undefined} lookupPowers
+ * @returns {Record<string, unknown>}
+ */
+const makeCodeModeEndowments = (
+  powers,
+  resolvedPowers,
+  baseEndowments,
+  lookupPowers,
+) => {
+  /** @type {Record<string, unknown>} */
+  const endowments = {
+    E,
+    ...baseEndowments,
+    ...resolvedPowers,
+  };
+  for (const namedPower of powers.namedPowers || []) {
+    if (!Object.prototype.hasOwnProperty.call(endowments, namedPower.name)) {
+      endowments[namedPower.name] = lookupRequiredPower(
+        lookupPowers,
+        namedPower.petName || namedPower.name,
+        namedPower.name,
+      );
+    }
+  }
+  return harden(endowments);
+};
+
+/**
+ * Construct a live code-mode agent: an agent whose sole tool is `execute`,
+ * which evaluates JavaScript in a Compartment endowed with the configured
+ * lexical powers. This is the code-mode preset of {@link defineAgent}; there is
+ * no separate `define*` wrapper. The powerless definition is `defineAgent`'s
+ * closure; supplying powers here is the powered stage.
+ *
+ * @param {MakeCodeModeAgentOptions} options
+ * @returns {{ agent: Agent, globals: CodeModeGlobal[], execute: CodeModeExecute, systemPrompt: string, model: Model<string> }}
+ */
+export const makeCodeModeAgent = options => {
+  const {
+    model,
+    powers = {},
+    lookupPowers,
+    credentials = makeEnvCredentials(),
+    endowments: baseEndowments = {},
+    storeResult,
+    messages,
+    streamFn,
+    getApiKey,
+    thinkingLevel,
+    preamble,
+  } = options;
+
+  const globals = options.globals
+    ? normalizeGlobals(options.globals)
+    : makeCodeModeGlobals(powers);
+  const systemPrompt =
+    options.systemPrompt || makeCodeModeSystemPrompt(globals, { preamble });
+
+  const resolvedPowers = resolveConfiguredPowers(powers, lookupPowers);
+  const execute =
+    options.execute ||
+    makeCompartmentExecute({
+      endowments: makeCodeModeEndowments(
+        powers,
+        resolvedPowers,
+        baseEndowments,
+        lookupPowers,
+      ),
+      storeResult,
+    });
+  const tool = makeExecuteTool(execute, globals);
+
+  const maker = defineAgent({
+    model,
+    instructions: systemPrompt,
+    tools: [toSmallcapsPiAgentTool(tool)],
+  });
+  const agent = maker({
+    credentials,
+    messages,
+    streamFn,
+    getApiKey,
+    thinkingLevel,
+  });
+  // The returned record is intentionally NOT hardened: `agent` is a live
+  // pi-agent-core instance that mutates its own run state (e.g. `activeRun`)
+  // while driving a conversation, so deep-freezing it would break the loop.
+  return { agent, globals, execute, systemPrompt, model };
+};
+harden(makeCodeModeAgent);
+
+/**
+ * @typedef {object} GitLoopOptions
+ * @property {Model<string>} model
+ * @property {CodeModePower} workspace
+ * @property {CodeModePower} git
+ * @property {CodeModeExecute} [execute]
+ * @property {Record<string, unknown>} [endowments]
+ * @property {CodeModeGlobal[]} [globals]
+ * @property {string} [systemPrompt]
+ * @property {AgentMessage[]} [messages]
+ * @property {StreamFn} [streamFn]
+ * @property {(provider: string) => Promise<string | undefined> | string | undefined} [getApiKey]
+ * @property {ThinkingLevel} [thinkingLevel]
+ * @property {boolean} [readOnlyGit]
+ */
+
+/**
+ * The git-loop preset: a thin alias over {@link makeCodeModeAgent} that wires a
+ * repository `workspace` Filesystem and a `git` capability as the lexical
+ * powers and supplies the repository-oriented preamble. Returns the live
+ * `Agent`.
+ *
+ * @param {GitLoopOptions} options
+ * @returns {Agent}
+ */
+export const makeCodeModeGitLoopAgent = options => {
+  const { workspace, git, readOnlyGit = false } = options;
+  const { agent } = makeCodeModeAgent({
+    model: options.model,
+    powers: {
+      workspace,
+      git,
+      gitMode: readOnlyGit ? 'readOnly' : 'readWrite',
+    },
+    endowments: options.endowments,
+    globals: options.globals,
+    systemPrompt: options.systemPrompt,
+    preamble:
+      'You are an Endo-hosted Pi coding agent. Use the execute tool to inspect and edit the repository through the workspace Filesystem and Git capabilities.',
+    execute: options.execute,
+    messages: options.messages,
+    streamFn: options.streamFn,
+    getApiKey: options.getApiKey,
+    thinkingLevel: options.thinkingLevel,
+  });
+  return agent;
+};
+harden(makeCodeModeGitLoopAgent);

--- a/packages/agentry/src/execute/preset.js
+++ b/packages/agentry/src/execute/preset.js
@@ -3,7 +3,7 @@
 
 /** @import { Model } from '@earendil-works/pi-ai' */
 /** @import { Agent, AgentMessage, StreamFn } from '@earendil-works/pi-agent-core' */
-/** @import { Credentials } from '../harness/credentials.js' */
+/** @import { Credentials, GetApiKey } from '../harness/credentials.js' */
 /** @import { ThinkingLevel } from '../harness/model.js' */
 /** @import { CodeModeExecute, CodeModeGlobal, CodeModePower, PowerHandle, LookupPowers } from './tool.js' */
 
@@ -11,7 +11,7 @@ import { E } from '@endo/far';
 import { isGitReadOnly } from '@endo/exo-git';
 
 import { defineAgent } from '../define-agent.js';
-import { makeEnvCredentials } from '../harness/credentials.js';
+import { getAmbientEnv, makeEnvCredentials } from '../harness/credentials.js';
 import { makeCompartmentExecute } from './compartment.js';
 import { makeExecuteTool, toSmallcapsPiAgentTool } from './tool.js';
 import { makeCodeModeSystemPrompt, normalizeGlobals } from './globals.js';
@@ -68,7 +68,7 @@ const lookupRequiredPower = (powers, petName, label) => {
  * @property {string} [preamble]
  * @property {AgentMessage[]} [messages]
  * @property {StreamFn} [streamFn]
- * @property {(provider: string) => Promise<string | undefined> | string | undefined} [getApiKey]
+ * @property {GetApiKey} [getApiKey]
  * @property {ThinkingLevel} [thinkingLevel]
  */
 
@@ -186,7 +186,7 @@ export const makeCodeModeAgent = options => {
     model,
     powers = {},
     lookupPowers,
-    credentials = makeEnvCredentials(),
+    credentials = makeEnvCredentials(getAmbientEnv()),
     endowments: baseEndowments = {},
     storeResult,
     messages,
@@ -246,7 +246,7 @@ harden(makeCodeModeAgent);
  * @property {string} [systemPrompt]
  * @property {AgentMessage[]} [messages]
  * @property {StreamFn} [streamFn]
- * @property {(provider: string) => Promise<string | undefined> | string | undefined} [getApiKey]
+ * @property {GetApiKey} [getApiKey]
  * @property {ThinkingLevel} [thinkingLevel]
  * @property {boolean} [readOnlyGit]
  */

--- a/packages/agentry/src/execute/tool.js
+++ b/packages/agentry/src/execute/tool.js
@@ -1,0 +1,129 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { ERef } from '@endo/far' */
+/** @import { Tool } from '@earendil-works/pi-ai' */
+/** @import { AgentTool } from '@earendil-works/pi-agent-core' */
+/** @import { ToolRecord } from '@endo/agent-tools' */
+
+import { makeTool } from '@endo/agent-tools/tool.js';
+import { toPiAgentTool } from '@endo/agent-tools/pi';
+
+import { toolResultToSmallcaps } from '../harness/marshal.js';
+import { normalizeGlobals } from './globals.js';
+
+const EXECUTE_PARAMETERS = harden({
+  type: 'object',
+  properties: {
+    source: {
+      type: 'string',
+      description:
+        'JavaScript source to evaluate in the code-mode compartment.',
+    },
+    resultName: {
+      anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+      description:
+        'Optional pet name or pet-name path where the completion value is stored.',
+    },
+  },
+  required: ['source'],
+  additionalProperties: false,
+});
+
+/**
+ * The settled shape of a code-mode power: an opaque object capability
+ * (typically an Endo remotable / exo). The model never sees a checked-in type
+ * for a power and discovers its method surface at runtime via
+ * `E(power).__getMethodNames__()`, so the static type is deliberately just
+ * `object` — narrow enough to exclude primitives, wide enough to accept any
+ * remotable regardless of which model provider drives the agent. Named
+ * separately from {@link CodeModePower} so a `lookup` result
+ * (a `Promise<PowerHandle>`) and an inline-passed power (an `ERef<PowerHandle>`)
+ * stay distinct without nesting promises.
+ *
+ * @typedef {object} PowerHandle
+ *
+ * An opaque, eventual-send capability handle endowed into the code-mode
+ * compartment under a lexical name. Provider-agnostic; a far reference to a
+ * {@link PowerHandle}.
+ *
+ * @typedef {ERef<PowerHandle>} CodeModePower
+ *
+ * The minimum required powers handle: an object exposing `lookup(petName)` for
+ * resolving capabilities that were not passed inline. This is the smallest
+ * surface the presets depend on, named so the `unknown` placeholder can be
+ * dropped at the call sites that resolve deferred powers.
+ *
+ * @typedef {{ lookup: (petName: string | string[]) => Promise<PowerHandle> }} LookupPowers
+ *
+ * @typedef {object} CodeModeGlobal
+ * @property {string} name
+ * @property {string | string[]} [petName]
+ * @property {string} [description]
+ *
+ * @typedef {object} CodeModeExecuteInput
+ * @property {string} source
+ * @property {string | string[]} [resultName]
+ * @property {CodeModeGlobal[]} globals
+ *
+ * @typedef {(input: CodeModeExecuteInput) => Promise<unknown>} CodeModeExecute
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {value is string | string[]}
+ */
+const isResultName = value =>
+  typeof value === 'string' ||
+  (Array.isArray(value) && value.every(part => typeof part === 'string'));
+
+/**
+ * Build the model-facing `execute` tool: a single JSON-schema'd tool whose
+ * invocation forwards validated `{ source, resultName }` to the supplied
+ * `execute` function alongside the normalized lexical globals.
+ *
+ * @param {CodeModeExecute} execute
+ * @param {CodeModeGlobal[]} globals
+ * @returns {ToolRecord}
+ */
+export const makeExecuteTool = (execute, globals) => {
+  const normalized = normalizeGlobals(globals);
+  return makeTool({
+    name: 'execute',
+    description:
+      'Evaluate JavaScript source with the code-mode powers in lexical scope.',
+    parameters: EXECUTE_PARAMETERS,
+    execute: async args => {
+      const { source, resultName } = args;
+      if (typeof source !== 'string') {
+        throw new Error('execute.source must be a string');
+      }
+      if (resultName !== undefined && !isResultName(resultName)) {
+        throw new Error('execute.resultName must be a string or string[]');
+      }
+      return execute({
+        source,
+        resultName,
+        globals: normalized,
+      });
+    },
+  });
+};
+harden(makeExecuteTool);
+
+/**
+ * Bridge the execute `ToolRecord` into a pi-agent-core `AgentTool`, injecting
+ * the harness SmallCaps renderer so completion values round-trip BigInts and
+ * sigil-prefixed strings to the model.
+ *
+ * @param {ToolRecord} tool
+ * @returns {AgentTool<Tool['parameters']>}
+ */
+export const toSmallcapsPiAgentTool = tool =>
+  // Pre-bind the harness's SmallCaps renderer onto the upstream
+  // `@endo/agent-tools/pi` `toPiAgentTool`: `renderToolResult` is that bridge's
+  // option key, and `toolResultToSmallcaps` is the encoder supplied as its
+  // value. The wrapper's sole job is this pre-binding, hence the codec-forward
+  // name paralleling `toolResultToSmallcaps`.
+  toPiAgentTool(tool, { renderToolResult: toolResultToSmallcaps });
+harden(toSmallcapsPiAgentTool);

--- a/packages/agentry/src/harness/credentials.js
+++ b/packages/agentry/src/harness/credentials.js
@@ -3,11 +3,19 @@
 
 /* global globalThis */
 
+// TODO(secure): the credentials provider built below reads whatever record it
+// is handed. The default record is the ambient process environment, which is
+// not a capability-scoped secret store. Swap the env-backed provider for one
+// at construction time: every caller resolves secrets through `.get()`, so the
+// swap is local to this module — a powered stage can inject a different
+// `Credentials` provider without touching call sites.
+
 /**
- * Read the ambient process environment as a plain record. This is the single
- * spot in the harness that reaches for `globalThis.process.env`; every other
- * module goes through a credentials provider (see {@link makeEnvCredentials})
- * so the env dependency stays isolated to one seam.
+ * Read the ambient process environment as a plain record. This is the
+ * **fallback** secret source for callers that do not supply their API keys via
+ * a better path (a swapped `Credentials` provider injected at construction
+ * time); it reaches for `globalThis.process.env` and hands the result to
+ * {@link makeEnvCredentials}, keeping the env dependency isolated to one seam.
  *
  * @returns {Record<string, string | undefined>}
  */
@@ -32,21 +40,40 @@ const nonEmptyString = value =>
  */
 
 /**
+ * The single signature for a pi-agent-core `getApiKey` hook: given a provider
+ * name, resolve its API key (synchronously or asynchronously), or `undefined`
+ * when none is available. Every consumer that wires `getApiKey` references this
+ * typedef rather than re-declaring the inline shape.
+ *
+ * @typedef {(provider: string) => Promise<string | undefined> | string | undefined} GetApiKey
+ */
+
+/**
  * Build an environment-backed credentials provider — the harness's one choke
  * point for reading secrets. `get(name)` resolves a key out of the supplied
- * `env` (the ambient process environment by default); a non-string or empty
- * value reads as `undefined`.
+ * `env`; a non-string or empty value reads as `undefined`. The default record
+ * is no longer ambient: a caller wanting the process environment passes
+ * `getAmbientEnv()` explicitly, so the env dependency is visible at every call
+ * site rather than hidden in a default argument.
  *
- * TODO(secure): swap this env-backed provider for a capability-scoped secret
- * store. Every caller resolves secrets through `.get()`, so that swap is local
- * to this module — a `sandbox()` or a powered stage can inject a different
- * provider without touching call sites.
- *
- * @param {Record<string, string | undefined>} [env]
+ * @param {Record<string, string | undefined>} env
  * @returns {Credentials}
  */
-export const makeEnvCredentials = (env = getAmbientEnv()) =>
+export const makeEnvCredentials = env =>
   harden({
     get: name => nonEmptyString(env[name]),
   });
 harden(makeEnvCredentials);
+
+/**
+ * Adapt a `Credentials` seam into a pi-agent-core `getApiKey` hook: the thin
+ * adaptor that makes `getApiKey` a view over the one secret seam rather than an
+ * ad-hoc reach into ambient env. Resolves `<PROVIDER>_API_KEY` for the given
+ * provider through `credentials.get`.
+ *
+ * @param {Credentials} credentials
+ * @returns {GetApiKey}
+ */
+export const makeApiKeyGetter = credentials => provider =>
+  credentials.get(`${provider.toUpperCase()}_API_KEY`);
+harden(makeApiKeyGetter);

--- a/packages/agentry/src/harness/credentials.js
+++ b/packages/agentry/src/harness/credentials.js
@@ -1,0 +1,52 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/* global globalThis */
+
+/**
+ * Read the ambient process environment as a plain record. This is the single
+ * spot in the harness that reaches for `globalThis.process.env`; every other
+ * module goes through a credentials provider (see {@link makeEnvCredentials})
+ * so the env dependency stays isolated to one seam.
+ *
+ * @returns {Record<string, string | undefined>}
+ */
+export const getAmbientEnv = () =>
+  /** @type {{ process?: { env?: Record<string, string | undefined> } }} */ (
+    globalThis
+  ).process?.env || {};
+harden(getAmbientEnv);
+
+/**
+ * @param {string | undefined} value
+ * @returns {string | undefined}
+ */
+const nonEmptyString = value =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+/**
+ * @typedef {object} Credentials
+ * @property {(name: string) => string | undefined} get Resolve a named secret
+ *   (an environment-variable name today) to its value, or `undefined` when it
+ *   is unset or empty.
+ */
+
+/**
+ * Build an environment-backed credentials provider — the harness's one choke
+ * point for reading secrets. `get(name)` resolves a key out of the supplied
+ * `env` (the ambient process environment by default); a non-string or empty
+ * value reads as `undefined`.
+ *
+ * TODO(secure): swap this env-backed provider for a capability-scoped secret
+ * store. Every caller resolves secrets through `.get()`, so that swap is local
+ * to this module — a `sandbox()` or a powered stage can inject a different
+ * provider without touching call sites.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {Credentials}
+ */
+export const makeEnvCredentials = (env = getAmbientEnv()) =>
+  harden({
+    get: name => nonEmptyString(env[name]),
+  });
+harden(makeEnvCredentials);

--- a/packages/agentry/src/harness/index.js
+++ b/packages/agentry/src/harness/index.js
@@ -1,7 +1,19 @@
 // @ts-check
 
+/**
+ * Re-export the credential-seam typedefs so consumers can `@import` them from
+ * `@endo/agentry/harness` without reaching into the module's internal paths.
+ *
+ * @typedef {import('./credentials.js').Credentials} Credentials
+ * @typedef {import('./credentials.js').GetApiKey} GetApiKey
+ */
+
 export { toolResultToSmallcaps, smallcapsMarshal } from './marshal.js';
-export { getAmbientEnv, makeEnvCredentials } from './credentials.js';
+export {
+  getAmbientEnv,
+  makeEnvCredentials,
+  makeApiKeyGetter,
+} from './credentials.js';
 export {
   resolveModel,
   resolveModelProfile,

--- a/packages/agentry/src/harness/index.js
+++ b/packages/agentry/src/harness/index.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+export { toolResultToSmallcaps, smallcapsMarshal } from './marshal.js';
+export { getAmbientEnv, makeEnvCredentials } from './credentials.js';
+export {
+  resolveModel,
+  resolveModelProfile,
+  resolveModelString,
+  buildOllamaModel,
+  defineModels,
+} from './model.js';
+export { makePiAgent } from './pi-agent.js';

--- a/packages/agentry/src/harness/marshal.js
+++ b/packages/agentry/src/harness/marshal.js
@@ -1,0 +1,48 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { Passable } from '@endo/pass-style' */
+
+import { makeMarshal } from '@endo/marshal';
+
+// SmallCaps marshaller for plain-data tool results and tool-call arguments,
+// the codec the Endo agent harness speaks end to end. `toCapData(harden(value))`
+// yields a `{ body: '#<smallcaps-json>', slots: [] }` record whose leading `#`
+// sentinel callers strip, so the model reads BigInts as `"+N"`/`"-N"` strings,
+// `undefined` as `"#undefined"`, and strings beginning with a SmallCaps special
+// character as `"!<s>"`. This codec is for plain data only; cap-bearing values
+// are stored out of band and never reach it.
+//
+// The codec is constructed once at module load. No slot converters are needed
+// because tool args and plain results never carry remotables or promises; the
+// defaults throw if one somehow reaches the boundary.
+/** @type {ReturnType<typeof makeMarshal>} */
+export const smallcapsMarshal = makeMarshal(undefined, undefined, {
+  serializeBodyFormat: 'smallcaps',
+  // Tool-result encoding only; error logging is irrelevant here.
+  marshalSaveError: () => {},
+});
+harden(smallcapsMarshal);
+
+/**
+ * Encode a plain-data tool result as the SmallCaps text the model reads; plain
+ * strings pass through unwrapped, while every other value is SmallCaps-encoded
+ * so BigInts, `undefined`, and SmallCaps-special-prefixed strings round-trip
+ * losslessly.
+ *
+ * @param {unknown} result
+ * @returns {string}
+ */
+export const toolResultToSmallcaps = result => {
+  if (typeof result === 'string') {
+    // Plain-string results carry no non-JSON values; no SmallCaps wrapping.
+    return result;
+  }
+  const { body } = smallcapsMarshal.toCapData(
+    /** @type {Passable} */ (harden(result)),
+  );
+  // `body` is '#<smallcaps-json>'; slice off the '#' sentinel so the model
+  // reads the raw SmallCaps JSON object/array.
+  return body.slice(1);
+};
+harden(toolResultToSmallcaps);

--- a/packages/agentry/src/harness/model.js
+++ b/packages/agentry/src/harness/model.js
@@ -1,0 +1,405 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { Model } from '@earendil-works/pi-ai' */
+/** @import { Credentials } from './credentials.js' */
+
+import { getModel, registerBuiltInApiProviders } from '@earendil-works/pi-ai';
+
+import { makeEnvCredentials } from './credentials.js';
+
+// Provider registration is NOT an import side effect: importing
+// `@endo/agentry/harness` does not mutate pi-ai's global registry. Instead,
+// the harness self-registers lazily on first model resolution. A module-level
+// one-shot guard runs `registerBuiltInApiProviders` (idempotent in pi-ai) the
+// first time either `resolveModelProfile` or `resolveModel` reaches pi-ai's
+// `getModel`, so a registry model resolves without any caller-side setup hook
+// while the import itself stays pure. The `let` is module-private (never
+// exported), so the mutable flag is safe under SES.
+let providersRegistered = false;
+const ensureBuiltInApiProvidersRegistered = () => {
+  if (!providersRegistered) {
+    registerBuiltInApiProviders();
+    providersRegistered = true;
+  }
+};
+
+const DEFAULT_HOST = 'http://localhost:11434';
+const DEFAULT_LOCAL_MODEL = 'qwen3';
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+const trimTrailingSlashes = value => value.replace(/\/+$/, '');
+
+/**
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+const normalizeOpenAIBaseUrl = baseUrl => {
+  const trimmed = trimTrailingSlashes(baseUrl);
+  return trimmed.match(/\/v1(?:\/.*)?$/) ? trimmed : `${trimmed}/v1`;
+};
+
+/**
+ * @typedef {object} ModelCost The per-token budget pi-ai bills an
+ *   accounting surface against. All four fields default to zero for an
+ *   OpenAI-compatible / ollama endpoint, which has no known cost table.
+ * @property {number} input
+ * @property {number} output
+ * @property {number} cacheRead
+ * @property {number} cacheWrite
+ *
+ * @typedef {object} ModelBudget The caller-configurable budget fields a built
+ *   OpenAI-compatible / ollama `Model` carries. Each is optional; an omitted
+ *   field falls back to the conservative default below.
+ * @property {ModelCost} [cost]
+ * @property {number} [contextWindow]
+ * @property {number} [maxTokens]
+ *
+ * @typedef {object} ModelProfileConfig
+ * @property {string} [provider]
+ * @property {string} [model]
+ * @property {string} [baseUrl]
+ * @property {'openai-completions' | string} [api]
+ * @property {boolean} [reasoning]
+ * @property {ModelCost} [cost]
+ * @property {number} [contextWindow]
+ * @property {number} [maxTokens]
+ */
+
+/**
+ * The reasoning-effort budget a caller can request of a thinking-capable model.
+ * Universal across providers: pi-agent-core maps the level onto each provider's
+ * own reasoning control. `'off'` disables thinking; the remaining levels scale
+ * effort from `'minimal'` to `'xhigh'`. The harness default is
+ * `reasoning ? 'medium' : 'off'` (see {@link makePiAgent}).
+ *
+ * @typedef {'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'} ThinkingLevel
+ */
+
+/**
+ * Conservative defaults for the budget fields of a built OpenAI-compatible /
+ * ollama `Model`. pi-ai does not budget these endpoints against a known cost
+ * table, so zero cost is the safe default; the context/token sizes match a
+ * common small local model. Callers override any field through the model
+ * profile (see {@link ModelBudget}).
+ *
+ * @type {ModelCost}
+ */
+const DEFAULT_MODEL_COST = harden({
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+});
+const DEFAULT_CONTEXT_WINDOW = 32_768;
+const DEFAULT_MAX_TOKENS = 8192;
+
+/**
+ * @param {string} id
+ * @param {string} baseUrl
+ * @param {string} provider
+ * @param {string} namePrefix
+ * @param {string} api
+ * @param {boolean | undefined} reasoning
+ * @param {ModelBudget} [budget]
+ * @returns {Model<string>}
+ */
+const buildOpenAICompatibleModel = (
+  id,
+  baseUrl,
+  provider,
+  namePrefix,
+  api,
+  reasoning,
+  budget = {},
+) =>
+  harden({
+    id,
+    name: `${namePrefix}/${id}`,
+    api,
+    provider,
+    baseUrl,
+    reasoning: reasoning === true,
+    input: ['text'],
+    cost: budget.cost ?? DEFAULT_MODEL_COST,
+    contextWindow: budget.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: budget.maxTokens ?? DEFAULT_MAX_TOKENS,
+  });
+
+/**
+ * Resolve a config-object model profile into a concrete pi-ai `Model`. Known
+ * registry providers go through `getModel(provider, id)`; ollama and bare
+ * OpenAI-compatible endpoints are built as a local OpenAI-completions `Model`.
+ *
+ * @param {ModelProfileConfig} modelConfig
+ * @returns {{ model: Model<string>, localOllama: boolean }}
+ */
+export const resolveModelProfile = (modelConfig = {}) => {
+  // Self-register pi-ai's built-in providers on first use so a registry model
+  // resolves without a caller-side setup hook; idempotent across calls.
+  ensureBuiltInApiProvidersRegistered();
+  const api = modelConfig.api || 'openai-completions';
+  const modelName = modelConfig.model || DEFAULT_LOCAL_MODEL;
+  const parsed =
+    modelConfig.provider === undefined && modelName.includes('/')
+      ? {
+          provider: modelName.slice(0, modelName.indexOf('/')),
+          model: modelName.slice(modelName.indexOf('/') + 1),
+        }
+      : undefined;
+  const provider = modelConfig.provider || parsed?.provider;
+  const id = parsed?.model || modelName;
+  const baseUrl = modelConfig.baseUrl;
+
+  if (
+    provider !== undefined &&
+    provider !== 'ollama' &&
+    provider !== 'openai-compatible' &&
+    baseUrl === undefined
+  ) {
+    // @ts-expect-error - permissive runtime lookup against KnownProvider overloads
+    const registryModel = getModel(provider, id);
+    if (registryModel === undefined) {
+      throw new Error(`Unknown pi-ai model: ${provider}/${id}`);
+    }
+    return harden({ model: registryModel, localOllama: false });
+  }
+
+  const localOllama =
+    provider === 'ollama' ||
+    (provider === undefined &&
+      (baseUrl === undefined || baseUrl.includes('localhost:11434')));
+  const endpoint = localOllama
+    ? normalizeOpenAIBaseUrl(baseUrl || DEFAULT_HOST)
+    : normalizeOpenAIBaseUrl(
+        baseUrl ||
+          (() => {
+            throw new Error(
+              'code-mode openai-compatible model config requires baseUrl',
+            );
+          })(),
+      );
+
+  return harden({
+    model: buildOpenAICompatibleModel(
+      id,
+      endpoint,
+      'openai',
+      localOllama ? 'ollama' : 'openai-compatible',
+      api,
+      modelConfig.reasoning,
+      {
+        cost: modelConfig.cost,
+        contextWindow: modelConfig.contextWindow,
+        maxTokens: modelConfig.maxTokens,
+      },
+    ),
+    localOllama,
+  });
+};
+harden(resolveModelProfile);
+
+/**
+ * Translate the legacy LAL_HOST + LAL_MODEL pair into a single
+ * "provider/modelId" string suitable for pi-ai's getModel(). Recognized
+ * LAL_HOST patterns:
+ *
+ *   contains "anthropic.com"  -> provider "anthropic"
+ *   contains "generativelanguage.googleapis.com" or "gemini" -> "google"
+ *   contains "openai.com"     -> provider "openai"
+ *   contains "openrouter"     -> provider "openrouter"
+ *   contains ":11434"         -> provider "ollama"
+ *   otherwise (incl. "/v1" llama.cpp servers) -> provider "openai"
+ *     (pi-ai's openai-completions adaptor speaks the same protocol)
+ *
+ * LAL_MODEL is used as the model id; a sensible default is chosen if
+ * LAL_MODEL is empty.
+ *
+ * @deprecated A LAL_* back-compat shim. pi-ai itself takes a
+ *   "provider/modelId" string directly and reads `<PROVIDER>_API_KEY` from the
+ *   environment (it handles local / ollama models too), so this translation
+ *   exists only for lal's legacy LAL_HOST + LAL_MODEL env-var configuration.
+ *   Its sole consumer is `packages/lal/agent.js`. Remove it once lal configures
+ *   pi-ai via a "provider/modelId" string directly; the harness export is kept
+ *   only while lal still depends on it.
+ * @param {{ LAL_HOST?: string, LAL_MODEL?: string }} env
+ * @returns {string}
+ */
+export const resolveModelString = env => {
+  const host = (env.LAL_HOST || 'http://localhost:11434').toLowerCase();
+  let provider = 'ollama';
+  // Temporary default until the subagent creation wizard ships and can guide
+  // users to select a model explicitly.
+  let defaultModel = 'qwen3.6';
+  if (host.includes('anthropic.com')) {
+    provider = 'anthropic';
+    defaultModel = 'claude-opus-4-5-20251101';
+  } else if (
+    host.includes('generativelanguage.googleapis.com') ||
+    host.includes('gemini')
+  ) {
+    // pi-ai exposes Google's Gemini models under the provider name 'google'.
+    provider = 'google';
+    defaultModel = 'gemini-2.0-flash';
+  } else if (host.includes('openrouter')) {
+    provider = 'openrouter';
+    defaultModel = 'openrouter/auto';
+  } else if (host.includes('openai.com')) {
+    provider = 'openai';
+    defaultModel = 'gpt-4o-mini';
+  } else if (host.includes(':11434')) {
+    // Native Ollama port.
+    // Temporary default until the subagent creation wizard ships.
+    provider = 'ollama';
+    defaultModel = 'qwen3.6';
+  } else if (host.includes('/v1')) {
+    // Any OpenAI-compatible local server (llama.cpp, vLLM, tgi).
+    provider = 'openai';
+    defaultModel = 'qwen3';
+  }
+  const modelId = env.LAL_MODEL || defaultModel;
+  return `${provider}/${modelId}`;
+};
+harden(resolveModelString);
+
+/**
+ * Build a pi-ai Model object for a local Ollama instance. Ollama exposes an
+ * OpenAI-compatible /v1/chat/completions endpoint, so we masquerade as the
+ * "openai" provider with a custom baseUrl.
+ *
+ * @param {string} id - The ollama model name (e.g. "qwen3")
+ * @param {Credentials} [credentials]
+ * @param {ModelBudget} [budget] - Caller overrides for the cost / context /
+ *   token budget; each field falls back to the conservative default.
+ * @returns {Promise<Model<'openai-completions'>>}
+ */
+export const buildOllamaModel = async (
+  id,
+  credentials = makeEnvCredentials(),
+  budget = {},
+) => {
+  await Promise.resolve();
+  const ollamaHost = credentials.get('OLLAMA_HOST') || 'http://127.0.0.1:11434';
+  return harden({
+    id,
+    name: `ollama/${id}`,
+    api: 'openai-completions',
+    provider: 'openai',
+    baseUrl: `${ollamaHost}/v1`,
+    reasoning: false,
+    input: ['text'],
+    cost: budget.cost ?? DEFAULT_MODEL_COST,
+    contextWindow: budget.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: budget.maxTokens ?? DEFAULT_MAX_TOKENS,
+  });
+};
+harden(buildOllamaModel);
+
+/**
+ * Resolve a "provider/modelId" string into a pi-ai Model object. Known
+ * providers go through `getModel(provider, modelId)`; the `ollama/` prefix is
+ * treated specially (Ollama is not in pi-ai's built-in registry and exposes an
+ * OpenAI-compatible /v1 endpoint).
+ *
+ * @param {string} modelString
+ * @param {Credentials} [credentials]
+ * @returns {Promise<Model<string>>}
+ */
+export const resolveModel = async (modelString, credentials) => {
+  // Self-register pi-ai's built-in providers on first use so a registry model
+  // resolves without a caller-side setup hook; idempotent across calls.
+  ensureBuiltInApiProvidersRegistered();
+  const parts = modelString.split('/');
+  const provider = parts[0];
+  const modelId = parts.slice(1).join('/');
+  if (provider === 'ollama') {
+    return buildOllamaModel(modelId, credentials);
+  }
+  // pi-ai's KnownProvider overloads of getModel typically resolve the modelId
+  // to `never` for the generic call site; we want the runtime registry lookup
+  // here, which works for any string the caller passed.
+  // @ts-expect-error - permissive runtime lookup against KnownProvider overloads
+  return getModel(provider, modelId);
+};
+harden(resolveModel);
+
+/**
+ * @typedef {object} ModelProfileDefinition
+ * @property {string} id A short profile name (e.g. 'sonnet') callers resolve by.
+ * @property {string} provider The pi-ai provider (e.g. 'anthropic', 'ollama').
+ * @property {string} model The provider's model id.
+ * @property {string} [baseUrl]
+ * @property {boolean} [reasoning]
+ * @property {ModelCost} [cost] Override the per-token budget for a built
+ *   OpenAI-compatible / ollama model (ignored for a registry-resolved model,
+ *   which carries pi-ai's own cost table).
+ * @property {number} [contextWindow] Override the context window for a built
+ *   OpenAI-compatible / ollama model.
+ * @property {number} [maxTokens] Override the max output tokens for a built
+ *   OpenAI-compatible / ollama model.
+ * @property {string | ((credentials: Credentials) => string | undefined)} [credential]
+ *   The secret this profile pairs with the model: a key-name resolved through
+ *   the credential seam, or a callback given the seam. Ollama profiles need
+ *   none.
+ *
+ * @typedef {object} ResolvedModelProfile
+ * @property {Model<string>} model
+ * @property {(credentials: Credentials) => string | undefined} resolveCredential
+ *   Resolve this profile's credential against a (possibly swapped) seam.
+ */
+
+/**
+ * Build a registry of provider/model profiles, each pairing a concrete pi-ai
+ * `Model` with the credential it needs. Callers resolve a profile by its short
+ * `id` (e.g. `defineAgent({ model: 'sonnet' })`) and bind the credential
+ * through the seam at construction time, so no secret is captured at definition
+ * time.
+ *
+ * @param {ModelProfileDefinition[]} definitions
+ * @returns {Map<string, ResolvedModelProfile>}
+ */
+export const defineModels = definitions => {
+  /** @type {Map<string, ResolvedModelProfile>} */
+  const registry = new Map();
+  for (const definition of definitions) {
+    const {
+      id,
+      provider,
+      model,
+      baseUrl,
+      reasoning,
+      cost,
+      contextWindow,
+      maxTokens,
+      credential,
+    } = definition;
+    if (typeof id !== 'string' || id.length === 0) {
+      throw new Error('model profile requires a non-empty id');
+    }
+    const { model: resolvedModel } = resolveModelProfile({
+      provider,
+      model,
+      baseUrl,
+      reasoning,
+      cost,
+      contextWindow,
+      maxTokens,
+    });
+    /** @type {(credentials: Credentials) => string | undefined} */
+    const resolveCredential = credentials => {
+      if (credential === undefined) {
+        return undefined;
+      }
+      if (typeof credential === 'function') {
+        return credential(credentials);
+      }
+      return credentials.get(credential);
+    };
+    registry.set(id, harden({ model: resolvedModel, resolveCredential }));
+  }
+  return registry;
+};
+harden(defineModels);

--- a/packages/agentry/src/harness/model.js
+++ b/packages/agentry/src/harness/model.js
@@ -6,7 +6,7 @@
 
 import { getModel, registerBuiltInApiProviders } from '@earendil-works/pi-ai';
 
-import { makeEnvCredentials } from './credentials.js';
+import { getAmbientEnv, makeEnvCredentials } from './credentials.js';
 
 // Provider registration is NOT an import side effect: importing
 // `@endo/agentry/harness` does not mutate pi-ai's global registry. Instead,
@@ -278,7 +278,7 @@ harden(resolveModelString);
  */
 export const buildOllamaModel = async (
   id,
-  credentials = makeEnvCredentials(),
+  credentials = makeEnvCredentials(getAmbientEnv()),
   budget = {},
 ) => {
   await Promise.resolve();

--- a/packages/agentry/src/harness/pi-agent.js
+++ b/packages/agentry/src/harness/pi-agent.js
@@ -1,0 +1,77 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { Message, Model } from '@earendil-works/pi-ai' */
+/** @import { Agent, AgentMessage, AgentTool, StreamFn } from '@earendil-works/pi-agent-core' */
+/** @import { ThinkingLevel } from './model.js' */
+
+import { Agent as PiAgent } from '@earendil-works/pi-agent-core';
+
+/**
+ * Default `convertToLlm`: keep only the message roles the LLM transcript reads
+ * (user, assistant, tool results). The same filter both the code-mode path and
+ * lal's worker loop install.
+ *
+ * @param {AgentMessage[]} messages
+ * @returns {Message[]}
+ */
+const defaultConvertToLlm = messages =>
+  /** @type {Message[]} */ (
+    /** @type {unknown} */ (
+      messages.filter(
+        m =>
+          m.role === 'user' ||
+          m.role === 'assistant' ||
+          m.role === 'toolResult',
+      )
+    )
+  );
+
+/**
+ * Construct a pi-agent-core `Agent` from harness-level inputs. This is the one
+ * place the harness builds a `PiAgent`: it owns the `initialState` shape, the
+ * default `convertToLlm` filter, the default thinking level
+ * (`reasoning ? 'medium' : 'off'`), and `toolExecution: 'sequential'`. A
+ * `getApiKey` is included in the constructor options only when one is supplied,
+ * matching the conditional-spread the callers relied on (pi-agent-core may
+ * distinguish an absent hook from an explicit `undefined`).
+ *
+ * @param {object} options
+ * @param {Model<string>} options.model
+ * @param {AgentTool<any>[]} options.tools
+ * @param {string} options.systemPrompt
+ * @param {AgentMessage[]} [options.messages]
+ * @param {StreamFn} [options.streamFn]
+ * @param {(messages: AgentMessage[]) => Message[] | Promise<Message[]>} [options.convertToLlm]
+ * @param {(provider: string) => Promise<string | undefined> | string | undefined} [options.getApiKey]
+ * @param {ThinkingLevel} [options.thinkingLevel]
+ * @param {'sequential' | 'parallel'} [options.toolExecution]
+ * @returns {Agent}
+ */
+export const makePiAgent = ({
+  model,
+  tools,
+  systemPrompt,
+  messages = [],
+  streamFn,
+  convertToLlm = defaultConvertToLlm,
+  getApiKey,
+  thinkingLevel = model?.reasoning ? 'medium' : 'off',
+  toolExecution = 'sequential',
+}) =>
+  new PiAgent({
+    initialState: {
+      systemPrompt,
+      model,
+      tools,
+      messages,
+      thinkingLevel,
+    },
+    convertToLlm,
+    toolExecution,
+    streamFn,
+    // Include getApiKey only when supplied, so a non-Ollama caller leaves the
+    // hook absent rather than explicitly `undefined`.
+    ...(getApiKey ? { getApiKey } : {}),
+  });
+harden(makePiAgent);

--- a/packages/agentry/src/harness/pi-agent.js
+++ b/packages/agentry/src/harness/pi-agent.js
@@ -4,6 +4,7 @@
 /** @import { Message, Model } from '@earendil-works/pi-ai' */
 /** @import { Agent, AgentMessage, AgentTool, StreamFn } from '@earendil-works/pi-agent-core' */
 /** @import { ThinkingLevel } from './model.js' */
+/** @import { GetApiKey } from './credentials.js' */
 
 import { Agent as PiAgent } from '@earendil-works/pi-agent-core';
 
@@ -43,7 +44,7 @@ const defaultConvertToLlm = messages =>
  * @param {AgentMessage[]} [options.messages]
  * @param {StreamFn} [options.streamFn]
  * @param {(messages: AgentMessage[]) => Message[] | Promise<Message[]>} [options.convertToLlm]
- * @param {(provider: string) => Promise<string | undefined> | string | undefined} [options.getApiKey]
+ * @param {GetApiKey} [options.getApiKey]
  * @param {ThinkingLevel} [options.thinkingLevel]
  * @param {'sequential' | 'parallel'} [options.toolExecution]
  * @returns {Agent}

--- a/packages/agentry/src/index.js
+++ b/packages/agentry/src/index.js
@@ -8,6 +8,7 @@ export {
   smallcapsMarshal,
   getAmbientEnv,
   makeEnvCredentials,
+  makeApiKeyGetter,
   resolveModel,
   resolveModelProfile,
   resolveModelString,

--- a/packages/agentry/src/index.js
+++ b/packages/agentry/src/index.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+// Package root: defineAgent plus the harness primitives. The execute-tool /
+// code-mode preset lives under the `@endo/agentry/execute` subpath.
+export { defineAgent } from './define-agent.js';
+export {
+  toolResultToSmallcaps,
+  smallcapsMarshal,
+  getAmbientEnv,
+  makeEnvCredentials,
+  resolveModel,
+  resolveModelProfile,
+  resolveModelString,
+  buildOllamaModel,
+  defineModels,
+  makePiAgent,
+} from './harness/index.js';

--- a/packages/agentry/test/code-mode-preset.test.js
+++ b/packages/agentry/test/code-mode-preset.test.js
@@ -1,0 +1,205 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import { E, Far } from '@endo/far';
+
+import {
+  makeCompartmentExecute,
+  makeExecuteTool,
+  normalizeGlobals,
+  makeCodeModeAgent,
+} from '../src/execute/index.js';
+
+/** @import { Model } from '@earendil-works/pi-ai' */
+
+/**
+ * A concrete, inert pi-ai `Model` good enough to construct an agent without
+ * touching the network.
+ *
+ * @type {Model<string>}
+ */
+const fauxModel = harden({
+  id: 'm',
+  name: 'faux/m',
+  api: 'openai-completions',
+  provider: 'openai',
+  baseUrl: 'http://invalid.example',
+  reasoning: false,
+  input: ['text'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 4096,
+  maxTokens: 1024,
+});
+
+test('makeCompartmentExecute hands the completion value to storeResult under a resultName', async t => {
+  /** @type {Array<[unknown, string | string[]]>} */
+  const stored = [];
+  const execute = makeCompartmentExecute({
+    endowments: { x: 41 },
+    storeResult: (value, resultName) => {
+      stored.push([value, resultName]);
+    },
+  });
+  const result = await execute({
+    source: 'x + 1',
+    resultName: 'answer',
+    globals: [],
+  });
+  t.is(result, 42);
+  t.deepEqual(stored, [[42, 'answer']]);
+});
+
+test('makeCompartmentExecute returns the value and skips storeResult with no resultName', async t => {
+  let stored = false;
+  const execute = makeCompartmentExecute({
+    endowments: { x: 1 },
+    storeResult: () => {
+      stored = true;
+    },
+  });
+  const result = await execute({ source: 'x + 1', globals: [] });
+  t.is(result, 2);
+  t.false(stored);
+});
+
+test('makeCompartmentExecute rejects a resultName when no storeResult is configured', async t => {
+  const execute = makeCompartmentExecute({ endowments: {} });
+  await t.throwsAsync(
+    () => execute({ source: '1', resultName: 'a', globals: [] }),
+    {
+      message: /no storeResult callback is configured/,
+    },
+  );
+});
+
+test('normalizeGlobals rejects a non-identifier global name', t => {
+  t.throws(() => normalizeGlobals(harden([{ name: '1bad' }])), {
+    message: /code-mode global name must be a JS identifier: 1bad/,
+  });
+});
+
+test('normalizeGlobals rejects an invalid petName', t => {
+  t.throws(
+    () =>
+      normalizeGlobals(
+        harden([{ name: 'ok', petName: /** @type {any} */ (123) }]),
+      ),
+    { message: /code-mode global "ok" has invalid petName/ },
+  );
+});
+
+test('normalizeGlobals defaults petName to name and accepts a petName path', t => {
+  const normalized = normalizeGlobals(
+    harden([{ name: 'a' }, { name: 'b', petName: ['x', 'y'] }]),
+  );
+  t.is(normalized[0].petName, 'a');
+  t.deepEqual(normalized[1].petName, ['x', 'y']);
+});
+
+test('makeExecuteTool.invoke forwards validated args plus normalized globals', async t => {
+  /** @type {any} */
+  let captured;
+  const tool = makeExecuteTool(
+    async input => {
+      captured = input;
+      return 'k';
+    },
+    harden([{ name: 'git', description: 'g' }]),
+  );
+  const out = await tool.invoke({ source: 'src', resultName: ['a', 'b'] });
+  t.is(out, 'k');
+  t.is(captured.source, 'src');
+  t.deepEqual(captured.resultName, ['a', 'b']);
+  t.deepEqual(captured.globals, [
+    { name: 'git', petName: 'git', description: 'g' },
+  ]);
+
+  // A bare source forwards an undefined resultName.
+  await tool.invoke({ source: 'src2' });
+  t.is(captured.resultName, undefined);
+});
+
+test('makeCodeModeAgent rejects a powers lookup name that is not a JS identifier', t => {
+  t.throws(
+    () =>
+      makeCodeModeAgent({
+        model: fauxModel,
+        powers: { git: Far('G', {}), gitPetName: 'not an id' },
+      }),
+    {
+      message:
+        /code-mode git petName must be a single JS identifier to use as a lexical binding/,
+    },
+  );
+});
+
+test('makeCodeModeAgent requires a lookup powers handle when a capability is named but not passed inline', t => {
+  // gitPetName names a git power, but neither `git` nor `lookupPowers` is
+  // supplied, so the required-power lookup has nothing to resolve against.
+  t.throws(
+    () =>
+      makeCodeModeAgent({
+        model: fauxModel,
+        powers: { gitPetName: 'git' },
+      }),
+    { message: /code-mode git capability requires powers/ },
+  );
+});
+
+test('makeCodeModeAgent resolves named powers through a live lookup handle', t => {
+  const looked = [];
+  const fakeCap = Far('Cap', {});
+  const lookupPowers = Far('Powers', {
+    async lookup(petName) {
+      looked.push(petName);
+      return fakeCap;
+    },
+  });
+  const { agent, globals, execute, systemPrompt, model } = makeCodeModeAgent({
+    model: fauxModel,
+    lookupPowers,
+    powers: {
+      namedPowers: [
+        { name: 'helper', petName: 'helper-cap', description: 'h' },
+      ],
+    },
+  });
+  t.is(model, fauxModel);
+  t.is(typeof execute, 'function');
+  t.true(systemPrompt.includes('declare const helper;'));
+  t.deepEqual(
+    globals.map(global => global.name),
+    ['helper'],
+  );
+  t.deepEqual(
+    agent.state.tools.map(tool => tool.name),
+    ['execute'],
+  );
+});
+
+test('makeCodeModeAgent honors an explicit globals list and preamble override', t => {
+  const { systemPrompt, globals } = makeCodeModeAgent({
+    model: fauxModel,
+    globals: harden([{ name: 'thing', description: 'a thing' }]),
+    preamble: 'CUSTOM PREAMBLE.',
+  });
+  t.true(systemPrompt.startsWith('CUSTOM PREAMBLE.'));
+  t.true(systemPrompt.includes('declare const thing;'));
+  t.deepEqual(
+    globals.map(global => global.name),
+    ['thing'],
+  );
+});
+
+test('makeCodeModeAgent uses a supplied execute and lexical endowments end to end', async t => {
+  const { execute } = makeCodeModeAgent({
+    model: fauxModel,
+    endowments: { tally: 10 },
+    powers: { namedPowers: [] },
+  });
+  // The default compartment execute runs the source against the endowments.
+  const result = await execute({ source: 'tally * 2', globals: [] });
+  t.is(result, 20);
+  // E is always endowed.
+  t.is(typeof E, 'function');
+});

--- a/packages/agentry/test/code-mode-preset.test.js
+++ b/packages/agentry/test/code-mode-preset.test.js
@@ -96,6 +96,51 @@ test('normalizeGlobals defaults petName to name and accepts a petName path', t =
   t.deepEqual(normalized[1].petName, ['x', 'y']);
 });
 
+test('normalizeGlobals throws on a duplicate global name rather than silently dropping it', t => {
+  // The well-known `git` global is pushed before namedPowers in
+  // makeCodeModeGlobals; a namedPower also named `git` would, without this
+  // guard, be silently shadowed by the well-known binding at endowment-merge
+  // time. Reject the collision so the author learns their power was shadowed.
+  t.throws(
+    () =>
+      normalizeGlobals(
+        harden([
+          { name: 'git', description: 'well-known git' },
+          { name: 'git', description: 'colliding named power' },
+        ]),
+      ),
+    { message: /code-mode global name "git" is declared twice/ },
+  );
+});
+
+test('normalizeGlobals throws on a global named E (collides with the injected eventual-send)', t => {
+  // `E` is always endowed into the code-mode compartment; a global named `E`
+  // would be shadowed by the injected binding (spread first) rather than win.
+  t.throws(
+    () => normalizeGlobals(harden([{ name: 'E', description: 'oops' }])),
+    {
+      message: /code-mode global name "E" is reserved and cannot be used/,
+    },
+  );
+});
+
+test('makeCodeModeAgent throws when a namedPower collides with the well-known git binding', t => {
+  // End-to-end: a configured git power plus a namedPower named `git` must be
+  // rejected at agent-construction time, not silently resolve to the
+  // well-known git capability.
+  t.throws(
+    () =>
+      makeCodeModeAgent({
+        model: fauxModel,
+        powers: {
+          git: Far('G', {}),
+          namedPowers: [{ name: 'git', petName: 'other', description: 'h' }],
+        },
+      }),
+    { message: /code-mode global name "git" is declared twice/ },
+  );
+});
+
 test('makeExecuteTool.invoke forwards validated args plus normalized globals', async t => {
   /** @type {any} */
   let captured;

--- a/packages/agentry/test/code-mode.test.js
+++ b/packages/agentry/test/code-mode.test.js
@@ -1,0 +1,413 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify as nodePromisify } from 'node:util';
+import { E, Far } from '@endo/far';
+import {
+  registerFauxProvider,
+  fauxAssistantMessage,
+  fauxToolCall,
+} from '@earendil-works/pi-ai';
+import { makeNodeFilesystem } from '@endo/platform/fs/extended';
+import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
+import { iterateBytesWriter } from '@endo/exo-stream/iterate-bytes-writer.js';
+import { makeGit } from '@endo/exo-git';
+import { makeNativeGitBackend } from '@endo/git';
+import { makeMount, lineageOf } from '@endo/daemon/src/mount.js';
+import { makeFilePowers } from '@endo/daemon/src/daemon-node-powers.js';
+
+import { defineAgent, makeEnvCredentials } from '../src/define-agent.js';
+import {
+  makeExecuteTool,
+  makeCompartmentExecute,
+  makeCodeModeSystemPrompt,
+  makeCodeModeAgent,
+  makeCodeModeGitLoopAgent,
+} from '../src/execute/index.js';
+
+/** @import { CodeModeGlobal, CodeModeExecute } from '../src/execute/tool.js' */
+/** @import { Model } from '@earendil-works/pi-ai' */
+/** @import { PassableBytesReader, PassableBytesWriter } from '@endo/exo-stream' */
+
+const execFileAsync = nodePromisify(execFile);
+
+/**
+ * Register a per-test faux pi-ai provider whose responses are seeded by the
+ * test. Returns the faux `Model` to drive an agent with, plus the registration
+ * handle (so the test can teardown the registration).
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {import('@earendil-works/pi-ai').AssistantMessage[]} responses
+ * @returns {Model<string>}
+ */
+const fauxModel = (t, responses) => {
+  const registration = registerFauxProvider({
+    provider: 'faux',
+    models: [{ id: 'faux-model' }],
+  });
+  registration.setResponses(responses);
+  t.teardown(() => registration.unregister());
+  return registration.getModel();
+};
+
+/**
+ * @param {Record<string, unknown>} endowments
+ * @returns {CodeModeExecute}
+ */
+const compartmentExecuteOver = endowments =>
+  makeCompartmentExecute({ endowments: harden({ E, ...endowments }) });
+
+/**
+ * @param {string[]} calls
+ */
+const makeStubGit = calls =>
+  Far('StubGit', {
+    async branches() {
+      calls.push('branches');
+      return harden([{ name: 'main', kind: 'branch' }]);
+    },
+    async currentBranch() {
+      calls.push('currentBranch');
+      return harden({ name: 'main', kind: 'branch' });
+    },
+  });
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ */
+const provisionGitWorktree = async t => {
+  const root = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'agentry-git-loop-'),
+  );
+  t.teardown(() => fs.promises.rm(root, { recursive: true, force: true }));
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  await execFileAsync('git', ['config', '--local', 'commit.gpgsign', 'false'], {
+    cwd: root,
+  });
+  await execFileAsync('git', ['config', '--local', 'tag.gpgsign', 'false'], {
+    cwd: root,
+  });
+  await execFileAsync('git', ['config', '--local', 'user.email', 't@t'], {
+    cwd: root,
+  });
+  await execFileAsync('git', ['config', '--local', 'user.name', 'T'], {
+    cwd: root,
+  });
+  await fs.promises.writeFile(path.join(root, 'note.txt'), 'before\n');
+  await execFileAsync('git', ['add', 'note.txt'], { cwd: root });
+  await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: root });
+  return root;
+};
+
+/**
+ * Build a live exo `Git` capability over a fresh real repository using the real
+ * daemon mount (the same recipe `@endo/agent-tools`'s git-flow test uses): a
+ * writable `EndoMount` over the worktree, a `NativeGitBackend`, and `makeGit`.
+ * This exercises the real, inert `EndoMountEntry` exo and its private
+ * `mountEntryRecords` WeakMap.
+ *
+ * @param {import('ava').ExecutionContext} t
+ */
+const makeRealGit = async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const workspace = makeNodeFilesystem({ rootPath: repoRoot });
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+  return harden({ repoRoot, workspace, git });
+};
+
+/**
+ * @param {PassableBytesReader} readerRef
+ * @returns {Promise<Uint8Array>}
+ */
+const collectBytes = async readerRef => {
+  /** @type {Uint8Array[]} */
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of iterateBytesReader(readerRef)) {
+    chunks.push(chunk);
+    total += chunk.length;
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return bytes;
+};
+
+/**
+ * @param {unknown} file
+ */
+const readFileText = async file => {
+  const fileRef = /** @type {any} */ (file);
+  const stat = await E(fileRef).getStat();
+  const openFile = await E(fileRef).open({ read: true });
+  try {
+    const reader = await E(openFile).read(0n, stat.size ?? 0n);
+    return new TextDecoder().decode(await collectBytes(reader));
+  } finally {
+    await E(openFile).close();
+  }
+};
+
+/**
+ * @param {unknown} file
+ * @param {string} text
+ */
+const writeFileText = async (file, text) => {
+  const bytes = new TextEncoder().encode(text);
+  const fileRef = /** @type {any} */ (file);
+  const openFile = await E(fileRef).open({ write: true });
+  try {
+    const writer = iterateBytesWriter(await E(openFile).write(0n));
+    await writer.next(bytes);
+    await writer.return();
+    await E(openFile).truncate(BigInt(bytes.length));
+  } finally {
+    await E(openFile).close();
+  }
+};
+
+test('the system prompt carries name + one-line description, no type blob', t => {
+  /** @type {CodeModeGlobal[]} */
+  const globals = harden([
+    {
+      name: 'git',
+      petName: 'git',
+      description: 'Read/write @endo/exo-git Git capability for the repo.',
+    },
+    {
+      name: 'repoName',
+      description: 'Human-readable repository name.',
+    },
+  ]);
+  const systemPrompt = makeCodeModeSystemPrompt(globals);
+
+  t.true(systemPrompt.includes('declare const git;'));
+  t.true(systemPrompt.includes('declare const repoName;'));
+  t.true(
+    systemPrompt.includes(
+      '// Read/write @endo/exo-git Git capability for the repo.',
+    ),
+  );
+  // No hand-maintained TS type declarations leak into the prompt; the model
+  // introspects live caps via __getMethodNames__ at runtime.
+  t.false(systemPrompt.includes('declare const git: {'));
+  t.false(systemPrompt.includes('currentBranch(): Promise'));
+  t.true(systemPrompt.includes('__getMethodNames__'));
+});
+
+test('makeEnvCredentials is the single env reader and reads through .get', t => {
+  const credentials = makeEnvCredentials({ TOKEN: 'secret', EMPTY: '' });
+  t.is(credentials.get('TOKEN'), 'secret');
+  // Empty values read as undefined.
+  t.is(credentials.get('EMPTY'), undefined);
+  t.is(credentials.get('ABSENT'), undefined);
+});
+
+test('defineAgent returns a maker that builds a powered agent', t => {
+  /** @type {Model<string>} */
+  const model = harden({
+    id: 'm',
+    name: 'faux/m',
+    api: 'openai-completions',
+    provider: 'openai',
+    baseUrl: 'http://invalid.example',
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 4096,
+    maxTokens: 1024,
+  });
+  const tool = makeExecuteTool(async () => 'ok', []);
+  const makeCodeModeAgentMaker = defineAgent({
+    model,
+    instructions: 'You are codeMode.',
+    tools: [
+      {
+        name: 'execute',
+        label: 'execute',
+        description: tool.description,
+        parameters: /** @type {any} */ (tool.parameters),
+        execute: async () => ({ content: [], details: undefined }),
+      },
+    ],
+  });
+  t.is(typeof makeCodeModeAgentMaker, 'function');
+  const agent = makeCodeModeAgentMaker();
+  t.deepEqual(
+    agent.state.tools.map(agentTool => agentTool.name),
+    ['execute'],
+  );
+  t.is(agent.state.systemPrompt, 'You are codeMode.');
+});
+
+test('makeCodeModeAgent exposes only execute and rejects non-readOnly git in readOnly mode', async t => {
+  const { workspace, git } = await makeRealGit(t);
+  const model = fauxModel(t, [fauxAssistantMessage('done')]);
+
+  t.throws(
+    () =>
+      makeCodeModeAgent({
+        model,
+        powers: { workspace, git, gitMode: 'readOnly' },
+      }),
+    { message: /requires an already read-only Git capability/ },
+  );
+
+  const readOnlyGit = /** @type {{ readOnly: () => unknown }} */ (
+    /** @type {unknown} */ (git)
+  ).readOnly();
+  const { agent, globals } = makeCodeModeAgent({
+    model,
+    powers: { workspace, git: readOnlyGit, gitMode: 'readOnly' },
+  });
+  t.deepEqual(
+    agent.state.tools.map(tool => tool.name),
+    ['execute'],
+  );
+  t.deepEqual(
+    globals.map(global => global.name),
+    ['workspace', 'git'],
+  );
+});
+
+test('faux provider drives a scripted execute-only code-mode agent', async t => {
+  const gitCalls = [];
+  const git = makeStubGit(gitCalls);
+  const executions = [];
+  const source =
+    '(async () => (await E(git).branches()).map(branch => branch.name))()';
+  const model = fauxModel(t, [
+    fauxAssistantMessage(fauxToolCall('execute', { source }), {
+      stopReason: 'toolUse',
+    }),
+    fauxAssistantMessage('done'),
+  ]);
+  const { agent } = makeCodeModeAgent({
+    model,
+    powers: { git, gitPetName: 'git', gitMode: 'readOnly' },
+    execute: async input => {
+      const result = await compartmentExecuteOver({ git })(input);
+      executions.push(result);
+      return result;
+    },
+  });
+
+  await agent.prompt('List branch names.');
+  await agent.waitForIdle();
+
+  t.deepEqual(gitCalls, ['branches']);
+  t.deepEqual(executions, [['main']]);
+});
+
+test('git-loop preset edits the workspace, commits, and reads HEAD~1 over a real mount', async t => {
+  const { repoRoot, workspace, git } = await makeRealGit(t);
+
+  const executions = [];
+  const source = `\
+(async () => {
+  const root = await E(workspace).root();
+  const cursor = await E(root).list();
+  const listed = await E(cursor).toArray();
+  const note = await E(root).lookup('note.txt');
+  const beforeStat = await E(note).getStat();
+
+  await writeFileText(note, 'after\\n');
+
+  const rows = await E(git).status();
+  const row = rows.find(candidate => candidate.path === 'note.txt');
+  if (row === undefined) {
+    throw new Error('note.txt did not appear in git status');
+  }
+  await E(git).add([row.entry]);
+  const stagedDiff = await E(git).diff({ cached: true, entries: [row.entry] });
+  const commit = await E(git).commit('agent edit');
+
+  const previousFs = await E(git).filesystemAt('HEAD~1');
+  const previousRoot = await E(previousFs).root();
+  const previousNote = await E(previousRoot).lookup('note.txt');
+  const previousText = await readFileText(previousNote);
+  const currentText = await readFileText(note);
+
+  return {
+    listed: listed.map(entry => entry.name).sort(),
+    beforeSize: String(beforeStat.size),
+    status: { path: row.path, index: row.index, worktree: row.worktree },
+    stagedDiffHasEdit: stagedDiff.includes('+after'),
+    commitSummary: commit.summary,
+    previousText,
+    currentText,
+  };
+})()`;
+  const execute = async input => {
+    const result = await compartmentExecuteOver({
+      git,
+      workspace,
+      readFileText,
+      writeFileText,
+    })(input);
+    executions.push(result);
+    return result;
+  };
+  const model = fauxModel(t, [
+    fauxAssistantMessage(fauxToolCall('execute', { source }), {
+      stopReason: 'toolUse',
+    }),
+    fauxAssistantMessage('done'),
+  ]);
+  const agent = makeCodeModeGitLoopAgent({
+    model,
+    workspace,
+    git,
+    execute,
+    globals: harden([
+      {
+        name: 'workspace',
+        description: 'Writable repository Filesystem.',
+      },
+      {
+        name: 'git',
+        description: 'Read/write repository Git capability.',
+      },
+      {
+        name: 'readFileText',
+        description: 'Read a UTF-8 file through an endo-fs File capability.',
+      },
+      {
+        name: 'writeFileText',
+        description: 'Write UTF-8 text through an endo-fs File capability.',
+      },
+    ]),
+  });
+
+  await agent.prompt('Edit note.txt, commit the change, and inspect HEAD~1.');
+  await agent.waitForIdle();
+
+  t.is(executions.length, 1);
+  t.deepEqual(executions[0], {
+    listed: ['.git', 'note.txt'],
+    beforeSize: '7',
+    status: { path: 'note.txt', index: 'clean', worktree: 'modified' },
+    stagedDiffHasEdit: true,
+    commitSummary: 'agent edit',
+    previousText: 'before\n',
+    currentText: 'after\n',
+  });
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'note.txt'), 'utf8'),
+    'after\n',
+  );
+  const { stdout } = await execFileAsync('git', ['log', '-1', '--format=%s'], {
+    cwd: repoRoot,
+  });
+  t.is(stdout.trim(), 'agent edit');
+});

--- a/packages/agentry/test/define-agent.test.js
+++ b/packages/agentry/test/define-agent.test.js
@@ -1,0 +1,175 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import { getModel } from '@earendil-works/pi-ai';
+
+import { defineAgent, makeEnvCredentials } from '../src/define-agent.js';
+
+/** @import { Model } from '@earendil-works/pi-ai' */
+/** @import { AgentTool } from '@earendil-works/pi-agent-core' */
+
+/**
+ * A minimal, well-typed `AgentTool` stub: enough fields to satisfy the pi-agent
+ * tool shape without a real schema or execution. Used to observe which tool
+ * surface `defineAgent` installs.
+ *
+ * @param {string} name
+ * @returns {AgentTool<any>}
+ */
+const fauxTool = name => ({
+  name,
+  label: name,
+  description: name,
+  parameters: /** @type {any} */ ({ type: 'object', properties: {} }),
+  execute: async () => ({ content: [], details: undefined }),
+});
+
+/** @type {Model<string>} */
+const concreteModel = harden({
+  id: 'x',
+  name: 'provider/x',
+  api: 'openai-completions',
+  provider: 'openai',
+  baseUrl: 'http://host/v1',
+  reasoning: false,
+  input: ['text'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1,
+  maxTokens: 1,
+});
+
+test('defineAgent passes a concrete Model object through unchanged', t => {
+  const maker = defineAgent({ model: concreteModel });
+  const agent = maker();
+  t.is(agent.state.model, concreteModel);
+});
+
+test('defineAgent resolves a model-profile config through the harness', t => {
+  const maker = defineAgent({
+    model: { provider: 'ollama', model: 'qwen3' },
+    instructions: 'hi',
+  });
+  const agent = maker();
+  t.is(agent.state.model.name, 'ollama/qwen3');
+  t.is(agent.state.systemPrompt, 'hi');
+});
+
+test('defineAgent defaults the model to a local ollama profile', t => {
+  const agent = defineAgent()();
+  t.is(agent.state.model.name, 'ollama/qwen3');
+  t.is(agent.state.systemPrompt, '');
+});
+
+test('defineAgent drives the endow seam to derive powered tools and getApiKey', t => {
+  /** @type {Array<{ localOllama: boolean, hasPowers: boolean }>} */
+  const seen = [];
+  const maker = defineAgent({
+    model: { provider: 'ollama', model: 'qwen3' },
+    instructions: 'sys',
+    tools: [fauxTool('placeholder')],
+    endow: (definition, options) => {
+      seen.push({
+        localOllama: definition.localOllama,
+        hasPowers: options.powers !== undefined,
+      });
+      return {
+        tools: [fauxTool('powered')],
+        getApiKey: () => 'KEY',
+      };
+    },
+  });
+  const agent = maker({ powers: { p: 1 } });
+  // The endow-derived tool surface replaces the powerless placeholder.
+  t.deepEqual(
+    agent.state.tools.map(tool => tool.name),
+    ['powered'],
+  );
+  t.deepEqual(seen, [{ localOllama: true, hasPowers: true }]);
+});
+
+test('defineAgent falls back to the powerless tool surface when no powered tools are supplied', t => {
+  const maker = defineAgent({
+    model: concreteModel,
+    tools: [fauxTool('only')],
+  });
+  const agent = maker();
+  t.deepEqual(
+    agent.state.tools.map(tool => tool.name),
+    ['only'],
+  );
+});
+
+test('defineAgent resolves a registry-provider model without any caller-side registration', t => {
+  // Preserves the intent the prior `onDefine` hook served: a registry model
+  // ('anthropic') resolves through defineAgent from configuration alone, with
+  // no `registerBuiltInApiProviders` call by the caller. The harness's lazy
+  // self-registration (the module-level guard at the top of
+  // `resolveModelProfile`/`resolveModel`) is what makes the caller-side hook
+  // unnecessary. NOTE: this asserts the wired-correctly end state, not the
+  // guard's first-call timing — pi-ai populates its own provider registry as an
+  // import side effect, so the registry lookup here would succeed even without
+  // the harness guard; the guard's value is for any future pi-ai that defers
+  // its own registration, and for keeping the harness import itself pure.
+  const maker = defineAgent({
+    model: { provider: 'anthropic', model: 'claude-opus-4-5-20251101' },
+  });
+  const agent = maker();
+  // The resolved model is the very object pi-ai's registry hands back, proving
+  // the registry lookup succeeded (it would throw 'Unknown pi-ai model' had the
+  // provider not been registered).
+  t.is(agent.state.model, getModel('anthropic', 'claude-opus-4-5-20251101'));
+});
+
+test('defineAgent resolves a "provider/modelId" string config through the harness', t => {
+  // Regression: a string config (the README's documented `model: 'anthropic/...'`
+  // form) was read as if it were an object — its absent `.provider` / `.model`
+  // properties resolved to `undefined` and the agent silently fell back to the
+  // default `ollama/qwen3` profile. The string now routes through the resolver.
+  const agent = defineAgent({
+    model: 'anthropic/claude-opus-4-5-20251101',
+  })();
+  t.is(agent.state.model, getModel('anthropic', 'claude-opus-4-5-20251101'));
+});
+
+test('defineAgent resolves a bare string model config rather than the default profile', t => {
+  // The README's other documented string form (`model: 'sonnet'`). Before the
+  // fix the bare string also collapsed to the default `ollama/qwen3`; it now
+  // names the resolved profile's model id.
+  const agent = defineAgent({ model: 'sonnet' })();
+  t.is(agent.state.model.name, 'ollama/sonnet');
+  t.not(agent.state.model.name, 'ollama/qwen3');
+});
+
+test('defineAgent derives getApiKey from supplied credentials for a local-Ollama model', t => {
+  // Regression: a caller wiring only the advertised `credentials` seam (no
+  // explicit getApiKey, no endow hook) built an agent with no key resolver at
+  // all, so the default local-Ollama path threw 'No API key for provider:
+  // openai'. The seam now yields a getApiKey; for a local-Ollama model it
+  // resolves the harmless 'ollama' sentinel when no real key is present.
+  const credentials = makeEnvCredentials({});
+  const agent = defineAgent({ model: { provider: 'ollama', model: 'qwen3' } })({
+    credentials,
+  });
+  t.is(typeof agent.getApiKey, 'function');
+  // `getApiKey` is optional on the Agent type; the `typeof` assertion above
+  // proves it is present, and the optional-chained call keeps the type-check
+  // happy without weakening the value assertion (a regressed `undefined`
+  // resolver yields `undefined !== 'ollama'` and still fails the test).
+  t.is(agent.getApiKey?.('openai'), 'ollama');
+});
+
+test('defineAgent-derived getApiKey resolves a real provider key from credentials', t => {
+  const credentials = makeEnvCredentials({ ANTHROPIC_API_KEY: 'real-key' });
+  const agent = defineAgent({
+    model: { provider: 'anthropic', model: 'claude-opus-4-5-20251101' },
+  })({ credentials });
+  t.is(agent.getApiKey?.('anthropic'), 'real-key');
+});
+
+test('defineAgent lets an explicit getApiKey win over the credentials seam', t => {
+  const credentials = makeEnvCredentials({ ANTHROPIC_API_KEY: 'seam-key' });
+  const agent = defineAgent({
+    model: { provider: 'anthropic', model: 'claude-opus-4-5-20251101' },
+  })({ credentials, getApiKey: () => 'explicit-key' });
+  t.is(agent.getApiKey?.('anthropic'), 'explicit-key');
+});

--- a/packages/agentry/test/exports.test.js
+++ b/packages/agentry/test/exports.test.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+test('agentry subpaths resolve through package exports', async t => {
+  const [rootModule, harnessModule, executeModule] = await Promise.all([
+    // eslint-disable-next-line import/no-unresolved
+    import('@endo/agentry'),
+    // eslint-disable-next-line import/no-unresolved
+    import('@endo/agentry/harness'),
+    // eslint-disable-next-line import/no-unresolved
+    import('@endo/agentry/execute'),
+  ]);
+  t.is(typeof rootModule.defineAgent, 'function');
+  t.is(typeof harnessModule.makePiAgent, 'function');
+  t.is(typeof executeModule.makeCodeModeAgent, 'function');
+});

--- a/packages/agentry/test/harness-marshal.test.js
+++ b/packages/agentry/test/harness-marshal.test.js
@@ -1,0 +1,32 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import {
+  toolResultToSmallcaps,
+  smallcapsMarshal,
+} from '../src/harness/marshal.js';
+
+test('toolResultToSmallcaps passes plain strings through unwrapped', t => {
+  t.is(toolResultToSmallcaps('plain text'), 'plain text');
+  // A string that happens to begin with a SmallCaps special character is still
+  // returned verbatim — string results carry no non-JSON values.
+  t.is(toolResultToSmallcaps('#undefined'), '#undefined');
+});
+
+test('toolResultToSmallcaps SmallCaps-encodes non-string values losslessly', t => {
+  // BigInts round-trip as signed-magnitude strings.
+  t.is(toolResultToSmallcaps(7n), '"+7"');
+  t.is(toolResultToSmallcaps(42), '42');
+  // undefined survives as the SmallCaps sentinel.
+  t.is(toolResultToSmallcaps(undefined), '"#undefined"');
+  // Nested structures keep their SmallCaps encoding per-field.
+  t.is(toolResultToSmallcaps({ a: 1, b: 2n }), '{"a":1,"b":"+2"}');
+});
+
+test('smallcapsMarshal is the shared codec backing toolResultToSmallcaps', t => {
+  const { body } = smallcapsMarshal.toCapData(harden({ n: 9n }));
+  // The leading '#' sentinel is what toolResultToSmallcaps slices off.
+  t.is(body[0], '#');
+  t.is(body.slice(1), '{"n":"+9"}');
+});

--- a/packages/agentry/test/harness-model.test.js
+++ b/packages/agentry/test/harness-model.test.js
@@ -1,0 +1,299 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import { getModel } from '@earendil-works/pi-ai';
+
+import {
+  resolveModelProfile,
+  resolveModelString,
+  buildOllamaModel,
+  resolveModel,
+  defineModels,
+} from '../src/harness/model.js';
+
+// Registry-provider resolution is not an import side effect of
+// `@endo/agentry/harness`: the harness self-registers pi-ai's built-in
+// providers lazily, on the first `resolveModelProfile`/`resolveModel` call that
+// reaches a registry lookup. The registry-resolution tests below therefore
+// resolve a known provider WITHOUT any caller-side registration call, proving
+// the lazy self-registration is wired correctly.
+
+const KNOWN_PROVIDER = 'anthropic';
+const KNOWN_MODEL = 'claude-opus-4-5-20251101';
+
+test('resolveModelProfile resolves a registry provider through getModel', t => {
+  const { model, localOllama } = resolveModelProfile({
+    provider: KNOWN_PROVIDER,
+    model: KNOWN_MODEL,
+  });
+  t.is(localOllama, false);
+  // The registry path returns the very object getModel hands back.
+  t.is(model, getModel(KNOWN_PROVIDER, KNOWN_MODEL));
+});
+
+test('resolveModelProfile throws on an unknown registry model', t => {
+  t.throws(
+    () =>
+      resolveModelProfile({
+        provider: KNOWN_PROVIDER,
+        model: 'definitely-not-a-real-model-xyz',
+      }),
+    {
+      message:
+        /Unknown pi-ai model: anthropic\/definitely-not-a-real-model-xyz/,
+    },
+  );
+});
+
+test('resolveModelProfile builds a local ollama OpenAI-compatible model', t => {
+  const { model, localOllama } = resolveModelProfile({
+    provider: 'ollama',
+    model: 'qwen3',
+  });
+  t.is(localOllama, true);
+  t.is(model.name, 'ollama/qwen3');
+  t.is(model.provider, 'openai');
+  t.is(model.api, 'openai-completions');
+  t.is(model.baseUrl, 'http://localhost:11434/v1');
+  t.is(model.reasoning, false);
+});
+
+test('resolveModelProfile builds a bare openai-compatible model and normalizes baseUrl', t => {
+  const { model, localOllama } = resolveModelProfile({
+    provider: 'openai-compatible',
+    baseUrl: 'http://host:1234',
+    model: 'mymodel',
+  });
+  t.is(localOllama, false);
+  t.is(model.name, 'openai-compatible/mymodel');
+  t.is(model.provider, 'openai');
+  // A bare host gains the /v1 suffix.
+  t.is(model.baseUrl, 'http://host:1234/v1');
+});
+
+test('resolveModelProfile leaves an existing /v1 baseUrl untouched (idempotent)', t => {
+  const { model } = resolveModelProfile({
+    provider: 'openai-compatible',
+    baseUrl: 'http://host/v1/',
+    model: 'm',
+  });
+  t.is(model.baseUrl, 'http://host/v1');
+});
+
+test('resolveModelProfile carries reasoning through to the built model', t => {
+  const { model } = resolveModelProfile({
+    provider: 'ollama',
+    model: 'qwen3',
+    reasoning: true,
+  });
+  t.is(model.reasoning, true);
+});
+
+test('resolveModelProfile threads caller budget overrides into the built model', t => {
+  const cost = { input: 3, output: 7, cacheRead: 1, cacheWrite: 2 };
+  const { model } = resolveModelProfile({
+    provider: 'ollama',
+    model: 'qwen3',
+    cost,
+    contextWindow: 200_000,
+    maxTokens: 16_384,
+  });
+  // The override reaches the built pi-ai Model, not the conservative defaults.
+  t.deepEqual(model.cost, cost);
+  t.is(model.contextWindow, 200_000);
+  t.is(model.maxTokens, 16_384);
+});
+
+test('resolveModelProfile falls back to the conservative budget defaults', t => {
+  const { model } = resolveModelProfile({ provider: 'ollama', model: 'qwen3' });
+  // Omitting the overrides yields the documented defaults.
+  t.deepEqual(model.cost, {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  });
+  t.is(model.contextWindow, 32_768);
+  t.is(model.maxTokens, 8192);
+});
+
+test('buildOllamaModel threads a caller budget override and falls back to defaults', async t => {
+  const cost = { input: 5, output: 11, cacheRead: 0, cacheWrite: 0 };
+  const overridden = await buildOllamaModel(
+    'qwen3',
+    { get: () => undefined },
+    { cost, contextWindow: 128_000, maxTokens: 4096 },
+  );
+  t.deepEqual(overridden.cost, cost);
+  t.is(overridden.contextWindow, 128_000);
+  t.is(overridden.maxTokens, 4096);
+
+  const defaulted = await buildOllamaModel('qwen3', { get: () => undefined });
+  t.deepEqual(defaulted.cost, {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  });
+  t.is(defaulted.contextWindow, 32_768);
+  t.is(defaulted.maxTokens, 8192);
+});
+
+test('defineModels threads a profile budget override into the built model', t => {
+  const cost = { input: 9, output: 13, cacheRead: 4, cacheWrite: 6 };
+  const registry = defineModels([
+    {
+      id: 'budgeted',
+      provider: 'ollama',
+      model: 'qwen3',
+      cost,
+      contextWindow: 64_000,
+      maxTokens: 2048,
+    },
+    { id: 'defaulted', provider: 'ollama', model: 'qwen3' },
+  ]);
+  const budgeted = registry.get('budgeted')?.model;
+  t.deepEqual(budgeted?.cost, cost);
+  t.is(budgeted?.contextWindow, 64_000);
+  t.is(budgeted?.maxTokens, 2048);
+
+  const defaulted = registry.get('defaulted')?.model;
+  t.deepEqual(defaulted?.cost, {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  });
+  t.is(defaulted?.contextWindow, 32_768);
+  t.is(defaulted?.maxTokens, 8192);
+});
+
+test('resolveModelProfile splits a bare "provider/model" string when no provider field', t => {
+  const { model, localOllama } = resolveModelProfile({ model: 'ollama/qwen3' });
+  t.is(localOllama, true);
+  t.is(model.name, 'ollama/qwen3');
+});
+
+test('resolveModelProfile defaults to a local ollama profile with no config', t => {
+  const { model, localOllama } = resolveModelProfile();
+  t.is(localOllama, true);
+  t.is(model.name, 'ollama/qwen3');
+});
+
+test('resolveModelProfile requires a baseUrl for a non-local openai-compatible config', t => {
+  t.throws(
+    () => resolveModelProfile({ provider: 'openai-compatible', model: 'm' }),
+    { message: /openai-compatible model config requires baseUrl/ },
+  );
+});
+
+test('resolveModelString maps known LAL_HOST patterns to provider/model strings', t => {
+  t.is(
+    resolveModelString({ LAL_HOST: 'https://api.anthropic.com' }),
+    'anthropic/claude-opus-4-5-20251101',
+  );
+  t.is(
+    resolveModelString({
+      LAL_HOST: 'https://generativelanguage.googleapis.com',
+    }),
+    'google/gemini-2.0-flash',
+  );
+  t.is(
+    resolveModelString({ LAL_HOST: 'https://my-gemini-proxy.example' }),
+    'google/gemini-2.0-flash',
+  );
+  t.is(
+    resolveModelString({ LAL_HOST: 'https://openrouter.ai/api' }),
+    'openrouter/openrouter/auto',
+  );
+  t.is(
+    resolveModelString({ LAL_HOST: 'https://api.openai.com' }),
+    'openai/gpt-4o-mini',
+  );
+  t.is(
+    resolveModelString({ LAL_HOST: 'http://localhost:11434' }),
+    'ollama/qwen3.6',
+  );
+  t.is(
+    resolveModelString({ LAL_HOST: 'http://localhost:8080/v1' }),
+    'openai/qwen3',
+  );
+});
+
+test('resolveModelString defaults host to local ollama and honors LAL_MODEL', t => {
+  // No LAL_HOST -> local ollama default.
+  t.is(resolveModelString({}), 'ollama/qwen3.6');
+  // An unrecognized host falls through to the ollama default.
+  t.is(resolveModelString({ LAL_HOST: 'http://weird.host' }), 'ollama/qwen3.6');
+  // LAL_MODEL overrides the per-provider default model id.
+  t.is(
+    resolveModelString({
+      LAL_HOST: 'https://api.anthropic.com',
+      LAL_MODEL: 'custom',
+    }),
+    'anthropic/custom',
+  );
+});
+
+test('buildOllamaModel uses the default host and reads OLLAMA_HOST through the seam', async t => {
+  const defaulted = await buildOllamaModel('qwen3', { get: () => undefined });
+  t.is(defaulted.name, 'ollama/qwen3');
+  t.is(defaulted.provider, 'openai');
+  t.is(defaulted.baseUrl, 'http://127.0.0.1:11434/v1');
+
+  const overridden = await buildOllamaModel('qwen3', {
+    get: name => (name === 'OLLAMA_HOST' ? 'http://h:9' : undefined),
+  });
+  t.is(overridden.baseUrl, 'http://h:9/v1');
+});
+
+test('resolveModel routes the ollama prefix to a local OpenAI-compatible model', async t => {
+  const model = await resolveModel('ollama/qwen3', { get: () => undefined });
+  t.is(model.name, 'ollama/qwen3');
+  t.is(model.baseUrl, 'http://127.0.0.1:11434/v1');
+});
+
+test('resolveModel routes a non-ollama prefix through the registry', async t => {
+  const model = await resolveModel(`${KNOWN_PROVIDER}/${KNOWN_MODEL}`);
+  t.is(model, getModel(KNOWN_PROVIDER, KNOWN_MODEL));
+});
+
+test('defineModels builds a registry resolving credentials three ways', t => {
+  const registry = defineModels([
+    { id: 'local', provider: 'ollama', model: 'qwen3' },
+    { id: 'keyed', provider: 'ollama', model: 'q', credential: 'MY_KEY' },
+    {
+      id: 'fn',
+      provider: 'ollama',
+      model: 'q',
+      credential: credentials => credentials.get('X'),
+    },
+  ]);
+  t.deepEqual([...registry.keys()], ['local', 'keyed', 'fn']);
+
+  // No credential configured -> always undefined, even with a populated seam.
+  t.is(
+    registry.get('local')?.resolveCredential({ get: () => 'anything' }),
+    undefined,
+  );
+  // String credential resolves the named key through the seam.
+  t.is(
+    registry.get('keyed')?.resolveCredential({
+      get: name => (name === 'MY_KEY' ? 'sekret' : undefined),
+    }),
+    'sekret',
+  );
+  // Callback credential is invoked with the seam.
+  t.is(
+    registry.get('fn')?.resolveCredential({
+      get: name => (name === 'X' ? 'xval' : undefined),
+    }),
+    'xval',
+  );
+});
+
+test('defineModels rejects a definition with an empty id', t => {
+  t.throws(() => defineModels([{ id: '', provider: 'ollama', model: 'q' }]), {
+    message: /model profile requires a non-empty id/,
+  });
+});

--- a/packages/agentry/tsconfig.json
+++ b/packages/agentry/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.eslint-base.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.js"
+  ]
+}

--- a/packages/lal/agent.js
+++ b/packages/lal/agent.js
@@ -14,9 +14,9 @@ import { tools } from './tools/index.js';
 import { makeExecuteTool, toAgentTool } from './tool-dispatch.js';
 import {
   resolveModelString,
-  setProviderApiKey,
   resolveModel,
-  getOllamaApiKey,
+  makeWorkerCredentials,
+  makeWorkerGetApiKey,
 } from './model-resolution.js';
 import { runRound } from './round-runner.js';
 import { runInboxLoop } from './inbox-loop.js';
@@ -77,9 +77,6 @@ export const spawnWorkerLoop = async (powers, context, workerEnv) => {
   // single "provider/modelId" string instead; we keep accepting the legacy
   // LAL_* variables and translate them.
   const model = resolveModelString(workerEnv);
-  if (workerEnv.LAL_AUTH_TOKEN) {
-    setProviderApiKey(model, workerEnv.LAL_AUTH_TOKEN);
-  }
 
   // Bind the tool dispatcher to this guest's powers, then build the
   // AgentTool array pi-agent-core consumes directly. We build the PiAgent via
@@ -101,12 +98,23 @@ export const spawnWorkerLoop = async (powers, context, workerEnv) => {
   const resolvedModel = await resolveModel(model);
   const isOllama = resolvedModel.name?.startsWith('ollama/');
 
+  // The worker's API key is resolved through the read-only `Credentials` seam
+  // and handed to pi-agent-core via a `getApiKey` callback — no ambient-env
+  // mutation. An ollama model keeps the harmless 'ollama' sentinel; any other
+  // provider takes a pre-existing real `<PROVIDER>_API_KEY` over the worker's
+  // LAL_AUTH_TOKEN (see `makeWorkerGetApiKey`).
+  const credentials = makeWorkerCredentials();
+  const getApiKey = makeWorkerGetApiKey(
+    credentials,
+    workerEnv.LAL_AUTH_TOKEN,
+    isOllama,
+  );
+
   const piAgent = makePiAgent({
     systemPrompt,
     model: resolvedModel,
     tools: agentTools,
-    // Pass getApiKey only for Ollama, matching the prior conditional spread.
-    getApiKey: isOllama ? async _provider => getOllamaApiKey() : undefined,
+    getApiKey,
   });
 
   /**

--- a/packages/lal/agent.js
+++ b/packages/lal/agent.js
@@ -7,8 +7,7 @@ import { E } from '@endo/eventual-send';
 import { iterateReader } from '@endo/exo-stream/iterate-reader.js';
 import { makeLocalTree } from '@endo/platform/fs/node';
 
-import { Agent as PiAgent } from '@earendil-works/pi-agent-core';
-import { registerBuiltInApiProviders } from '@earendil-works/pi-ai';
+import { makePiAgent } from '@endo/agentry/harness';
 
 import { systemPrompt } from './prompts/system.js';
 import { tools } from './tools/index.js';
@@ -25,13 +24,15 @@ import { runInboxLoop } from './inbox-loop.js';
 /** @import { FarRef } from '@endo/eventual-send' */
 /** @import { GuestPowers, LalContext } from './agent.types.js' */
 
-// Register pi-ai's built-in API providers (anthropic, openai, google,
-// openrouter, mistral, deepseek, groq, xai, github-copilot, and ~20 others)
-// so getModel(provider, modelId) lookups succeed for any caller-supplied
-// "provider/modelId" string. Ollama is *not* in this registry; lal handles
-// "ollama/<id>" specially in `resolveWorkerModel` below by constructing a
-// custom Model that points at a local OpenAI-compatible Ollama endpoint.
-registerBuiltInApiProviders();
+// pi-ai's built-in API providers (anthropic, openai, google, openrouter,
+// mistral, deepseek, groq, xai, github-copilot, and ~20 others) are registered
+// lazily by the harness on first model resolution, so `getModel(provider,
+// modelId)` lookups succeed for any caller-supplied "provider/modelId" string
+// without an explicit registration call here: the worker's `resolveModel`
+// (re-exported from `@endo/agentry/harness`) self-registers before its first
+// registry lookup. Ollama is *not* in this registry; lal handles "ollama/<id>"
+// specially in `resolveModel` by constructing a custom Model that points at a
+// local OpenAI-compatible Ollama endpoint.
 
 // ============================================================================
 // Interface Definition
@@ -81,10 +82,13 @@ export const spawnWorkerLoop = async (powers, context, workerEnv) => {
   }
 
   // Bind the tool dispatcher to this guest's powers, then build the
-  // AgentTool array pi-agent-core consumes directly. We construct the
-  // PiAgent in-line (rather than via a higher-level harness helper) so that
-  //   (a) we are free to seed `initialState.messages` from prior
-  //       transcripts when cross-restart continuity lands (see PR body),
+  // AgentTool array pi-agent-core consumes directly. We build the PiAgent via
+  // `@endo/agentry/harness`'s `makePiAgent` (which owns the shared
+  // `initialState` shape, the user/assistant/toolResult `convertToLlm` filter,
+  // the `reasoning ? 'medium' : 'off'` thinking default, and
+  // `toolExecution: 'sequential'`) so that
+  //   (a) we are free to seed `messages` from prior transcripts when
+  //       cross-restart continuity lands (see PR body),
   //   (b) we control the system prompt verbatim (no policy suffix or
   //       security-notes wrapping is applied), and
   //   (c) the per-tool parameter schema lives at the tool boundary,
@@ -97,23 +101,12 @@ export const spawnWorkerLoop = async (powers, context, workerEnv) => {
   const resolvedModel = await resolveModel(model);
   const isOllama = resolvedModel.name?.startsWith('ollama/');
 
-  const piAgent = new PiAgent({
-    initialState: {
-      systemPrompt,
-      model: resolvedModel,
-      tools: agentTools,
-      messages: [],
-      thinkingLevel: resolvedModel.reasoning ? 'medium' : 'off',
-    },
-    convertToLlm: msgs =>
-      msgs.filter(
-        m =>
-          m.role === 'user' ||
-          m.role === 'assistant' ||
-          m.role === 'toolResult',
-      ),
-    toolExecution: 'sequential',
-    ...(isOllama ? { getApiKey: async _provider => getOllamaApiKey() } : {}),
+  const piAgent = makePiAgent({
+    systemPrompt,
+    model: resolvedModel,
+    tools: agentTools,
+    // Pass getApiKey only for Ollama, matching the prior conditional spread.
+    getApiKey: isOllama ? async _provider => getOllamaApiKey() : undefined,
   });
 
   /**

--- a/packages/lal/model-resolution.js
+++ b/packages/lal/model-resolution.js
@@ -4,72 +4,26 @@
  *
  * pi-ai expects a single "provider/modelId" string and reads provider API
  * keys from `process.env.<PROVIDER>_API_KEY`. lal's historical configuration
- * passes LAL_HOST + LAL_MODEL + LAL_AUTH_TOKEN. The helpers below translate
- * the legacy LAL_* variables into the pi-ai shape so existing `.env.example`
- * files continue to work.
+ * passes LAL_HOST + LAL_MODEL + LAL_AUTH_TOKEN.
+ *
+ * `resolveModelString` (the legacy LAL_* → "provider/modelId" translation) and
+ * `resolveModel` (the "provider/modelId" → pi-ai Model resolver, including the
+ * Ollama special case) now live in `@endo/agentry/harness`; lal re-exports them
+ * so the harness owns the extracted primitives. The two helpers defined locally
+ * (`setProviderApiKey` / `getOllamaApiKey`) stay here because they touch the
+ * ambient provider-key environment, which the harness's read-only credential
+ * seam does not model — but they now read through `getAmbientEnv`.
  *
  * `spawnWorkerLoop` in `agent.js` is the sole consumer.
  */
 
-import { getModel } from '@earendil-works/pi-ai';
+import {
+  getAmbientEnv,
+  resolveModelString,
+  resolveModel,
+} from '@endo/agentry/harness';
 
-/** @import { Model } from '@earendil-works/pi-ai' */
-
-/**
- * Translate the legacy LAL_HOST + LAL_MODEL pair into a single
- * "provider/modelId" string suitable for pi-ai's getModel(). Recognized
- * LAL_HOST patterns:
- *
- *   contains "anthropic.com"  -> provider "anthropic"
- *   contains "generativelanguage.googleapis.com" or "gemini" -> "google"
- *   contains "openai.com"     -> provider "openai"
- *   contains "openrouter"     -> provider "openrouter"
- *   contains ":11434"         -> provider "ollama"
- *   otherwise (incl. "/v1" llama.cpp servers) -> provider "openai"
- *     (pi-ai's openai-completions adaptor speaks the same protocol)
- *
- * LAL_MODEL is used as the model id; a sensible default is chosen if
- * LAL_MODEL is empty.
- *
- * @param {{ LAL_HOST?: string, LAL_MODEL?: string }} env
- * @returns {string}
- */
-export function resolveModelString(env) {
-  const host = (env.LAL_HOST || 'http://localhost:11434').toLowerCase();
-  let provider = 'ollama';
-  // Temporary default until the subagent creation wizard ships and can guide
-  // users to select a model explicitly.
-  let defaultModel = 'qwen3.6';
-  if (host.includes('anthropic.com')) {
-    provider = 'anthropic';
-    defaultModel = 'claude-opus-4-5-20251101';
-  } else if (
-    host.includes('generativelanguage.googleapis.com') ||
-    host.includes('gemini')
-  ) {
-    // pi-ai exposes Google's Gemini models under the provider name 'google'.
-    provider = 'google';
-    defaultModel = 'gemini-2.0-flash';
-  } else if (host.includes('openrouter')) {
-    provider = 'openrouter';
-    defaultModel = 'openrouter/auto';
-  } else if (host.includes('openai.com')) {
-    provider = 'openai';
-    defaultModel = 'gpt-4o-mini';
-  } else if (host.includes(':11434')) {
-    // Native Ollama port.
-    // Temporary default until the subagent creation wizard ships.
-    provider = 'ollama';
-    defaultModel = 'qwen3.6';
-  } else if (host.includes('/v1')) {
-    // Any OpenAI-compatible local server (llama.cpp, vLLM, tgi).
-    provider = 'openai';
-    defaultModel = 'qwen3';
-  }
-  const modelId = env.LAL_MODEL || defaultModel;
-  return `${provider}/${modelId}`;
-}
-harden(resolveModelString);
+export { resolveModelString, resolveModel };
 
 /**
  * Install the caller-supplied API key into the appropriate environment
@@ -80,9 +34,7 @@ harden(resolveModelString);
  * @param {string} authToken
  */
 export function setProviderApiKey(modelString, authToken) {
-  // eslint-disable-next-line no-undef
-  const env = globalThis?.process?.env;
-  if (!env) return;
+  const env = getAmbientEnv();
   const [provider] = modelString.split('/');
   const keyName = `${provider.toUpperCase()}_API_KEY`;
   if (!env[keyName] || env[keyName] === 'ollama') {
@@ -90,57 +42,6 @@ export function setProviderApiKey(modelString, authToken) {
   }
 }
 harden(setProviderApiKey);
-
-/**
- * Resolve a "provider/modelId" string into a pi-ai Model object. Known
- * providers go through `getModel(provider, modelId)`; the `ollama/` prefix
- * is treated specially (Ollama is not in pi-ai's built-in registry and
- * exposes an OpenAI-compatible /v1 endpoint).
- *
- * @param {string} modelString
- * @returns {Promise<Model<'openai-completions'>>}
- */
-export async function resolveModel(modelString) {
-  const parts = modelString.split('/');
-  const provider = parts[0];
-  const modelId = parts.slice(1).join('/');
-  if (provider === 'ollama') {
-    return buildOllamaModel(modelId);
-  }
-  // pi-ai's KnownProvider overloads of getModel typically resolve the modelId
-  // to `never` for the generic call site; we want the runtime registry lookup
-  // here, which works for any string the caller passed.
-  // @ts-expect-error - permissive runtime lookup against KnownProvider overloads
-  return getModel(provider, modelId);
-}
-harden(resolveModel);
-
-/**
- * Build a pi-ai Model object for a local Ollama instance. Ollama exposes
- * an OpenAI-compatible /v1/chat/completions endpoint, so we masquerade as
- * the "openai" provider with a custom baseUrl.
- *
- * @param {string} id - The ollama model name (e.g. "qwen3")
- * @returns {Promise<Model<'openai-completions'>>}
- */
-async function buildOllamaModel(id) {
-  await Promise.resolve();
-  // eslint-disable-next-line no-undef
-  const env = globalThis?.process?.env ?? {};
-  const ollamaHost = env.OLLAMA_HOST || 'http://127.0.0.1:11434';
-  return harden({
-    id,
-    name: `ollama/${id}`,
-    api: 'openai-completions',
-    provider: 'openai',
-    baseUrl: `${ollamaHost}/v1`,
-    reasoning: false,
-    input: ['text'],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 32_768,
-    maxTokens: 8192,
-  });
-}
 
 /**
  * API-key resolver for Ollama models. Ollama itself does not require a key,
@@ -152,8 +53,6 @@ async function buildOllamaModel(id) {
  * @returns {string}
  */
 export function getOllamaApiKey() {
-  // eslint-disable-next-line no-undef
-  const env = globalThis?.process?.env ?? {};
-  return env.OLLAMA_API_KEY || 'ollama';
+  return getAmbientEnv().OLLAMA_API_KEY || 'ollama';
 }
 harden(getOllamaApiKey);

--- a/packages/lal/model-resolution.js
+++ b/packages/lal/model-resolution.js
@@ -9,50 +9,90 @@
  * `resolveModelString` (the legacy LAL_* → "provider/modelId" translation) and
  * `resolveModel` (the "provider/modelId" → pi-ai Model resolver, including the
  * Ollama special case) now live in `@endo/agentry/harness`; lal re-exports them
- * so the harness owns the extracted primitives. The two helpers defined locally
- * (`setProviderApiKey` / `getOllamaApiKey`) stay here because they touch the
- * ambient provider-key environment, which the harness's read-only credential
- * seam does not model — but they now read through `getAmbientEnv`.
+ * so the harness owns the extracted primitives.
+ *
+ * lal's per-worker API key resolution is now a `getApiKey` callback derived
+ * from the harness's `Credentials` seam (`makeWorkerGetApiKey` below) rather
+ * than an ambient-env mutation: the worker's LAL_AUTH_TOKEN is handed to pi-ai
+ * through the callback, with any pre-existing real `<PROVIDER>_API_KEY` in the
+ * environment still taking precedence (matching the prior
+ * "don't clobber an already-set key" rule). No module here writes to ambient
+ * env any more; the seam is read-only by design.
  *
  * `spawnWorkerLoop` in `agent.js` is the sole consumer.
  */
 
 import {
   getAmbientEnv,
+  makeEnvCredentials,
   resolveModelString,
   resolveModel,
 } from '@endo/agentry/harness';
 
+/** @import { Credentials, GetApiKey } from '@endo/agentry/harness' */
+
 export { resolveModelString, resolveModel };
 
 /**
- * Install the caller-supplied API key into the appropriate environment
- * variable so pi-ai's provider adaptor finds it. We avoid clobbering an
- * already-set variable; this is best-effort and explicitly per-worker.
+ * Build the per-worker `getApiKey` callback for pi-agent-core, resolving keys
+ * through the harness `Credentials` seam instead of mutating ambient env.
  *
- * @param {string} modelString - "provider/modelId"
- * @param {string} authToken
+ * Precedence mirrors the prior `setProviderApiKey` + `getOllamaApiKey`
+ * behavior exactly:
+ *
+ *   - Ollama worker (`isOllama`): a real `OLLAMA_API_KEY` read through the seam
+ *     wins, else the per-worker `authToken` (the legacy LAL_AUTH_TOKEN, which
+ *     the old `setProviderApiKey` path copied into `OLLAMA_API_KEY` before
+ *     `getOllamaApiKey()` read it, so a protected / remote Ollama still
+ *     authenticates), else the harmless `'ollama'` sentinel (pi-ai's
+ *     openai-completions adaptor rejects a missing key). The sentinel value is
+ *     treated as "unset" so the `authToken` overrides it. The ollama-ness is
+ *     decided by the resolved model (its `provider` is masqueraded as
+ *     `'openai'`, so the `provider` argument pi-agent-core passes cannot be
+ *     used to detect it) — hence the flag.
+ *   - Any other worker: a pre-existing real `<PROVIDER>_API_KEY` in the
+ *     environment wins; otherwise the worker's `authToken` (the legacy
+ *     LAL_AUTH_TOKEN) is supplied. The `'ollama'` sentinel value is treated as
+ *     "unset" so the auth token overrides it, matching the prior
+ *     `!env[KEY] || env[KEY] === 'ollama'` guard.
+ *
+ * @param {Credentials} credentials The read-only secret seam.
+ * @param {string | undefined} authToken The worker's LAL_AUTH_TOKEN, if any.
+ * @param {boolean} isOllama Whether the resolved model is a local Ollama model.
+ * @returns {GetApiKey}
  */
-export function setProviderApiKey(modelString, authToken) {
-  const env = getAmbientEnv();
-  const [provider] = modelString.split('/');
-  const keyName = `${provider.toUpperCase()}_API_KEY`;
-  if (!env[keyName] || env[keyName] === 'ollama') {
-    env[keyName] = authToken;
-  }
+export function makeWorkerGetApiKey(credentials, authToken, isOllama) {
+  return provider => {
+    if (isOllama) {
+      // A real OLLAMA_API_KEY wins (a remote / protected Ollama the operator
+      // configured), else the per-worker authToken (the legacy LAL_AUTH_TOKEN,
+      // which the old setProviderApiKey path copied into OLLAMA_API_KEY before
+      // getOllamaApiKey() read it), else the harmless 'ollama' sentinel that
+      // pi-ai's openai-completions adaptor accepts in lieu of a key. The
+      // sentinel value is treated as "unset" so the authToken overrides it.
+      const existing = credentials.get('OLLAMA_API_KEY');
+      if (existing !== undefined && existing !== 'ollama') {
+        return existing;
+      }
+      return authToken || 'ollama';
+    }
+    const existing = credentials.get(`${provider.toUpperCase()}_API_KEY`);
+    if (existing !== undefined && existing !== 'ollama') {
+      return existing;
+    }
+    return authToken;
+  };
 }
-harden(setProviderApiKey);
+harden(makeWorkerGetApiKey);
 
 /**
- * API-key resolver for Ollama models. Ollama itself does not require a key,
- * but pi-ai's openai-completions adaptor refuses requests without one.
- * Prefer `OLLAMA_API_KEY` (in case the operator has set one for a remote
- * Ollama), else fall back to a harmless sentinel that the operator's setup
- * commonly uses already.
+ * Build the worker's `Credentials` seam over the ambient process environment.
+ * The seam is the one read-only choke point for the worker's secrets; swapping
+ * in a capability-scoped provider later is local to this call.
  *
- * @returns {string}
+ * @returns {Credentials}
  */
-export function getOllamaApiKey() {
-  return getAmbientEnv().OLLAMA_API_KEY || 'ollama';
+export function makeWorkerCredentials() {
+  return makeEnvCredentials(getAmbientEnv());
 }
-harden(getOllamaApiKey);
+harden(makeWorkerCredentials);

--- a/packages/lal/package.json
+++ b/packages/lal/package.json
@@ -38,6 +38,7 @@
     "@anthropic-ai/sdk": "^0.95.1",
     "@earendil-works/pi-agent-core": "^0.79.0",
     "@earendil-works/pi-ai": "^0.79.0",
+    "@endo/agentry": "workspace:^",
     "@endo/daemon": "workspace:^",
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",

--- a/packages/lal/test/model-resolution.test.js
+++ b/packages/lal/test/model-resolution.test.js
@@ -1,0 +1,49 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+import { makeEnvCredentials } from '@endo/agentry/harness';
+
+import { makeWorkerGetApiKey } from '../model-resolution.js';
+
+// The resolved Ollama model masquerades as the 'openai' provider, so that is
+// the provider name pi-agent-core passes the getApiKey hook for an Ollama
+// worker.
+const OLLAMA_PROVIDER = 'openai';
+
+test('Ollama worker honors the per-worker authToken when no OLLAMA_API_KEY is set', t => {
+  // Regression: a worker configured via the Lal form with a real LAL_AUTH_TOKEN
+  // must authenticate against a protected / remote Ollama. The prior
+  // setProviderApiKey path copied LAL_AUTH_TOKEN into OLLAMA_API_KEY; dropping
+  // the token here silently returned only the 'ollama' sentinel.
+  const credentials = makeEnvCredentials({});
+  const getApiKey = makeWorkerGetApiKey(credentials, 'worker-token', true);
+  t.is(getApiKey(OLLAMA_PROVIDER), 'worker-token');
+});
+
+test('Ollama worker prefers a real OLLAMA_API_KEY over the authToken', t => {
+  const credentials = makeEnvCredentials({ OLLAMA_API_KEY: 'real-key' });
+  const getApiKey = makeWorkerGetApiKey(credentials, 'worker-token', true);
+  t.is(getApiKey(OLLAMA_PROVIDER), 'real-key');
+});
+
+test('Ollama worker treats the OLLAMA_API_KEY sentinel as unset so the authToken overrides it', t => {
+  const credentials = makeEnvCredentials({ OLLAMA_API_KEY: 'ollama' });
+  const getApiKey = makeWorkerGetApiKey(credentials, 'worker-token', true);
+  t.is(getApiKey(OLLAMA_PROVIDER), 'worker-token');
+});
+
+test('Ollama worker falls back to the sentinel when neither key nor authToken is present', t => {
+  const credentials = makeEnvCredentials({});
+  const getApiKey = makeWorkerGetApiKey(credentials, undefined, true);
+  t.is(getApiKey(OLLAMA_PROVIDER), 'ollama');
+});
+
+test('non-Ollama worker prefers a real provider key over the authToken', t => {
+  const credentials = makeEnvCredentials({ ANTHROPIC_API_KEY: 'real-key' });
+  const getApiKey = makeWorkerGetApiKey(credentials, 'worker-token', false);
+  t.is(getApiKey('anthropic'), 'real-key');
+});
+
+test('non-Ollama worker supplies the authToken when no provider key is set', t => {
+  const credentials = makeEnvCredentials({});
+  const getApiKey = makeWorkerGetApiKey(credentials, 'worker-token', false);
+  t.is(getApiKey('anthropic'), 'worker-token');
+});

--- a/packages/lal/tool-dispatch.js
+++ b/packages/lal/tool-dispatch.js
@@ -17,7 +17,7 @@
 
 import { mustMatch } from '@endo/patterns';
 import { E } from '@endo/eventual-send';
-import { makeMarshal } from '@endo/marshal';
+import { toolResultToSmallcaps, smallcapsMarshal } from '@endo/agentry/harness';
 
 import { tools } from './tools/index.js';
 
@@ -34,18 +34,12 @@ import { tools } from './tools/index.js';
 // produce correct encodings; the patterns matchers then validate the
 // decoded passables rather than the raw JSON strings.
 //
-// The codec is constructed once at module load. No slot converters are
-// needed because tool args never carry remotables or promises; the defaults
-// (`dontEncodeRemotableToSmallcaps` / `dontEncodePromiseToSmallcaps`) are
-// the right handlers and will throw if a remotable somehow reaches the
-// boundary.
-
-/** @type {ReturnType<typeof makeMarshal>} */
-const smallcapsMarshal = makeMarshal(undefined, undefined, {
-  serializeBodyFormat: 'smallcaps',
-  // Tool-result encoding only; error logging is irrelevant here.
-  marshalSaveError: () => {},
-});
+// The `smallcapsMarshal` codec and the `toolResultToSmallcaps` tool-result
+// encoder now live in `@endo/agentry/harness` (imported above). The codec is
+// constructed once at module load there; no slot converters are needed because
+// tool args never carry remotables or promises, and the defaults
+// (`dontEncodeRemotableToSmallcaps` / `dontEncodePromiseToSmallcaps`) throw if
+// a remotable somehow reaches the boundary.
 
 // Pre-index each tool's @endo/patterns matcher by tool name. The matcher
 // validates the SmallCaps-decoded args record before dispatch, matching the
@@ -444,19 +438,9 @@ export function toAgentTool(name, summary, executeTool) {
       // Encode the tool result as SmallCaps so the model reads BigInts as
       // `"+N"` strings (consistent with the encoding it must produce for
       // inbound messageNumber fields) and strings starting with special
-      // chars as `"!<s>"`. `toCapData` produces `{ body: '#<json>', slots: [] }`;
-      // we strip the `#` sentinel and present the SmallCaps JSON directly.
-      let text;
-      if (typeof result === 'string') {
-        // Plain-string results need no SmallCaps wrapping; they carry no
-        // non-JSON values.
-        text = result;
-      } else {
-        const { body } = smallcapsMarshal.toCapData(harden(result));
-        // body is '#<smallcaps-json>'; slice off the '#' sentinel so the
-        // model reads the raw SmallCaps JSON object/array.
-        text = body.slice(1);
-      }
+      // chars as `"!<s>"`. Plain strings pass through unwrapped. The encoder is
+      // the shared `toolResultToSmallcaps` from `@endo/agentry/harness`.
+      const text = toolResultToSmallcaps(result);
       /** @type {AgentToolResult<any>} */
       const toolResult = {
         content: [{ type: 'text', text }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1220,10 +1220,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/agent-tools@workspace:packages/agent-tools":
+"@endo/agent-tools@workspace:^, @endo/agent-tools@workspace:packages/agent-tools":
   version: 0.0.0-use.local
   resolution: "@endo/agent-tools@workspace:packages/agent-tools"
   dependencies:
+    "@earendil-works/pi-agent-core": "npm:^0.79.0"
+    "@earendil-works/pi-ai": "npm:^0.79.0"
     "@endo/daemon": "workspace:^"
     "@endo/exo-git": "workspace:^"
     "@endo/far": "workspace:^"
@@ -1234,6 +1236,38 @@ __metadata:
     ajv: "npm:^8.17.1"
     ava: "catalog:dev"
     c8: "catalog:dev"
+    eslint: "catalog:dev"
+    typescript: "catalog:dev"
+  peerDependencies:
+    "@earendil-works/pi-agent-core": ^0.79.0
+    "@earendil-works/pi-ai": ^0.79.0
+  peerDependenciesMeta:
+    "@earendil-works/pi-agent-core":
+      optional: true
+    "@earendil-works/pi-ai":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
+"@endo/agentry@workspace:^, @endo/agentry@workspace:packages/agentry":
+  version: 0.0.0-use.local
+  resolution: "@endo/agentry@workspace:packages/agentry"
+  dependencies:
+    "@earendil-works/pi-agent-core": "npm:^0.79.0"
+    "@earendil-works/pi-ai": "npm:^0.79.0"
+    "@endo/agent-tools": "workspace:^"
+    "@endo/daemon": "workspace:^"
+    "@endo/exo-git": "workspace:^"
+    "@endo/exo-stream": "workspace:^"
+    "@endo/far": "workspace:^"
+    "@endo/git": "workspace:^"
+    "@endo/init": "workspace:^"
+    "@endo/lockdown": "workspace:^"
+    "@endo/marshal": "workspace:^"
+    "@endo/pass-style": "workspace:^"
+    "@endo/platform": "workspace:^"
+    "@endo/ses-ava": "workspace:^"
+    ava: "catalog:dev"
     eslint: "catalog:dev"
     typescript: "catalog:dev"
   languageName: unknown
@@ -2127,6 +2161,7 @@ __metadata:
     "@anthropic-ai/sdk": "npm:^0.95.1"
     "@earendil-works/pi-agent-core": "npm:^0.79.0"
     "@earendil-works/pi-ai": "npm:^0.79.0"
+    "@endo/agentry": "workspace:^"
     "@endo/cli": "workspace:^"
     "@endo/daemon": "workspace:^"
     "@endo/errors": "workspace:^"


### PR DESCRIPTION
## What

`@endo/agentry` — a small, private harness library for building agentic harnesses across endo packages — plus a `defineAgent` builder, with code mode as its first agent. This restructures the prior execute-only code-mode runtime into a layered package and dogfoods the extracted primitives by rewiring `@endo/lal` to import them.

Layout (`packages/agentry/src`):

- `define-agent.js` — `defineAgent(config)` returns a **maker function**. The powerless definition is the closure; calling the returned maker with a powers handle is the powered stage. Config scoped to `{ model, instructions, tools, endow }`; the `endow` hook is the seam where a powerless definition is granted live powers. `actions`/`skills`/`cwd` deferred.
- `harness/` — code-mode-independent primitives:
  - `marshal.js` — `toolResultToSmallcaps` + the SmallCaps codec (renders a plain-data tool result into the model-facing SmallCaps text).
  - `credentials.js` — the credential seam: `getAmbientEnv` (the **fallback** `process.env` reader, used only when a caller supplies no better source), `makeEnvCredentials` / `Credentials.get(name)`, and `makeApiKeyGetter` + the `GetApiKey` type so a provider `getApiKey` is a single thin view over the one secret seam. A file-level `TODO(secure)` marks a future capability-scoped secret store.
  - `model.js` — `resolveModelProfile` / `resolveModel` (providers self-register lazily on first resolution — no import side effect), `defineModels` (provider/model profiles, each pairing a model with a credential resolved via the seam), a configurable `ModelBudget`, the exported `ThinkingLevel` type, and the `@deprecated resolveModelString` LAL_* back-compat shim.
  - `pi-agent.js` — `makePiAgent` (shared `initialState`, `convertToLlm` filter, thinking default).
- `execute/` — the code-mode `execute` tool and its presets (`makeCodeModeAgent`, `makeCodeModeGitLoopAgent`), built on `defineAgent`.

`toPiAgentTool` moves to `@endo/agent-tools/pi` (an optional `./pi` subpath) with the SmallCaps render injected as a hook, so `@endo/agent-tools` stays marshalling-agnostic and only optionally depends on the pi packages. Inside agentry, `toSmallcapsPiAgentTool` is the thin specialization that pre-binds the SmallCaps renderer.

`@endo/lal` is rewired to import the extracted harness primitives (`toolResultToSmallcaps`, the codec, `makePiAgent`, the model resolvers) instead of its local copies — the extracted code is behavior-identical and lal stays green — and its worker API keys now flow to pi-agent-core through a seam-derived `getApiKey` rather than ambient-env mutation.

## Why

Code mode is the git vehicle: an agent drives a git workspace by writing JS for one `execute` tool, with `git` / `workspace` as live caps in lexical scope — no per-arg tool schema, no marshalling of caps within a turn. Factoring the harness primitives out of the code-mode runtime (and out of lal) gives a shared substrate for the agent-builder lane (`defineAgent`) and keeps a single implementation of the marshalling, credential, model, and pi-agent seams.

## Key shape decisions

- **`defineAgent` is the core; code mode is just an agent that uses `execute`.** There is no `defineCodeModeAgent`. `defineAgent(config)` returns a maker; `const makeCodeModeAgent = defineAgent({…})`; `makeCodeModeAgent(powers?)` builds the instance.
- **One credential seam.** Secrets resolve through `Credentials.get`; a provider `getApiKey` is an adaptor over it (`makeApiKeyGetter`), and the ambient `process.env` is just the default *fallback* backing — swappable in one place.
- **`EndoMountEntry` stays inert** (inert exo + private `mountEntryRecords` WeakMap). Code-mode (live entries in-process) is the git vehicle; lal-as-git-tool is off the table (its `slots:[]` marshal can't carry the live `EndoMountEntry` that `git.add` requires).
- **Capability type-strings are dropped.** A lexical global is advertised to the model by name + a one-line description only; the model introspects a cap's method surface at runtime via `E(cap).__getMethodNames__()`. Codegen is a follow-up.

## Test plan

- `corepack yarn workspace @endo/agentry test` — 51 tests green, including the high-fidelity `git-loop preset edits the workspace, commits, and reads HEAD~1 over a real mount` (a **real daemon mount** + the inert `EndoMountEntry` exo; **no API key or live model needed**). The pi **faux provider** (`registerFauxProvider` from `@earendil-works/pi-ai`) drives the scripted agent turns; the git **tool** tests live in `@endo/agent-tools`.
- `corepack yarn workspace @endo/lal test` — green (the SmallCaps render and pi-agent dispatch tests prove the lal rewire is behavior-identical).
- `corepack yarn workspace @endo/agent-tools test` — green (the new `./pi` bridge is unit-tested).
- `lint` clean across the three packages.

## Notes

- Within-turn git loop is real and green (entries stay live in the Compartment).
- The credential seam is read-only (`.get`). `@endo/lal` no longer mutates the ambient environment — `setProviderApiKey` is removed; worker keys reach pi-agent-core via a seam-derived `getApiKey` (`makeWorkerGetApiKey`). The file-level `TODO(secure)` marks the future capability-scoped swap.
- Provider registration is not an import side effect: the harness registers pi-ai's built-in providers lazily on first model resolution.
- Private packages; no changeset.

Draft pending review — the `feat(agentry): defineAgent builder` commit is the focal commit.
