### PR TITLE
feat(agent-tools): name git tool params from the method

### DIFF
--- a/.changeset/agent-tools-named-tool-params.md
+++ b/.changeset/agent-tools-named-tool-params.md
@@ -1,0 +1,5 @@
+---
+'@endo/agent-tools': minor
+---
+
+Name each git tool's parameters from its method instead of the generic `arg0`/`arg1` convention. `gitToolSchemas` now declares real, declarative property names that read as an LLM-facing signature (`commit` → `message`, `show` → `ref`, `createBranch` → `name`/`options`, `switchBranch` → `branch`, `log`/`diff` → `options`), and `makeTool` marshals the named-args record into positionals by each schema's declared `parameters.properties` order and `required` set rather than the hardcoded `argN` keys. Arity, required-key validation, and the schema-to-guard parity are preserved.

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -56,7 +56,7 @@ const gitToolSchemas = harden({
     description: 'List commit history, most recent first.',
     parameters: {
       type: 'object',
-      properties: { arg0: OPTIONS_PROP },
+      properties: { options: OPTIONS_PROP },
       required: [],
       additionalProperties: false,
     },
@@ -65,7 +65,7 @@ const gitToolSchemas = harden({
     description: 'Show changes between commits, the index, and the worktree.',
     parameters: {
       type: 'object',
-      properties: { arg0: OPTIONS_PROP },
+      properties: { options: OPTIONS_PROP },
       required: [],
       additionalProperties: false,
     },
@@ -74,8 +74,8 @@ const gitToolSchemas = harden({
     description: 'Show the contents of a git object (commit, tag, blob).',
     parameters: {
       type: 'object',
-      properties: { arg0: REF_PROP },
-      required: ['arg0'],
+      properties: { ref: REF_PROP },
+      required: ['ref'],
       additionalProperties: false,
     },
   },
@@ -84,9 +84,9 @@ const gitToolSchemas = harden({
     parameters: {
       type: 'object',
       properties: {
-        arg0: { type: 'string', description: 'The commit message.' },
+        message: { type: 'string', description: 'The commit message.' },
       },
-      required: ['arg0'],
+      required: ['message'],
       additionalProperties: false,
     },
   },
@@ -99,10 +99,10 @@ const gitToolSchemas = harden({
     parameters: {
       type: 'object',
       properties: {
-        arg0: { type: 'string', description: 'The new branch name.' },
-        arg1: OPTIONS_PROP,
+        name: { type: 'string', description: 'The new branch name.' },
+        options: OPTIONS_PROP,
       },
-      required: ['arg0'],
+      required: ['name'],
       additionalProperties: false,
     },
   },
@@ -111,9 +111,9 @@ const gitToolSchemas = harden({
     parameters: {
       type: 'object',
       properties: {
-        arg0: { type: 'string', description: 'The branch to switch to.' },
+        branch: { type: 'string', description: 'The branch to switch to.' },
       },
-      required: ['arg0'],
+      required: ['branch'],
       additionalProperties: false,
     },
   },
@@ -161,17 +161,21 @@ export const makeGitTool = gitCap => {
   const records = gitToolMethods.map(method => {
     const schema = gitToolSchemas[method];
     const argGuards = positionalArgGuards(method);
+    // The schema's declared property order is the positional argument order,
+    // matching the convention `makeTool` applies to the named-args record.
+    const paramNames = Object.keys(
+      /** @type {{ properties?: Record<string, unknown> }} */ (
+        schema.parameters
+      ).properties || {},
+    );
     return makeTool({
       name: method,
       description: schema.description,
       parameters: schema.parameters,
       argGuards,
       execute: async argsRecord => {
-        // Marshal named args back to positional order.
-        const positional = [];
-        for (let i = 0; i < argGuards.length; i += 1) {
-          positional.push(argsRecord[`arg${i}`]);
-        }
+        // Marshal named args back to positional order by declared name.
+        const positional = paramNames.map(paramName => argsRecord[paramName]);
         while (
           positional.length > 0 &&
           positional[positional.length - 1] === undefined

--- a/packages/agent-tools/src/tool.js
+++ b/packages/agent-tools/src/tool.js
@@ -6,20 +6,59 @@
 import { mustMatch } from '@endo/patterns';
 
 /**
- * Marshal a named-args record `{arg0, arg1, …}` into a positional array in
- * ordinal order. Optional trailing `undefined` values are dropped; required
- * positions are retained for guard validation.
+ * Read the ordered list of declared parameter property names from a JSON Schema
+ * `parameters` object. The property insertion order is the positional argument
+ * order: the first declared property maps to the first positional slot, and so
+ * on. A schema with no `properties` (or a non-object one) has no named slots.
+ *
+ * @param {object} parameters
+ * @returns {string[]}
+ */
+const getParamNames = parameters => {
+  const { properties } = /** @type {{ properties?: unknown }} */ (parameters);
+  if (
+    properties === null ||
+    typeof properties !== 'object' ||
+    Array.isArray(properties)
+  ) {
+    return harden([]);
+  }
+  return harden(Object.keys(properties));
+};
+
+/**
+ * Read the set of required parameter property names from a JSON Schema
+ * `parameters` object, restricted to names that are actually declared as
+ * positional slots (so a stray `required` entry cannot enlarge arity).
+ *
+ * @param {object} parameters
+ * @param {string[]} paramNames Ordered declared property names.
+ * @returns {Set<string>}
+ */
+const getRequiredParamNames = (parameters, paramNames) => {
+  const { required } = /** @type {{ required?: unknown }} */ (parameters);
+  const declared = new Set(paramNames);
+  if (!Array.isArray(required)) {
+    return new Set();
+  }
+  return new Set(
+    required.filter(key => typeof key === 'string' && declared.has(key)),
+  );
+};
+
+/**
+ * Marshal a named-args record into a positional array, ordering the values by
+ * the schema's declared property-name order. Trailing optional `undefined`
+ * values are dropped; the leading `requiredCount` positions are always
+ * retained for guard validation.
  *
  * @param {Record<string, unknown>} argsRecord
- * @param {number} arity Number of positional slots (`argGuards.length`).
- * @param {number} requiredCount Number of required positional slots.
+ * @param {string[]} paramNames Ordered declared property names.
+ * @param {number} requiredCount Number of leading positional slots to retain.
  * @returns {unknown[]}
  */
-const namedToPositional = (argsRecord, arity, requiredCount) => {
-  const positional = [];
-  for (let i = 0; i < arity; i += 1) {
-    positional.push(argsRecord[`arg${i}`]);
-  }
+const namedToPositional = (argsRecord, paramNames, requiredCount) => {
+  const positional = paramNames.map(name => argsRecord[name]);
   // Drop trailing `undefined` (optional/absent args).
   while (
     positional.length > requiredCount &&
@@ -28,36 +67,6 @@ const namedToPositional = (argsRecord, arity, requiredCount) => {
     positional.pop();
   }
   return positional;
-};
-
-const ARG_KEY_PATTERN = /^arg(?:0|[1-9]\d*)$/;
-
-/**
- * @param {object} parameters
- * @returns {string[]}
- */
-const getRequiredArgKeys = parameters => {
-  const { required } = /** @type {{ required?: unknown }} */ (parameters);
-  if (!Array.isArray(required)) {
-    return harden([]);
-  }
-  return harden(
-    required.filter(
-      key => typeof key === 'string' && ARG_KEY_PATTERN.test(key),
-    ),
-  );
-};
-
-/**
- * @param {string[]} requiredArgKeys
- * @returns {number}
- */
-const getRequiredArgCount = requiredArgKeys => {
-  let requiredCount = 0;
-  for (const key of requiredArgKeys) {
-    requiredCount = Math.max(requiredCount, Number(key.slice(3)) + 1);
-  }
-  return requiredCount;
 };
 
 /**
@@ -80,6 +89,11 @@ const copyHardenArgsRecord = argsRecord => {
  * dispatch function. The schema is advertised to callers; the guards enforce
  * the same positional argument contract at runtime.
  *
+ * The schema's `parameters.properties` insertion order is the positional
+ * argument order, and `parameters.required` names the leading required slots.
+ * The named-args record a caller supplies is marshalled into positionals by
+ * that declared order before the guards validate it.
+ *
  * @param {ToolSpec} spec
  * @returns {ToolRecord}
  */
@@ -87,8 +101,19 @@ export const makeTool = spec => {
   const { name, description, parameters, argGuards, execute } = spec;
   // Avoid retaining a mutable caller-owned schema object.
   const hardenedParameters = harden(parameters);
-  const requiredArgKeys = getRequiredArgKeys(hardenedParameters);
-  const requiredArgCount = getRequiredArgCount(requiredArgKeys);
+  const paramNames = getParamNames(hardenedParameters);
+  const requiredParamNames = getRequiredParamNames(
+    hardenedParameters,
+    paramNames,
+  );
+  // Required slots must be the leading positional arguments, so arity counts up
+  // to the last required declared property.
+  let requiredCount = 0;
+  paramNames.forEach((paramName, index) => {
+    if (requiredParamNames.has(paramName)) {
+      requiredCount = Math.max(requiredCount, index + 1);
+    }
+  });
   return harden({
     name,
     description,
@@ -100,14 +125,14 @@ export const makeTool = spec => {
     invoke: async argsRecord => {
       const hardenedArgsRecord = copyHardenArgsRecord(argsRecord);
       if (argGuards !== undefined) {
-        // Reject keys outside the positional guard list.
-        const allowed = new Set(argGuards.map((_g, i) => `arg${i}`));
+        // Reject keys outside the declared property list.
+        const allowed = new Set(paramNames);
         for (const key of Object.keys(hardenedArgsRecord)) {
           if (!allowed.has(key)) {
             throw new Error(`unexpected tool argument key "${key}"`);
           }
         }
-        for (const key of requiredArgKeys) {
+        for (const key of requiredParamNames) {
           if (
             !Object.prototype.hasOwnProperty.call(hardenedArgsRecord, key) ||
             hardenedArgsRecord[key] === undefined
@@ -117,12 +142,12 @@ export const makeTool = spec => {
         }
         const positional = namedToPositional(
           hardenedArgsRecord,
-          argGuards.length,
-          requiredArgCount,
+          paramNames,
+          requiredCount,
         );
         // `namedToPositional` drops omitted optional tail args.
         for (let i = 0; i < positional.length; i += 1) {
-          mustMatch(positional[i], argGuards[i], `${name} arg${i}`);
+          mustMatch(positional[i], argGuards[i], `${name} ${paramNames[i]}`);
         }
       }
       return execute(hardenedArgsRecord);

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -45,7 +45,11 @@ export interface ToolSpec {
    * runs.
    */
   argGuards?: Pattern[];
-  /** Dispatch target. Receives the named-args record `{arg0, arg1, ...}`. */
+  /**
+   * Dispatch target. Receives the named-args record keyed by the schema's
+   * declared `parameters.properties` names (e.g. `{ message }`, `{ name,
+   * options }`).
+   */
   execute: (args: Record<string, unknown>) => Promise<unknown>;
 }
 

--- a/packages/agent-tools/test/divergence.test.js
+++ b/packages/agent-tools/test/divergence.test.js
@@ -47,20 +47,22 @@ const guardShapeFor = method => {
 };
 
 /**
- * Decide whether the runtime guards accept a named-args record.
+ * Decide whether the runtime guards accept a named-args record, mapping the
+ * record's keys onto positional slots by the schema's declared property order.
  *
  * @param {{requiredCount:number, guards:Pattern[]}} shape
+ * @param {string[]} paramNames Declared property names, in positional order.
  * @param {Record<string, unknown>} record
  */
-const guardAccepts = (shape, record) => {
+const guardAccepts = (shape, paramNames, record) => {
   const { requiredCount, guards } = shape;
-  const allowed = new Set(guards.map((_g, i) => `arg${i}`));
+  const allowed = new Set(paramNames.slice(0, guards.length));
   for (const key of Object.keys(record)) {
     if (!allowed.has(key)) return false;
   }
   for (let i = 0; i < guards.length; i += 1) {
-    const key = `arg${i}`;
-    // JSON has no `undefined`, so a known `argN: undefined` is treated as absent.
+    const key = paramNames[i];
+    // JSON has no `undefined`, so a known `name: undefined` is treated as absent.
     const present =
       Object.prototype.hasOwnProperty.call(record, key) &&
       record[key] !== undefined;
@@ -74,40 +76,76 @@ const guardAccepts = (shape, record) => {
 };
 
 /**
- * Candidate named-args records covering valid and invalid shapes.
+ * Candidate args records covering valid and invalid shapes, keyed by abstract
+ * positional slots (`slot0`/`slot1`) plus an out-of-band `extra` key. The macro
+ * remaps each slot to the tool's real declared property name, so the same
+ * coverage exercises every tool's named signature.
  */
-const candidateRecords = harden([
+const slotRecords = harden([
   {},
-  { arg0: 'a-string' },
-  { arg0: '' },
-  { arg0: 42 },
-  { arg0: 42n },
-  { arg0: true },
-  { arg0: null },
-  { arg0: undefined },
-  { arg0: {} },
-  { arg0: { k: 'v' } },
-  { arg0: [] },
-  { arg1: 'only-second' },
-  { arg0: 'a', arg1: {} },
-  { arg0: 'a', arg1: { opt: 1 } },
-  { arg0: 'a', arg1: 'not-a-record' },
-  { arg0: 'a', arg1: 5 },
-  { arg0: {}, arg1: {} },
-  { arg0: 'a', arg2: 'extra' },
-  { arg0: 'a', extra: 'x' },
+  { slot0: 'a-string' },
+  { slot0: '' },
+  { slot0: 42 },
+  { slot0: 42n },
+  { slot0: true },
+  { slot0: null },
+  { slot0: undefined },
+  { slot0: {} },
+  { slot0: { k: 'v' } },
+  { slot0: [] },
+  { slot1: 'only-second' },
+  { slot0: 'a', slot1: {} },
+  { slot0: 'a', slot1: { opt: 1 } },
+  { slot0: 'a', slot1: 'not-a-record' },
+  { slot0: 'a', slot1: 5 },
+  { slot0: {}, slot1: {} },
+  { slot0: 'a', extra: 'x' },
   { extra: 'x' },
   { extra: undefined },
-  { arg0: undefined, arg1: undefined },
-  { arg0: 'a', arg1: {}, arg2: 'too-many' },
+  { slot0: undefined, slot1: undefined },
   // Open-object option records.
-  { arg0: { a: 1, b: 2 } },
-  { arg0: { nested: { x: 1 } } },
-  { arg0: harden({ author: 'alice', oneline: true, maxCount: 10 }) },
-  { arg0: 'a', arg1: { a: 1, b: 2 } },
-  { arg0: 'a', arg1: { nested: { x: 1 } } },
-  { arg0: 'a', arg1: harden({ track: true, startPoint: 'main' }) },
+  { slot0: { a: 1, b: 2 } },
+  { slot0: { nested: { x: 1 } } },
+  { slot0: harden({ author: 'alice', oneline: true, maxCount: 10 }) },
+  { slot0: 'a', slot1: { a: 1, b: 2 } },
+  { slot0: 'a', slot1: { nested: { x: 1 } } },
+  { slot0: 'a', slot1: harden({ track: true, startPoint: 'main' }) },
 ]);
+
+/**
+ * Declared property names for a tool, in positional order.
+ *
+ * @param {ToolRecord} tool
+ * @returns {string[]}
+ */
+const paramNamesOf = tool =>
+  Object.keys(
+    /** @type {{ properties?: Record<string, unknown> }} */ (tool.parameters)
+      .properties || {},
+  );
+
+/**
+ * Remap an abstract slot record onto a tool's real property names. `slot0` →
+ * the first declared property, `slot1` → the second; unknown slots and `extra`
+ * are preserved verbatim so the out-of-band-key cases still exercise rejection.
+ *
+ * @param {Record<string, unknown>} slotRecord
+ * @param {string[]} paramNames
+ * @returns {Record<string, unknown>}
+ */
+const toNamedRecord = (slotRecord, paramNames) => {
+  /** @type {Record<string, unknown>} */
+  const named = {};
+  for (const [slot, value] of Object.entries(slotRecord)) {
+    const match = /^slot(\d+)$/.exec(slot);
+    const key =
+      match && paramNames[Number(match[1])] !== undefined
+        ? paramNames[Number(match[1])]
+        : slot;
+    named[key] = value;
+  }
+  return named;
+};
 
 const gitTools = makeGitTool(
   // This test inspects schemas and guards; it never invokes the capability.
@@ -123,10 +161,12 @@ const gitTools = makeGitTool(
 const schemaGuardAgree = test.macro({
   exec(t, /** @type {ToolRecord} */ tool) {
     const shape = guardShapeFor(tool.name);
+    const paramNames = paramNamesOf(tool);
     const validate = ajv.compile(tool.parameters);
     let checked = 0;
-    for (const record of candidateRecords) {
-      const guardOk = guardAccepts(shape, record);
+    for (const slotRecord of slotRecords) {
+      const record = toNamedRecord(slotRecord, paramNames);
+      const guardOk = guardAccepts(shape, paramNames, record);
       const schemaOk = validate({ ...record });
       t.is(
         schemaOk,

--- a/packages/agent-tools/test/git-flow.test.js
+++ b/packages/agent-tools/test/git-flow.test.js
@@ -129,7 +129,7 @@ test('makeGitTool drives a real Git cap: stage → status → commit → log →
 
   // `commit` (tool) records it; the marshalled message reaches the cap.
   const commit = /** @type {{ oid: string, summary: string }} */ (
-    await byName('commit').invoke({ arg0: 'add greeting' })
+    await byName('commit').invoke({ message: 'add greeting' })
   );
   t.regex(commit.oid, /^[0-9a-f]{7,64}$/);
   t.is(commit.summary, 'add greeting');
@@ -172,10 +172,10 @@ test('makeGitTool drives branch operations over a real Git cap', async t => {
 
   // `createBranch` then `switchBranch` (tools); the new branch becomes current.
   const created = /** @type {{ name: string }} */ (
-    await byName('createBranch').invoke({ arg0: 'feature' })
+    await byName('createBranch').invoke({ name: 'feature' })
   );
   t.is(created.name, 'feature');
-  await byName('switchBranch').invoke({ arg0: 'feature' });
+  await byName('switchBranch').invoke({ branch: 'feature' });
   const afterSwitch = /** @type {{ name: string }} */ (
     await byName('currentBranch').invoke({})
   );
@@ -193,10 +193,10 @@ test('the runtime guard rejects a bad arg before reaching the live cap', async t
   const { git } = await provisionGit(t);
   const byName = byNameOf(makeGitTool(git));
   await null;
-  // `commit`'s arg0 guard is M.string(); a number must be rejected by the
+  // `commit`'s `message` guard is M.string(); a number must be rejected by the
   // tool's `mustMatch` before the capability is ever touched — proving the
   // guard fires over a live cap, not only the stub.
-  await t.throwsAsync(() => byName('commit').invoke({ arg0: 123 }));
+  await t.throwsAsync(() => byName('commit').invoke({ message: 123 }));
   // The fail-closed key check rejects an unknown arg key too.
   await t.throwsAsync(() => byName('commit').invoke({ bogus: 'x' }));
 });

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -100,9 +100,9 @@ test('invoke marshals named args to positional and calls the capability', async 
 
   await null;
 
-  await byName('commit').invoke({ arg0: 'a message' });
-  await byName('createBranch').invoke({ arg0: 'feature' });
-  await byName('createBranch').invoke({ arg0: 'feature', arg1: harden({}) });
+  await byName('commit').invoke({ message: 'a message' });
+  await byName('createBranch').invoke({ name: 'feature' });
+  await byName('createBranch').invoke({ name: 'feature', options: harden({}) });
   await byName('log').invoke({});
 
   t.deepEqual(calls, [
@@ -118,5 +118,88 @@ test('invoke rejects an arg that violates the runtime guard', async t => {
   const commit = tools.find(tool => tool.name === 'commit');
   if (!commit) throw new Error('no commit tool');
   await null;
-  await t.throwsAsync(() => commit.invoke({ arg0: 123 }));
+  await t.throwsAsync(() => commit.invoke({ message: 123 }));
+});
+
+test('the schemas advertise real, declarative property names', t => {
+  const tools = makeGitTool(makeStubGit([]));
+  const byName = name => {
+    const found = tools.find(tool => tool.name === name);
+    if (!found) throw new Error(`no tool named ${name}`);
+    return found;
+  };
+  const propsOf = name =>
+    Object.keys(
+      /** @type {{ properties?: object }} */ (byName(name).parameters)
+        .properties || {},
+    );
+
+  // No method advertises the generic `argN` convention any more.
+  for (const tool of tools) {
+    const props = Object.keys(
+      /** @type {{ properties?: object }} */ (tool.parameters).properties || {},
+    );
+    for (const prop of props) {
+      t.false(
+        /^arg\d+$/.test(prop),
+        `${tool.name} should not advertise a generic argN property; got ${prop}`,
+      );
+    }
+  }
+
+  t.deepEqual(propsOf('commit'), ['message']);
+  t.deepEqual(propsOf('show'), ['ref']);
+  t.deepEqual(propsOf('createBranch'), ['name', 'options']);
+  t.deepEqual(propsOf('switchBranch'), ['branch']);
+  t.deepEqual(propsOf('log'), ['options']);
+  t.deepEqual(propsOf('diff'), ['options']);
+});
+
+test('invoke resolves named args by their real property names', async t => {
+  const calls = [];
+  const tools = makeGitTool(makeStubGit(calls));
+  const byName = name => {
+    const found = tools.find(tool => tool.name === name);
+    if (!found) throw new Error(`no tool named ${name}`);
+    return found;
+  };
+
+  await null;
+
+  await byName('show').invoke({ ref: 'HEAD' });
+  await byName('switchBranch').invoke({ branch: 'feature' });
+  await byName('log').invoke({ options: harden({ maxCount: 3 }) });
+
+  t.deepEqual(calls, [
+    ['show', 'HEAD'],
+    ['switchBranch', 'feature'],
+    ['log', { maxCount: 3 }],
+  ]);
+});
+
+test('invoke rejects a wrong property name and a missing required one', async t => {
+  const tools = makeGitTool(makeStubGit([]));
+  const byName = name => {
+    const found = tools.find(tool => tool.name === name);
+    if (!found) throw new Error(`no tool named ${name}`);
+    return found;
+  };
+
+  await null;
+
+  // The legacy `arg0` key is no longer accepted; `commit` wants `message`.
+  const wrongName = await t.throwsAsync(() =>
+    byName('commit').invoke({ arg0: 'a message' }),
+  );
+  t.true(
+    wrongName !== undefined && wrongName.message.includes('arg0'),
+    `error should name the offending key; got: ${wrongName?.message}`,
+  );
+
+  // Omitting the required `message` is rejected before the capability is hit.
+  const missing = await t.throwsAsync(() => byName('commit').invoke({}));
+  t.true(
+    missing !== undefined && missing.message.includes('message'),
+    `error should name the missing required key; got: ${missing?.message}`,
+  );
 });

--- a/packages/agent-tools/test/tool.test.js
+++ b/packages/agent-tools/test/tool.test.js
@@ -123,7 +123,61 @@ test('invoke rejects unknown argN keys', async t => {
   t.is(await tool.invoke({ arg0: 'hello' }), 5);
 });
 
-test('invoke marshals named args to positional and validates each', async t => {
+test('invoke maps real property names to positional order', async t => {
+  const tool = makeTool({
+    name: 'createBranch',
+    description: 'Create a branch.',
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        options: { type: 'object' },
+      },
+      required: ['name'],
+      additionalProperties: false,
+    },
+    argGuards: [M.string(), M.recordOf(M.string(), M.any())],
+    execute: async args => args,
+  });
+
+  await null;
+
+  // The named record reaches `execute` unchanged…
+  t.deepEqual(await tool.invoke({ name: 'feature' }), { name: 'feature' });
+  t.deepEqual(
+    await tool.invoke({ name: 'feature', options: { track: true } }),
+    {
+      name: 'feature',
+      options: { track: true },
+    },
+  );
+
+  // …a value under the wrong (undeclared) key is rejected.
+  const wrong = await t.throwsAsync(() => tool.invoke({ branch: 'feature' }));
+  t.true(
+    wrong !== undefined && wrong.message.includes('branch'),
+    `error should name the offending key; got: ${wrong?.message}`,
+  );
+
+  // …a missing required key is rejected by its real name.
+  const missing = await t.throwsAsync(() =>
+    tool.invoke({ options: { track: true } }),
+  );
+  t.true(
+    missing !== undefined && missing.message.includes('name'),
+    `error should name the missing required key; got: ${missing?.message}`,
+  );
+
+  // …a value of the wrong type under the right name fails its guard, and the
+  // guard label names the real property, not a generic `argN`.
+  const badType = await t.throwsAsync(() => tool.invoke({ name: 42 }));
+  t.true(
+    badType !== undefined && badType.message.includes('createBranch name'),
+    `guard label should name the real property; got: ${badType?.message}`,
+  );
+});
+
+test('invoke maps named args to positional and validates each', async t => {
   const tool = makeTool({
     name: 'pair',
     description: 'Two args.',


### PR DESCRIPTION
## Description

Today `@endo/agent-tools` bridges its JSON-Schema tool surface to the positional
`EndoGit` method calls through a generic `arg0`/`arg1` convention: every method
advertises `properties: { arg0: … }` to the LLM, so the tool signature carries no
domain meaning.

This PR names each git tool's parameters from its method:

- `gitToolSchemas` (`src/git-tool.js`) declares real property names that match
  domain meaning: `commit` → `message`, `show` → `ref`, `createBranch` → `name`,
  `options`, `switchBranch` → `branch`, `log`/`diff` → `options`.
- `makeTool` (`src/tool.js`) marshals the named-args record into a positional
  array by each schema's declared `parameters.properties` order, with required
  slots taken from `parameters.required` — replacing the hardcoded `argN`
  convention. Arity, required-key validation, and unexpected-key rejection are
  preserved; the runtime guard label now names the real property.

The change is minimal and self-contained to `@endo/agent-tools`; nothing outside
the package is touched. No change to the authority surface — only the schema
property names and the named→positional mapping change.

Callers that constructed `{ arg0: … }` records by hand must switch to the real
names. A `minor` changeset is included. `yarn workspace @endo/agent-tools test`
(44 tests) and `lint` are green.
