### PR TITLE
feat(agentry): inject generated TypeScript declarations for code-mode globals

### DIFF
--- a/packages/agentry/package.json
+++ b/packages/agentry/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "build": "exit 0",
+    "gen:code-mode-types": "node scripts/gen-code-mode-types.js",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
@@ -59,6 +60,7 @@
     "@endo/git": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/lockdown": "workspace:^",
+    "@endo/patterns": "workspace:^",
     "@endo/platform": "workspace:^",
     "@endo/ses-ava": "workspace:^",
     "ava": "catalog:dev",

--- a/packages/agentry/scripts/code-mode-fs-extract.js
+++ b/packages/agentry/scripts/code-mode-fs-extract.js
@@ -1,0 +1,76 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * Filesystem-specific code-mode type extraction: the `workspace` declaration,
+ * built with the generic guard walker ({@link extractGuardIR}) from the
+ * `@endo/platform/fs/extended` interface guards.
+ *
+ * `workspace` reads the runtime `M.interface` guards of
+ * `@endo/platform/fs/extended` (`FilesystemInterface` and the remotables it
+ * reaches). The FS `.d.ts` is a deliberate four-method stub, so the TypeScript
+ * path would yield a near-useless declaration here; the guards are the richest
+ * available source for this exo. Enriching the FS `.d.ts` so a TypeScript path
+ * could replace this is parked for a separate later design.
+ */
+
+import {
+  FilesystemInterface,
+  DirectoryInterface,
+  FileInterface,
+  CursorInterface,
+  OpenFileInterface,
+  LockInterface,
+  XattrsInterface,
+  NodeWatcherInterface,
+  BlobRefInterface,
+  PassableReaderInterface,
+  PassableBytesReaderInterface,
+  PassableBytesWriterInterface,
+} from '@endo/platform/fs/extended/type-guards.js';
+
+import { extractGuardIR, renderDeclaration } from './code-mode-type-extract.js';
+
+/**
+ * The FS interface guards reachable from the `workspace` Filesystem, keyed by
+ * the remotable label the guards use. A label not in this registry renders as
+ * an opaque `unknown` alias.
+ *
+ * @type {Map<string, import('@endo/patterns').InterfaceGuard>}
+ */
+const FS_REGISTRY = new Map(
+  /** @type {[string, any][]} */ ([
+    ['Filesystem', FilesystemInterface],
+    ['Directory', DirectoryInterface],
+    ['File', FileInterface],
+    ['Cursor', CursorInterface],
+    ['OpenFile', OpenFileInterface],
+    ['Lock', LockInterface],
+    ['Xattrs', XattrsInterface],
+    ['NodeWatcher', NodeWatcherInterface],
+    ['BlobRef', BlobRefInterface],
+    ['PassableReader', PassableReaderInterface],
+    ['PassableBytesReader', PassableBytesReaderInterface],
+    ['PassableBytesWriter', PassableBytesWriterInterface],
+  ]),
+);
+
+const WORKSPACE_ROOT = 'Filesystem';
+
+/**
+ * Build the `workspace` IR by walking the `Filesystem` guard.
+ *
+ * @returns {import('./code-mode-type-extract.js').GlobalTypeIR}
+ */
+export const buildWorkspaceIR = () =>
+  extractGuardIR({ registry: FS_REGISTRY, rootLabel: WORKSPACE_ROOT });
+harden(buildWorkspaceIR);
+
+/**
+ * Render the `workspace` `{ aux, body }` declaration strings.
+ *
+ * @returns {Record<'workspace', { aux: string, body: string }>}
+ */
+export const buildFsTypeDeclarations = () =>
+  harden({ workspace: renderDeclaration(buildWorkspaceIR()) });
+harden(buildFsTypeDeclarations);

--- a/packages/agentry/scripts/code-mode-git-extract.js
+++ b/packages/agentry/scripts/code-mode-git-extract.js
@@ -1,0 +1,95 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * Git-specific code-mode type extraction: the `git` and `gitReadOnly`
+ * declarations, built with the generic TypeScript renderer
+ * ({@link extractTsModuleIR}) from the hand-written `@endo/exo-git` types.
+ *
+ * `git` reads the hand-written TypeScript at `packages/exo-git/types.d.ts` (the
+ * `EndoGit` alias), which is full-fidelity: named parameters, no lossy
+ * positional guards. This is the TypeScript path for this exo; the divergence
+ * gate keeps it from drifting from the runtime `GitInterface` guard.
+ *
+ * The read-only vs read-write `git` split is a code-mode prompt-surface POLICY
+ * (a per-mode member allowlist, {@link GIT_READONLY_MEMBERS}), applied to the
+ * shared IR rather than read from the source. The runtime read-only enforcement
+ * remains the exo guard / `readOnly()` rejection; this allowlist only governs
+ * which verbs the prompt advertises.
+ *
+ * Guard-canonical DERIVATION for git (synthesizing the printed types from
+ * `GitInterface` instead of the TS) was considered and is TABLED: it would
+ * discard the more expressive hand-written TS. The guard stays the enforcement
+ * layer; the divergence gate keeps the printed git types aligned with it.
+ */
+
+import {
+  extractTsModuleIR,
+  renderDeclaration,
+} from './code-mode-type-extract.js';
+
+const GIT_DTS_URL = new URL('../../exo-git/types.d.ts', import.meta.url);
+const GIT_MODULE = '@endo/exo-git';
+const GIT_ROOT_TYPE = 'EndoGit';
+
+/**
+ * The read-only code-mode git prompt surface: the inspection verbs. Mutating
+ * verbs (`add`, `restore`, `commit`, branch/stash mutations, `merge`, `rebase`,
+ * checkout) are omitted so a read-only agent is not told about verbs that would
+ * reject at the cap boundary.
+ *
+ * @type {string[]}
+ */
+export const GIT_READONLY_MEMBERS = harden([
+  'worktree',
+  'status',
+  'diff',
+  'log',
+  'show',
+  'revParse',
+  'currentBranch',
+  'branches',
+  'tree',
+  'filesystemAt',
+  'stashList',
+  'stashShow',
+  'readOnly',
+]);
+harden(GIT_READONLY_MEMBERS);
+
+/**
+ * Build the `git` and `gitReadOnly` IRs from the hand-written `EndoGit`
+ * TypeScript alias; the read-only IR is the same source narrowed to
+ * {@link GIT_READONLY_MEMBERS}.
+ *
+ * @returns {{ git: import('./code-mode-type-extract.js').GlobalTypeIR, gitReadOnly: import('./code-mode-type-extract.js').GlobalTypeIR }}
+ */
+export const buildGitIRs = () =>
+  harden({
+    git: extractTsModuleIR({
+      dtsUrl: GIT_DTS_URL,
+      moduleName: GIT_MODULE,
+      rootType: GIT_ROOT_TYPE,
+    }),
+    gitReadOnly: extractTsModuleIR({
+      dtsUrl: GIT_DTS_URL,
+      moduleName: GIT_MODULE,
+      rootType: GIT_ROOT_TYPE,
+      memberFilter: GIT_READONLY_MEMBERS,
+    }),
+  });
+harden(buildGitIRs);
+
+/**
+ * Render the `git` and `gitReadOnly` `{ aux, body }` declaration strings.
+ *
+ * @returns {Record<'git' | 'gitReadOnly', { aux: string, body: string }>}
+ */
+export const buildGitTypeDeclarations = () => {
+  const irs = buildGitIRs();
+  return harden({
+    git: renderDeclaration(irs.git),
+    gitReadOnly: renderDeclaration(irs.gitReadOnly),
+  });
+};
+harden(buildGitTypeDeclarations);

