### PR TITLE
feat(agentry): git code-mode eval with outcome-assertion scoring

### DIFF
--- a/packages/agentry/ava-live.config.js
+++ b/packages/agentry/ava-live.config.js
@@ -1,0 +1,10 @@
+// The live-model eval runs only via `yarn workspace @endo/agentry test:live`,
+// never under the default `yarn test`. It is a separate ava config so that a
+// host with `ENDO_LLM_*` / `LAL_*` credentials in its environment does not run
+// the live eval (which reaches a real provider) as a side effect of a plain
+// `yarn test` at the package or workspace root. See test/eval-live.test.js and
+// src/eval/README.md.
+export default {
+  files: ['test/eval-live.test.js'],
+  timeout: '2m',
+};

--- a/packages/agentry/package.json
+++ b/packages/agentry/package.json
@@ -46,7 +46,8 @@
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",
     "prepack": "exit 0",
-    "test": "ava"
+    "test": "ava",
+    "test:live": "ava --config ava-live.config.js"
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "^0.79.0",
@@ -87,7 +88,8 @@
   },
   "ava": {
     "files": [
-      "test/**/*.test.*"
+      "test/**/*.test.*",
+      "!test/eval-live.test.js"
     ],
     "timeout": "2m"
   }

--- a/packages/agentry/package.json
+++ b/packages/agentry/package.json
@@ -33,6 +33,10 @@
       "types": "./src/execute/index.js",
       "default": "./src/execute/index.js"
     },
