### PR TITLE
feat(floot): per-session model selection + read-only codebase mount for full control

### DIFF
--- a/packages/chat/floot-component.js
+++ b/packages/chat/floot-component.js
@@ -442,11 +442,12 @@ const DEFAULT_PRESET_ID = 'general';
  * the view (see packages/space-floot/DESIGN.md).
  *
  * The factory owns every session; the UI never sees the backing guests. Its
- * interface is `createSession(title?, presetId?) -> facet`, `listSessions() ->
- * [{id,title,createdAt,presetId}]`, `getSession(id) -> facet`,
- * `renameSession(id,title)`, `deleteSession(id)`, `listPresets()`. A session
- * facet exposes `converse(input) -> replyReader`, `getHistory()`, `getInfo()`,
- * and `getUsage()`.
+ * interface is `createSession(title?, presetId?, model?) -> facet`,
+ * `listSessions() -> [{id,title,createdAt,presetId,model}]`, `getSession(id) ->
+ * facet`, `renameSession(id,title)`, `deleteSession(id)`, `listPresets()`,
+ * `listModels() -> [{id,title,description,default}]`. A session facet exposes
+ * `converse(input) -> replyReader`, `getHistory()`, `getInfo()`, and
+ * `getUsage()`.
  *
  * When `audioPath` is given, it resolves a speech-to-text object and enables a
  * mic: speech is captured as 16 kHz mono PCM, streamed to
@@ -510,12 +511,17 @@ export const flootComponent = (
    *   meta?: { mail?: { from?: string } },
    *   name?: string, args?: string, result?: string | null }} HistoryMessage
    * @typedef {{ id: string, title: string, createdAt: number, presetId: string,
-   *   messages: HistoryMessage[], facet: any, loaded: boolean }} FlootSession
+   *   model: string, messages: HistoryMessage[], facet: any, loaded: boolean }}
+   *   FlootSession
    * @typedef {{ id: string, title: string, description: string }} FlootPreset
+   * @typedef {{ id: string, title: string, description: string,
+   *   default: boolean }} FlootModel
    */
 
   /** @type {FlootPreset[]} */
   let presets = [];
+  /** @type {FlootModel[]} */
+  let models = [];
   /** @type {FlootSession[]} */
   let sessions = [];
   /** @type {string | null} */