--- a/packages/agentry/scripts/code-mode-type-extract.js
+++ b/packages/agentry/scripts/code-mode-type-extract.js
@@ -1,0 +1,476 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * Generic, exo-agnostic code-mode type machinery: the shared intermediate
+ * representation ({@link GlobalTypeIR}) plus BOTH renderers that fill it from a
+ * source and the one renderer that prints it.
+ *
+ * This module is NOT part of the `@endo/agentry` runtime graph: it depends on
+ * the `typescript` compiler API and the `@endo/patterns` guard payload helpers,
+ * both dev-only. The per-exo extractors (`code-mode-git-extract.js`,
+ * `code-mode-fs-extract.js`) compose these primitives with their own
+ * source configuration; `scripts/gen-code-mode-types.js` composes the per-exo
+ * extractors to write the checked-in runtime artifacts, and the divergence gate
+ * in `test/code-mode-types.test.js` re-runs them to keep those artifacts fresh.
+ *
+ * Two renderers fill the IR from two different kinds of source; the module
+ * exports both and picks no canonical one:
+ *
+ * - {@link extractTsModuleIR} reads a hand-written `.d.ts` and prints the named
+ *   root type with the `typescript` compiler API. Full-fidelity TypeScript is
+ *   the richest source when one exists (named parameters, prose-free signatures
+ *   straight from the author).
+ * - {@link extractGuardIR} walks the runtime `M.interface` guards of a remotable
+ *   and the transitive closure of remotables they reach. This is the richest
+ *   source when no expressive `.d.ts` exists (a stub, or a generated one).
+ *
+ * Neither is canonical: `M.interface` guards are lossy as a type source
+ * (positional patterns with no parameter names, no JSDoc or prose context), so
+ * the TypeScript path stays valuable; a stub `.d.ts` makes the guard path the
+ * only useful one. A consumer composes whichever fits each exo.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import {
+  getInterfaceGuardPayload,
+  getMethodGuardPayload,
+} from '@endo/patterns';
+import { getTag, passStyleOf } from '@endo/pass-style';
+
+/**
+ * @typedef {object} TypeMember
+ * @property {string} name Member (method) name.
+ * @property {string} signature TS type of the member, e.g. `() => Promise<string>`.
+ *
+ * @typedef {object} AuxType
+ * @property {string} name Type name (may be generic, e.g. `ERef<T>`).
+ * @property {string} text Right-hand side of the `type <name> = <text>` alias.
+ *
+ * @typedef {object} GlobalTypeIR
+ * @property {string} rootName Name of the global's root object type, e.g. `EndoGit`.
+ * @property {TypeMember[]} members Members of the root object type.
+ * @property {AuxType[]} auxTypes Supporting named types the members reference
+ *   (excluding the root type itself, which the renderer synthesizes from
+ *   `members` so a read-only member filter cannot leak the full surface back in
+ *   through a self-referential return).
+ */
+
+// #region shared renderer (no typescript / patterns dependency)
+
+/**
+ * @param {TypeMember[]} members
+ * @returns {string}
+ */
+const renderObjectType = members =>
+  `{\n${members.map(m => `  ${m.name}: ${m.signature};`).join('\n')}\n}`;
+
+/**
+ * @param {AuxType[]} auxTypes
+ * @returns {string}
+ */
+const renderAuxTypes = auxTypes =>
+  auxTypes.map(a => `type ${a.name} = ${a.text};`).join('\n');
+
+/**
+ * The single renderer applied to every IR regardless of source: synthesize the
+ * root `type` from `members`, print it alongside the supporting aliases as
+ * `aux`, and reference it by name as the `body` spliced after
+ * `declare const <name>:`.
+ *
+ * @param {GlobalTypeIR} ir
+ * @returns {{ aux: string, body: string }}
+ */
+export const renderDeclaration = ir =>
+  harden({
+    aux: renderAuxTypes([
+      { name: ir.rootName, text: renderObjectType(ir.members) },
+      ...ir.auxTypes,
+    ]),
+    body: ir.rootName,
+  });
+harden(renderDeclaration);
+
+// #endregion
+
+// #region TypeScript renderer (`type` -> declaration, via the typescript printer)
+
+/**
+ * @param {URL} dtsUrl
+ * @param {string} moduleName
+ * @returns {{ sourceFile: ts.SourceFile, aliasMap: Map<string, ts.TypeAliasDeclaration> }}
+ */
+const parseDtsModule = (dtsUrl, moduleName) => {
+  const text = readFileSync(fileURLToPath(dtsUrl), 'utf8');
+  const sourceFile = ts.createSourceFile(
+    fileURLToPath(dtsUrl),
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  /** @type {ts.ModuleBlock | undefined} */
+  let moduleBody;
+  for (const stmt of sourceFile.statements) {
+    if (
+      ts.isModuleDeclaration(stmt) &&
+      ts.isStringLiteral(stmt.name) &&
+      stmt.name.text === moduleName &&
+      stmt.body &&
+      ts.isModuleBlock(stmt.body)
+    ) {
+      moduleBody = stmt.body;
+      break;
+    }
+  }
+  if (!moduleBody) {
+    throw new Error(`could not find declare module '${moduleName}'`);
+  }
+  /** @type {Map<string, ts.TypeAliasDeclaration>} */
+  const aliasMap = new Map();
+  for (const stmt of moduleBody.statements) {
+    if (ts.isTypeAliasDeclaration(stmt)) {
+      aliasMap.set(stmt.name.text, stmt);
+    }
+  }
+  return { sourceFile, aliasMap };
+};
+
+/**
+ * The TypeScript renderer: build a {@link GlobalTypeIR} by parsing a
+ * hand-written `.d.ts`, locating the named root `type` alias inside a
+ * `declare module`, and printing the kept members and the supporting aliases
+ * they reach with the `typescript` printer.
+ *
+ * With a `memberFilter`, only the named members (and the types they reach) are
+ * kept; this is how a read-only or otherwise narrowed variant is produced from
+ * the same source.
+ *
+ * @param {object} config
+ * @param {URL} config.dtsUrl URL of the `.d.ts` to read.
+ * @param {string} config.moduleName The `declare module '<name>'` the root type
+ *   lives in.
+ * @param {string} config.rootType Name of the root `type` alias to print.
+ * @param {string[]} [config.memberFilter] When set, keep only these members.
+ * @returns {GlobalTypeIR}
+ */
+export const extractTsModuleIR = ({
+  dtsUrl,
+  moduleName,
+  rootType,
+  memberFilter,
+}) => {
+  const printer = ts.createPrinter({ removeComments: true });
+  const { sourceFile, aliasMap } = parseDtsModule(dtsUrl, moduleName);
+  const rootAlias = aliasMap.get(rootType);
+  if (!rootAlias || !ts.isTypeLiteralNode(rootAlias.type)) {
+    throw new Error(`${rootType} is not a type literal`);
+  }
+  const keep = name => !memberFilter || memberFilter.includes(name);
+
+  /** @type {TypeMember[]} */
+  const members = [];
+  /** @type {ts.TypeNode[]} */
+  const keptTypeNodes = [];
+  for (const m of rootAlias.type.members) {
+    if (
+      ts.isPropertySignature(m) &&
+      m.type &&
+      keep(m.name.getText(sourceFile))
+    ) {
+      members.push({
+        name: m.name.getText(sourceFile),
+        signature: printer.printNode(
+          ts.EmitHint.Unspecified,
+          m.type,
+          sourceFile,
+        ),
+      });
+      keptTypeNodes.push(m.type);
+    }
+  }
+
+  // Transitively collect the supporting type aliases the kept members reach.
+  /** @type {Set<string>} */
+  const referenced = new Set();
+  /** @param {ts.Node} node */
+  const collect = node => {
+    if (ts.isTypeReferenceNode(node)) {
+      const tn = node.typeName.getText(sourceFile);
+      const alias = aliasMap.get(tn);
+      // Skip the root type itself: the renderer synthesizes it from the
+      // (possibly filtered) members, so a self-referential return such as
+      // `readOnly(): EndoGit` must not pull the full unfiltered alias back in.
+      if (alias && tn !== rootType && !referenced.has(tn)) {
+        referenced.add(tn);
+        collect(alias.type);
+      }
+    }
+    ts.forEachChild(node, collect);
+  };
+  for (const node of keptTypeNodes) {
+    collect(node);
+  }
+
+  const auxTypes = [...referenced].sort().map(name => ({
+    name,
+    text: printer.printNode(
+      ts.EmitHint.Unspecified,
+      /** @type {ts.TypeAliasDeclaration} */ (aliasMap.get(name)).type,
+      sourceFile,
+    ),
+  }));
+
+  return harden({ rootName: rootType, members, auxTypes });
+};
+harden(extractTsModuleIR);
+
+// #endregion
+
+// #region guard renderer (`guard` -> declaration, via the patterns guard walker)
+
+/**
+ * @param {string[]} parts
+ * @returns {string[]}
+ */
+const unique = parts => [...new Set(parts)];
+
+/**
+ * Render one method-pattern argument or return guard to a TS type, recording
+ * any referenced remotable labels in `refs`.
+ *
+ * @param {unknown} node
+ * @param {Set<string>} refs
+ * @returns {string}
+ */
+const patternToTs = (node, refs) => {
+  const ps = passStyleOf(node);
+  if (ps === 'string') {
+    return JSON.stringify(node);
+  }
+  if (ps === 'number' || ps === 'boolean') {
+    return String(node);
+  }
+  if (ps === 'bigint') {
+    return `${String(node)}n`;
+  }
+  if (ps !== 'tagged') {
+    return 'unknown';
+  }
+  const tag = getTag(/** @type {any} */ (node));
+  const { payload } = /** @type {{ payload: any }} */ (node);
+  switch (tag) {
+    case 'match:string':
+      return 'string';
+    case 'match:symbol':
+      return 'symbol';
+    case 'match:bigint':
+      return 'bigint';
+    case 'match:number':
+    case 'match:nat':
+      return 'number';
+    case 'match:boolean':
+      return 'boolean';
+    case 'match:undefined':
+      return 'undefined';
+    case 'match:null':
+      return 'null';
+    case 'match:remotable': {
+      const label = String(payload.label);
+      refs.add(label);
+      return label;
+    }
+    case 'match:kind': {
+      switch (String(payload)) {
+        case 'string':
+          return 'string';
+        case 'number':
+          return 'number';
+        case 'bigint':
+          return 'bigint';
+        case 'boolean':
+          return 'boolean';
+        case 'undefined':
+          return 'undefined';
+        case 'null':
+          return 'null';
+        case 'symbol':
+          return 'symbol';
+        case 'promise':
+          return 'Promise<unknown>';
+        case 'remotable':
+          return 'object';
+        case 'error':
+          return 'Error';
+        case 'copyArray':
+          return 'unknown[]';
+        case 'copyRecord':
+          return 'Record<string, unknown>';
+        default:
+          return 'unknown';
+      }
+    }
+    case 'match:eq': {
+      const vps = passStyleOf(payload);
+      if (vps === 'string') {
+        return JSON.stringify(payload);
+      }
+      if (vps === 'number' || vps === 'boolean') {
+        return String(payload);
+      }
+      if (vps === 'bigint') {
+        return `${String(payload)}n`;
+      }
+      if (payload === undefined) {
+        return 'undefined';
+      }
+      if (payload === null) {
+        return 'null';
+      }
+      return 'unknown';
+    }
+    case 'match:or': {
+      const parts = /** @type {unknown[]} */ (payload);
+      // `M.eref(T)` is `M.or(T, M.promise())`; print it as `ERef<T>`.
+      if (parts.length === 2) {
+        const promiseIdx = parts.findIndex(
+          p =>
+            passStyleOf(p) === 'tagged' &&
+            getTag(/** @type {any} */ (p)) === 'match:kind' &&
+            String(/** @type {{ payload: any }} */ (p).payload) === 'promise',
+        );
+        if (promiseIdx !== -1) {
+          return `ERef<${patternToTs(parts[1 - promiseIdx], refs)}>`;
+        }
+      }
+      return unique(parts.map(p => patternToTs(p, refs))).join(' | ');
+    }
+    case 'match:and':
+      return unique(
+        /** @type {unknown[]} */ (payload).map(p => patternToTs(p, refs)),
+      ).join(' & ');
+    case 'match:arrayOf': {
+      const element = Array.isArray(payload) ? payload[0] : payload;
+      return `Array<${patternToTs(element, refs)}>`;
+    }
+    case 'match:recordOf': {
+      const [keyPattern, valuePattern] = payload;
+      return `Record<${patternToTs(keyPattern, refs)}, ${patternToTs(
+        valuePattern,
+        refs,
+      )}>`;
+    }
+    default:
+      // `M.await(...)` arg wrappers and other guard:* nodes carry an inner
+      // `argGuard`; unwrap to the settled shape. Anything else is opaque.
+      if (payload && typeof payload === 'object' && 'argGuard' in payload) {
+        return patternToTs(payload.argGuard, refs);
+      }
+      return 'unknown';
+  }
+};
+
+/**
+ * @param {import('@endo/patterns').MethodGuard} methodGuard
+ * @param {Set<string>} refs
+ * @returns {string}
+ */
+const methodSignature = (methodGuard, refs) => {
+  const {
+    argGuards = [],
+    optionalArgGuards = [],
+    restArgGuard,
+    returnGuard,
+  } = getMethodGuardPayload(methodGuard);
+  const params = [];
+  argGuards.forEach((g, i) => params.push(`arg${i}: ${patternToTs(g, refs)}`));
+  optionalArgGuards.forEach((g, i) =>
+    params.push(`arg${argGuards.length + i}?: ${patternToTs(g, refs)}`),
+  );
+  if (restArgGuard) {
+    params.push(`...rest: ${patternToTs(restArgGuard, refs)}`);
+  }
+  return `(${params.join(', ')}) => ${patternToTs(returnGuard, refs)}`;
+};
+
+/**
+ * @param {import('@endo/patterns').InterfaceGuard} interfaceGuard
+ * @param {Set<string>} refs
+ * @returns {TypeMember[]}
+ */
+const interfaceMembers = (interfaceGuard, refs) => {
+  const { methodGuards } = getInterfaceGuardPayload(interfaceGuard);
+  return Object.keys(methodGuards)
+    .sort()
+    .map(name => ({
+      name,
+      signature: methodSignature(methodGuards[name], refs),
+    }));
+};
+
+/**
+ * The guard renderer: build a {@link GlobalTypeIR} by walking the root
+ * `M.interface` guard and rendering the transitive closure of the remotable
+ * interfaces it reaches as supporting `type` aliases. A remotable label present
+ * in `registry` is rendered from its guard; a label not registered renders as
+ * an opaque `unknown` alias.
+ *
+ * `ERef<T>` is declared first because every eventual-send return prints as
+ * `ERef<...>`; that convention belongs to the guard walker, not to any
+ * particular exo.
+ *
+ * @param {object} config
+ * @param {Map<string, import('@endo/patterns').InterfaceGuard>} config.registry
+ *   Remotable label -> interface guard, keyed by the label the guards use.
+ * @param {string} config.rootLabel The label of the root remotable.
+ * @returns {GlobalTypeIR}
+ */
+export const extractGuardIR = ({ registry, rootLabel }) => {
+  /** @type {Set<string>} */
+  const refs = new Set();
+  const rootGuard = registry.get(rootLabel);
+  if (!rootGuard) {
+    throw new Error(`no guard registered for ${rootLabel}`);
+  }
+  const members = interfaceMembers(rootGuard, refs);
+
+  /** @type {AuxType[]} */
+  const interfaceAux = [];
+  const done = new Set([rootLabel]);
+  const queue = [...refs];
+  while (queue.length) {
+    const name = /** @type {string} */ (queue.shift());
+    if (!done.has(name)) {
+      done.add(name);
+      const guard = registry.get(name);
+      if (!guard) {
+        interfaceAux.push({ name, text: 'unknown' });
+      } else {
+        /** @type {Set<string>} */
+        const innerRefs = new Set();
+        interfaceAux.push({
+          name,
+          text: renderObjectType(interfaceMembers(guard, innerRefs)),
+        });
+        for (const ref of innerRefs) {
+          if (!done.has(ref)) {
+            queue.push(ref);
+          }
+        }
+      }
+    }
+  }
+  interfaceAux.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  // `ERef<T>` is referenced by every eventual-send return; declare it first.
+  const auxTypes = [
+    { name: 'ERef<T>', text: 'T | Promise<T>' },
+    ...interfaceAux,
+  ];
+  return harden({ rootName: rootLabel, members, auxTypes });
+};
+harden(extractGuardIR);
+
+// #endregion

--- a/packages/agentry/scripts/gen-code-mode-types.js
+++ b/packages/agentry/scripts/gen-code-mode-types.js
@@ -1,0 +1,134 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * Build-time codegen for the per-exo code-mode global type declarations.
+ *
+ * Composes the per-exo extractors (`code-mode-git-extract.js`,
+ * `code-mode-fs-extract.js`), each of which pairs a source with the generic
+ * renderer it needs, and writes one checked-in runtime artifact per exo:
+ *
+ *   - `src/execute/git-types.js` (git, gitReadOnly)
+ *   - `src/execute/fs-types.js`  (workspace)
+ *
+ * Run with: `yarn workspace agentry gen:code-mode-types`
+ *
+ * `test/code-mode-types.test.js` is the divergence gate: it re-runs the same
+ * extraction and fails if a checked-in artifact is stale, so a change to any
+ * source (the exo-git types, the FS guards) or to a renderer must be
+ * regenerated and committed.
+ *
+ * `typescript` and `@endo/patterns` are dev dependencies and are only used here
+ * and in the gate, never at agentry runtime: the artifacts are plain checked-in
+ * data.
+ */
+
+import '@endo/init';
+
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { buildGitTypeDeclarations } from './code-mode-git-extract.js';
+import { buildFsTypeDeclarations } from './code-mode-fs-extract.js';
+
+/**
+ * @param {string} descriptorFile The per-exo runtime descriptor module that
+ *   consumes this artifact (e.g. `git.js`).
+ * @param {string} sourceDoc Provenance note for the generated file header.
+ * @returns {string}
+ */
+const header = (descriptorFile, sourceDoc) => `// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * GENERATED FILE - do not edit by hand.
+ *
+ * Regenerate with: yarn workspace agentry gen:code-mode-types
+ *
+ * Source of truth:
+${sourceDoc}
+ *
+ * The generic extraction and rendering live in
+ * scripts/code-mode-type-extract.js; this exo's source configuration lives in
+ * its scripts/code-mode-*-extract.js extractor. The divergence gate in
+ * test/code-mode-types.test.js keeps this artifact fresh.
+ *
+ * Each entry is consumed by formatGlobalDeclarations in execute/globals.js via
+ * the per-exo descriptor in execute/${descriptorFile}:
+ * \`aux\` is the supporting \`type\` aliases, \`body\` is the object type spliced
+ * after the dynamic \`declare const <name>:\`.
+ */
+`;
+
+/**
+ * @param {string} s
+ * @returns {string}
+ */
+const guardTemplate = s => {
+  if (s.includes('`') || s.includes('${')) {
+    throw new Error('generated declaration contains a template-literal sigil');
+  }
+  return s;
+};
+
+/**
+ * @param {Record<string, { aux: string, body: string }>} declarations
+ * @returns {string}
+ */
+const renderEntries = declarations =>
+  Object.entries(declarations)
+    .map(
+      ([key, { aux, body }]) =>
+        `  ${key}: {\n    aux: \`${guardTemplate(aux)}\`,\n    body: \`${guardTemplate(
+          body,
+        )}\`,\n  },`,
+    )
+    .join('\n');
+
+/**
+ * @param {object} artifact
+ * @param {string} artifact.outPath Path relative to this script's directory.
+ * @param {string} artifact.exportName The `export const <name>` to emit.
+ * @param {string} artifact.descriptorFile The per-exo runtime descriptor module
+ *   that consumes this artifact.
+ * @param {string} artifact.sourceDoc Provenance note for the header.
+ * @param {Record<string, { aux: string, body: string }>} artifact.declarations
+ */
+const writeArtifact = ({
+  outPath,
+  exportName,
+  descriptorFile,
+  sourceDoc,
+  declarations,
+}) => {
+  const outUrl = new URL(outPath, import.meta.url);
+  const body = `${header(descriptorFile, sourceDoc)}
+export const ${exportName} = harden({
+${renderEntries(declarations)}
+});
+harden(${exportName});
+`;
+  writeFileSync(fileURLToPath(outUrl), body);
+  console.error(
+    `wrote ${fileURLToPath(outUrl)} (${Object.keys(declarations).join(', ')})`,
+  );
+};
+
+writeArtifact({
+  outPath: '../src/execute/git-types.js',
+  exportName: 'gitCodeModeTypeDeclarations',
+  descriptorFile: 'git.js',
+  sourceDoc: ` *   - git / gitReadOnly: packages/exo-git/types.d.ts (the \`EndoGit\` alias),
+ *     printed by the typescript compiler API (TypeScript-canonical).`,
+  declarations: buildGitTypeDeclarations(),
+});
+
+writeArtifact({
+  outPath: '../src/execute/fs-types.js',
+  exportName: 'fsCodeModeTypeDeclarations',
+  descriptorFile: 'fs.js',
+  sourceDoc: ` *   - workspace: the platform/fs/extended interface guards
+ *     (\`FilesystemInterface\` and the remotables it reaches), the richest
+ *     available source since the FS \`.d.ts\` is a stub.`,
+  declarations: buildFsTypeDeclarations(),
+});

--- a/packages/agentry/src/execute/fs-types.js
+++ b/packages/agentry/src/execute/fs-types.js
@@ -1,0 +1,123 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * GENERATED FILE - do not edit by hand.
+ *
+ * Regenerate with: yarn workspace agentry gen:code-mode-types
+ *
+ * Source of truth:
+ *   - workspace: the platform/fs/extended interface guards
+ *     (`FilesystemInterface` and the remotables it reaches), the richest
+ *     available source since the FS `.d.ts` is a stub.
+ *
+ * The generic extraction and rendering live in
+ * scripts/code-mode-type-extract.js; this exo's source configuration lives in
+ * its scripts/code-mode-*-extract.js extractor. The divergence gate in
+ * test/code-mode-types.test.js keeps this artifact fresh.
+ *
+ * Each entry is consumed by formatGlobalDeclarations in execute/globals.js via
+ * the per-exo descriptor in execute/fs.js:
+ * `aux` is the supporting `type` aliases, `body` is the object type spliced
+ * after the dynamic `declare const <name>:`.
+ */
+
+export const fsCodeModeTypeDeclarations = harden({
+  workspace: {
+    aux: `type Filesystem = {
+  brands: () => Promise<unknown>;
+  help: (arg0?: string) => string;
+  named: (arg0: string) => ERef<Directory>;
+  root: () => ERef<Directory>;
+  statfs: () => Promise<unknown>;
+};
+type ERef<T> = T | Promise<T>;
+type Cursor = {
+  close: () => Promise<unknown>;
+  help: (arg0?: string) => string;
+  read: (arg0?: bigint) => Promise<unknown>;
+  rewind: () => Promise<unknown>;
+  skip: (arg0: bigint) => Promise<unknown>;
+  stream: () => ERef<PassableReader>;
+  toArray: () => Promise<unknown>;
+};
+type Directory = {
+  copy: (arg0: string | Array<string>, arg1: string | Array<string>) => Promise<unknown>;
+  create: (arg0: string, arg1: unknown) => ERef<OpenFile>;
+  fsync: () => Promise<unknown>;
+  getAttrs: () => Promise<unknown>;
+  getQid: () => unknown;
+  getStat: () => Promise<unknown>;
+  help: (arg0?: string) => string;
+  list: () => ERef<Cursor>;
+  lookup: (arg0: string | Array<string>) => ERef<Directory | File>;
+  lookupStep: (arg0: string) => ERef<Directory | File>;
+  makeDirectory: (arg0: string, arg1: unknown) => ERef<Directory>;
+  materialise: (arg0: Array<string>, arg1: unknown) => ERef<Directory>;
+  mkdir: (arg0: string, arg1: unknown) => ERef<Directory>;
+  move: (arg0: string | Array<string>, arg1: string | Array<string>) => Promise<unknown>;
+  remove: (arg0: string) => Promise<unknown>;
+  rename: (arg0: string, arg1: Directory, arg2: string) => undefined;
+  setAttrs: (arg0: unknown) => Promise<unknown>;
+  setStat: (arg0: unknown) => Promise<unknown>;
+  subView: (arg0: string | Array<string>) => ERef<Directory>;
+  unlink: (arg0: string) => Promise<unknown>;
+  watch: () => ERef<NodeWatcher>;
+  watchFrom: () => ERef<unknown>;
+  write: (arg0: string, arg1: string) => Promise<unknown>;
+  xattrs: () => ERef<Xattrs>;
+};
+type File = {
+  getAttrs: () => Promise<unknown>;
+  getQid: () => unknown;
+  getStat: () => Promise<unknown>;
+  help: (arg0?: string) => string;
+  open: (arg0: unknown) => ERef<OpenFile>;
+  setAttrs: (arg0: unknown) => Promise<unknown>;
+  setStat: (arg0: unknown) => Promise<unknown>;
+  snapshot: () => Promise<unknown>;
+  watch: () => ERef<NodeWatcher>;
+  xattrs: () => ERef<Xattrs>;
+};
+type Lock = {
+  help: (arg0?: string) => string;
+  release: () => Promise<unknown>;
+};
+type NodeWatcher = {
+  cancel: () => Promise<unknown>;
+  events: () => ERef<PassableReader>;
+};
+type OpenFile = {
+  close: () => Promise<unknown>;
+  fsync: (arg0: unknown) => Promise<unknown>;
+  getLock: (arg0: unknown) => Promise<unknown>;
+  help: (arg0?: string) => string;
+  lock: (arg0: unknown) => ERef<Lock>;
+  read: (arg0?: bigint, arg1?: bigint) => unknown;
+  truncate: (arg0: bigint) => Promise<unknown>;
+  write: (arg0?: bigint) => unknown;
+};
+type PassableBytesReader = {
+  readReturnPattern: () => undefined | unknown;
+  streamBase64: (arg0: unknown) => Promise<unknown>;
+};
+type PassableBytesWriter = {
+  streamBase64: (arg0: unknown) => Promise<unknown>;
+  writeReturnPattern: () => undefined | unknown;
+};
+type PassableReader = {
+  readPattern: () => undefined | unknown;
+  readReturnPattern: () => undefined | unknown;
+  stream: (arg0: unknown) => Promise<unknown>;
+};
+type Xattrs = {
+  get: (arg0: string) => ERef<PassableBytesReader>;
+  help: (arg0?: string) => string;
+  list: () => ERef<PassableReader>;
+  remove: (arg0: string) => Promise<unknown>;
+  set: (arg0: string, arg1: unknown) => ERef<PassableBytesWriter>;
+};`,
+    body: `Filesystem`,
+  },
+});
+harden(fsCodeModeTypeDeclarations);

--- a/packages/agentry/src/execute/fs.js
+++ b/packages/agentry/src/execute/fs.js
@@ -1,0 +1,34 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { CodeModeGlobal } from './tool.js' */
+
+import { fsCodeModeTypeDeclarations } from './fs-types.js';
+
+/**
+ * The filesystem exo's generated TypeScript declarations, keyed by code-mode
+ * surface: `workspace` (the writable `@endo/platform/fs/extended` Filesystem).
+ * A consumer composing its own code-mode agent can read these directly to
+ * inject the workspace types into a hand-built global.
+ */
+export { fsCodeModeTypeDeclarations };
+
+/**
+ * Build the code-mode global descriptor for a writable
+ * `@endo/platform/fs/extended` Filesystem (the repository `workspace`).
+ *
+ * @param {object} options
+ * @param {string} options.name JS-identifier lexical binding name.
+ * @param {string | string[]} [options.petName] Pet name to look the capability
+ *   up by; defaults to `name`.
+ * @returns {CodeModeGlobal}
+ */
+export const makeWorkspaceGlobal = ({ name, petName = name }) =>
+  harden({
+    name,
+    petName,
+    description:
+      'Writable @endo/platform/fs/extended Filesystem for the repository.',
+    declaration: fsCodeModeTypeDeclarations.workspace,
+  });
+harden(makeWorkspaceGlobal);

--- a/packages/agentry/src/execute/git-types.js
+++ b/packages/agentry/src/execute/git-types.js
@@ -1,0 +1,174 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * GENERATED FILE - do not edit by hand.
+ *
+ * Regenerate with: yarn workspace agentry gen:code-mode-types
+ *
+ * Source of truth:
+ *   - git / gitReadOnly: packages/exo-git/types.d.ts (the `EndoGit` alias),
+ *     printed by the typescript compiler API (TypeScript-canonical).
+ *
+ * The generic extraction and rendering live in
+ * scripts/code-mode-type-extract.js; this exo's source configuration lives in
+ * its scripts/code-mode-*-extract.js extractor. The divergence gate in
+ * test/code-mode-types.test.js keeps this artifact fresh.
+ *
+ * Each entry is consumed by formatGlobalDeclarations in execute/globals.js via
+ * the per-exo descriptor in execute/git.js:
+ * `aux` is the supporting `type` aliases, `body` is the object type spliced
+ * after the dynamic `declare const <name>:`.
+ */
+
+export const gitCodeModeTypeDeclarations = harden({
+  git: {
+    aux: `type EndoGit = {
+  worktree: () => EndoMount;
+  status: () => Promise<GitStatusEntry[]>;
+  diff: (options?: GitDiffOptions) => Promise<string>;
+  log: (options?: GitLogOptions) => Promise<GitCommit[]>;
+  show: (ref: GitRef | string) => Promise<string>;
+  revParse: (ref: GitRef | string) => Promise<GitRef>;
+  add: (entries: EndoMountEntry[]) => Promise<void>;
+  restore: (entries: EndoMountEntry[], options?: GitRestoreOptions) => Promise<void>;
+  commit: (message: string) => Promise<GitCommit>;
+  currentBranch: () => Promise<GitRef | undefined>;
+  branches: () => Promise<GitRef[]>;
+  createBranch: (name: string, options?: GitCreateBranchOptions) => Promise<GitRef>;
+  deleteBranch: (name: string, options?: GitDeleteBranchOptions) => Promise<void>;
+  renameBranch: (from: string, to: string) => Promise<void>;
+  switchBranch: (name: string) => Promise<void>;
+  detach: (ref: GitRef | string) => Promise<void>;
+  switch: (ref: GitRef | string) => Promise<void>;
+  merge: (ref: GitRef | string, options?: GitMergeOptions) => Promise<string>;
+  rebase: (input: GitRebaseInput) => Promise<string>;
+  stashPush: (options?: GitStashPushOptions) => Promise<string>;
+  stashList: () => Promise<string[]>;
+  stashShow: (index?: number) => Promise<string>;
+  stashApply: (index?: number) => Promise<void>;
+  stashPop: (index?: number) => Promise<void>;
+  stashDrop: (index?: number) => Promise<void>;
+  tree: (ref: GitRef | string) => Promise<ReadableTreeView>;
+  filesystemAt: (ref: GitRef | string) => Promise<unknown>;
+  readOnly: () => EndoGit;
+};
+type EndoMount = unknown;
+type EndoMountEntry = unknown;
+type GitCommit = {
+    oid: string;
+    summary: string;
+    author?: string;
+    committedAt?: number;
+};
+type GitCreateBranchOptions = {
+    startPoint?: string;
+    switchAfterCreate?: boolean;
+};
+type GitDeleteBranchOptions = {
+    force?: boolean;
+};
+type GitDiffOptions = {
+    cached?: boolean;
+    base?: GitRef | string;
+    head?: GitRef | string;
+    entries?: unknown[];
+    paths?: string[];
+};
+type GitIndexStatus = 'clean' | 'added' | 'modified' | 'deleted' | 'renamed' | 'copied' | 'conflicted';
+type GitLogOptions = {
+    maxCount?: number;
+    ref?: GitRef | string;
+    since?: string;
+    until?: string;
+};
+type GitMergeOptions = {
+    fastForwardOnly?: boolean;
+    noFastForward?: boolean;
+};
+type GitRebaseInput = {
+    mode?: 'start' | 'continue' | 'abort' | 'skip';
+    upstream?: string;
+};
+type GitRef = {
+    name: string;
+    kind: string;
+    oid?: string;
+};
+type GitRestoreOptions = {
+    staged?: boolean;
+};
+type GitStashPushOptions = {
+    message?: string;
+    entries?: unknown[];
+    paths?: string[];
+    includeUntracked?: boolean;
+};
+type GitStatusEntry = {
+    entry: unknown;
+    path: string;
+    index: GitIndexStatus;
+    worktree: GitWorktreeStatus;
+    node?: unknown;
+    renamedFrom?: string;
+};
+type GitWorktreeStatus = 'clean' | 'modified' | 'deleted' | 'untracked' | 'ignored' | 'conflicted';
+type ReadableTreeView = unknown;`,
+    body: `EndoGit`,
+  },
+  gitReadOnly: {
+    aux: `type EndoGit = {
+  worktree: () => EndoMount;
+  status: () => Promise<GitStatusEntry[]>;
+  diff: (options?: GitDiffOptions) => Promise<string>;
+  log: (options?: GitLogOptions) => Promise<GitCommit[]>;
+  show: (ref: GitRef | string) => Promise<string>;
+  revParse: (ref: GitRef | string) => Promise<GitRef>;
+  currentBranch: () => Promise<GitRef | undefined>;
+  branches: () => Promise<GitRef[]>;
+  stashList: () => Promise<string[]>;
+  stashShow: (index?: number) => Promise<string>;
+  tree: (ref: GitRef | string) => Promise<ReadableTreeView>;
+  filesystemAt: (ref: GitRef | string) => Promise<unknown>;
+  readOnly: () => EndoGit;
+};
+type EndoMount = unknown;
+type GitCommit = {
+    oid: string;
+    summary: string;
+    author?: string;
+    committedAt?: number;
+};
+type GitDiffOptions = {
+    cached?: boolean;
+    base?: GitRef | string;
+    head?: GitRef | string;
+    entries?: unknown[];
+    paths?: string[];
+};
+type GitIndexStatus = 'clean' | 'added' | 'modified' | 'deleted' | 'renamed' | 'copied' | 'conflicted';
+type GitLogOptions = {
+    maxCount?: number;
+    ref?: GitRef | string;
+    since?: string;
+    until?: string;
+};
+type GitRef = {
+    name: string;
+    kind: string;
+    oid?: string;
+};
+type GitStatusEntry = {
+    entry: unknown;
+    path: string;
+    index: GitIndexStatus;
+    worktree: GitWorktreeStatus;
+    node?: unknown;
+    renamedFrom?: string;
+};
+type GitWorktreeStatus = 'clean' | 'modified' | 'deleted' | 'untracked' | 'ignored' | 'conflicted';
+type ReadableTreeView = unknown;`,
+    body: `EndoGit`,
+  },
+});
+harden(gitCodeModeTypeDeclarations);

--- a/packages/agentry/src/execute/git.js
+++ b/packages/agentry/src/execute/git.js
@@ -1,0 +1,41 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { CodeModeGlobal } from './tool.js' */
+
+import { gitCodeModeTypeDeclarations } from './git-types.js';
+
+/**
+ * The git exo's per-mode generated TypeScript declarations, keyed by code-mode
+ * surface: `git` (read/write) and `gitReadOnly` (inspection verbs only). A
+ * consumer composing its own code-mode agent can read these directly to inject
+ * git types into a hand-built global.
+ */
+export { gitCodeModeTypeDeclarations };
+
+/**
+ * Build the code-mode global descriptor for an `@endo/exo-git` Git capability.
+ * The read-only vs read-write split is a prompt-surface choice: `readOnly`
+ * selects the `gitReadOnly` declaration (inspection verbs only) and the
+ * matching one-line description. Runtime read-only enforcement stays the exo
+ * guard; this only governs which verbs the prompt advertises.
+ *
+ * @param {object} options
+ * @param {string} options.name JS-identifier lexical binding name.
+ * @param {string | string[]} [options.petName] Pet name to look the capability
+ *   up by; defaults to `name`.
+ * @param {boolean} [options.readOnly] Select the read-only prompt surface.
+ * @returns {CodeModeGlobal}
+ */
+export const makeGitGlobal = ({ name, petName = name, readOnly = false }) =>
+  harden({
+    name,
+    petName,
+    description: readOnly
+      ? 'Read-only @endo/exo-git Git capability for repository inspection.'
+      : 'Read/write @endo/exo-git Git capability for repository changes.',
+    declaration: readOnly
+      ? gitCodeModeTypeDeclarations.gitReadOnly
+      : gitCodeModeTypeDeclarations.git,
+  });
+harden(makeGitGlobal);

--- a/packages/agentry/src/execute/globals.js
+++ b/packages/agentry/src/execute/globals.js
@@ -1,7 +1,7 @@
 // @ts-check
 /// <reference types="ses"/>
 
-/** @import { CodeModeGlobal } from './tool.js' */
+/** @import { CodeModeGlobal, GlobalDeclaration } from './tool.js' */
 
 const IDENTIFIER_RE = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
 
@@ -21,11 +21,31 @@ const isResultName = value =>
   (Array.isArray(value) && value.every(part => typeof part === 'string'));
 
 /**
+ * @param {unknown} value
+ * @returns {value is GlobalDeclaration}
+ */
+const isDeclaration = value => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const record = /** @type {{ body?: unknown, aux?: unknown }} */ (value);
+  return (
+    typeof record.body === 'string' &&
+    (record.aux === undefined || typeof record.aux === 'string')
+  );
+};
+
+/**
  * Normalize a list of code-mode globals: each global must have a JS-identifier
- * `name`; `petName` defaults to `name`; `description` is carried as-is. Type
- * declarations are intentionally not part of the prompt surface — the model
- * introspects a live capability via `E(cap).__getMethodNames__()` rather than
- * reading a hand-maintained type blob.
+ * `name`; `petName` defaults to `name`; `description` is carried as-is. An
+ * optional `declaration` (`{ aux?, body }`) is a generated TypeScript block
+ * that `formatGlobalDeclarations` splices into the prompt so the model can pick
+ * a method and its arguments before its first call. This module is exo-agnostic:
+ * the per-exo files (`git.js`, `fs.js`) supply the `declaration`, and a consumer
+ * can attach its own. Globals without a `declaration` (the common `namedPowers`
+ * case) stay name-only, and `E(cap).__getMethodNames__()` remains the runtime
+ * fallback for any method a declaration does not cover (a guard-derived
+ * declaration can be a subset of the live surface by design).
  *
  * Global names must be unique and must not collide with a reserved binding
  * (`E`). A duplicate or reserved name is a misconfiguration — the well-known
@@ -43,7 +63,7 @@ export const normalizeGlobals = globals => {
   const seen = new Set();
   return harden(
     globals.map(global => {
-      const { name, petName = name, description } = global;
+      const { name, petName = name, description, declaration } = global;
       if (!IDENTIFIER_RE.test(name)) {
         throw new Error(
           `code-mode global name must be a JS identifier: ${name}`,
@@ -61,30 +81,64 @@ export const normalizeGlobals = globals => {
       if (!isResultName(petName)) {
         throw new Error(`code-mode global "${name}" has invalid petName`);
       }
-      return harden({ name, petName, description });
+      if (declaration !== undefined && !isDeclaration(declaration)) {
+        throw new Error(
+          `code-mode global "${name}" has an invalid declaration (expected { aux?: string, body: string })`,
+        );
+      }
+      return harden({
+        name,
+        petName,
+        description,
+        ...(declaration !== undefined && { declaration }),
+      });
     }),
   );
 };
 harden(normalizeGlobals);
 
 /**
- * Format the lexical globals as a prompt fragment: one `declare const <name>;`
- * per global, annotated with its one-line description. No type declaration is
- * emitted — the model discovers a capability's method surface at runtime via
- * CapTP introspection (`E(name).__getMethodNames__()`).
+ * Format the lexical globals as a prompt fragment. A global carrying a
+ * `declaration` is emitted as a real typed declaration: its supporting `type`
+ * aliases followed by `declare const <name>: <RootType>;`. The per-exo files
+ * supply those declarations (printed from the canonical TypeScript for `git`
+ * and from the FS interface guards for `workspace`); this formatter is
+ * exo-agnostic and prints whatever `declaration` a global carries. A global
+ * without a `declaration` stays name-only (`declare const <name>;`); the model
+ * discovers its method surface at runtime via CapTP introspection
+ * (`E(name).__getMethodNames__()`), which is also the fallback for any method a
+ * declaration omits.
+ *
+ * Each distinct supporting-aux block is emitted once even if two globals share
+ * the same `declaration`, so the `type` aliases are not duplicated in the
+ * prompt.
  *
  * @param {CodeModeGlobal[]} globals
  * @returns {string}
  */
