### PR TITLE
feat(agent-tools): reconcile makeMountReadTool onto the canonical ToolRecord

### DIFF
--- a/packages/agent-tools/src/mount-fs.d.ts
+++ b/packages/agent-tools/src/mount-fs.d.ts
@@ -1,8 +1,8 @@
 import type { ERef } from '@endo/far';
 import type { Filesystem } from '@endo/platform/fs/extended';
-import type { MountReadToolRecord, MountReadToolOptions } from './types.js';
+import type { ToolRecord, MountReadToolOptions } from './types.js';
 
 export declare const makeMountReadTool: (
   fs: ERef<Filesystem>,
   opts?: MountReadToolOptions,
-) => MountReadToolRecord;
+) => ToolRecord;

--- a/packages/agent-tools/src/mount-fs.js
+++ b/packages/agent-tools/src/mount-fs.js
@@ -3,10 +3,12 @@
 
 /** @import { ERef } from '@endo/far' */
 /** @import { File, Filesystem } from '@endo/platform/fs/extended' */
-/** @import { MountReadToolRecord, ToolSchema } from './types.js' */
+/** @import { ToolRecord } from './types.js' */
 
 import { E } from '@endo/far';
 import { walk, collectBytes } from '@endo/platform/fs/extended';
+
+import { makeTool } from './tool.js';
 
 /**
  * Default text-read truncation cap, in characters. A `maxChars` option of `0`
@@ -15,9 +17,30 @@ import { walk, collectBytes } from '@endo/platform/fs/extended';
 const DEFAULT_MAX_TEXT_CHARS = 50_000;
 
 /**
- * A read-only filesystem tool bound to an `@endo/platform/fs/extended` `Filesystem`
- * capability. Reads a single text file by root-relative path and returns
- * its UTF-8 contents.
+ * JSON Schema for the single `path` parameter the mount read tool advertises.
+ * Used verbatim as both the LLM `parameters` and the MCP `inputSchema` by
+ * `makeTool`.
+ */
+const mountReadTextParameters = harden({
+  type: 'object',
+  properties: {
+    path: {
+      type: 'string',
+      description: 'Mount-relative path to the file to read.',
+    },
+  },
+  required: ['path'],
+  additionalProperties: false,
+});
+
+/**
+ * A read-only filesystem tool bound to an `@endo/platform/fs/extended`
+ * `Filesystem` capability. Reads a single text file by root-relative path and
+ * returns its UTF-8 contents.
+ *
+ * Built through {@link makeTool}, so it emits a canonical `ToolRecord`
+ * (`name`/`description`/`parameters`/`inputSchema`/`invoke`) at parity with the
+ * git tools and flows through `toPiAgentTool` unchanged.
  *
  * The path is split into `Filesystem` segments and resolved by `walk`.
  * Confinement, symlink containment, and revocation are enforced by the
@@ -30,7 +53,7 @@ const DEFAULT_MAX_TEXT_CHARS = 50_000;
  *   before the result is truncated. Defaults to `DEFAULT_MAX_TEXT_CHARS`
  *   (50,000). A value of `0` disables the limit; the full file contents are
  *   returned untruncated.
- * @returns {MountReadToolRecord}
+ * @returns {ToolRecord}
  */
 export const makeMountReadTool = (fs, opts = {}) => {
   const { maxChars = DEFAULT_MAX_TEXT_CHARS } = opts;
@@ -39,31 +62,14 @@ export const makeMountReadTool = (fs, opts = {}) => {
   // byte to detect overflow past the cap. With the limit disabled, read the
   // whole file in one unbounded request.
   const readLength = limitDisabled ? undefined : BigInt(maxChars + 1);
-  /** @type {ToolSchema} */
-  const schema = harden({
-    type: 'function',
-    function: {
-      name: 'mountReadText',
-      description:
-        'Read a UTF-8 text file from the mounted project directory. ' +
-        'Path is relative to the mount root; "../" escapes are rejected.',
-      parameters: {
-        type: 'object',
-        properties: {
-          path: {
-            type: 'string',
-            description: 'Mount-relative path to the file to read.',
-          },
-        },
-        required: ['path'],
-        additionalProperties: false,
-      },
-    },
-  });
 
-  return harden({
-    schema: () => schema,
-    async execute(args) {
+  return makeTool({
+    name: 'mountReadText',
+    description:
+      'Read a UTF-8 text file from the mounted project directory. ' +
+      'Path is relative to the mount root; "../" escapes are rejected.',
+    parameters: mountReadTextParameters,
+    execute: async args => {
       for (const key of Object.keys(args)) {
         if (key !== 'path') {
           throw new Error(`unexpected mountReadText argument key "${key}"`);
@@ -93,8 +99,6 @@ export const makeMountReadTool = (fs, opts = {}) => {
       }
       return content;
     },
-    help: () =>
-      'Read a text file from the mounted project directory (read-only).',
   });
 };
 harden(makeMountReadTool);

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -67,26 +67,6 @@ export interface ToolRecord {
   invoke: (args: Record<string, unknown>) => Promise<unknown>;
 }
 
-export interface ToolSchema {
-  type: 'function';
-  function: {
-    name: string;
-    description: string;
-    parameters: {
-      type: 'object';
-      properties: Record<string, unknown>;
-      required?: readonly string[];
-      additionalProperties?: boolean;
-    };
-  };
-}
-
-export interface MountReadToolRecord {
-  schema: () => ToolSchema;
-  execute: (args: Record<string, unknown>) => Promise<string>;
-  help: () => string;
-}
-
 export declare function makeTool(spec: ToolSpec): ToolRecord;
 
 export declare function makeGitTool(
@@ -104,4 +84,4 @@ export interface MountReadToolOptions {
 export declare function makeMountReadTool(
   fs: ERef<Filesystem>,
   opts?: MountReadToolOptions,
-): MountReadToolRecord;
+): ToolRecord;

--- a/packages/agent-tools/test/mount-fs.test.js
+++ b/packages/agent-tools/test/mount-fs.test.js
@@ -22,6 +22,7 @@ import {
 } from '@endo/platform/fs/extended';
 
 import { makeMountReadTool } from '../src/mount-fs.js';
+import { toPiAgentTool } from '../src/pi.js';
 
 /**
  * @typedef {object} TestFilesystemLike
@@ -63,7 +64,7 @@ test('reads a text file inside the filesystem', async t => {
 
   const tool = makeMountReadTool(filesystem);
   await null;
-  t.is(await tool.execute({ path: 'a.txt' }), 'hello mount');
+  t.is(await tool.invoke({ path: 'a.txt' }), 'hello mount');
 });
 
 test('reads a file in a subdirectory by relative path', async t => {
@@ -74,7 +75,7 @@ test('reads a file in a subdirectory by relative path', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
 
   const tool = makeMountReadTool(filesystem);
-  t.is(await tool.execute({ path: 'sub/b.txt' }), 'nested');
+  t.is(await tool.invoke({ path: 'sub/b.txt' }), 'nested');
 });
 
 test('reads through a chroot subtree view as the new root', async t => {
@@ -88,8 +89,8 @@ test('reads through a chroot subtree view as the new root', async t => {
   ]);
 
   const tool = makeMountReadTool(filesystem);
-  t.is(await tool.execute({ path: 'c.txt' }), 'in subtree');
-  await t.throwsAsync(() => tool.execute({ path: 'top.txt' }), {
+  t.is(await tool.invoke({ path: 'c.txt' }), 'in subtree');
+  await t.throwsAsync(() => tool.invoke({ path: 'top.txt' }), {
     message: /ENOENT/,
   });
 });
@@ -101,7 +102,7 @@ test('reads an empty file as the empty string', async t => {
 
   const tool = makeMountReadTool(filesystem);
   await null;
-  t.is(await tool.execute({ path: 'empty.txt' }), '');
+  t.is(await tool.invoke({ path: 'empty.txt' }), '');
 });
 
 test('truncates content beyond the 50k-char cap', async t => {
@@ -111,7 +112,7 @@ test('truncates content beyond the 50k-char cap', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
 
   const tool = makeMountReadTool(filesystem);
-  const result = await tool.execute({ path: 'big.txt' });
+  const result = await tool.invoke({ path: 'big.txt' });
   t.true(result.startsWith('x'.repeat(50_000)));
   t.true(result.includes('truncated at 50000 chars'));
   t.is(result.indexOf('\n\n... (truncated'), 50_000);
@@ -124,7 +125,7 @@ test('truncates at a caller-supplied maxChars', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
 
   const tool = makeMountReadTool(filesystem, { maxChars: 8 });
-  const result = await tool.execute({ path: 'big.txt' });
+  const result = await tool.invoke({ path: 'big.txt' });
   t.true(result.startsWith('x'.repeat(8)));
   t.true(result.includes('truncated at 8 chars'));
   t.is(result.indexOf('\n\n... (truncated'), 8);
@@ -137,7 +138,7 @@ test('maxChars: 0 disables the limit and returns full contents', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
 
   const tool = makeMountReadTool(filesystem, { maxChars: 0 });
-  const result = await tool.execute({ path: 'big.txt' });
+  const result = await tool.invoke({ path: 'big.txt' });
   t.is(result, big);
   t.false(result.includes('truncated'));
 });
@@ -150,9 +151,9 @@ test('normalizes leading, trailing, and doubled slashes to "." no-op steps', asy
 
   const tool = makeMountReadTool(filesystem);
   await null;
-  t.is(await tool.execute({ path: '/sub/d.txt' }), 'normalized');
-  t.is(await tool.execute({ path: 'sub//d.txt' }), 'normalized');
-  t.is(await tool.execute({ path: 'sub/d.txt/' }), 'normalized');
+  t.is(await tool.invoke({ path: '/sub/d.txt' }), 'normalized');
+  t.is(await tool.invoke({ path: 'sub//d.txt' }), 'normalized');
+  t.is(await tool.invoke({ path: 'sub/d.txt/' }), 'normalized');
 });
 
 test('bounds the underlying file read before draining bytes', async t => {
@@ -184,31 +185,34 @@ test('bounds the underlying file read before draining bytes', async t => {
   const tool = makeMountReadTool(
     /** @type {ERef<Filesystem>} */ (/** @type {unknown} */ (filesystem)),
   );
-  const result = await tool.execute({ path: 'big.txt' });
+  const result = await tool.invoke({ path: 'big.txt' });
   t.is(result.indexOf('\n\n... (truncated'), 50_000);
 });
 
-test('help() returns a one-line capability description', t => {
+test('emits a canonical ToolRecord with a one-line description', t => {
   const rootPath = makeTempRoot(t);
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
   const tool = makeMountReadTool(filesystem);
 
-  const help = tool.help();
-  t.is(typeof help, 'string');
-  t.true(help.length > 0);
-  t.false(help.includes('\n'));
+  t.is(tool.name, 'mountReadText');
+  t.is(typeof tool.description, 'string');
+  t.true(tool.description.length > 0);
+  t.is(typeof tool.invoke, 'function');
 });
 
-test('schema advertises the mountReadText tool name and a required path', t => {
+test('parameters and inputSchema advertise the mountReadText required path', t => {
   const rootPath = makeTempRoot(t);
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
   const tool = makeMountReadTool(filesystem);
 
-  const schema = tool.schema();
-  t.is(schema.type, 'function');
-  t.is(schema.function.name, 'mountReadText');
-  t.deepEqual(schema.function.parameters.required, ['path']);
-  t.false(schema.function.parameters.additionalProperties);
+  // The same JSON Schema is used verbatim as both LLM `parameters` and MCP
+  // `inputSchema`.
+  t.is(tool.parameters, tool.inputSchema);
+  const { parameters } = tool;
+  t.is(parameters.type, 'object');
+  t.deepEqual(parameters.properties.path.type, 'string');
+  t.deepEqual(parameters.required, ['path']);
+  t.false(parameters.additionalProperties);
 });
 
 test('rejects extra arguments before any filesystem send', async t => {
@@ -222,7 +226,7 @@ test('rejects extra arguments before any filesystem send', async t => {
   const tool = makeMountReadTool(filesystem);
 
   const err = await t.throwsAsync(() =>
-    tool.execute({ path: 'a.txt', extra: 'ignored' }),
+    tool.invoke({ path: 'a.txt', extra: 'ignored' }),
   );
   t.true(
     err !== undefined && err.message.includes('extra'),
@@ -236,10 +240,10 @@ test('rejects a missing or empty path before any send', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
   const tool = makeMountReadTool(filesystem);
 
-  await t.throwsAsync(() => tool.execute({}), {
+  await t.throwsAsync(() => tool.invoke({}), {
     message: /non-empty string path/,
   });
-  await t.throwsAsync(() => tool.execute({ path: '' }), {
+  await t.throwsAsync(() => tool.invoke({ path: '' }), {
     message: /non-empty string path/,
   });
 });
@@ -257,10 +261,10 @@ test('rejects a "../" escape via the Filesystem, not a string check', async t =>
     fs.readFileSync(path.join(outsideRoot, 'secret'), 'utf-8'),
     'TOP SECRET',
   );
-  await t.throwsAsync(() => tool.execute({ path: '../secret' }), {
+  await t.throwsAsync(() => tool.invoke({ path: '../secret' }), {
     message: /reserved|EINVAL|ENOENT/,
   });
-  t.is(await tool.execute({ path: 'inside.txt' }), 'ok');
+  t.is(await tool.invoke({ path: 'inside.txt' }), 'ok');
 });
 
 test('rejects reading through a symlink that escapes the root', async t => {
@@ -273,9 +277,29 @@ test('rejects reading through a symlink that escapes the root', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
 
   const tool = makeMountReadTool(filesystem);
-  await t.throwsAsync(() => tool.execute({ path: 'link-out' }), {
+  await t.throwsAsync(() => tool.invoke({ path: 'link-out' }), {
     message: /escapes filesystem root|EACCES|ENOENT/,
   });
+});
+
+test('bridges through toPiAgentTool and reads a file end to end', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'bridged content');
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+
+  const tool = makeMountReadTool(filesystem);
+  const agentTool = toPiAgentTool(tool);
+
+  // The model-facing surface is copied verbatim from the canonical record.
+  t.is(agentTool.name, 'mountReadText');
+  t.is(agentTool.label, 'mountReadText');
+  t.is(agentTool.description, tool.description);
+  t.is(agentTool.parameters, tool.parameters);
+
+  // Invoking through the bridge resolves the file and renders the contents.
+  const result = await agentTool.execute('call-1', { path: 'a.txt' });
+  t.deepEqual(result.content, [{ type: 'text', text: 'bridged content' }]);
+  t.is(result.details, 'bridged content');
 });
 
 test('fails closed after the Filesystem is revoked, with no ambient fallback', async t => {
@@ -298,10 +322,10 @@ test('fails closed after the Filesystem is revoked, with no ambient fallback', a
   );
 
   await null;
-  t.is(await tool.execute({ path: 'a.txt' }), 'live content');
+  t.is(await tool.invoke({ path: 'a.txt' }), 'live content');
 
   revoked = true;
-  await t.throwsAsync(() => tool.execute({ path: 'a.txt' }), {
+  await t.throwsAsync(() => tool.invoke({ path: 'a.txt' }), {
     message: /revoked/,
   });
 

--- a/packages/agent-tools/test/mount-fs.test.js
+++ b/packages/agent-tools/test/mount-fs.test.js
@@ -112,7 +112,7 @@ test('truncates content beyond the 50k-char cap', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
 
   const tool = makeMountReadTool(filesystem);
-  const result = await tool.invoke({ path: 'big.txt' });
+  const result = /** @type {string} */ (await tool.invoke({ path: 'big.txt' }));
   t.true(result.startsWith('x'.repeat(50_000)));
   t.true(result.includes('truncated at 50000 chars'));
   t.is(result.indexOf('\n\n... (truncated'), 50_000);
@@ -125,7 +125,7 @@ test('truncates at a caller-supplied maxChars', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
 
   const tool = makeMountReadTool(filesystem, { maxChars: 8 });
-  const result = await tool.invoke({ path: 'big.txt' });
+  const result = /** @type {string} */ (await tool.invoke({ path: 'big.txt' }));
   t.true(result.startsWith('x'.repeat(8)));
   t.true(result.includes('truncated at 8 chars'));
   t.is(result.indexOf('\n\n... (truncated'), 8);
@@ -138,7 +138,7 @@ test('maxChars: 0 disables the limit and returns full contents', async t => {
   const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
 
   const tool = makeMountReadTool(filesystem, { maxChars: 0 });
-  const result = await tool.invoke({ path: 'big.txt' });
+  const result = /** @type {string} */ (await tool.invoke({ path: 'big.txt' }));
   t.is(result, big);
   t.false(result.includes('truncated'));
 });
@@ -185,7 +185,7 @@ test('bounds the underlying file read before draining bytes', async t => {
   const tool = makeMountReadTool(
     /** @type {ERef<Filesystem>} */ (/** @type {unknown} */ (filesystem)),
   );
-  const result = await tool.invoke({ path: 'big.txt' });
+  const result = /** @type {string} */ (await tool.invoke({ path: 'big.txt' }));
   t.is(result.indexOf('\n\n... (truncated'), 50_000);
 });
 
@@ -208,7 +208,10 @@ test('parameters and inputSchema advertise the mountReadText required path', t =
   // The same JSON Schema is used verbatim as both LLM `parameters` and MCP
   // `inputSchema`.
   t.is(tool.parameters, tool.inputSchema);
-  const { parameters } = tool;
+  const parameters =
+    /** @type {{ type: string, properties: { path: { type: string } }, required: string[], additionalProperties: boolean }} */ (
+      tool.parameters
+    );
   t.is(parameters.type, 'object');
   t.deepEqual(parameters.properties.path.type, 'string');
   t.deepEqual(parameters.required, ['path']);


### PR DESCRIPTION
## Description

`makeMountReadTool` in `packages/agent-tools` returned a bespoke `{ schema(), execute(), help() }` record that was incompatible with the canonical `ToolRecord` shape (`name` / `description` / `parameters` / `inputSchema` / `invoke`) that `makeGitTool` produces via `makeTool`. As a result the filesystem read tool could not flow through `toPiAgentTool` (which reads `.name` / `.parameters` / `.invoke`), making it a second-class island next to the git tools.

This builds `makeMountReadTool` through `makeTool`, mirroring `makeGitTool`, so it now emits a canonical `ToolRecord` and is a first-class, pipeline-compatible export at parity with git.

Most critical files to review:
- `packages/agent-tools/src/mount-fs.js` — the reconciliation: the maker now returns `makeTool({ name, description, parameters, execute })`.
- `packages/agent-tools/src/types.ts` — drops the now-dead `MountReadToolRecord` and `ToolSchema` interfaces; `makeMountReadTool` now returns `ToolRecord`.
- `packages/agent-tools/test/mount-fs.test.js` — assertions adapted to the record shape, plus a new `toPiAgentTool` round-trip test.

Behavior is preserved: chroot-to-subtree, `maxChars` truncation (including `0` to disable the limit), slash normalization, the one-extra-byte bounded read, and the extra-key / missing-or-empty-path rejections all still hold. The validation that used to live in the bespoke `execute` is retained inside the `execute` passed to `makeTool`, so the same error messages fire before any filesystem send.

### Security Considerations

No change to the authority surface. Confinement, symlink containment, and revocation are still enforced entirely by the `Filesystem` capability the tool receives; the tool still reads a single text file by mount-relative path and rejects `../` escapes through the capability rather than a string check. The only shape change is how the record is assembled, not what it can reach.

### Scaling Considerations

None. The read path is unchanged (single bounded read of `maxChars + 1` bytes, truncating past the cap).

### Documentation Considerations

The public return type of `makeMountReadTool` changes from the bespoke `MountReadToolRecord` to the canonical `ToolRecord`. Callers that invoked the old `.execute()` / `.schema()` / `.help()` methods must move to `.invoke()` / `.parameters` (used verbatim as both LLM `parameters` and MCP `inputSchema`). No in-tree consumer used the old surface.

### Testing Considerations

The existing `mount-fs.test.js` suite is retained with assertions adapted to the record shape, and a new test bridges the mount tool through `toPiAgentTool` and reads a file end to end, proving the previously-missing path now works. Full `packages/agent-tools` suite (48 tests) passes; `lint` and `tsc` are clean.

### Compatibility Considerations

Breaking for any external caller of the old `{ schema, execute, help }` surface (none in-tree). The new shape matches `makeGitTool`, so tools from both makers are now interchangeable through the same bridge.

### Upgrade Considerations

None for live systems.