@@ -605,11 +611,13 @@ export const flootComponent = (
   /**
    * @param {string} [title]
    * @param {string} [presetId]
+   * @param {string} [model]
    */
-  const createSession = async (title, presetId) => {
+  const createSession = async (title, presetId, model) => {
     const facet = await E(factory).createSession(
       title || DEFAULT_TITLE,
       presetId,
+      model,
     );
     const info = await E(facet).getInfo();
     /** @type {FlootSession} */
@@ -618,6 +626,7 @@ export const flootComponent = (
       title: info.title || DEFAULT_TITLE,
       createdAt: info.createdAt || Date.now(),
       presetId: info.presetId || DEFAULT_PRESET_ID,
+      model: info.model || '',
       messages: [],
       facet,
       loaded: true,
@@ -677,6 +686,7 @@ export const flootComponent = (
         title: s.title,
         createdAt: s.createdAt,
         presetId: s.presetId,
+        model: s.model,
         status: liveTurnFor(s.id)
           ? /** @type {const} */ ('streaming')
           : sessionStatus.get(s.id) || 'idle',
@@ -688,6 +698,12 @@ export const flootComponent = (
         id: p.id,
         title: p.title,
         description: p.description,
+      })),
+      models: models.map(m => ({
+        id: m.id,
+        title: m.title,
+        description: m.description,
+        default: m.default,
       })),
       messages: allMessages.map(toViewMessage),
       streamingText: liveTurn ? liveTurn.streamingText : '',
@@ -978,10 +994,13 @@ export const flootComponent = (
     openActiveHistory();
   };
 
-  /** @param {string} [presetId] */
-  const newSession = presetId => {
+  /**
+   * @param {string} [presetId]
+   * @param {string} [model]
+   */
+  const newSession = (presetId, model) => {
     if (busy) return;
-    createSession(undefined, presetId)
+    createSession(undefined, presetId, model)
       .then(() => {
         stick = true;
         notify();
@@ -1494,8 +1513,11 @@ export const flootComponent = (
     selectSession(/** @type {string} */ id) {
       selectSession(id);
     },
-    newSession(/** @type {string | undefined} */ presetId) {
-      newSession(presetId);
+    newSession(
+      /** @type {string | undefined} */ presetId,
+      /** @type {string | undefined} */ model,
+    ) {
+      newSession(presetId, model);
     },
     renameSession(/** @type {string} */ id, /** @type {string} */ title) {
       renameSession(id, title);
@@ -1565,13 +1587,17 @@ export const flootComponent = (
   // default session if the factory has none, then repaint the active history.
   (async () => {
     try {
-      const [metas, presetList] = await Promise.all([
+      const [metas, presetList, modelList] = await Promise.all([
         E(factory).listSessions(),
         E(factory)
           .listPresets()
           .catch(() => []),
+        E(factory)
+          .listModels()
+          .catch(() => []),
       ]);
       presets = presetList;
+      models = modelList;
       sessions = [...metas]
         .sort(
           (/** @type {any} */ a, /** @type {any} */ b) =>
@@ -1582,6 +1608,7 @@ export const flootComponent = (
           title: m.title || DEFAULT_TITLE,
           createdAt: m.createdAt || 0,
           presetId: m.presetId || DEFAULT_PRESET_ID,
+          model: m.model || '',
           messages: [],
           facet: null,
           loaded: false,

--- a/packages/chat/floot-component.js
+++ b/packages/chat/floot-component.js
@@ -1592,9 +1592,7 @@ export const flootComponent = (
         E(factory)
           .listPresets()
           .catch(() => []),
-        E(factory)
-          .listModels()
-          .catch(() => []),
+        E(factory).listModels(),
       ]);
       presets = presetList;
       models = modelList;

--- a/packages/floot/agent.js
+++ b/packages/floot/agent.js
@@ -234,6 +234,16 @@ Operating the daemon — reach the host in exec with
 - \`E(endo).provideGuest(name)\` and \`E(endo).provideHost(name)\` mint new agents;
   \`E(endo).provideWorker(name)\` mints a worker.
 - \`E(endo).cancel(name)\` tears a capability down — destructive, so confirm first.
+
+Your petstore also contains "endo-src" — a READ-ONLY mount of the Endo
+codebase you run inside. Use it to understand the capabilities you operate
+before acting through "endo". In exec, look it up and read from it:
+- \`const src = await E(powers).lookup('endo-src')\`
+- \`E(src).list()\` (optionally a sub-path) lists entries; \`E(src).readText(path)\`
+  reads a file, e.g. \`E(src).readText('packages/daemon/src/interfaces.js')\`.
+- It is strictly read-only — you cannot modify it. It may be absent if the
+  daemon host does not have the source on disk; if a lookup fails, carry on
+  without it.
 Speak short, plain summaries of what you did — never read code or raw capability
 output aloud.`;
 
@@ -264,7 +274,10 @@ const PRESETS = [
     description:
       'Full control of the Endo daemon via an "endo" host reference. High access — handle with care.',
     systemPrompt: fullControlSystemPrompt,
-    objects: [{ kind: 'host-powers', petName: 'endo' }],
+    objects: [
+      { kind: 'host-powers', petName: 'endo' },
+      { kind: 'code-mount', petName: 'endo-src' },
+    ],
   },
 ];
 const DEFAULT_PRESET_ID = 'general';
@@ -312,6 +325,9 @@ const isKnownModel = id => MODELS.some(m => m.id === id);
  * @param {any} sessionGuest - the resolved guest facet (for `has` checks)
  * @param {string} id - session id (used to namespace temporary host petnames)
  * @param {Array<{ kind: string, petName: string }>} objects
+ * @param {string} [codePath] - absolute host path to the Endo codebase, for the
+ *   `code-mount` object kind (read-only). Absent when the daemon host has no
+ *   source on disk; such objects are then skipped.
  */
 const provisionPresetObjects = async (
   host,
@@ -319,6 +335,7 @@ const provisionPresetObjects = async (
   sessionGuest,
   id,
   objects,
+  codePath,
 ) => {
   for (const obj of objects) {
     const alreadyPresent = await E(sessionGuest).has(obj.petName);
@@ -356,6 +373,25 @@ const provisionPresetObjects = async (
       // only adds a name in the guest; deleting the session drops that name and
       // reaps nothing else.
       await E(host).copy(['@agent'], [agentName, obj.petName]);
+    } else if (obj.kind === 'code-mount') {
+      // Mount the Endo codebase read-only so the session can read the source it
+      // runs inside. Skip silently when no path was configured (the daemon host
+      // may not have the source on disk). The mount points at an EXISTING
+      // external directory — unlike a scratch mount it does not own that dir, so
+      // GC of the formula when the session is deleted never touches the source.
+      // Provide into a session-scoped temp host name (cleared first in case a
+      // prior attempt aborted), then move it into the guest's petstore so the
+      // guest is the only reference.
+      if (!codePath) {
+        console.warn(
+          `[floot-factory] no code path configured; skipping "${obj.petName}" mount for session ${id}`,
+        );
+      } else {
+        const mountTmp = `_floot-codemount-${id}`;
+        if (await E(host).has(mountTmp)) await E(host).remove(mountTmp);
+        await E(host).provideMount(codePath, mountTmp, { readOnly: true });
+        await E(host).move([mountTmp], [agentName, obj.petName]);
+      }
     } else {
       console.warn(
         `[floot-factory] unknown preset object kind "${obj.kind}" for session ${id}`,
@@ -941,6 +977,10 @@ export const make = (hostPowers, _context, { env } = {}) => {
   /** @type {any} */
   const powers = hostPowers;
   const systemPrompt = env?.FLOOT_SYSTEM_PROMPT || undefined;
+  // Absolute host path to the Endo codebase, mounted read-only into full-control
+  // sessions (see the `code-mount` preset object). Resolved by the setup script
+  // and passed through env; empty when the daemon host has no source on disk.
+  const codePath = env?.FLOOT_CODE_PATH || undefined;
 
   // The factory runs with its own host powers, so it provisions session guests
   // directly — no introduced `host-agent` reference (that rehydrates as a
@@ -1072,6 +1112,7 @@ export const make = (hostPowers, _context, { env } = {}) => {
             sessionGuest,
             id,
             preset.objects,
+            codePath,
           );
         } catch (err) {
           console.warn(

--- a/packages/floot/agent.js
+++ b/packages/floot/agent.js
@@ -114,10 +114,11 @@ const makeBufferingWriter = () => {
 
 const FlootFactoryInterface = M.interface('FlootFactory', {
   createSession: M.callWhen()
-    .optional(M.string(), M.string())
+    .optional(M.string(), M.string(), M.string())
     .returns(M.remotable()),
   listSessions: M.callWhen().returns(M.arrayOf(M.record())),
   listPresets: M.callWhen().returns(M.arrayOf(M.record())),
+  listModels: M.callWhen().returns(M.arrayOf(M.record())),
   getSession: M.callWhen(M.string()).returns(M.remotable()),
   renameSession: M.callWhen(M.string(), M.string()).returns(M.undefined()),
   deleteSession: M.callWhen(M.string()).returns(M.undefined()),
@@ -272,6 +273,33 @@ const getPreset = id =>
   /** @type {(typeof PRESETS)[number]} */ (
     PRESETS.find(p => p.id === DEFAULT_PRESET_ID)
   );
+
+// Catalog of models selectable for a new session. A session that does not pin
+// one of these follows the factory's configured default model (the `model` in
+// the `llm-provider` config, or the provider's own fallback). Ids are passed
+// verbatim to the provider, so they must be valid for the configured backend —
+// these are the Anthropic ids used by the default provider.
+const MODELS = [
+  {
+    id: 'claude-opus-4-8',
+    title: 'Claude Opus 4.8',
+    description: 'Most capable — best for hard reasoning and agentic work.',
+  },
+  {
+    id: 'claude-sonnet-4-6',
+    title: 'Claude Sonnet 4.6',
+    description: 'Balanced speed and capability — a good default.',
+  },
+  {
+    id: 'claude-haiku-4-5-20251001',
+    title: 'Claude Haiku 4.5',
+    description: 'Fastest and cheapest — best for quick, simple turns.',
+  },
+];
+// Mirrors createStreamingProvider's fallback so the UI's notion of "default"
+// agrees with what an unpinned session actually runs.
+const DEFAULT_MODEL_ID = 'claude-sonnet-4-6';
+const isKnownModel = id => MODELS.some(m => m.id === id);
 
 /**
  * Provision a preset's objects into a session guest's petstore, referenced ONLY
@@ -920,27 +948,49 @@ export const make = (hostPowers, _context, { env } = {}) => {
   // revived sessions). `powers` here is the factory's own host.
   const getHost = () => powers;
 
-  let providerP;
-  const getProvider = () => {
+  // The provider config (backend kind, default model, auth token) lives behind
+  // the `llm-provider` capability handle. Resolve it once and cache it; every
+  // per-model provider is built from it.
+  let providerConfigP;
+  const getProviderConfig = () => {
+    if (!providerConfigP) {
+      providerConfigP = E(powers)
+        .lookup('llm-provider')
+        .catch(error => {
+          providerConfigP = undefined;
+          throw error;
+        });
+    }
+    return providerConfigP;
+  };
+
+  // One streaming provider per model. Sessions that don't pin a model share the
+  // entry under the empty-string key (the factory's configured default model).
+  /** @type {Map<string, Promise<any>>} */
+  const providersByModel = new Map();
+  const getProvider = model => {
+    const key = model || '';
+    let providerP = providersByModel.get(key);
     if (!providerP) {
       providerP = (async () => {
-        const cfg = await E(powers).lookup('llm-provider');
+        const cfg = await getProviderConfig();
         return createStreamingProvider({
           FLOOT_PROVIDER: cfg.provider,
-          FLOOT_MODEL: cfg.model,
+          FLOOT_MODEL: model || cfg.model,
           FLOOT_AUTH_TOKEN: cfg.authToken,
         });
       })().catch(error => {
-        providerP = undefined;
+        providersByModel.delete(key);
         throw error;
       });
+      providersByModel.set(key, providerP);
     }
     return providerP;
   };
 
   // In-memory session registry, mirrored to the factory's petstore. Loaded
   // lazily so make() never awaits.
-  /** @type {Array<{ id: string, title: string, createdAt: number }> | undefined} */
+  /** @type {Array<{ id: string, title: string, createdAt: number, presetId?: string, systemPrompt?: string, model?: string }> | undefined} */
   let registry;
   const loadRegistry = async () => {
     if (registry) return registry;
@@ -1029,7 +1079,9 @@ export const make = (hostPowers, _context, { env } = {}) => {
             err instanceof Error ? err.message : String(err),
           );
         }
-        const provider = await getProvider();
+        // Build (or reuse) the provider for this session's pinned model; an
+        // unpinned session follows the factory's configured default.
+        const provider = await getProvider(entry?.model);
         const agent = await makeStreamingAgent(
           sessionGuest,
           undefined,
@@ -1064,6 +1116,7 @@ export const make = (hostPowers, _context, { env } = {}) => {
             title: entry?.title || '',
             createdAt: entry?.createdAt || 0,
             presetId: entry?.presetId || DEFAULT_PRESET_ID,
+            model: entry?.model || '',
           });
         },
         /**
@@ -1134,21 +1187,25 @@ export const make = (hostPowers, _context, { env } = {}) => {
     /**
      * @param {string} [title]
      * @param {string} [presetId]
+     * @param {string} [model]
      * @returns {Promise<object>} an opaque session facet
      */
-    async createSession(title, presetId) {
+    async createSession(title, presetId, model) {
       await loadRegistry();
       const preset = getPreset(presetId || DEFAULT_PRESET_ID);
       const id = newSessionId();
       // Snapshot the preset's id and prompt so later catalog edits don't change
       // a live session. The object set is re-read from the catalog by id in
-      // getAgent (objects are provisioned once, idempotently).
+      // getAgent (objects are provisioned once, idempotently). A model is pinned
+      // only when the caller chose a known one; otherwise the session follows
+      // the factory's configured default model.
       const entry = harden({
         id,
         title: title || 'New chat',
         createdAt: Date.now(),
         presetId: preset.id,
         systemPrompt: preset.systemPrompt,
+        ...(isKnownModel(model) ? { model } : {}),
       });
       /** @type {any[]} */ (registry).push(entry);
       await saveRegistry();
@@ -1157,22 +1214,25 @@ export const make = (hostPowers, _context, { env } = {}) => {
       // preset objects are provisioned up front.
       getAgent(id).catch(() => {});
       console.error(
-        `[floot-factory] Created session "${id}" (preset "${preset.id}")`,
+        `[floot-factory] Created session "${id}" (preset "${preset.id}"${
+          entry.model ? `, model "${entry.model}"` : ''
+        })`,
       );
       return getFacet(id);
     },
 
     /**
-     * @returns {Promise<Array<{ id: string, title: string, createdAt: number, presetId: string }>>}
+     * @returns {Promise<Array<{ id: string, title: string, createdAt: number, presetId: string, model: string }>>}
      */
     async listSessions() {
       await loadRegistry();
       return harden(
-        (registry || []).map(({ id, title, createdAt, presetId }) => ({
+        (registry || []).map(({ id, title, createdAt, presetId, model }) => ({
           id,
           title,
           createdAt,
           presetId: presetId || DEFAULT_PRESET_ID,
+          model: model || '',
         })),
       );
     },
@@ -1186,6 +1246,33 @@ export const make = (hostPowers, _context, { env } = {}) => {
           id,
           title,
           description,
+        })),
+      );
+    },
+
+    /**
+     * The selectable models for a new session. `default` marks the model an
+     * unpinned session runs (the factory's configured model, or the conventional
+     * fallback when that is unset or not in the catalog).
+     *
+     * @returns {Promise<Array<{ id: string, title: string, description: string, default: boolean }>>}
+     */
+    async listModels() {
+      let defaultModel = '';
+      try {
+        const cfg = await getProviderConfig();
+        defaultModel = (cfg && cfg.model) || '';
+      } catch {
+        // Provider config not resolvable yet — fall back to the conventional
+        // default so the picker still has a sensible pre-selection.
+      }
+      if (!isKnownModel(defaultModel)) defaultModel = DEFAULT_MODEL_ID;
+      return harden(
+        MODELS.map(({ id, title, description }) => ({
+          id,
+          title,
+          description,
+          default: id === defaultModel,
         })),
       );
     },
@@ -1250,15 +1337,17 @@ export const make = (hostPowers, _context, { env } = {}) => {
      */
     help(methodName) {
       if (methodName === undefined) {
-        return 'Floot factory: owns all chat sessions. createSession(title?, presetId?) -> session facet; listSessions() -> [{id,title,createdAt,presetId}]; listPresets() -> [{id,title,description}]; getSession(id) -> facet; renameSession(id,title); deleteSession(id). A session facet exposes converse(input) (streaming reply reader), getHistory(), and getInfo().';
+        return 'Floot factory: owns all chat sessions. createSession(title?, presetId?, model?) -> session facet; listSessions() -> [{id,title,createdAt,presetId,model}]; listPresets() -> [{id,title,description}]; listModels() -> [{id,title,description,default}]; getSession(id) -> facet; renameSession(id,title); deleteSession(id). A session facet exposes converse(input) (streaming reply reader), getHistory(), and getInfo().';
       }
       const docs = {
         createSession:
-          'createSession(title?, presetId?) — Create a new session (its own guest/petstore) seeded by a preset (default "general") and return an opaque session facet.',
+          'createSession(title?, presetId?, model?) — Create a new session (its own guest/petstore) seeded by a preset (default "general"), optionally pinning a model from listModels() (default: the factory\'s configured model), and return an opaque session facet.',
         listSessions:
-          'listSessions() — Return metadata [{id, title, createdAt, presetId}] for all sessions.',
+          'listSessions() — Return metadata [{id, title, createdAt, presetId, model}] for all sessions.',
         listPresets:
           'listPresets() — Return the available session presets [{id, title, description}].',
+        listModels:
+          'listModels() — Return the selectable models [{id, title, description, default}] for new sessions.',
         getSession: 'getSession(id) — Return the session facet for an id.',
         renameSession: 'renameSession(id, title) — Rename a session.',
         deleteSession:

--- a/packages/floot/floot-factory-setup.js
+++ b/packages/floot/floot-factory-setup.js
@@ -10,9 +10,32 @@
 // to the factory behind an `llm-provider` capability handle, so no secret lives
 // in env. Persistence is daemon-only.
 
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { E } from '@endo/eventual-send';
 
 const flootFactorySpecifier = new URL('agent.js', import.meta.url).href;
+
+// Absolute host path to the Endo codebase, mounted read-only into full-control
+// sessions. Default: the repo root, two directories up from this script
+// (packages/floot/) — derivable because this setup script runs unconfined from
+// its real on-disk location. Override with FLOOT_CODE_PATH (e.g. to mount a
+// subset, or when the script is run from a copy outside the repo). Resolved to
+// '' when the path does not exist on disk, which makes the factory skip the
+// mount instead of failing per session.
+const resolveCodePath = () => {
+  const configured =
+    process.env.FLOOT_CODE_PATH ||
+    fileURLToPath(new URL('../../', import.meta.url));
+  if (!existsSync(configured)) {
+    console.warn(
+      `Floot: code path "${configured}" does not exist; full-control sessions will have no source mount.`,
+    );
+    return '';
+  }
+  return configured;
+};
 
 /**
  * Provision (or revive) the floot-factory: its guest, its provider handle, the
@@ -36,6 +59,7 @@ export const main = async agent => {
   const authToken =
     process.env.ANTHROPIC_API_KEY || process.env.FLOOT_AUTH_TOKEN || '';
   const systemPrompt = process.env.FLOOT_SYSTEM_PROMPT || '';
+  const codePath = resolveCodePath();
 
   if (provider === 'anthropic' && !authToken) {
     throw new Error(
@@ -75,7 +99,10 @@ export const main = async agent => {
   await E(agent).makeUnconfined('@main', flootFactorySpecifier, {
     powersName: agentName,
     resultName: controllerPath,
-    env: harden({ FLOOT_SYSTEM_PROMPT: systemPrompt }),
+    env: harden({
+      FLOOT_SYSTEM_PROMPT: systemPrompt,
+      FLOOT_CODE_PATH: codePath,
+    }),
   });
 
   // 4. Tuck the factory host + its profile under floot/ so the top level stays
@@ -96,8 +123,8 @@ export const main = async agent => {
     console.log('Seeded a default session.');
   }
   console.log(
-    `Ready (provider: ${provider}${
-      model ? `, model: ${model}` : ''
+    `Ready (provider: ${provider}${model ? `, model: ${model}` : ''}${
+      codePath ? `, code mount: ${codePath}` : ''
     }). Look up "${dir}/controller" and call createSession()/listSessions().`,
   );
 };

--- a/packages/space-floot/DESIGN.md
+++ b/packages/space-floot/DESIGN.md
@@ -124,9 +124,10 @@ The controller is the model; `FlootApp` is the view.
 controller = {
   // --- reactive state (pure data; re-read after every `change` notification) ---
   getState() => {
-    sessions: Array<{ id, title, createdAt, presetId, streaming, error }>,
+    sessions: Array<{ id, title, createdAt, presetId, model, streaming, error }>,
     activeSessionId: string | null,
     presets: Array<{ id, title, description }>,
+    models: Array<{ id, title, description, default }>,  // selectable for a new session
     messages: Array<FlootMessage>,   // active session transcript (history + live turn)
     streamingText: string,           // in-progress assistant bubble, '' when idle
     phase: string,                   // 'thinking' | 'using tools' | ...
@@ -144,7 +145,7 @@ controller = {
 
   // --- callbacks (the view calls these; the host does the imperative work) ---
   send(text), stop(),                   // compose / barge-in stop
-  selectSession(id), newSession(presetId?), renameSession(id, title),
+  selectSession(id), newSession(presetId?, model?), renameSession(id, title),
   deleteSession(id),
   toggleMic(), toggleTts(), replayMessage(text),
   toggleSettings(), setInput(text),     // input is host-held for IME/caret safety

--- a/packages/space-floot/src/FlootApp.js
+++ b/packages/space-floot/src/FlootApp.js
@@ -122,7 +122,10 @@ export const FlootApp = ({ controller }) => {
     // Skip the modal only when there is nothing to choose — a single preset and
     // no model alternatives. Multiple models alone still warrant the picker.
     if (presets.length <= 1 && models.length <= 1) {
-      controller.newSession(presets[0] ? presets[0].id : undefined);
+      controller.newSession(
+        presets[0] ? presets[0].id : undefined,
+        models[0] ? models[0].id : undefined,
+      );
       setDrawerOpen(false);
     } else {
       setModalOpen(true);

--- a/packages/space-floot/src/FlootApp.js
+++ b/packages/space-floot/src/FlootApp.js
@@ -10,7 +10,7 @@ import { ComposeBar } from './ComposeBar.js';
 import { SettingsPanel } from './SettingsPanel.js';
 
 /** @import { VNode } from 'preact' */
-/** @import { FlootController, FlootPreset, FlootSafeEvent } from './types.js' */
+/** @import { FlootController, FlootPreset, FlootModel, FlootSafeEvent } from './types.js' */
 
 // Floot voice-assistant space as a PURE confined Preact component. The host
 // (packages/chat/floot-component.js) owns the imperative engine — mic capture,
@@ -35,11 +35,20 @@ const formatTokens = (/** @type {number} */ n) => {
 };
 
 /**
- * @param {{ presets: FlootPreset[], onPick: (id: string) => void, onClose: () => void }} props
+ * @param {{
+ *   presets: FlootPreset[],
+ *   models: FlootModel[],
+ *   onPick: (id: string, model: string) => void,
+ *   onClose: () => void,
+ * }} props
  * @returns {VNode}
  */
-const PresetModal = ({ presets, onPick, onClose }) =>
-  h(
+const PresetModal = ({ presets, models, onPick, onClose }) => {
+  // Pre-select the factory's default model (falling back to the first listed),
+  // so picking a preset alone still creates a session with a sensible model.
+  const preferred = models.find(m => m.default) || models[0];
+  const [model, setModel] = useState(preferred ? preferred.id : '');
+  return h(
     'div',
     { class: 'floot-modal-backdrop', onClick: onClose },
     h(
@@ -50,6 +59,29 @@ const PresetModal = ({ presets, onPick, onClose }) =>
         onClick: (/** @type {FlootSafeEvent} */ e) => e.stopPropagation(),
       },
       h('div', { class: 'floot-modal-title' }, 'Start a new session'),
+      models.length
+        ? h(
+            'label',
+            { class: 'floot-modal-field' },
+            h('span', { class: 'floot-modal-label' }, 'Model'),
+            h(
+              'select',
+              {
+                class: 'floot-model-select',
+                value: model,
+                onChange: (/** @type {FlootSafeEvent} */ e) =>
+                  setModel(e.target.value),
+              },
+              models.map(m =>
+                h(
+                  'option',
+                  { key: m.id, value: m.id },
+                  `${m.title}${m.default ? ' (default)' : ''}`,
+                ),
+              ),
+            ),
+          )
+        : null,
       h(
         'div',
         { class: 'floot-preset-list' },
@@ -60,7 +92,7 @@ const PresetModal = ({ presets, onPick, onClose }) =>
               type: 'button',
               key: p.id,
               class: 'floot-preset-card',
-              onClick: () => onPick(p.id),
+              onClick: () => onPick(p.id, model),
             },
             h('div', { class: 'floot-preset-name' }, p.title),
             h('div', { class: 'floot-preset-desc' }, p.description || ''),
@@ -69,6 +101,7 @@ const PresetModal = ({ presets, onPick, onClose }) =>
       ),
     ),
   );
+};
 harden(PresetModal);
 
 /**
@@ -82,21 +115,26 @@ export const FlootApp = ({ controller }) => {
   const [titleEditing, setTitleEditing] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
 
-  const { sessions, activeSessionId, presets, usage, status } = state;
+  const { sessions, activeSessionId, presets, models, usage, status } = state;
   const active = sessions.find(s => s.id === activeSessionId);
 
   const onNew = () => {
-    if (presets.length <= 1) {
+    // Skip the modal only when there is nothing to choose — a single preset and
+    // no model alternatives. Multiple models alone still warrant the picker.
+    if (presets.length <= 1 && models.length <= 1) {
       controller.newSession(presets[0] ? presets[0].id : undefined);
       setDrawerOpen(false);
     } else {
       setModalOpen(true);
     }
   };
-  const pickPreset = (/** @type {string} */ id) => {
+  const pickPreset = (
+    /** @type {string} */ id,
+    /** @type {string} */ model,
+  ) => {
     setModalOpen(false);
     setDrawerOpen(false);
-    controller.newSession(id);
+    controller.newSession(id, model);
   };
 
   const commitTitle = () => {
@@ -195,6 +233,7 @@ export const FlootApp = ({ controller }) => {
     modalOpen
       ? h(PresetModal, {
           presets,
+          models,
           onPick: pickPreset,
           onClose: () => setModalOpen(false),
         })

--- a/packages/space-floot/src/floot.css
+++ b/packages/space-floot/src/floot.css
@@ -674,6 +674,30 @@
   font-weight: 600;
   margin-bottom: 0.75rem;
 }
+.floot-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.85rem;
+}
+.floot-modal-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--fl-text-muted);
+}
+.floot-model-select {
+  width: 100%;
+  background: var(--fl-surface2);
+  border: 1px solid var(--fl-border);
+  border-radius: 8px;
+  padding: 0.5rem 0.6rem;
+  color: var(--fl-text);
+  font-size: 0.85rem;
+}
+.floot-model-select:focus {
+  outline: none;
+  border-color: var(--fl-accent);
+}
 .floot-preset-list {
   display: flex;
   flex-direction: column;

--- a/packages/space-floot/src/types.js
+++ b/packages/space-floot/src/types.js
@@ -25,6 +25,7 @@ export {};
  *   title: string,
  *   createdAt: number,
  *   presetId: string,
+ *   model?: string,
  *   status?: 'idle' | 'streaming' | 'error',
  *   messageCount?: number,
  *   loaded?: boolean,
@@ -33,6 +34,17 @@ export {};
 
 /**
  * @typedef {{ id: string, title: string, description?: string }} FlootPreset
+ */
+
+/**
+ * A model selectable for a new session. `default` marks the model an unpinned
+ * session runs (the factory's configured default).
+ * @typedef {{
+ *   id: string,
+ *   title: string,
+ *   description?: string,
+ *   default?: boolean,
+ * }} FlootModel
  */
 
 /**
@@ -70,6 +82,7 @@ export {};
  *   sessions: FlootSessionMeta[],
  *   activeSessionId: string | null,
  *   presets: FlootPreset[],
+ *   models: FlootModel[],
  *   messages: FlootMessage[],
  *   streamingText: string,
  *   phase: string,
@@ -91,7 +104,7 @@ export {};
  * @property {(text?: string) => void} send
  * @property {() => void} stop
  * @property {(id: string) => void} selectSession
- * @property {(presetId?: string) => void} newSession
+ * @property {(presetId?: string, model?: string) => void} newSession
  * @property {(id: string, title: string) => void} renameSession
  * @property {(id: string) => void} deleteSession
  * @property {() => void} toggleMic


### PR DESCRIPTION
## Summary

Two related Floot improvements:

1. **Select a model when creating a new session** — sessions can pin their own model instead of all sharing one global setting.
2. **Read-only Endo codebase mount for full-control sessions** — the agent that holds the daemon host can also read the source it runs inside.

---

## 1. Per-session model selection

When you click **+** for a new session, the "Start a new session" modal now has a **Model** dropdown (pre-selected to the factory's default). Picking a preset creates the session pinned to the chosen model, and that session runs on it for every turn.

### Backend — `packages/floot/agent.js`
- Added a **`MODELS` catalog** (Opus 4.8, Sonnet 4.6, Haiku 4.5) and a new **`listModels()`** factory method returning `[{id, title, description, default}]`, where `default` reflects the factory's configured model (falling back to the conventional default when unset).
- **`createSession(title?, presetId?, model?)`** snapshots a pinned model into the session registry entry — only when it's a known catalog model, otherwise the session keeps following the global default.
- Refactored provider resolution to be **per-model and cached**: each distinct model gets one provider instance; unpinned sessions share the default. The `llm-provider` config (backend kind + auth token) is resolved once and reused.
- Surfaced `model` in `getInfo()` / `listSessions()` and updated the `help()` docs.

### UI — `packages/chat/floot-component.js` + `packages/space-floot/*`
- The host fetches `listModels()` and threads the selected model through `newSession` → `createSession`; `models` and per-session `model` are exposed in the state snapshot.
- `FlootApp`'s `PresetModal` renders the model `<select>`, pre-selected to the default; the modal now also opens when only the model differs.
- Types, CSS, and `DESIGN.md` updated to match.

## 2. Read-only codebase mount for full control

Full-control sessions already hold `endo` (the daemon host). They now also get **`endo-src`**, a read-only mount of the Endo source, so the agent can look up a capability's real behavior before acting.

- **`floot-factory-setup.js`** derives the codebase path (repo root, two dirs up from the unconfined setup script; `FLOOT_CODE_PATH` overrides), `existsSync`-checks it (resolving to `''` when absent), and passes it to the factory via env.
- **`agent.js`** adds a `code-mount` preset-object kind that `provideMount`s the path **read-only** and moves it into the session guest under `endo-src`. It targets an existing external dir (not a scratch mount), so GC of the formula on session deletion never touches the source. Skipped cleanly when no path is configured or it doesn't exist on the daemon host.
- The full-control system prompt documents `endo-src` and how to read from it via `exec` (`lookup` + `list`/`readText`).

Note: existing full-control sessions gain the `endo-src` mount on next revival (the idempotency guard only skips the already-present `endo`), but keep their snapshotted prompt — only new sessions get the prompt text describing it; the mount is still discoverable via `list`.

---

## Verification

All changed files pass `node --check` and Prettier. I was **unable** to run `tsc`, `eslint`, or `ava` in this environment — `yarn install` could not reach the package registry, so `node_modules` was never populated. Please run the pre-PR checklist (`yarn lint`, `yarn docs`/`tsc`, `npx ava` in `packages/floot`) in an environment with registry access before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)