-export const formatGlobalDeclarations = globals =>
-  globals
-    .map(global => {
-      const description = global.description
-        ? ` // ${global.description.replaceAll('\n', ' ')}`
-        : '';
-      return `declare const ${global.name};${description}`;
-    })
-    .join('\n');
+export const formatGlobalDeclarations = globals => {
+  /** @type {string[]} */
+  const lines = [];
+  const emittedAux = new Set();
+  for (const global of globals) {
+    const description = global.description
+      ? ` // ${global.description.replaceAll('\n', ' ')}`
+      : '';
+    const { declaration } = global;
+    if (declaration) {
+      if (declaration.aux && !emittedAux.has(declaration.aux)) {
+        emittedAux.add(declaration.aux);
+        lines.push(declaration.aux);
+      }
+      lines.push(
+        `declare const ${global.name}: ${declaration.body};${description}`,
+      );
+    } else {
+      lines.push(`declare const ${global.name};${description}`);
+    }
+  }
+  return lines.join('\n');
+};
 
 /**
  * Build the system prompt for the narrow code-mode agent.
@@ -102,7 +156,7 @@ export const makeCodeModeSystemPrompt = (globals, options = {}) => {
 
 You have exactly one tool: execute. Do not call any other tool and do not answer in prose when a tool call can do the work.
 
-The execute tool evaluates JavaScript source in an Endo Compartment. The compartment includes hardened SES globals plus the powers listed below. These powers are already in lexical scope; do not look them up by pet name. Discover a capability's methods at runtime with E(capability).__getMethodNames__().
+The execute tool evaluates JavaScript source in an Endo Compartment. The compartment includes hardened SES globals plus the powers listed below. These powers are already in lexical scope; do not look them up by pet name. The TypeScript declarations below are your primary reference: use them to pick a method and its arguments before your first call rather than probing at runtime. They may be a subset of a capability's live surface, so if you need a method that is not declared, discover it with E(capability).__getMethodNames__().
 
 Use E(capability).method(...) for remotable capabilities. Top-level await is not available, so use an async IIFE when you need multiple awaits or a final awaited result:
 

--- a/packages/agentry/src/execute/index.js
+++ b/packages/agentry/src/execute/index.js
@@ -7,4 +7,6 @@ export {
   formatGlobalDeclarations,
   makeCodeModeSystemPrompt,
 } from './globals.js';
+export { makeGitGlobal, gitCodeModeTypeDeclarations } from './git.js';
+export { makeWorkspaceGlobal, fsCodeModeTypeDeclarations } from './fs.js';
 export { makeCodeModeAgent, makeCodeModeGitLoopAgent } from './preset.js';

--- a/packages/agentry/src/execute/preset.js
+++ b/packages/agentry/src/execute/preset.js
@@ -15,6 +15,8 @@ import { getAmbientEnv, makeEnvCredentials } from '../harness/credentials.js';
 import { makeCompartmentExecute } from './compartment.js';
 import { makeExecuteTool, toSmallcapsPiAgentTool } from './tool.js';
 import { makeCodeModeSystemPrompt, normalizeGlobals } from './globals.js';
+import { makeGitGlobal } from './git.js';
+import { makeWorkspaceGlobal } from './fs.js';
 
 const IDENTIFIER_RE = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
 
@@ -74,8 +76,13 @@ const lookupRequiredPower = (powers, petName, label) => {
 
 /**
  * Build the lexical globals for a code-mode agent from its configured powers.
- * Each global carries a name, pet name, and a one-line description; type blobs
- * are intentionally absent (the model introspects live caps at runtime).
+ * This builder only chooses WHICH globals to inject from the configured powers;
+ * the per-exo specifics (descriptions, generated declarations, the read-only
+ * member policy) live in `git.js` and `fs.js`, which this delegates to. The
+ * read-only vs read-write split is a prompt-surface policy: `gitMode:
+ * 'readOnly'` selects the `gitReadOnly` declaration (inspection verbs only),
+ * while the runtime read-only enforcement stays the exo guard. `namedPowers`
+ * stay name-only unless the caller attached its own `declaration`.
  *
  * @param {CodeModePowers} powers
  * @returns {CodeModeGlobal[]}
@@ -85,23 +92,22 @@ const makeCodeModeGlobals = (powers = {}) => {
   const globals = [];
   if (powers.workspace !== undefined || powers.workspacePetName !== undefined) {
     const workspacePetName = powers.workspacePetName ?? 'workspace';
-    globals.push({
-      name: petNameToBindingName(workspacePetName, 'workspace'),
-      petName: workspacePetName,
-      description:
-        'Writable @endo/platform/fs/extended Filesystem for the repository.',
-    });
+    globals.push(
+      makeWorkspaceGlobal({
+        name: petNameToBindingName(workspacePetName, 'workspace'),
+        petName: workspacePetName,
+      }),
+    );
   }
   if (powers.git !== undefined || powers.gitPetName !== undefined) {
-    const readOnlyGit = powers.gitMode === 'readOnly';
     const gitPetName = powers.gitPetName ?? 'git';
-    globals.push({
-      name: petNameToBindingName(gitPetName, 'git'),
-      petName: gitPetName,
-      description: readOnlyGit
-        ? 'Read-only @endo/exo-git Git capability for repository inspection.'
-        : 'Read/write @endo/exo-git Git capability for repository changes.',
-    });
+    globals.push(
+      makeGitGlobal({
+        name: petNameToBindingName(gitPetName, 'git'),
+        petName: gitPetName,
+        readOnly: powers.gitMode === 'readOnly',
+      }),
+    );
   }
   globals.push(...(powers.namedPowers || []));
   return normalizeGlobals(globals);

--- a/packages/agentry/src/execute/tool.js
+++ b/packages/agentry/src/execute/tool.js
@@ -56,10 +56,22 @@ const EXECUTE_PARAMETERS = harden({
  *
  * @typedef {{ lookup: (petName: string | string[]) => Promise<PowerHandle> }} LookupPowers
  *
+ * @typedef {object} GlobalDeclaration A generated TypeScript declaration for a
+ *   code-mode global. `body` is the root type name spliced after
+ *   `declare const <name>:`; `aux` is the supporting `type` aliases emitted
+ *   above it (omitted when the body needs no supporting aliases).
+ * @property {string} body
+ * @property {string} [aux]
+ *
  * @typedef {object} CodeModeGlobal
  * @property {string} name
  * @property {string | string[]} [petName]
  * @property {string} [description]
+ * @property {GlobalDeclaration} [declaration] Generated TypeScript declaration
+ *   for this global. When set, `formatGlobalDeclarations` emits a typed
+ *   `declare const` for this global instead of a name-only one. The per-exo
+ *   files (`git.js`, `fs.js`) supply these; unset for `namedPowers`, which stay
+ *   name-only. A consumer can attach its own.
  *
  * @typedef {object} CodeModeExecuteInput
  * @property {string} source

--- a/packages/agentry/test/code-mode-types.test.js
+++ b/packages/agentry/test/code-mode-types.test.js
@@ -1,0 +1,117 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import { getInterfaceGuardPayload } from '@endo/patterns';
+import { GitInterface } from '@endo/exo-git';
+import { FilesystemInterface } from '@endo/platform/fs/extended/type-guards.js';
+
+/** @import { InterfaceGuard } from '@endo/patterns' */
+
+import { gitCodeModeTypeDeclarations } from '../src/execute/git-types.js';
+import { fsCodeModeTypeDeclarations } from '../src/execute/fs-types.js';
+import {
+  buildGitTypeDeclarations,
+  buildGitIRs,
+  GIT_READONLY_MEMBERS,
+} from '../scripts/code-mode-git-extract.js';
+import {
+  buildFsTypeDeclarations,
+  buildWorkspaceIR,
+} from '../scripts/code-mode-fs-extract.js';
+
+// Freshness gate (git): the checked-in git artifact must equal a fresh
+// extraction, so a change to the exo-git types.d.ts or to a renderer cannot
+// land without regenerating and committing the declarations.
+test('generated git-types.js is up to date with its source', t => {
+  const fresh = buildGitTypeDeclarations();
+  t.deepEqual(
+    Object.keys(gitCodeModeTypeDeclarations).sort(),
+    Object.keys(fresh).sort(),
+  );
+  for (const key of Object.keys(fresh)) {
+    t.deepEqual(
+      gitCodeModeTypeDeclarations[key],
+      fresh[key],
+      `${key} declaration is stale; run: yarn workspace agentry gen:code-mode-types`,
+    );
+  }
+});
+
+// Freshness gate (fs): the checked-in workspace artifact must equal a fresh
+// extraction from the FS guards.
+test('generated fs-types.js is up to date with its source', t => {
+  const fresh = buildFsTypeDeclarations();
+  t.deepEqual(
+    Object.keys(fsCodeModeTypeDeclarations).sort(),
+    Object.keys(fresh).sort(),
+  );
+  for (const key of Object.keys(fresh)) {
+    t.deepEqual(
+      fsCodeModeTypeDeclarations[key],
+      fresh[key],
+      `${key} declaration is stale; run: yarn workspace agentry gen:code-mode-types`,
+    );
+  }
+});
+
+// Guard divergence gate: the TypeScript-canonical git declaration must
+// enumerate exactly the methods the runtime `GitInterface` guard enforces, so
+// the printed types cannot silently drift from the enforcement layer.
+test('git declarations cover exactly the GitInterface guard methods', t => {
+  const { git } = buildGitIRs();
+  const tsMembers = git.members.map(member => member.name).sort();
+  const guardMethods = Object.keys(
+    getInterfaceGuardPayload(/** @type {InterfaceGuard} */ (GitInterface))
+      .methodGuards,
+  ).sort();
+  t.deepEqual(tsMembers, guardMethods);
+});
+
+test('read-only git is a subset of read-write git and omits mutators', t => {
+  const { git, gitReadOnly } = buildGitIRs();
+  const readWrite = new Set(git.members.map(member => member.name));
+  const readOnly = gitReadOnly.members.map(member => member.name);
+  for (const name of readOnly) {
+    t.true(
+      readWrite.has(name),
+      `read-only member ${name} missing from read-write`,
+    );
+  }
+  t.deepEqual([...readOnly].sort(), [...GIT_READONLY_MEMBERS].sort());
+  // A self-referential return (`readOnly(): EndoGit`) must not leak the
+  // mutating surface back into the read-only declaration.
+  t.false(gitReadOnly.members.some(member => member.name === 'commit'));
+  t.false(gitReadOnly.members.some(member => member.name === 'merge'));
+  t.false(gitCodeModeTypeDeclarations.gitReadOnly.aux.includes('commit:'));
+  t.true(readOnly.includes('log'));
+  t.true(readOnly.includes('diff'));
+});
+
+// The FS `.d.ts` is a stub, so `workspace` is derived from the interface
+// guards. `sloppy: true` on FilesystemInterface means the live surface can be a
+// superset; the declaration must stay a subset of the guard's declared methods.
+test('workspace declarations derive from the Filesystem guard', t => {
+  const workspace = buildWorkspaceIR();
+  const members = workspace.members.map(member => member.name);
+  const guardMethods = Object.keys(
+    getInterfaceGuardPayload(
+      /** @type {InterfaceGuard} */ (FilesystemInterface),
+    ).methodGuards,
+  );
+  for (const name of members) {
+    t.true(
+      guardMethods.includes(name),
+      `${name} is not a Filesystem guard method`,
+    );
+  }
+});
+
+test('workspace declaration reaches the Directory surface transitively', t => {
+  const { workspace } = fsCodeModeTypeDeclarations;
+  t.is(workspace.body, 'Filesystem');
+  t.true(workspace.aux.includes('type ERef<T> = T | Promise<T>;'));
+  t.true(workspace.aux.includes('type Directory = {'));
+  // Directory verbs only reachable transitively from `root()`.
+  t.true(workspace.aux.includes('lookup:'));
+  t.true(workspace.aux.includes('write:'));
+});