+    "./eval": {
+      "types": "./src/eval/index.js",
+      "default": "./src/eval/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/agentry/src/eval/README.md
+++ b/packages/agentry/src/eval/README.md
@@ -1,0 +1,95 @@
+# Git code-mode eval
+
+A harness for testing **git code mode**: drive a code-mode agent against a git
+repository and score whether the repository reached a target end-state.
+
+## Eval vs. optimize
+
+These are two different concerns, and this module is the first one only.
+
+- **Eval** (this module) measures a fixed agent: run a scenario, then make a
+  pass/fail judgment by **outcome assertion**. Pass means the repository reached
+  the target end-state (a commit exists, the tree and index match, the file
+  contents are right). It answers "did it work?" for one model and one prompt.
+- **Optimize** (out of scope here, deferred) searches for a better prompt:
+  GEPA / `ax`-style prompt-tuning loops that mutate the system prompt and select
+  on a score. It answers "what prompt works best?".
+
+Optimization consumes an eval as its objective, but the eval stands alone and
+ships first. This module does no prompt-tuning; it only runs an agent and
+asserts the outcome.
+
+## Why outcome assertion, not trace scoring
+
+A code-mode agent's only tool is `execute`: it runs `E(git).x()` and
+`E(workspace).x()` **inside** a Compartment, so the outer pi-agent tool-call
+trace sees a single opaque `execute` call, not the individual git operations.
+There is therefore no git-op trace to score with edit distance, and there
+should not need to be: a correct run might stage in a different order, read
+status an extra time, or use a different method to the same end. Outcome
+assertion reads the repository's actual final state through the live `git`
+capability and checks it against the target, so it needs no in-compartment
+instrumentation and accepts any alternate-but-correct path.
+
+Capturing the run's events is still useful for debugging *why* a scenario
+failed, but it is a diagnostic, never the gate.
+
+## Layout
+
+The harness splits along the seam between a **shared harness** (the runner, the
+env model, the shared types, the export surface, the README, and the generic
+outcome primitives) and **per-eval content** (one scenario's prompt, its outcome
+assertion, and the repository it runs against). The shared harness is
+scenario-agnostic and changes rarely; per-eval content grows with each new eval,
+so each eval gets its own folder.
+
+Shared harness (this directory's root):
+
+- `index.js` — the `@endo/agentry/eval` export surface: re-exports the shared
+  harness and each eval's public symbols (the per-folder barrels).
+- `run.js` — `runGitScenario({ model, workspace, git, scenario, readText, ... })`:
+  builds the real code-mode git-loop agent, runs the scenario prompt, and scores
+  by outcome assertion. Only the `model` differs between a no-LLM run and a live
+  run.
+- `env-model.js` — `resolveEvalModelFromEnv(env)`: build a live model +
+  `getApiKey` from the `ENDO_LLM_*` / `LAL_*` environment variables, or
+  `undefined` when no credentials are present.
+- `types.js` — `GitScenario`, `ReadText`: the contract every scenario
+  implements.
+- `outcome-kit.js` — the shared outcome primitives: `check()`, the `OutcomeReport`
+  shape, and the small shared readers (`readTrackedFileAt` reads a tracked file
+  at a ref through `filesystemAt`; `branchLog` resolves a branch's commit list).
+  Per-eval scorers build on these so each stays short. Cap-based and portable;
+  the byte reader is injected.
+
+Per-eval content (one folder under `scenarios/`):
+
+- `scenarios/stage-and-commit/` — the minimal-success eval: `scenario.js`
+  (`makeStageAndCommitScenario(...)`, stage an untracked file and commit it with
+  a given message), `outcome.js` (`assertGitCommitOutcome(...)`, the scorer that
+  reads HEAD's commit message, the file tracked at HEAD and its content, and the
+  working-tree status), and `index.js` (the two-line barrel re-exporting both).
+
+A scenario's no-LLM assertion-path test and its per-eval repository fixture live
+together under `test/eval/` (see "Running" below), mirroring this source layout.
+
+## Running
+
+- **No credentials (anywhere):** `test/eval/stage-and-commit.test.js` runs the
+  full harness with a scripted faux provider standing in for the model. This is
+  the assertion-path test; it needs no network and no secrets, and each eval's
+  test co-locates with its per-eval repository fixture (`_stage-and-commit-repo.js`)
+  under `test/eval/`.
+- **Live model (credentialed host):** `test/eval-live.test.js` runs the same
+  scenarios and scorers against a real provider, table-driven over a registry
+  with one row per eval. It skips unless the credentials are present. To run it,
+  set `ENDO_LLM_HOST` / `ENDO_LLM_MODEL` /
+  `ENDO_LLM_AUTH_TOKEN` (or their `LAL_*` aliases) in the environment to point
+  at an OpenAI-compatible endpoint, then:
+
+  ```sh
+  yarn workspace @endo/agentry test
+  ```
+
+  Supply the token through the environment only; it never appears in code,
+  config, or a committed file.

--- a/packages/agentry/src/eval/README.md
+++ b/packages/agentry/src/eval/README.md
@@ -79,16 +79,20 @@ together under `test/eval/` (see "Running" below), mirroring this source layout.
   full harness with a scripted faux provider standing in for the model. This is
   the assertion-path test; it needs no network and no secrets, and each eval's
   test co-locates with its per-eval repository fixture (`_stage-and-commit-repo.js`)
-  under `test/eval/`.
+  under `test/eval/`. It runs under the default `yarn test`.
 - **Live model (credentialed host):** `test/eval-live.test.js` runs the same
   scenarios and scorers against a real provider, table-driven over a registry
-  with one row per eval. It skips unless the credentials are present. To run it,
-  set `ENDO_LLM_HOST` / `ENDO_LLM_MODEL` /
-  `ENDO_LLM_AUTH_TOKEN` (or their `LAL_*` aliases) in the environment to point
-  at an OpenAI-compatible endpoint, then:
+  with one row per eval. It is **not** part of the default `yarn test`: it runs
+  only via its own `test:live` command, under a dedicated ava config
+  (`ava-live.config.js`), so that a host that happens to have the credentials in
+  its environment does not reach a real provider as a side effect of a plain
+  `yarn test` at the package or workspace root. The live test additionally skips
+  every row unless the credentials are present. To run it, set `ENDO_LLM_HOST` /
+  `ENDO_LLM_MODEL` / `ENDO_LLM_AUTH_TOKEN` (or their `LAL_*` aliases) in the
+  environment to point at an OpenAI-compatible endpoint, then:
 
   ```sh
-  yarn workspace @endo/agentry test
+  yarn workspace @endo/agentry test:live
   ```
 
   Supply the token through the environment only; it never appears in code,

--- a/packages/agentry/src/eval/env-model.js
+++ b/packages/agentry/src/eval/env-model.js
@@ -1,0 +1,57 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { Model } from '@earendil-works/pi-ai' */
+/** @import { GetApiKey } from '../harness/credentials.js' */
+
+import { resolveModelProfile } from '../harness/model.js';
+
+/**
+ * Build a live eval model from an openai-compatible env-var contract.
+ *
+ * Reads `ENDO_LLM_HOST` / `ENDO_LLM_MODEL` / `ENDO_LLM_AUTH_TOKEN` (with
+ * `LAL_*` aliases) from the environment: a base URL, a model id, and a bearer
+ * token. The base URL is expected to point at an endpoint that speaks the
+ * OpenAI-completions protocol (an OpenRouter base URL such as
+ * `https://openrouter.ai/api/v1` is one such endpoint), so the model is built
+ * as an `openai-compatible` profile pointed at that base URL.
+ *
+ * The full model id (such as `nvidia/nemotron-...:free`) is passed with an
+ * explicit `provider` so `resolveModelProfile` does not split the leading
+ * `nvidia/` segment off as a pi-ai provider name. The whole string is the
+ * endpoint's model id and must reach the request body intact.
+ *
+ * The returned `getApiKey` ignores its provider argument and returns the single
+ * configured token: there is exactly one credential, and the token never
+ * appears in code, config, or a committed file. It reaches only the in-process
+ * environment.
+ *
+ * Returns `undefined` when any of host / model / token is absent, so a caller
+ * (a test, a runner) can cleanly skip the live path on a host with no
+ * credentials rather than constructing a model that would 401.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {{ model: Model<string>, getApiKey: GetApiKey } | undefined}
+ */
+export const resolveEvalModelFromEnv = env => {
+  const host = env.ENDO_LLM_HOST || env.LAL_HOST;
+  const modelId = env.ENDO_LLM_MODEL || env.LAL_MODEL;
+  const token = env.ENDO_LLM_AUTH_TOKEN || env.LAL_AUTH_TOKEN;
+  if (!host || !modelId || !token) {
+    return undefined;
+  }
+  // A model id advertising itself as a reasoning model gets the harness's
+  // default thinking budget (`reasoning ? 'medium' : 'off'`).
+  const reasoning = /reasoning|thinking/i.test(modelId);
+  const { model } = resolveModelProfile({
+    provider: 'openai-compatible',
+    baseUrl: host,
+    model: modelId,
+    api: 'openai-completions',
+    reasoning,
+  });
+  /** @type {GetApiKey} */
+  const getApiKey = () => token;
+  return harden({ model, getApiKey });
+};
+harden(resolveEvalModelFromEnv);

--- a/packages/agentry/src/eval/index.js
+++ b/packages/agentry/src/eval/index.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+// The git code-mode eval harness: drive a code-mode git-loop agent against a
+// scenario and score it by **outcome assertion** (did the repository reach the
+// target end-state), not by trace-edit-distance. See ./README.md for the
+// eval-vs-optimize distinction.
+
+// Shared harness.
+export { runGitScenario } from './run.js';
+export { resolveEvalModelFromEnv } from './env-model.js';
+
+// Per-eval public symbols, re-exported from each eval's folder.
+export {
+  makeStageAndCommitScenario,
+  assertGitCommitOutcome,
+} from './scenarios/stage-and-commit/index.js';

--- a/packages/agentry/src/eval/outcome-kit.js
+++ b/packages/agentry/src/eval/outcome-kit.js
@@ -1,0 +1,80 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { ReadText } from './types.js' */
+
+import { E } from '@endo/far';
+
+/**
+ * One outcome check: a named pass/fail with a human-readable detail string.
+ * Shared by every eval's outcome assertion.
+ *
+ * @param {string} name
+ * @param {boolean} ok
+ * @param {string} detail
+ * @returns {{ name: string, ok: boolean, detail: string }}
+ */
+export const check = (name, ok, detail) => harden({ name, ok, detail });
+harden(check);
+
+/**
+ * @typedef {object} OutcomeReport The structured result of an outcome
+ *   assertion: a pass/fail per named check, plus an overall pass that holds only
+ *   when every check holds.
+ * @property {boolean} pass True only when every check holds.
+ * @property {Array<{ name: string, ok: boolean, detail: string }>} checks
+ */
+
+/**
+ * Read the UTF-8 content of a tracked file at a git ref, or `undefined` when the
+ * path is not tracked at that ref. Reads out of the committed tree
+ * (`filesystemAt(ref)`), never the working tree, so a file written-but-not-
+ * committed does not pass a content check.
+ *
+ * The endo fs `lookup` raises an `ENOENT`-tagged error when the path is absent
+ * from the tree; that genuine "path not tracked" case returns `undefined`. Any
+ * other failure (a backend fault, a broken capability, an unexpected error
+ * shape) is infrastructure, not a model miss, and is rethrown so it surfaces
+ * loudly rather than masquerading as a clean "file not committed".
+ *
+ * The byte reader is injected as `readText` so this kit carries no stream
+ * dependency.
+ *
+ * @param {object} args
+ * @param {unknown} args.git A live `@endo/exo-git` Git capability.
+ * @param {ReadText} args.readText Read a File capability's content as UTF-8.
+ * @param {string} args.ref The ref whose tree to read (a branch name, `HEAD`).
+ * @param {string} args.path Repository-relative path to read.
+ * @returns {Promise<string | undefined>}
+ */
+export const readTrackedFileAt = async ({ git, readText, ref, path }) => {
+  const gitRef = /** @type {any} */ (git);
+  try {
+    const committedFs = await E(gitRef).filesystemAt(ref);
+    const committedRoot = await E(committedFs).root();
+    const file = await E(committedRoot).lookup(path);
+    return await readText(file);
+  } catch (err) {
+    const message = /** @type {Error} */ (err)?.message ?? '';
+    if (!/ENOENT/.test(message)) {
+      throw err;
+    }
+    return undefined;
+  }
+};
+harden(readTrackedFileAt);
+
+/**
+ * Resolve a branch's commit list, newest-first, through the live `git`
+ * capability. `log({ ref })` returns the branch's commits with the tip first.
+ *
+ * @param {object} args
+ * @param {unknown} args.git A live `@endo/exo-git` Git capability.
+ * @param {string} args.ref The branch (or ref) whose log to read.
+ * @returns {Promise<Array<{ oid: string, summary: string }>>}
+ */
+export const branchLog = async ({ git, ref }) => {
+  const gitRef = /** @type {any} */ (git);
+  return E(gitRef).log({ ref });
+};
+harden(branchLog);

--- a/packages/agentry/src/eval/run.js
+++ b/packages/agentry/src/eval/run.js
@@ -1,0 +1,76 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { Model } from '@earendil-works/pi-ai' */
+/** @import { StreamFn } from '@earendil-works/pi-agent-core' */
+/** @import { GetApiKey } from '../harness/credentials.js' */
+/** @import { ThinkingLevel } from '../harness/model.js' */
+/** @import { GitScenario, ReadText } from './types.js' */
+
+import { makeCodeModeGitLoopAgent } from '../execute/preset.js';
+
+/**
+ * @typedef {object} RunGitScenarioOptions
+ * @property {Model<string>} model The model under eval (faux or live).
+ * @property {unknown} workspace A live writable `@endo/platform/fs` Filesystem
+ *   over the scenario repository.
+ * @property {unknown} git A live read/write `@endo/exo-git` Git capability over
+ *   the same repository.
+ * @property {GitScenario} scenario
+ * @property {ReadText} readText Read a committed File's content as UTF-8; passed
+ *   through to the scenario's outcome assertion.
+ * @property {GetApiKey} [getApiKey] Resolve the model's API key. Omit for a
+ *   faux/local model.
+ * @property {ThinkingLevel} [thinkingLevel]
+ * @property {StreamFn} [streamFn]
+ *
+ * @typedef {object} RunGitScenarioResult
+ * @property {import('./outcome-kit.js').OutcomeReport} outcome
+ */
+
+/**
+ * Run one git code-mode scenario end to end and score it by outcome assertion.
+ *
+ * The agent is the real code-mode git-loop preset: its sole tool is `execute`,
+ * which evaluates JavaScript against the live `workspace` and `git` powers in a
+ * Compartment. Only the model varies between a no-LLM run (a scripted faux
+ * model) and a live run (a credentialed provider) — the agent, the powers, and
+ * the scorer are identical, so the no-LLM path exercises the same machinery the
+ * live path does.
+ *
+ * Scoring is outcome assertion, never trace-edit-distance: this returns the
+ * scenario's `OutcomeReport` (did the repository reach the target end-state),
+ * not a transcript score. Capturing the run's events for debugging is a
+ * separate, optional concern and is not the gate.
+ *
+ * @param {RunGitScenarioOptions} options
+ * @returns {Promise<RunGitScenarioResult>}
+ */
+export const runGitScenario = async ({
+  model,
+  workspace,
+  git,
+  scenario,
+  readText,
+  getApiKey,
+  thinkingLevel,
+  streamFn,
+}) => {
+  const agent = makeCodeModeGitLoopAgent({
+    model,
+    workspace,
+    git,
+    getApiKey,
+    thinkingLevel,
+    streamFn,
+  });
+
+  // `agent` is a local pi-agent-core instance (not a remotable), so drive it
+  // directly rather than through eventual-send, matching the code-mode tests.
+  await agent.prompt(scenario.prompt);
+  await agent.waitForIdle();
+
+  const outcome = await scenario.assertOutcome({ git, workspace, readText });
+  return harden({ outcome });
+};
+harden(runGitScenario);

--- a/packages/agentry/src/eval/scenarios/stage-and-commit/index.js
+++ b/packages/agentry/src/eval/scenarios/stage-and-commit/index.js
@@ -1,0 +1,5 @@
+// @ts-check
+
+// Barrel for the stage-and-commit eval: its scenario and its outcome assertion.
+export { makeStageAndCommitScenario } from './scenario.js';
+export { assertGitCommitOutcome } from './outcome.js';

--- a/packages/agentry/src/eval/scenarios/stage-and-commit/outcome.js
+++ b/packages/agentry/src/eval/scenarios/stage-and-commit/outcome.js
@@ -1,0 +1,119 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { ReadText } from '../../types.js' */
+/** @import { OutcomeReport } from '../../outcome-kit.js' */
+
+import { E } from '@endo/far';
+
+import { check, readTrackedFileAt } from '../../outcome-kit.js';
+
+/**
+ * @typedef {object} GitCommitTarget The end-state a stage-and-commit scenario is
+ *   scored against.
+ * @property {string} path Repository-relative path the scenario commits.
+ * @property {string} content The exact UTF-8 content the committed file must
+ *   carry at HEAD.
+ * @property {string} message The exact commit message HEAD must carry.
+ */
+
+/**
+ * Score a git code-mode run by **outcome assertion**: read the repository's
+ * actual end-state through the live `git` capability and confirm it reached the
+ * target. This deliberately ignores how the agent got there — the agent ran
+ * `E(git).x()` / `E(workspace).x()` inside an opaque `execute` block, so there
+ * is no per-git-op tool-call trace to score, and an alternate-but-correct call
+ * sequence (different staging order, an extra status read) must still pass.
+ *
+ * The three checks mirror the minimal-success bar: a commit exists carrying the
+ * target message, the target file is tracked at HEAD with the exact content,
+ * and the working tree is clean for that path (the change was committed, not
+ * merely written).
+ *
+ * Reading the committed bytes needs an `@endo/exo-stream`-style byte reader,
+ * which is injected as `readText` rather than imported here so this scorer
+ * stays free of a stream dependency and runs anywhere the caller can supply a
+ * reader.
+ *
+ * @param {object} args
+ * @param {unknown} args.git A live `@endo/exo-git` Git capability.
+ * @param {ReadText} args.readText Read a File capability's content as UTF-8.
+ * @param {GitCommitTarget} args.expected
+ * @returns {Promise<OutcomeReport>}
+ */
+export const assertGitCommitOutcome = async ({ git, readText, expected }) => {
+  const gitRef = /** @type {any} */ (git);
+  /** @type {Array<{ name: string, ok: boolean, detail: string }>} */
+  const checks = [];
+
+  // 1. A commit exists at HEAD carrying the target message.
+  const recent = await E(gitRef).log({ maxCount: 1 });
+  const head = recent[0];
+  checks.push(
+    check(
+      'commit-exists',
+      head !== undefined,
+      head !== undefined
+        ? `HEAD is ${head.oid}`
+        : 'no commit found at HEAD (log is empty)',
+    ),
+  );
+  checks.push(
+    check(
+      'commit-message',
+      head !== undefined && head.summary === expected.message,
+      `HEAD summary ${JSON.stringify(head?.summary)} (expected ${JSON.stringify(
+        expected.message,
+      )})`,
+    ),
+  );
+
+  // 2. The target file is tracked at HEAD with the exact content. Read it out
+  // of the committed tree (`filesystemAt('HEAD')`), not the working tree, so a
+  // file written-but-not-committed does not pass the content check.
+  const committedText = await readTrackedFileAt({
+    git,
+    readText,
+    ref: 'HEAD',
+    path: expected.path,
+  });
+  const tracked = committedText !== undefined;
+  checks.push(
+    check(
+      'file-tracked-at-head',
+      tracked,
+      tracked
+        ? `${expected.path} is present in the HEAD tree`
+        : `${expected.path} is not tracked at HEAD`,
+    ),
+  );
+  checks.push(
+    check(
+      'file-content',
+      committedText === expected.content,
+      `committed content ${JSON.stringify(
+        committedText,
+      )} (expected ${JSON.stringify(expected.content)})`,
+    ),
+  );
+
+  // 3. The working tree is clean for the target path: the scenario asked for a
+  // commit, so the file must no longer show as untracked or modified.
+  const rows = await E(gitRef).status();
+  const lingering = rows.find(
+    /** @param {{ path: string }} row */ row => row.path === expected.path,
+  );
+  checks.push(
+    check(
+      'worktree-clean',
+      lingering === undefined,
+      lingering === undefined
+        ? `${expected.path} has no pending status row`
+        : `${expected.path} still shows index=${lingering.index} worktree=${lingering.worktree}`,
+    ),
+  );
+
+  const pass = checks.every(entry => entry.ok);
+  return harden({ pass, checks });
+};
+harden(assertGitCommitOutcome);

--- a/packages/agentry/src/eval/scenarios/stage-and-commit/scenario.js
+++ b/packages/agentry/src/eval/scenarios/stage-and-commit/scenario.js
@@ -1,0 +1,40 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/** @import { GitScenario } from '../../types.js' */
+
+import { assertGitCommitOutcome } from './outcome.js';
+
+/**
+ * The minimal-success git code-mode scenario: an untracked file already exists
+ * in the working tree; the agent must stage it and commit it with a given
+ * message. Scoring is pure outcome assertion (see {@link assertGitCommitOutcome}):
+ * the commit exists with the message, the file is tracked at HEAD with the
+ * exact content, and the working tree is clean.
+ *
+ * The scenario is model-agnostic. The caller provisions a repository whose
+ * working tree already holds `path` with `content` untracked (see the test
+ * fixture), then drives this scenario with whichever model is under eval.
+ *
+ * @param {object} [options]
+ * @param {string} [options.path] Repository-relative path. Default `README.md`.
+ * @param {string} [options.content] The untracked file's content. Default a
+ *   one-line README.
+ * @param {string} [options.message] The commit message the agent must use.
+ * @returns {GitScenario}
+ */
+export const makeStageAndCommitScenario = ({
+  path = 'README.md',
+  content = '# endo-but-for-bots\n\nA repository for bots.\n',
+  message = 'docs: add README',
+} = {}) => {
+  const expected = harden({ path, content, message });
+  return harden({
+    name: 'stage-and-commit',
+    expected,
+    prompt: `The file ${path} already exists in the working tree but git is not yet tracking it. Stage ${path} and commit it. Use exactly this commit message: ${message}`,
+    assertOutcome: ({ git, readText }) =>
+      assertGitCommitOutcome({ git, readText, expected }),
+  });
+};
+harden(makeStageAndCommitScenario);

--- a/packages/agentry/src/eval/types.js
+++ b/packages/agentry/src/eval/types.js
@@ -1,0 +1,26 @@
+// @ts-check
+
+/**
+ * Read the UTF-8 content of an `@endo/platform/fs`-style File capability. The
+ * eval scorer is handed one of these rather than importing a byte-stream
+ * library, so the scorer carries no stream dependency and the caller picks the
+ * reader (the tests build one over `@endo/exo-stream`).
+ *
+ * @typedef {(file: unknown) => Promise<string>} ReadText
+ */
+
+/**
+ * A git code-mode eval scenario: a self-contained, model-agnostic description
+ * of one task plus its outcome assertion. The same scenario is driven by a
+ * scripted faux model (the no-LLM assertion-path test) and by a live model (a
+ * credentialed run), so it holds no model and no provisioning — only the
+ * prompt, the target end-state, and the cap-based assertion.
+ *
+ * @typedef {object} GitScenario
+ * @property {string} name
+ * @property {string} prompt The user turn handed to the code-mode agent.
+ * @property {import('./scenarios/stage-and-commit/outcome.js').GitCommitTarget} expected
+ * @property {(args: { git: unknown, workspace: unknown, readText: ReadText }) => Promise<import('./outcome-kit.js').OutcomeReport>} assertOutcome
+ */
+
+export {};

--- a/packages/agentry/test/_eval-fixture.js
+++ b/packages/agentry/test/_eval-fixture.js
@@ -1,0 +1,117 @@
+// @ts-check
+
+// Shared, non-test helpers for the git code-mode eval tests. Named with a
+// leading underscore so ava's `test/**/*.test.*` glob does not pick it up as a
+// test file. This is the node-side, stream-side half of the eval harness, the
+// part every scenario's repository shares: the UTF-8 `readText` reader the
+// portable scorer is handed, the `workspace` + `git` powers built over an
+// on-disk worktree, and the repo bootstrap (init, identity, gpgsign off). Each
+// scenario's own repository shape lives in its per-eval `_<name>-repo.js`.
+
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify as nodePromisify } from 'node:util';
+
+import { E } from '@endo/far';
+import { makeNodeFilesystem } from '@endo/platform/fs/extended';
+import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
+import { makeGit } from '@endo/exo-git';
+import { makeNativeGitBackend } from '@endo/git';
+import { makeMount, lineageOf } from '@endo/daemon/src/mount.js';
+import { makeFilePowers } from '@endo/daemon/src/daemon-node-powers.js';
+
+const execFileAsync = nodePromisify(execFile);
+
+/**
+ * @param {unknown} readerRef
+ * @returns {Promise<Uint8Array>}
+ */
+const collectBytes = async readerRef => {
+  /** @type {Uint8Array[]} */
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of iterateBytesReader(
+    /** @type {any} */ (readerRef),
+  )) {
+    chunks.push(chunk);
+    total += chunk.length;
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return bytes;
+};
+
+/**
+ * Read an `@endo/platform/fs` File capability's content as UTF-8. This is the
+ * `readText` the eval scorer is injected with.
+ *
+ * @param {unknown} file
+ * @returns {Promise<string>}
+ */
+export const readText = async file => {
+  const fileRef = /** @type {any} */ (file);
+  const stat = await E(fileRef).getStat();
+  const openFile = await E(fileRef).open({ read: true });
+  try {
+    const reader = await E(openFile).read(0n, stat.size ?? 0n);
+    return new TextDecoder().decode(await collectBytes(reader));
+  } finally {
+    await E(openFile).close();
+  }
+};
+harden(readText);
+
+/**
+ * Build the live `workspace` + `git` powers over an existing git worktree on
+ * disk. Shared by every per-eval provisioning helper.
+ *
+ * @param {string} repoRoot
+ * @returns {{ workspace: unknown, git: unknown }}
+ */
+export const makePowersOver = repoRoot => {
+  const workspace = makeNodeFilesystem({ rootPath: repoRoot });
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+  return harden({ workspace, git });
+};
+harden(makePowersOver);
+
+/**
+ * Bootstrap an empty git repository every eval shares: a fresh temp directory
+ * (torn down with the test), `git init` on the named branch, gpg signing
+ * disabled, and a committer identity configured. Returns the on-disk `repoRoot`
+ * and a `run(args)` helper that shells `git` in it, so each per-eval fixture
+ * adds only the commits and branches its scenario needs.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {object} [options]
+ * @param {string} [options.branch] The initial branch name. Default `main`.
+ * @param {string} [options.prefix] The temp-directory name prefix.
+ * @returns {Promise<{
+ *   repoRoot: string,
+ *   run: (args: string[]) => Promise<{ stdout: string, stderr: string }>,
+ * }>}
+ */
+export const initRepo = async (
+  t,
+  { branch = 'main', prefix = 'agentry-eval-git-' } = {},
+) => {
+  const repoRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  t.teardown(() => fs.promises.rm(repoRoot, { recursive: true, force: true }));
+  const run = args => execFileAsync('git', args, { cwd: repoRoot });
+  await run(['init', '-q', '-b', branch]);
+  await run(['config', '--local', 'commit.gpgsign', 'false']);
+  await run(['config', '--local', 'tag.gpgsign', 'false']);
+  await run(['config', '--local', 'user.email', 'eval@example.invalid']);
+  await run(['config', '--local', 'user.name', 'Eval']);
+  return harden({ repoRoot, run });
+};
+harden(initRepo);

--- a/packages/agentry/test/eval-live.test.js
+++ b/packages/agentry/test/eval-live.test.js
@@ -1,0 +1,93 @@
+// @ts-check
+
+// The live-model git code-mode eval: the SAME scenarios and SAME outcome scorers
+// as the no-LLM tests, but driven by a real provider. It is gated on the
+// `ENDO_LLM_*` / `LAL_*` environment credentials: when they are absent every row
+// skips rather than failing. To run it, set `ENDO_LLM_HOST` / `ENDO_LLM_MODEL`
+// / `ENDO_LLM_AUTH_TOKEN` (or their `LAL_*` aliases) to point at an
+// OpenAI-compatible endpoint, then:
+//
+//   yarn workspace @endo/agentry test
+//
+// Pass = the repository reached the target end-state (outcome assertion), not a
+// transcript score. A failure here is an eval signal about the model, not a
+// harness bug; the no-LLM tests are what prove the harness.
+//
+// The test is table-driven over a registry of eval rows, one per scenario, so
+// the credential-gating logic lives in one place and adding an eval adds one
+// row rather than one more gated file.
+
+/* global globalThis */
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import {
+  makeStageAndCommitScenario,
+  runGitScenario,
+  resolveEvalModelFromEnv,
+} from '../src/eval/index.js';
+import { readText } from './_eval-fixture.js';
+import { provisionStageAndCommitRepo } from './eval/_stage-and-commit-repo.js';
+
+/**
+ * @typedef {object} EvalRow One live-eval scenario.
+ * @property {string} title The test title for this row.
+ * @property {(t: import('ava').ExecutionContext) => Promise<{ repoRoot: string, workspace: unknown, git: unknown }>} provisionRepo
+ *   Provision the scenario's repository and return its powers.
+ * @property {(repo: any) => import('../src/eval/types.js').GitScenario} makeScenario
+ *   Build the scenario from the provisioned repository.
+ */
+
+/**
+ * The registered scenarios. Each eval folder contributes one row; the live test
+ * iterates them all under the single credential gate.
+ *
+ * @type {EvalRow[]}
+ */
+const evalRows = [
+  {
+    title: 'a live model stages and commits the file (outcome assertion)',
+    provisionRepo: t => {
+      const scenario = makeStageAndCommitScenario();
+      return provisionStageAndCommitRepo(t, {
+        path: scenario.expected.path,
+        content: scenario.expected.content,
+      });
+    },
+    makeScenario: () => makeStageAndCommitScenario(),
+  },
+];
+
+const env =
+  /** @type {{ process?: { env?: Record<string, string | undefined> } }} */ (
+    globalThis
+  ).process?.env || {};
+const live = resolveEvalModelFromEnv(env);
+const liveTest = live ? test : test.skip;
+
+for (const row of evalRows) {
+  liveTest(row.title, async t => {
+    // `live` is defined here (otherwise this test was skipped at registration).
+    const { model, getApiKey } = /** @type {NonNullable<typeof live>} */ (live);
+    const repo = await row.provisionRepo(t);
+    const scenario = row.makeScenario(repo);
+
+    const { outcome } = await runGitScenario({
+      model,
+      workspace: repo.workspace,
+      git: repo.git,
+      scenario,
+      readText,
+      getApiKey,
+    });
+
+    t.true(
+      outcome.pass,
+      `live run did not reach target end-state in ${repo.repoRoot}; checks: ${JSON.stringify(
+        outcome.checks,
+        null,
+        2,
+      )}`,
+    );
+  });
+}

--- a/packages/agentry/test/eval-live.test.js
+++ b/packages/agentry/test/eval-live.test.js
@@ -1,13 +1,16 @@
 // @ts-check
 
 // The live-model git code-mode eval: the SAME scenarios and SAME outcome scorers
-// as the no-LLM tests, but driven by a real provider. It is gated on the
-// `ENDO_LLM_*` / `LAL_*` environment credentials: when they are absent every row
-// skips rather than failing. To run it, set `ENDO_LLM_HOST` / `ENDO_LLM_MODEL`
-// / `ENDO_LLM_AUTH_TOKEN` (or their `LAL_*` aliases) to point at an
-// OpenAI-compatible endpoint, then:
+// as the no-LLM tests, but driven by a real provider. It runs ONLY via its own
+// `test:live` command and a dedicated ava config (`ava-live.config.js`); it is
+// deliberately excluded from the default `yarn test` so that a host with
+// `ENDO_LLM_*` / `LAL_*` credentials in its environment does not reach a real
+// provider as a side effect of a plain `yarn test`. It is also gated on those
+// same credentials: when they are absent every row skips rather than failing. To
+// run it, set `ENDO_LLM_HOST` / `ENDO_LLM_MODEL` / `ENDO_LLM_AUTH_TOKEN` (or
+// their `LAL_*` aliases) to point at an OpenAI-compatible endpoint, then:
 //
-//   yarn workspace @endo/agentry test
+//   yarn workspace @endo/agentry test:live
 //
 // Pass = the repository reached the target end-state (outcome assertion), not a
 // transcript score. A failure here is an eval signal about the model, not a

--- a/packages/agentry/test/eval/_stage-and-commit-repo.js
+++ b/packages/agentry/test/eval/_stage-and-commit-repo.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+// The per-eval repository fixture for the stage-and-commit scenario. Named with
+// a leading underscore so ava's `test/**/*.test.*` glob does not pick it up as
+// a test file. It builds on the shared bootstrap in `../_eval-fixture.js` and
+// adds only the commits and untracked file this scenario's repository needs.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { initRepo, makePowersOver } from '../_eval-fixture.js';
+
+/**
+ * Provision a real git repository for the stage-and-commit scenario: an initial
+ * commit (so HEAD exists), then the scenario's target file written into the
+ * working tree **untracked**. Returns the live `workspace` Filesystem and `git`
+ * capability over that worktree, plus the on-disk `repoRoot` for any out-of-band
+ * ground-truth checks the test wants to make.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {object} options
+ * @param {string} options.path Repository-relative path of the untracked file.
+ * @param {string} options.content Its content.
+ * @returns {Promise<{ repoRoot: string, workspace: unknown, git: unknown }>}
+ */
+export const provisionStageAndCommitRepo = async (
+  t,
+  { path: filePath, content },
+) => {
+  const { repoRoot, run } = await initRepo(t, { branch: 'main' });
+  // An initial commit so the repository has a HEAD before the scenario runs.
+  await fs.promises.writeFile(path.join(repoRoot, '.keep'), '');
+  await run(['add', '.keep']);
+  await run(['commit', '-q', '-m', 'chore: initialize repository']);
+  // The scenario's target file, present in the working tree but untracked.
+  await fs.promises.writeFile(path.join(repoRoot, filePath), content);
+
+  const { workspace, git } = makePowersOver(repoRoot);
+  return harden({ repoRoot, workspace, git });
+};
+harden(provisionStageAndCommitRepo);

--- a/packages/agentry/test/eval/stage-and-commit.test.js
+++ b/packages/agentry/test/eval/stage-and-commit.test.js
@@ -1,0 +1,244 @@
+// @ts-check
+
+// The no-LLM assertion-path test for the git code-mode eval. It runs the real
+// code-mode git-loop agent and the real outcome scorer against a real git
+// repository, with the only non-live piece being a scripted faux pi-ai provider
+// standing in for the model. It needs zero credentials and no network, so it
+// runs anywhere — the live-model counterpart (same scenario, same scorer) runs
+// only on a host where the `ENDO_LLM_*` / `LAL_*` credentials are present.
+
+import test from '@endo/ses-ava/prepare-endo.js';
+import {
+  registerFauxProvider,
+  fauxAssistantMessage,
+  fauxToolCall,
+} from '@earendil-works/pi-ai';
+
+import {
+  makeStageAndCommitScenario,
+  runGitScenario,
+} from '../../src/eval/index.js';
+import { readText } from '../_eval-fixture.js';
+import { provisionStageAndCommitRepo } from './_stage-and-commit-repo.js';
+
+/** @import { Model } from '@earendil-works/pi-ai' */
+
+/**
+ * Register a per-test faux pi-ai provider seeded with `responses` and return
+ * the faux `Model`. The registration is torn down with the test.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {import('@earendil-works/pi-ai').AssistantMessage[]} responses
+ * @returns {Model<string>}
+ */
+const fauxModel = (t, responses) => {
+  const registration = registerFauxProvider({
+    provider: 'faux',
+    models: [{ id: 'faux-model' }],
+  });
+  registration.setResponses(responses);
+  t.teardown(() => registration.unregister());
+  return registration.getModel();
+};
+
+/**
+ * Source the faux model "writes" into a single execute call: find the target
+ * path's status row, stage it, and commit with `message`. This is the reference
+ * solution a competent code-mode agent would converge on; the live eval scores
+ * a real model against the same outcome.
+ *
+ * @param {string} filePath
+ * @param {string} message
+ * @returns {string}
+ */
+const stageAndCommitSource = (filePath, message) => `\
+(async () => {
+  const rows = await E(git).status();
+  const row = rows.find(candidate => candidate.path === ${JSON.stringify(filePath)});
+  if (row === undefined) {
+    throw new Error('target path not found in git status');
+  }
+  await E(git).add([row.entry]);
+  const commit = await E(git).commit(${JSON.stringify(message)});
+  return commit.summary;
+})()`;
+
+/**
+ * A faux-model source that overwrites the target path with the WRONG bytes
+ * before staging and committing it with the RIGHT message. The working tree's
+ * `wrongContent` replaces the fixture's correct content, so the commit lands the
+ * right path under the right message but the committed content diverges from
+ * `expected.content`. This discriminates the scorer's `file-content` check from
+ * `file-tracked-at-head`: they no longer share a truth value.
+ *
+ * @param {string} filePath
+ * @param {string} wrongContent
+ * @param {string} message
+ * @returns {string}
+ */
+const stageWrongContentAndCommitSource = (filePath, wrongContent, message) => `\
+(async () => {
+  const root = await E(workspace).root();
+  await E(root).write(${JSON.stringify(filePath)}, ${JSON.stringify(
+    wrongContent,
+  )});
+  const rows = await E(git).status();
+  const row = rows.find(candidate => candidate.path === ${JSON.stringify(
+    filePath,
+  )});
+  if (row === undefined) {
+    throw new Error('target path not found in git status');
+  }
+  await E(git).add([row.entry]);
+  const commit = await E(git).commit(${JSON.stringify(message)});
+  return commit.summary;
+})()`;
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} source
+ * @returns {Model<string>}
+ */
+const executeOnceModel = (t, source) =>
+  fauxModel(t, [
+    fauxAssistantMessage(fauxToolCall('execute', { source }), {
+      stopReason: 'toolUse',
+    }),
+    fauxAssistantMessage('done'),
+  ]);
+
+test('outcome assertion passes when the scripted run reaches the target end-state', async t => {
+  const scenario = makeStageAndCommitScenario();
+  const { workspace, git } = await provisionStageAndCommitRepo(t, {
+    path: scenario.expected.path,
+    content: scenario.expected.content,
+  });
+  const model = executeOnceModel(
+    t,
+    stageAndCommitSource(scenario.expected.path, scenario.expected.message),
+  );
+
+  const { outcome } = await runGitScenario({
+    model,
+    workspace,
+    git,
+    scenario,
+    readText,
+  });
+
+  t.true(
+    outcome.pass,
+    `expected pass; checks: ${JSON.stringify(outcome.checks, null, 2)}`,
+  );
+  t.deepEqual(
+    outcome.checks.map(c => [c.name, c.ok]),
+    [
+      ['commit-exists', true],
+      ['commit-message', true],
+      ['file-tracked-at-head', true],
+      ['file-content', true],
+      ['worktree-clean', true],
+    ],
+  );
+});
+
+test('outcome assertion fails the commit-message check when the wrong message is used', async t => {
+  const scenario = makeStageAndCommitScenario();
+  const { workspace, git } = await provisionStageAndCommitRepo(t, {
+    path: scenario.expected.path,
+    content: scenario.expected.content,
+  });
+  // The run stages and commits the right file with the WRONG message.
+  const model = executeOnceModel(
+    t,
+    stageAndCommitSource(scenario.expected.path, 'chore: wrong message'),
+  );
+
+  const { outcome } = await runGitScenario({
+    model,
+    workspace,
+    git,
+    scenario,
+    readText,
+  });
+
+  t.false(outcome.pass);
+  const byName = Object.fromEntries(outcome.checks.map(c => [c.name, c.ok]));
+  // The file is tracked with the right content, but the message is wrong, so
+  // only the message check fails — outcome assertion is precise about why.
+  t.false(byName['commit-message']);
+  t.true(byName['file-tracked-at-head']);
+  t.true(byName['file-content']);
+  t.true(byName['worktree-clean']);
+});
+
+test('outcome assertion fails the file-content check when the wrong content is committed', async t => {
+  const scenario = makeStageAndCommitScenario();
+  const { workspace, git } = await provisionStageAndCommitRepo(t, {
+    path: scenario.expected.path,
+    content: scenario.expected.content,
+  });
+  // The run overwrites the target path with the WRONG bytes, then stages and
+  // commits it under the RIGHT path with the RIGHT message. This isolates the
+  // `file-content` check: the file is tracked at HEAD and the message matches,
+  // but the committed content differs from the target.
+  const wrongContent = `${scenario.expected.content}DIVERGED\n`;
+  const model = executeOnceModel(
+    t,
+    stageWrongContentAndCommitSource(
+      scenario.expected.path,
+      wrongContent,
+      scenario.expected.message,
+    ),
+  );
+
+  const { outcome } = await runGitScenario({
+    model,
+    workspace,
+    git,
+    scenario,
+    readText,
+  });
+
+  t.false(outcome.pass);
+  const byName = Object.fromEntries(outcome.checks.map(c => [c.name, c.ok]));
+  // The file is tracked under the right message, but the committed content is
+  // wrong, so only the content check fails — outcome assertion is precise about
+  // why, and the `file-content` comparison is exercised in its discriminating
+  // direction (true `file-tracked-at-head`, false `file-content`).
+  t.false(byName['file-content']);
+  t.true(byName['file-tracked-at-head']);
+  t.true(byName['commit-message']);
+  t.true(byName['worktree-clean']);
+});
+
+test('outcome assertion fails when the agent never commits the file', async t => {
+  const scenario = makeStageAndCommitScenario();
+  const { workspace, git } = await provisionStageAndCommitRepo(t, {
+    path: scenario.expected.path,
+    content: scenario.expected.content,
+  });
+  // The model answers in prose without ever calling execute: the working tree
+  // is untouched, so the target file stays untracked.
+  const model = fauxModel(t, [
+    fauxAssistantMessage('I will not touch the repo.'),
+  ]);
+
+  const { outcome } = await runGitScenario({
+    model,
+    workspace,
+    git,
+    scenario,
+    readText,
+  });
+
+  t.false(outcome.pass);
+  const byName = Object.fromEntries(outcome.checks.map(c => [c.name, c.ok]));
+  t.false(byName['file-tracked-at-head']);
+  t.false(byName['file-content']);
+  t.false(byName['worktree-clean']);
+  // The pre-existing initial commit is still there, so a commit "exists" — but
+  // it is not the scenario's commit, so the message check fails.
+  t.true(byName['commit-exists']);
+  t.false(byName['commit-message']);
+});

--- a/packages/agentry/test/exports.test.js
+++ b/packages/agentry/test/exports.test.js
@@ -3,15 +3,22 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
 test('agentry subpaths resolve through package exports', async t => {
-  const [rootModule, harnessModule, executeModule] = await Promise.all([
-    // eslint-disable-next-line import/no-unresolved
-    import('@endo/agentry'),
-    // eslint-disable-next-line import/no-unresolved
-    import('@endo/agentry/harness'),
-    // eslint-disable-next-line import/no-unresolved
-    import('@endo/agentry/execute'),
-  ]);
+  const [rootModule, harnessModule, executeModule, evalModule] =
+    await Promise.all([
+      // eslint-disable-next-line import/no-unresolved
+      import('@endo/agentry'),
+      // eslint-disable-next-line import/no-unresolved
+      import('@endo/agentry/harness'),
+      // eslint-disable-next-line import/no-unresolved
+      import('@endo/agentry/execute'),
+      // eslint-disable-next-line import/no-unresolved
+      import('@endo/agentry/eval'),
+    ]);
   t.is(typeof rootModule.defineAgent, 'function');
   t.is(typeof harnessModule.makePiAgent, 'function');
   t.is(typeof executeModule.makeCodeModeAgent, 'function');
+  t.is(typeof evalModule.runGitScenario, 'function');
+  t.is(typeof evalModule.makeStageAndCommitScenario, 'function');
+  t.is(typeof evalModule.assertGitCommitOutcome, 'function');
+  t.is(typeof evalModule.resolveEvalModelFromEnv, 'function');
 });


### PR DESCRIPTION
## Description

Adds a self-contained harness in `packages/agentry` for testing git code mode: drive the code-mode git-loop agent against a scenario, then score whether the git repository reached the target end-state. This is new work in `packages/agentry`; it does not touch or port the existing lal eval harness.

The harness separates two concerns and implements only the first:

- Eval (this change) measures a fixed agent: run a scenario, then judge pass/fail by outcome assertion. Pass means the repository reached the target end-state (the commit exists, the tree and index match, the file contents are right). It answers "did it work?".
- Optimize (deferred, out of scope) would search for a better prompt. It answers "what prompt works best?".

Optimization would consume an eval as its objective, but the eval stands alone and ships first. This change does no prompt-tuning; the agent runs through agentry's own pi-agent / pi-ai harness.

Scoring is by outcome assertion rather than trace edit-distance. A code-mode agent's only tool is `execute`: it runs `E(git).x()` and `E(workspace).x()` inside a Compartment, so the outer pi tool-call trace sees a single opaque `execute`, not the individual git operations. There is therefore no git-op trace to score, and there should not need to be: a correct run might stage in a different order, read status an extra time, or reach the same end a different way. Outcome assertion reads the repository's actual final state through the live `git` capability and checks it against the target, so it needs no in-compartment instrumentation and accepts any alternate-but-correct path. Capturing the run's events stays a debugging diagnostic, never the gate.

Files most critical to review:

- `src/eval/outcome.js` — `assertGitCommitOutcome({ git, readText, expected })`: the scorer. Checks HEAD's commit message, the file tracked at HEAD and its content, and the working-tree status; returns a structured `{ pass, checks }`. Cap-based and portable (the byte reader is injected, so `src/` carries no stream dependency).
- `src/eval/scenarios.js` — `makeStageAndCommitScenario(...)`: the model-agnostic scenario (prompt plus target end-state plus outcome assertion).
- `src/eval/run.js` — `runGitScenario({ model, workspace, git, scenario, readText, ... })`: builds the real code-mode git-loop agent, runs the prompt, scores by outcome assertion. Only the `model` differs between a no-LLM run and a live run; the agent, powers, and scorer are identical.
- `src/eval/env-model.js` — `resolveEvalModelFromEnv(env)`: builds a live model plus `getApiKey` from `ENDO_LLM_*` / `LAL_*` environment variables, or `undefined` when no credentials are present.
- Exposed on the `@endo/agentry/eval` subpath (verified by `exports.test.js`).

### Security Considerations

This change introduces one new authority: `resolveEvalModelFromEnv` constructs a live model and a `getApiKey` hook from credentials read out of the environment (`ENDO_LLM_HOST` / `ENDO_LLM_MODEL` / `ENDO_LLM_AUTH_TOKEN`, with `LAL_*` aliases). When any of those are absent the function returns `undefined`, so a caller cleanly skips the live path rather than constructing a model that would fail to authenticate. The token is never written to code, config, or a committed file; it reaches only the in-process environment and the request to the configured endpoint. The returned `getApiKey` resolves the single configured token and ignores its provider argument, so there is exactly one credential in play.

### Scaling Considerations

None. The harness runs a single scenario per invocation. The live path makes one model's worth of requests and is opt-in (it skips without credentials); the default no-LLM path makes no network calls.

### Documentation Considerations

`src/eval/README.md` documents the eval-vs-optimize split, the rationale for outcome assertion, the module's pieces, and how to run both the no-LLM and live paths. No downstream-facing API beyond the new `@endo/agentry/eval` subpath; no migration of existing data or deployments.

### Testing Considerations

- `test/eval-git-code-mode.test.js` — the no-LLM assertion-path test. Runs the real code-mode agent and the real scorer against a real git repository, with a scripted faux pi-ai provider standing in for the model. Needs zero credentials and no network. Covers one passing scenario plus precise negative cases (a wrong commit message fails only the message check; a no-op run fails the tracked / content / clean checks).
- `test/eval-git-code-mode-live.test.js` — the live counterpart: same scenario, same scorer, a real provider. It skips unless `ENDO_LLM_*` / `LAL_*` credentials are present.

`yarn workspace @endo/agentry test` reports 59 passed, 1 skipped (the live test, no credentials in CI). No new CI surface beyond the package's existing test job.

### Compatibility Considerations

Additive only. New files under `src/eval/` and a new `@endo/agentry/eval` export subpath; no existing usage pattern changes.

### Upgrade Considerations

None. No production system consumes this harness; it is a development and CI tool.
