### PR TITLE
probe(agentry): gap-revealing skeleton for the ocap SWE loop — clone → push (gap-revealing prototype)

### DIFF
--- a/packages/agentry/src/execute/swe-loop-probe.js
+++ b/packages/agentry/src/execute/swe-loop-probe.js
@@ -1,0 +1,275 @@
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * Gap-revealing prototype: ocap-disciplined SWE loop (clone → push).
+ *
+ * This module walks the full software-engineering loop that a code-mode
+ * agent would need to run — clone, worktree-add, yarn install, file
+ * create/edit, test run, push to a local bare remote — using ONLY the
+ * capability surface that exists on the `llm` branch today.
+ *
+ * Every step that cannot be written without a capability gap is left as a
+ * stub with a `// gap: see PR body §N` comment. Steps that compose
+ * cleanly are implemented with real code.
+ *
+ * @module swe-loop-probe
+ */
+
+import { E } from '@endo/far';
+
+// ---------------------------------------------------------------------------
+// Types used by the skeleton
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} SweLoopPowers
+ *   The set of lexical powers a code-mode agent would receive for the full
+ *   SWE loop. Today's code-mode preset (`CodeModePowers`) supplies only
+ *   `workspace` and `git`; the additional fields below are the gaps.
+ *
+ * @property {object} workspace
+ *   A writable `@endo/platform/fs/extended` Filesystem rooted at the
+ *   repository checkout. (PRESENT — supplied by the current preset.)
+ *
+ * @property {object} git
+ *   A read/write `@endo/exo-git` Git capability bound to the same root.
+ *   (PRESENT — supplied by the current preset.)
+ *
+ * @property {object} [remote]
+ *   A `@endo/exo-git` GitRemote capability pre-configured for a LOCAL
+ *   bare-remote URL (file: transport). Used for the push step.
+ *   (GAP 4 — not exposed as a code-mode lexical power; see §4 below.)
+ *
+ * @property {object} [exec]
+ *   A capability to run a confined subprocess (yarn install, npm test).
+ *   (GAP 3 — no such power exists in code-mode today; see §3 below.)
+ */
+
+// ---------------------------------------------------------------------------
+// Step 1: Clone — GAP 1
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrate the clone gap.
+ *
+ * A code-mode agent has no way to obtain a Git cap over a *freshly cloned*
+ * repository. `provideGit(mountCap, petName)` mints a Git cap over an
+ * EXISTING mount; it does not clone. The `GitBackend` contract has no
+ * `clone` method; `GitRemote` has `fetch` and `push` but no `clone`.
+ * The native backend (`makeNativeGitBackend`) has no `clone` entry.
+ *
+ * // gap: see PR body §1 — no clone operation on any public surface
+ *
+ * @param {SweLoopPowers} _powers
+ * @returns {Promise<never>}
+ */
+export const probeClone = async _powers => {
+  // gap: see PR body §1
+  throw new Error(
+    'clone is not available on any code-mode capability surface; ' +
+      'the agent cannot obtain a Git cap over a freshly cloned repo',
+  );
+};
+harden(probeClone);
+
+// ---------------------------------------------------------------------------
+// Step 2: Worktree-add — GAP 2
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrate the worktree-add gap.
+ *
+ * `git.worktree()` (on the `EndoGit` exo, `git.js:308`) returns the CURRENT
+ * worktree authority (the `EndoMount` the Git cap was constructed over). It
+ * does not mint a new worktree via `git worktree add`.
+ *
+ * // gap: see PR body §2
+ *
+ * @param {Pick<SweLoopPowers, 'git'>} powers
+ * @returns {Promise<object>} The CURRENT worktree mount (not a new worktree).
+ */
+export const probeWorktreeAuthority = async powers => {
+  // This composes: returns the existing worktree authority.
+  const currentWorktree = await E(powers.git).worktree();
+  return currentWorktree;
+  // gap: see PR body §2 — no way to ADD a new linked worktree
+};
+harden(probeWorktreeAuthority);
+
+// ---------------------------------------------------------------------------
+// Step 3: exec/spawn (yarn install, npm test) — GAP 3
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrate the exec/spawn gap.
+ *
+ * `yarn install` and `npm test` require spawning a subprocess. No subprocess
+ * power exists in the code-mode `CodeModePowers` set. The genie's `Spawner`
+ * seam (`packages/genie/src/tools/spawner.js`) and the `SandboxHandle.spawn`
+ * adapter (`sandbox-spawner.js`) exist on the genie side but are not plumbed
+ * as a code-mode lexical capability.
+ *
+ * // gap: see PR body §3
+ *
+ * @param {SweLoopPowers} _powers
+ * @returns {Promise<never>}
+ */
+export const probeExec = async _powers => {
+  // gap: see PR body §3
+  throw new Error(
+    'no exec/spawn power is exposed as a code-mode lexical capability; ' +
+      'yarn install and npm test cannot run through the cap boundary',
+  );
+};
+harden(probeExec);
+
+// ---------------------------------------------------------------------------
+// Step 4: File create/edit — COMPOSES
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrate that file create/edit via the workspace Filesystem composes.
+ *
+ * The `EndoMount` surface exposed under `workspace` supports:
+ *   - `writeText(pathArg, content)` — creates parent dirs automatically,
+ *     creates the file if absent, overwrites if present.
+ *   - `makeFile(pathArg, content)` — creates parent dirs, creates file
+ *     if absent (idempotent on missing path).
+ *   - `makeDirectory(pathArg)` — recursive mkdir.
+ *   - `readText(pathArg)` — read file text.
+ *
+ * Creating a file at a path whose parent dirs do not exist works:
+ * `makePath(parent)` is called internally before the write.
+ *
+ * @param {Pick<SweLoopPowers, 'workspace'>} powers
+ * @param {string} relPath  Repository-relative path, e.g. 'src/foo.js'.
+ * @param {string} content  UTF-8 text to write.
+ * @returns {Promise<void>}
+ */
+export const probeFileWrite = async (powers, relPath, content) => {
+  // writeText creates parent dirs and the file. This is the clear path
+  // for a code-mode agent to create or update a file.
+  await E(powers.workspace).writeText(relPath, content);
+};
+harden(probeFileWrite);
+
+/**
+ * Verify a file can be read back after writing.
+ *
+ * @param {Pick<SweLoopPowers, 'workspace'>} powers
+ * @param {string} relPath
+ * @returns {Promise<string>}
+ */
+export const probeFileRead = async (powers, relPath) => {
+  return E(powers.workspace).readText(relPath);
+};
+harden(probeFileRead);
+
+// ---------------------------------------------------------------------------
+// Step 5: git add/commit — COMPOSES
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrate that git add and commit via the Git cap compose.
+ *
+ * The `EndoGit` exo exposes `add(entries)` and `commit(message)`. Both
+ * require an `EndoMountEntry[]` for the `add` path (produced by
+ * `E(git).status()` rows' `.entry` field or by `E(mount).entry(segments)`).
+ *
+ * @param {Pick<SweLoopPowers, 'git'>} powers
+ * @param {string} repoRelPath  Repo-relative path to stage, e.g. 'src/foo.js'.
+ * @param {string} message  Commit message.
+ * @returns {Promise<import('@endo/exo-git/src/types.js').GitCommit>}
+ */
+export const probeAddCommit = async (powers, repoRelPath, message) => {
+  // Obtain the mount so we can mint an EndoMountEntry for the path.
+  const mount = await E(powers.git).worktree();
+  const segments = repoRelPath.split('/');
+  const entry = await E(mount).entry(segments);
+  // Add the file to the staging area.
+  await E(powers.git).add([entry]);
+  // Commit and return the resulting GitCommit record.
+  return E(powers.git).commit(message);
+};
+harden(probeAddCommit);
+
+// ---------------------------------------------------------------------------
+// Step 6: Push to local bare remote — GAP 4
+// ---------------------------------------------------------------------------
+
+/**
+ * Demonstrate the push/credential gap.
+ *
+ * `GitRemote.push()` EXISTS on the `@endo/exo-git` surface and the
+ * native backend's `remotePush` is implemented. However:
+ *
+ *   (a) A `GitRemote` cap must be minted by the daemon via
+ *       `provideGitRemote(gitCap, petName, opts)`; a code-mode agent
+ *       cannot mint one itself.
+ *   (b) For a `file:` URL the `normalizeRemoteUrl` validator in
+ *       `git-remote.js` requires `allowLocalFileTransport: true` in the
+ *       policy. This flag is not part of the current `GitRemotePolicy`
+ *       default.
+ *   (c) A credential cap is required for `https:` URLs; it is minted
+ *       via `provideBearerCredential` / `provideBasicCredential` on the
+ *       `EndoHost` (host-side only). A code-mode agent cannot mint one.
+ *
+ * For a LOCAL bare remote (file: URL) the credential requirement is
+ * absent, but items (a) and (b) still block the push from code-mode.
+ *
+ * // gap: see PR body §4
+ *
+ * @param {SweLoopPowers} _powers
+ * @returns {Promise<never>}
+ */
+export const probePush = async _powers => {
+  // gap: see PR body §4
+  throw new Error(
+    'push requires a GitRemote cap that is not accessible from code-mode; ' +
+      'the daemon must mint it and introduce it as a lexical power',
+  );
+};
+harden(probePush);
+
+// ---------------------------------------------------------------------------
+// Step 7: File-write surface verification — COMPOSES (with a note)
+// ---------------------------------------------------------------------------
+
+/**
+ * Confirm that `EndoMountEntry` (a structural entry descriptor minted by
+ * `E(mount).entry(segments)`) is INERT with respect to I/O.
+ *
+ * An `EndoMountEntry` carries only path metadata (`segments()`); it does
+ * not carry read/write authority. Write authority lives on the node
+ * (`E(mount).lookup(segments)`) or on the parent mount's methods
+ * (`writeText`, `makeFile`). This is not a gap for the SWE loop — the
+ * workspace mount's `writeText` is the clear ergonomic write path — but
+ * the job spec asks to confirm the surface.
+ *
+ * The `write(blob)` on `EndoMount` expects a `ReadableBlob` or
+ * `ReadableTree` for binary/tree writes; UTF-8 text writes go through
+ * `writeText`. There is no gap here: these compose cleanly.
+ *
+ * @param {Pick<SweLoopPowers, 'workspace'>} powers
+ * @returns {Promise<{ hasEntry: boolean; canWriteViaMount: boolean }>}
+ */
+export const probeFileWriteSurface = async powers => {
+  // Mint an entry for a sentinel path.
+  const entry = await E(powers.workspace).entry(['probe-sentinel.txt']);
+  // The entry exists as an authority-bearing descriptor; it is not inert
+  // in the "undefined" sense, but its I/O authority is scoped: it cannot
+  // initiate a write on its own. The write must go through the mount.
+  const hasEntry = entry !== undefined;
+
+  // Demonstrate the ergonomic write path via writeText on the mount.
+  await E(powers.workspace).writeText('probe-sentinel.txt', '// probe file\n');
+  const readBack = await E(powers.workspace).readText('probe-sentinel.txt');
+  const canWriteViaMount = readBack === '// probe file\n';
+
+  // Clean up.
+  await E(powers.workspace).remove('probe-sentinel.txt');
+
+  return harden({ hasEntry, canWriteViaMount });
+};
+harden(probeFileWriteSurface);

--- a/packages/agentry/test/swe-loop-probe.test.js
+++ b/packages/agentry/test/swe-loop-probe.test.js
@@ -1,0 +1,72 @@
+// @ts-check
+
+/**
+ * Smoke tests for the swe-loop-probe gap-revealing prototype.
+ *
+ * These tests verify that the probe functions import and behave as
+ * documented — the clear-path functions compose, and the gap-path
+ * functions throw with the expected gap message. No contract tests
+ * are written against the unfinalized design (per the probe skill's
+ * § Notes).
+ */
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import {
+  probeClone,
+  probeWorktreeAuthority,
+  probeExec,
+  probeFileWrite,
+  probeFileRead,
+  probeAddCommit,
+  probePush,
+  probeFileWriteSurface,
+} from '../src/execute/swe-loop-probe.js';
+
+// ---------------------------------------------------------------------------
+// Gap stubs throw with the documented gap message
+// ---------------------------------------------------------------------------
+
+test('probeClone throws — clone is not available on any code-mode capability surface', async t => {
+  await t.throwsAsync(probeClone({}), {
+    message: /clone is not available on any code-mode capability surface/,
+  });
+});
+
+test('probeExec throws — no exec/spawn power is exposed as a code-mode lexical capability', async t => {
+  await t.throwsAsync(probeExec({}), {
+    message:
+      /no exec\/spawn power is exposed as a code-mode lexical capability/,
+  });
+});
+
+test('probePush throws — push requires a GitRemote cap that is not accessible from code-mode', async t => {
+  await t.throwsAsync(probePush({}), {
+    message:
+      /push requires a GitRemote cap that is not accessible from code-mode/,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clear-path stubs import without error (smoke — no live daemon available)
+// ---------------------------------------------------------------------------
+
+test('probeFileWrite is a callable function', t => {
+  t.is(typeof probeFileWrite, 'function');
+});
+
+test('probeFileRead is a callable function', t => {
+  t.is(typeof probeFileRead, 'function');
+});
+
+test('probeAddCommit is a callable function', t => {
+  t.is(typeof probeAddCommit, 'function');
+});
+
+test('probeWorktreeAuthority is a callable function', t => {
+  t.is(typeof probeWorktreeAuthority, 'function');
+});
+
+test('probeFileWriteSurface is a callable function', t => {
+  t.is(typeof probeFileWriteSurface, 'function');
+});

--- a/packages/agentry/test/swe-loop-probe.test.js
+++ b/packages/agentry/test/swe-loop-probe.test.js
@@ -12,6 +12,8 @@
 
 import test from '@endo/ses-ava/prepare-endo.js';
 
+/** @import { SweLoopPowers } from '../src/execute/swe-loop-probe.js' */
+
 import {
   probeClone,
   probeWorktreeAuthority,
@@ -28,20 +30,22 @@ import {
 // ---------------------------------------------------------------------------
 
 test('probeClone throws — clone is not available on any code-mode capability surface', async t => {
-  await t.throwsAsync(probeClone({}), {
+  // The gap stub throws before touching its powers, so empty powers exercise
+  // the gap path; cast documents that the input is intentionally incomplete.
+  await t.throwsAsync(probeClone(/** @type {SweLoopPowers} */ ({})), {
     message: /clone is not available on any code-mode capability surface/,
   });
 });
 
 test('probeExec throws — no exec/spawn power is exposed as a code-mode lexical capability', async t => {
-  await t.throwsAsync(probeExec({}), {
+  await t.throwsAsync(probeExec(/** @type {SweLoopPowers} */ ({})), {
     message:
       /no exec\/spawn power is exposed as a code-mode lexical capability/,
   });
 });
 
 test('probePush throws — push requires a GitRemote cap that is not accessible from code-mode', async t => {
-  await t.throwsAsync(probePush({}), {
+  await t.throwsAsync(probePush(/** @type {SweLoopPowers} */ ({})), {
     message:
       /push requires a GitRemote cap that is not accessible from code-mode/,
   });


### PR DESCRIPTION
Gap-revealing prototype of the ocap-disciplined SWE loop design session
recorded at journal2 `entries/2026/06/25/133528Z-artifact-liaison-718bf0.md`
(slate item P0). There is no separate design PR — the lifecycle described
in the job spec IS the spec; this probe surfaces the gaps that sharpen the
D1 (exec/Spawner) and D2 (clone+worktree provisioning) design jobs.

**This PR stays DRAFT.** The panel/cleaner/fixer/un-draft chain does not
apply. The maintainer reads the gap report, revises the design jobs, and
either authorizes a follow-up build or closes this probe as superseded.

---

## Gaps surfaced

### Gap 1: No clone operation on any capability surface

**Where in the design.** `packages/exo-git/src/git.js` (full `GitBackend`
typedef), `packages/git/src/native-git-backend.js` (full implementation),
`packages/exo-git/src/git-remote.js` (`GitRemote` exo), and
`packages/daemon/src/host.js` `provideGit`.

**Verbatim quote.** From the job spec: "clone a repo" — step 1 of the
target loop. From the code: `provideGit(mountCap, petName)` — mints a
Git cap over an EXISTING daemon-minted mount.

**What's needed to implement.** A primitive that, given a source URL
(or another `GitRemote` fetch policy) and a destination mount, runs
`git clone` into the destination and returns a new Git cap over the
populated worktree. The caller's code-mode agent cannot touch host paths
directly; the operation must go through a host-controlled capability.

**Candidate resolutions.**
- **A.** Add a `clone(url, destMount, petName, credential)` method to
  `EndoHost` parallel to `provideGit`. The daemon runs `git clone`
  into the `destMount`'s backing path, then calls `formulateGit` on it
  and returns the cap. Trade-off: simple and consistent with the
  existing `provideGit` shape; requires the caller already hold a
  destination `Mount` cap (which the code-mode agent cannot mint either
  — see Gap 2's connection to provisioning).
- **B.** Extend `GitRemote` with a `clone(destMount, petName)` operation.
  The `GitRemote` already holds the URL and credential; a `clone` method
  on it would be ergonomic. Trade-off: blurs the `GitRemote` as a
  "live-repo remote" abstraction into a "provisioning" abstraction.
- **C.** Introduce a separate `GitProvisioner` capability (daemon-minted,
  bound to a local bare-remote URL or `GitRemote` policy) that the host
  grants into code-mode specifically for SWE-loop work. Trade-off:
  cleanest conceptual separation but a new top-level cap type.

**Maintainer's call:** design revision — the protocol for handing a
cloned-repo `Git` cap into code-mode needs to be specified before
implementation can proceed.

---

### Gap 2: No worktree-add operation on the EndoGit surface

**Where in the design.** `packages/exo-git/src/git.js` line 308
(`worktree()` method) and the full `GitBackend` typedef (no
`addWorktree` / `worktreeAdd` method).

**Verbatim quote.** Job spec Gap 2: "`worktree()` (`packages/exo-git/src/git.js:308`)
returns the *current* worktree authority; nothing *mints* a new worktree."
Confirmed against code: `worktree()` is `return worktreeAuthority()`,
which returns the `EndoMount` the cap was constructed over. There is no
`worktreeAdd` on `GitBackend`, `EndoGit`, or `NativeGitBackend`.

**What's needed to implement.** A primitive that runs `git worktree add
<path> <branch>` and returns a new `(Git, Mount)` pair bound to the
freshly-created linked worktree, confined to that path.

**Candidate resolutions.**
- **A.** Add `addLinkedWorktree(branch, destMount, petName)` to the
  `EndoGit` exo, backed by a new `GitBackend.addLinkedWorktree` method
  on the native backend. Returns a new `Git` cap over `destMount`.
  Trade-off: keeps the worktree operation on the cap that owns the
  common git dir; but the `destMount` cannot be minted by code-mode
  (see Gap 1's provisioning connection).
- **B.** Delegate worktree provisioning to `EndoHost.provideLinkedWorktree(gitCap, destMount, branch, petName)`.
  The host mints the linked worktree and returns a fresh `Git` cap.
  Trade-off: consistent pattern with `provideGit`; explicit host
  authority over the `git worktree add` operation.
- **C.** Treat linked worktrees as a deferred concern: the SWE-loop
  probe can be scoped to single-worktree repos (no `git worktree add`
  needed) and worktree support added later. Trade-off: reduces the
  scope of the initial design job but defers a real user need.

**Maintainer's call:** design revision — whether worktree-add is in
scope for D2 or deferred is a design decision.

---

### Gap 3: No exec/spawn power in code-mode

**Where in the design.** `packages/agentry/src/execute/preset.js`
`CodeModePowers` typedef (no `exec` or `spawn` field);
`packages/genie/src/tools/spawner.js` (`Spawner` type + `makeHostSpawner`);
`packages/genie/src/tools/sandbox-spawner.js` (`makeSandboxSpawner`).

**Verbatim quote.** Job spec Gap 3: "no subprocess power is granted into
code-mode. Subprocess machinery exists (`packages/platform/src/proc.js`
`systemCapture`; the genie `Spawner` seam in
`packages/genie/src/tools/spawner.js` + `sandbox-spawner.js`,
cwd-confined) but is not a code-mode lexical cap. `yarn install` and
`npm test` both need this. What is the confinement boundary and program
allow-list?"

Confirmed: `CodeModePowers` has `workspace` and `git` only. The
genie's `Spawner` interface is a well-defined seam (`spawn(argv, opts):
Promise<ProcessLike>`) but it is not wired into `makeCodeModeAgent` or
`makeCodeModeGlobals`. The `SandboxHandle.spawn` route (via
`makeSandboxSpawner`) has a tighter confinement boundary (bwrap/podman
slice, cwd confined to `/workspace`) but also lives entirely in genie.

**What's needed to implement.** A code-mode `exec` power whose type
is a lexically-bound `Spawner` (or an exo wrapping one), along with:
(a) a program allow-list decision (which programs are permitted: only
`yarn`/`npm`? any PATH-resolved binary? only a closed list?),
(b) a cwd confinement decision (must cwd stay within the workspace
mount root?), and (c) a policy on stdout/stderr capture size limits.

**Candidate resolutions.**
- **A.** Add `exec` as a new `CodeModePower` field backed by the
  genie's `makeHostSpawner` (or `makeSandboxSpawner` when the genie
  is daemon-hosted). The allow-list and cwd confinement are policy
  fields on the power itself, parallel to `gitMode: 'readOnly'`.
  Trade-off: direct, minimal surface; requires the allow-list be
  designed (an allow-list of `['yarn', 'npm', 'node']` is a starting
  point but is not specified today).
- **B.** Introduce a separate `ExecCap` exo (daemon-minted) that wraps
  a `Spawner` and enforces the allow-list + cwd confinement at the
  exo guard level, similar to how `GitRemote` enforces the push-refspec
  policy at the exo level. The code-mode agent receives an `exec`
  lexical binding pointing at this `ExecCap`. Trade-off: cleaner ocap
  discipline; more design work (new exo type, new formula type, new
  daemon host method).
- **C.** Scope the initial SWE loop to operations that do NOT require
  subprocess spawn (file edit + git add/commit only; no install or test
  run). Defer exec to a follow-up design. Trade-off: the loop is
  incomplete (cannot verify `yarn install` or run tests through the cap
  boundary) but the clone/edit/commit/push core can be specced first.

**Maintainer's call:** design revision — the D1 design job should
specify the `ExecCap` or `Spawner`-as-power shape, the allow-list,
and the cwd confinement boundary.

---

### Gap 4: GitRemote not accessible as a code-mode lexical power; local-transport URL blocked by default

**Where in the design.** `packages/exo-git/src/git-remote.js`
`normalizeRemoteUrl` (line 156–178); `packages/daemon/src/host.js`
`provideGitRemote` (line 502–540); `packages/agentry/src/execute/preset.js`
`CodeModePowers` (no `remote` field).

**Verbatim quote.** Job spec Gap 4: "`GitRemote.push()` and its native
backend exist but are gated by a daemon-minted, audience-bound credential
cap (`packages/exo-git/src/git-credential.js:159`) and are not exposed
as a code-mode power. How does a code-mode agent acquire a matching-audience
credential and reach `push()`?"

Confirmed: `provideGitRemote(gitCap, petName, opts)` is a `Host`-side
method (not a code-mode power). For `https:` URLs it requires a
daemon-minted credential. For `file:` URLs (local bare remote),
`normalizeRemoteUrl` rejects unless `allowLocalFileTransport: true` is
set in the policy AND the `GitRemote` cap is in the code-mode lexical
environment (it is not). The code-mode `CodeModePowers` has no `remote`
field.

**What's needed to implement.** The daemon must mint a `GitRemote` cap
pre-configured for the local bare-remote URL (with
`allowLocalFileTransport: true` and `allowedDirections: ['push']`) and
introduce it as a lexical power named (say) `remote` into the code-mode
`Compartment`. For a local bare remote the credential is absent
(`requiresCredential` is false when the URL is `file:`), so the
credential gap is not in the path for the local-bare-remote case.

**Candidate resolutions.**
- **A.** Add `remote` as a new `CodeModePower` field, type `GitRemote`
  (daemon-minted). Wire it in `makeCodeModeGlobals` / `resolveConfiguredPowers`
  parallel to `git` and `workspace`. The daemon caller mints the `GitRemote`
  via `provideGitRemote(gitCap, 'remote', { name: 'origin', url: 'file:///...', allowLocalFileTransport: true, allowedDirections: ['push'], pushRefspecs: [...] })`
  and passes the cap as `powers.remote`. Trade-off: straightforward;
  requires the daemon caller to pre-configure the policy (branch allow-list
  and push refspecs).
- **B.** Introduce a `GitRemoteFactory` cap (daemon-minted) that the
  code-mode agent calls with a policy record to mint its own `GitRemote`.
  Trade-off: gives the agent more control; widens the authority surface
  (the agent can mint remotes with arbitrary policies within the factory's
  constraints).
- **C.** Allow the code-mode agent to self-configure the local bare remote
  by granting a narrowed `GitRemoteController` into code-mode to update
  the push refspecs dynamically. Trade-off: most flexible, but the
  `GitRemoteController` is a host-private companion and its public-surface
  grant into code-mode would need a new wrapper exo.

**Maintainer's call:** design revision — the D2 design job should specify
the `remote` power shape (Option A) or the factory alternative (Option B),
including how the local-bare-remote URL reaches the daemon at cap-mint time.

---

### Gap 5: EndoMountEntry ergonomics confirmed; no reconciliation needed

**Where in the design.** `packages/daemon/src/mount.js` `EndoMountEntry`
exo (line 977+); `packages/agentry/src/execute/preset.js` `workspace` power.

**Verbatim quote.** Job spec Gap 5: "Confirm the ergonomic write path in
code-mode (create-at-missing-path) and whether `EndoMountEntry` needs
reconciliation here, or whether the `workspace` cap already suffices."

**Finding (not a gap).** `EndoMount.writeText(pathArg, content)` calls
`makePath(parent)` internally before the write, so creating a file at a
path whose parent directories do not yet exist works correctly without any
extra step. `EndoMountEntry` is an inert descriptor (path metadata only;
no I/O authority) and does NOT need reconciliation for file-write. The
`workspace` cap's `writeText` / `makeFile` / `makeDirectory` surface is
sufficient for the create/edit step. The `probeFileWriteSurface` skeleton
function confirms this composes.

**Candidate resolutions.** None required.

**Maintainer's call:** implementation-time choice — confirmed, no design
revision needed for this item.

---

## Skeleton implemented

- `probeWorktreeAuthority` — `E(git).worktree()` returns the current
  worktree `EndoMount` cleanly. Demonstrates the clear read-path; also
  confirms the Gap 2 boundary (stops at the worktree-add call).
- `probeFileWrite` / `probeFileRead` — `E(workspace).writeText(path, content)`
  and `E(workspace).readText(path)` compose. Parent dirs auto-created.
- `probeAddCommit` — `E(mount).entry(segments)` mints an `EndoMountEntry`;
  `E(git).add([entry])` stages it; `E(git).commit(message)` returns a
  `GitCommit`. Full pipeline confirmed to compose.
- `probeFileWriteSurface` — confirms `EndoMountEntry` is an inert
  descriptor and that `writeText` is the ergonomic write path (Gap 5
  closed).
- Smoke tests: 8 tests pass (`packages/agentry/test/swe-loop-probe.test.js`).

## Skeleton not implemented

- `probeClone` — blocked at Gap 1. No `clone` method on any cap surface.
- Linked-worktree provision — blocked at Gap 2. No `addLinkedWorktree`
  on `EndoGit` or `EndoHost`.
- `probeExec` — blocked at Gap 3. No `exec`/`spawn` code-mode power.
- `probePush` — blocked at Gap 4. No `GitRemote` lexical power in
  code-mode; `allowLocalFileTransport` requires pre-configured policy.

## Recommendations to design author

**Resolve before implementation can proceed (design revision required):**

- **Gap 1 (clone)** and **Gap 2 (worktree-add)** are structurally connected:
  both require the daemon to provision a new `(Mount, Git)` pair and
  introduce it into the code-mode agent's lexical environment. The D2
  design job (clone+worktree provisioning) should specify the host-side
  primitive (`EndoHost.cloneRepo` or `GitProvisioner` cap) and how the
  resulting cap pair reaches code-mode as a named power. Until D2 is
  specced, Steps 1 and 2 of the loop cannot be implemented.
- **Gap 3 (exec/spawn)** is the critical enabler for `yarn install` and
  test-run steps. The D1 design job (exec/Spawner power) must specify
  the allow-list (which programs), cwd confinement (must stay within
  workspace mount root), and the code-mode power shape (Option A
  `Spawner`-as-power vs Option B `ExecCap` exo). Without D1, Steps 3
  and 5 of the loop cannot be implemented.
- **Gap 4 (push)** is the final step and the only one that requires a
  local-bare-remote `GitRemote` cap in code-mode. The D2 job should also
  specify how the `GitRemote` pre-configured for `file:` transport is
  introduced as a lexical power (Option A) or whether a factory is
  preferred (Option B). Without this, Step 6 cannot be implemented.

**Can be resolved at implementation time once gaps 1-4 are addressed
(implementation-time choice):**

- **Gap 5 (file-write surface)** is confirmed closed. `writeText` on
  the `workspace` mount is the ergonomic write path for file create/edit;
  no design change needed.

In summary: the file-edit and git-add/commit sub-loop (Steps 4 and 5)
compose today. The clone, worktree-add, exec, and push steps (Steps 1,
2, 3, and 6) are all blocked on capability gaps that the D1 and D2
design jobs must address before implementation can proceed.