--- a/packages/agentry/test/code-mode.test.js
+++ b/packages/agentry/test/code-mode.test.js
@@ -27,6 +27,8 @@ import {
   makeCodeModeSystemPrompt,
   makeCodeModeAgent,
   makeCodeModeGitLoopAgent,
+  gitCodeModeTypeDeclarations,
+  fsCodeModeTypeDeclarations,
 } from '../src/execute/index.js';
 
 /** @import { CodeModeGlobal, CodeModeExecute } from '../src/execute/tool.js' */
@@ -176,7 +178,7 @@ const writeFileText = async (file, text) => {
   }
 };
 
-test('the system prompt carries name + one-line description, no type blob', t => {
+test('an untyped global carries name + one-line description only', t => {
   /** @type {CodeModeGlobal[]} */
   const globals = harden([
     {
@@ -191,6 +193,8 @@ test('the system prompt carries name + one-line description, no type blob', t =>
   ]);
   const systemPrompt = makeCodeModeSystemPrompt(globals);
 
+  // Globals without a declaration stay name-only; the model introspects live
+  // caps via __getMethodNames__ at runtime.
   t.true(systemPrompt.includes('declare const git;'));
   t.true(systemPrompt.includes('declare const repoName;'));
   t.true(
@@ -198,11 +202,51 @@ test('the system prompt carries name + one-line description, no type blob', t =>
       '// Read/write @endo/exo-git Git capability for the repo.',
     ),
   );
-  // No hand-maintained TS type declarations leak into the prompt; the model
-  // introspects live caps via __getMethodNames__ at runtime.
-  t.false(systemPrompt.includes('declare const git: {'));
-  t.false(systemPrompt.includes('currentBranch(): Promise'));
+  t.false(systemPrompt.includes('declare const git:'));
   t.true(systemPrompt.includes('__getMethodNames__'));
+});
+
+test('a typed global injects its generated declaration into the prompt', t => {
+  /** @type {CodeModeGlobal[]} */
+  const globals = harden([
+    {
+      name: 'git',
+      petName: 'git',
+      description: 'Read/write git.',
+      declaration: gitCodeModeTypeDeclarations.git,
+    },
+    {
+      name: 'workspace',
+      petName: 'workspace',
+      description: 'Writable Filesystem.',
+      declaration: fsCodeModeTypeDeclarations.workspace,
+    },
+  ]);
+  const systemPrompt = makeCodeModeSystemPrompt(globals);
+
+  // git: TS-canonical, referenced by its named root type plus the supporting
+  // aliases the printer emitted.
+  t.true(systemPrompt.includes('declare const git: EndoGit;'));
+  t.true(systemPrompt.includes('type EndoGit = {'));
+  t.true(
+    systemPrompt.includes('commit: (message: string) => Promise<GitCommit>;'),
+  );
+  // workspace: guard-derived, reaching the Directory surface transitively.
+  t.true(systemPrompt.includes('declare const workspace: Filesystem;'));
+  t.true(systemPrompt.includes('type Directory = {'));
+  // The runtime introspection fallback is still advertised.
+  t.true(systemPrompt.includes('__getMethodNames__'));
+});
+
+test('makeCodeModeAgent injects typed git + workspace declarations from powers', async t => {
+  const { workspace, git } = await makeRealGit(t);
+  const { systemPrompt } = makeCodeModeAgent({
+    model: fauxModel(t, []),
+    powers: { workspace, git },
+  });
+  t.true(systemPrompt.includes('declare const git: EndoGit;'));
+  t.true(systemPrompt.includes('declare const workspace: Filesystem;'));
+  t.true(systemPrompt.includes('type EndoGit = {'));
 });
 
 test('makeEnvCredentials is the single env reader and reads through .get', t => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,6 +1265,7 @@ __metadata:
     "@endo/lockdown": "workspace:^"
     "@endo/marshal": "workspace:^"
     "@endo/pass-style": "workspace:^"
+    "@endo/patterns": "workspace:^"
     "@endo/platform": "workspace:^"
     "@endo/ses-ava": "workspace:^"
     ava: "catalog:dev"


### PR DESCRIPTION
Refs: #517

## Description

Code-mode declared its injected globals by name only (`declare const git;`), so the model had to discover methods at runtime with `E(cap).__getMethodNames__()` before its first call. This generates real TypeScript declarations for the `git` and `workspace` globals and splices them into the system prompt, so the model can pick a method and its arguments up front (saving a round-trip). Runtime introspection stays the fallback for anything a declaration omits.

Before:

```ts
declare const git; // Read/write @endo/exo-git Git capability for repository changes.
declare const workspace; // Writable @endo/platform/fs/extended Filesystem for the repository.
```

After (excerpt):

```ts
type EndoGit = {
  status: () => Promise<GitStatusEntry[]>;
  diff: (options?: GitDiffOptions) => Promise<string>;
  commit: (message: string) => Promise<GitCommit>;
  ...
};
declare const git: EndoGit; // Read/write ...

type Filesystem = { root: () => ERef<Directory>; ... };
type Directory = { lookup: (arg0: string | Array<string>) => ERef<Directory | File>; write: ...; ... };
declare const workspace: Filesystem; // Writable ...
```

Code mode is the runtime for any exo invoked through `execute`, not a git/fs feature, so the type machinery is generic and exo-agnostic, with the per-exo git and fs specifics kept separate:

- **Generic (exo-agnostic)** in `scripts/code-mode-type-extract.js`: the shared IR plus both renderers, exported so consumers compose. `extractTsModuleIR` is the `type -> declaration` renderer (the `typescript` printer over a `.d.ts`); `extractGuardIR` is the `guard -> declaration` renderer (the `M.interface` walker). Neither is canonical: interface guards are lossy as a type source, so the TypeScript path stays valuable. `renderDeclaration` prints either IR.
- **Per-exo extraction config**: `scripts/code-mode-git-extract.js` (the `EndoGit` `.d.ts` config plus the `GIT_READONLY_MEMBERS` read-only policy) and `scripts/code-mode-fs-extract.js` (the Filesystem guard registry). `gen-code-mode-types.js` composes them and writes one checked-in artifact per exo: `src/execute/git-types.js` (git, gitReadOnly) and `src/execute/fs-types.js` (workspace).
- **Per-exo runtime descriptors**: `src/execute/git.js` (`makeGitGlobal`) and `src/execute/fs.js` (`makeWorkspaceGlobal`), each pulling its own declaration. The generic `globals`/`tool` modules carry no git/fs knowledge: a global carries its declaration directly (`{ aux?, body }`), so `formatGlobalDeclarations` prints whatever declaration a global carries. The preset builder chooses which globals to inject and delegates the specifics to the per-exo files; both descriptor factories and declarations are exported from `./execute` so a consumer can inject git/workspace types or bring its own.

Sourcing policy:

- `git` is **TS-canonical**: the `typescript` compiler API prints the `EndoGit` alias from `packages/exo-git/types.d.ts` (the full-fidelity hand-written TS).
- `workspace` is **richest-available-canonical**: the FS `.d.ts` (`packages/platform/src/fs/extended/types.d.ts`) is a deliberate four-method stub, so strict TS-canonical there would yield a near-useless declaration. The renderer instead walks the `@endo/platform/fs/extended` interface guards (`FilesystemInterface` plus the remotables it reaches transitively: `Directory`, `File`, `OpenFile`, `Cursor`), the richest available source.

The read-only vs read-write `git` split is a **prompt-surface policy** (an explicit member allowlist, `GIT_READONLY_MEMBERS`, applied to the shared IR), not a property of either source; the runtime read-only enforcement remains the exo guard / `readOnly()` rejection. Guard-canonical *derivation* for git was considered and is **tabled** (unproven, and it would discard the more expressive hand-written TS). The deeper type-sourcing story (enriching the FS `.d.ts`, unifying derivation) is parked for a separate design.

Most critical files to review: `src/execute/globals.js` (the declaration-printing wiring), `scripts/code-mode-type-extract.js` (the generic IR plus both renderers), and `test/code-mode-types.test.js` (the divergence gate).

### Security Considerations

The generated declarations describe the same authorities the code-mode globals already grant; no new authority is introduced. The split keeps the runtime read-only enforcement where it was: the exo guard and the `readOnly()` rejection, not the printed types. The divergence gate is the load-bearing safety property here. `test/code-mode-types.test.js` asserts that the git declaration enumerates exactly the `GitInterface` guard methods, that the read-only variant is a mutator-free subset that does not leak the full surface back through `readOnly(): EndoGit`, and that `workspace` members are a subset of the `FilesystemInterface` guard. This prevents the prompt's advertised surface from silently drifting wider than the enforcement layer. Printing happens at build time, so `typescript` stays a dev-only dependency and never enters the runtime trust base.

### Scaling Considerations

No runtime cost increase. Declarations are generated once at build time into checked-in plain-data artifacts, so prompt assembly is a string splice, not a compile. The injected declarations enlarge the system prompt by a bounded, fixed number of tokens, which is offset by removing the per-session `__getMethodNames__()` discovery round-trips the model previously needed.

### Documentation Considerations

The generated artifacts (`src/execute/git-types.js`, `src/execute/fs-types.js`) are derived, not hand-maintained: regenerate them with `yarn workspace @endo/agentry gen:code-mode-types` after any change to a source `.d.ts`, an interface guard, or the renderer. The divergence gate fails CI if they are stale. Consumers wiring their own code-mode agent can import the descriptor factories and declarations from `@endo/agentry/.../execute` to inject git/workspace types or supply their own.

### Testing Considerations

`yarn workspace @endo/agentry test` is 64 passing, including the new `code-mode-types` gate suite (freshness per artifact, git/read-only/workspace guard-divergence) and typed-injection coverage, with an end-to-end `makeCodeModeAgent` over a real git plus workspace mount. The freshness check ties CI to source: a change to either source or the renderer cannot land without regenerating. No new CI infrastructure is required.

### Compatibility Considerations

The public surface of `./execute` gains exports (the per-exo descriptor factories and declarations) and a global now carries its declaration directly rather than indirecting through a `typeKey` registry; existing callers that construct globals through the preset builder are unaffected. The prior fused `src/execute/code-mode-types.js` artifact is replaced by the per-exo `git-types.js` / `fs-types.js`. A `namedPowers` entry without a declaration still renders name-only, preserving the prior behavior for untyped globals.

### Upgrade Considerations

No live-system upgrade actions. There is no persisted data format change; the only artifacts are checked-in generated source consumed at prompt-build time. No changeset is included because this is an unreleased in-development package (`@endo/agentry`) on the `llm` branch and the change is additive to its prompt surface.
