### PR TITLE
fix(git): drive rebase --continue without an interactive editor

### DIFF
--- a/.changeset/git-noninteractive-rebase-continue.md
+++ b/.changeset/git-noninteractive-rebase-continue.md
@@ -1,0 +1,13 @@
+---
+'@endo/git': patch
+---
+
+Make `NativeGitBackend` git invocations non-interactive with respect to the
+editor. Under the default merge backend, `git rebase --continue` (and a
+non-fast-forward `git merge`) open the configured editor to confirm a commit
+message. With no controlling terminal the spawned editor blocks waiting on
+stdin or fails outright, stranding a conflict-resolution `rebase({ mode:
+'continue' })` mid-rebase. The backend now pins `GIT_EDITOR=true` and
+`GIT_SEQUENCE_EDITOR=:` in the sanitized environment it hands each git child,
+so the continue path completes non-interactively while preserving the original
+commit message.

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -1589,6 +1589,108 @@ test('NativeGitBackend.rebase rebases a local branch onto upstream', async t => 
   );
 });
 
+test('NativeGitBackend.rebase continues a conflicted rebase without an interactive editor', async t => {
+  // Under the merge backend, `git rebase --continue` opens the editor to
+  // confirm the conflicted commit's message.  With no controlling terminal
+  // that editor blocks or fails, stranding the rebase.  The backend pins
+  // `GIT_EDITOR=true` so the continue path completes non-interactively,
+  // preserving the original message.  The timeout bounds the test so a
+  // reintroduced editor hang fails fast instead of waiting out the global
+  // AVA timeout.
+  t.timeout(10_000);
+  const repoRoot = await provisionGitWorktree(t);
+
+  // Pin a deliberately failing editor in repo-local config.  If the backend
+  // ever stops overriding the editor, `git rebase --continue` would fall back
+  // to this `false` and abort with a non-zero exit, failing the test; with the
+  // `GIT_EDITOR=true` override in place the failing editor is never consulted.
+  await execFileAsync('git', ['config', '--local', 'core.editor', 'false'], {
+    cwd: repoRoot,
+  });
+
+  // A base commit both branches share, then a divergent edit to the same file
+  // on each branch so the rebase is guaranteed to conflict.
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'base\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'base commit',
+    ],
+    { cwd: repoRoot },
+  );
+  await execFileAsync('git', ['switch', '-c', 'feature'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'feature\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'feature commit',
+    ],
+    { cwd: repoRoot },
+  );
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'main\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'main commit',
+    ],
+    { cwd: repoRoot },
+  );
+  await execFileAsync('git', ['switch', 'feature'], { cwd: repoRoot });
+
+  const backend = makeNativeGitBackend({ repoRoot });
+
+  // Starting the rebase stops on the conflict and surfaces a non-zero exit.
+  await t.throwsAsync(
+    () => backend.rebase({ mode: 'start', upstream: 'main' }),
+    {
+      message: /rebase failed/,
+    },
+  );
+
+  // Resolve the conflict and stage the resolution.
+  await fs.promises.writeFile(
+    path.join(repoRoot, 'conflict.txt'),
+    'resolved\n',
+  );
+  await backend.add(['conflict.txt']);
+
+  // The continue must complete non-interactively and preserve the original
+  // commit message (the editor override accepts the prepared message as-is).
+  await backend.rebase({ mode: 'continue' });
+
+  const commits = await backend.log({ maxCount: 2 });
+  t.deepEqual(
+    commits.map(commit => commit.summary),
+    ['feature commit', 'main commit'],
+  );
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'conflict.txt'), 'utf8'),
+    'resolved\n',
+  );
+});
+
 test('Git stash methods preserve path authority through EndoMountEntry', async t => {
   const repoRoot = await provisionGitWorktree(t);
   await fs.promises.writeFile(path.join(repoRoot, 'tracked.txt'), 'before\n');

--- a/packages/git/src/native-git-backend.js
+++ b/packages/git/src/native-git-backend.js
@@ -173,6 +173,19 @@ const makeGitEnv = repoRoot => ({
   GIT_CONFIG_GLOBAL: gitNullDevice,
   // No interactive prompts.
   GIT_TERMINAL_PROMPT: '0',
+  // No interactive editor.  Some porcelain commands (notably
+  // `rebase --continue` under the merge backend, and a non-fast-forward
+  // `merge`) open the editor to confirm a commit message.  With no
+  // controlling terminal that editor hangs on stdin or fails, stranding
+  // the operation mid-rebase.  `GIT_EDITOR=true` is a no-op editor that
+  // exits success, so git keeps the message it already prepared and the
+  // command completes non-interactively.  Takes precedence over any
+  // repository-local `core.editor`.
+  GIT_EDITOR: 'true',
+  // The same no-op for the rebase todo-list editor, should an
+  // interactive rebase ever be wired in.  Takes precedence over any
+  // repository-local `sequence.editor`.
+  GIT_SEQUENCE_EDITOR: ':',
   // Suppress the opportunistic index refresh that read commands
   // (status, diff) otherwise perform.  Without this, a "read-only"
   // inspection rewrites `.git/index` metadata as a side effect and


### PR DESCRIPTION
## Description

`NativeGitBackend.rebase({ mode: 'continue' })` could strand a conflict
resolution mid-rebase in any headless context (a daemon, a code-mode agent,
CI). Under git's default merge rebase backend, `git rebase --continue` opens
the configured editor to confirm the conflicted commit's message. The backend
spawns git with no controlling terminal, so the editor either blocks waiting on
stdin or fails outright, and the operation never completes.

This wires a non-interactive editor into the sanitized environment that every
git child inherits (`makeGitEnv`): `GIT_EDITOR=true` (a no-op that exits
success, so git keeps the message it already prepared) and
`GIT_SEQUENCE_EDITOR=:` (the same for the rebase todo-list editor, should an
interactive rebase ever be wired in). Both take precedence over any
repository-local `core.editor` / `sequence.editor`. The same override also
makes a non-fast-forward `merge` complete with its default merge summary
instead of opening an editor.

Most critical to review:

- `packages/git/src/native-git-backend.js` — the two env additions in
  `makeGitEnv`. The environment is constructed fresh per git invocation and is
  never applied to the daemon process itself, so the scope is the spawned git
  child only.
- `packages/daemon/test/git.test.js` — the regression test.

### Security Considerations

No new authority. `GIT_EDITOR=true` / `GIT_SEQUENCE_EDITOR=:` narrow git's
behavior (they replace any editor with a no-op); they cannot run
attacker-controlled code. The additions sit alongside the existing hardening in
`makeGitEnv` (`GIT_TERMINAL_PROMPT=0`, redirected `HOME` / global config,
suppressed credential helpers) and extend the same "no interactive surface"
posture to the editor. They override a repository-local `core.editor`, removing
one more committed-in-config channel that could otherwise influence a spawned
git process.

### Scaling Considerations

None. No additional processes, allocations, or round-trips.

### Documentation Considerations

None. Behavior-only fix to an internal backend; no public API surface changes.

### Testing Considerations

Adds `NativeGitBackend.rebase continues a conflicted rebase without an
interactive editor` to `packages/daemon/test/git.test.js`. It drives a real
conflicted rebase through the backend, resolves the conflict, and continues to
a clean end-state, asserting the original commit message is preserved. The test
pins a deliberately failing repo-local `core.editor` (`false`) so that without
the `GIT_EDITOR` override the continue aborts with a non-zero exit — making the
test a genuine regression guard (verified: it fails when the override is
removed). An explicit `t.timeout(30_000)` fails fast if an editor hang is ever
reintroduced.

### Compatibility Considerations

No break. A `rebase --continue` / non-fast-forward `merge` that previously
relied on an interactive editor now uses the prepared message non-interactively.
In a headless backend there was never a usable interactive editor, so this only
turns a hang/failure into a successful completion.

### Upgrade Considerations

None.
