### PR TITLE
test(agent-tools): file:// git round-trip and SWE-loop integration over exo-git

### DIFF
--- a/packages/agent-tools/test/git-clone-loop.test.js
+++ b/packages/agent-tools/test/git-clone-loop.test.js
@@ -1,0 +1,163 @@
+// @ts-check
+
+// Establish a SES perimeter (provides the `harden` global).
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { E } from '@endo/far';
+import { makeGitRemote } from '@endo/exo-git';
+
+import {
+  seedBareRemote,
+  composeGitOverWorktree,
+} from './git-remote-fixtures.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Host-stand-in clone: run an OS-level `git clone` of the bare remote into a
+ * fresh working directory, then compose a mount -> Git over that cloned
+ * worktree. This is the deliberate degenerate form of a not-yet-built host
+ * clone capability: today the operator clones at the host, then wraps the
+ * result; once that capability lands this bootstrap is the only part that
+ * changes.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} remoteRoot
+ */
+const hostCloneStandIn = async (t, remoteRoot) => {
+  const cloneParent = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'git-clone-loop-host-'),
+  );
+  t.teardown(() =>
+    fs.promises.rm(cloneParent, { recursive: true, force: true }),
+  );
+  const root = path.join(cloneParent, 'worktree');
+  await execFileAsync('git', ['clone', remoteRoot, root]);
+  return composeGitOverWorktree(root);
+};
+
+test('host-clone -> edit (incl. new path) -> add -> commit -> push -> re-fetch round-trips over file://', async t => {
+  t.timeout(30_000);
+  // The full local SWE loop against a real file:// bare remote, bootstrapped
+  // from a host-stand-in clone (no new capability). The producer worktree is
+  // an OS-level clone of the bare remote; the loop edits an existing file and
+  // a path that does not yet exist, commits through the exo Git, and pushes
+  // through the exo GitRemote. A second, independent consumer clone re-fetches
+  // the pushed branch, and raw `git cat-file` proves the commit and the new
+  // blob are materially present in the consumer's object store — the same
+  // object-presence bar the push/fetch round-trip set, now drawn around the
+  // whole loop.
+  const remoteRoot = await seedBareRemote(t);
+  const remoteUrl = pathToFileURL(remoteRoot).href;
+
+  // 1 + 2. Host-stand-in bootstrap.
+  const host = await hostCloneStandIn(t, remoteRoot);
+  const { remote } = makeGitRemote({
+    git: host.git,
+    name: 'origin',
+    policy: {
+      url: remoteUrl,
+      allowLocalFileTransport: true,
+      allowedDirections: ['push'],
+      fetchRefspecs: [],
+      pushRefspecs: ['refs/heads/agent/*:refs/heads/agent/*'],
+    },
+  });
+
+  // 3. Drive the loop on a fresh branch.
+  await E(host.git).createBranch('agent/loop', { switchAfterCreate: true });
+
+  // Edit an existing file...
+  const editedReadme = 'seed\nedited by agent\n';
+  const readmeEntry = await E(host.mount).entry(['README.md']);
+  await E(host.mount).writeText(readmeEntry, editedReadme);
+
+  // ...and create a path that does not yet exist (a nested one, to exercise
+  // parent-directory creation on the way to the new blob).
+  const freshContent = 'fresh agent file\n';
+  const freshEntry = await E(host.mount).entry(['agent', 'notes.md']);
+  await E(host.mount).writeText(freshEntry, freshContent);
+
+  await E(host.git).add([readmeEntry, freshEntry]);
+  await E(host.git).commit('test: agent SWE-loop commit over host clone');
+
+  const pushResult = await E(remote).push({
+    source: 'refs/heads/agent/loop',
+    destination: 'refs/heads/agent/loop',
+    setUpstream: true,
+  });
+  const pushedRefs = [...pushResult.updatedRefs];
+  t.is(pushedRefs.length, 1);
+  const pushedOid = pushedRefs[0].local.oid;
+  t.regex(pushedOid, /^[0-9a-f]{40}$/u);
+  t.like(pushedRefs[0], {
+    remote: 'refs/heads/agent/loop',
+    result: 'created',
+  });
+
+  // 4. Re-fetch into a second, independent consumer clone of the same bare
+  // remote (unrelated to the host clone). A fresh clone materializes every
+  // remote branch as a remote-tracking ref, so the pushed branch and its
+  // objects arrive here.
+  const consumerParent = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'git-clone-loop-consumer-'),
+  );
+  t.teardown(() =>
+    fs.promises.rm(consumerParent, { recursive: true, force: true }),
+  );
+  const consumerRoot = path.join(consumerParent, 'worktree');
+  await execFileAsync('git', ['clone', remoteRoot, consumerRoot]);
+
+  // The pushed commit must resolve in the consumer to the same oid.
+  const { stdout: consumerOid } = await execFileAsync(
+    'git',
+    ['rev-parse', 'refs/remotes/origin/agent/loop'],
+    { cwd: consumerRoot },
+  );
+  t.is(consumerOid.trim(), pushedOid);
+
+  // The commit object is materially present, not just a dangling ref.
+  const { stdout: objectType } = await execFileAsync(
+    'git',
+    ['cat-file', '-t', pushedOid],
+    { cwd: consumerRoot },
+  );
+  t.is(objectType.trim(), 'commit');
+
+  // The newly created path's blob is present by object id and recovers its
+  // bytes verbatim.
+  const { stdout: freshBlobOid } = await execFileAsync(
+    'git',
+    ['rev-parse', `${pushedOid}:agent/notes.md`],
+    { cwd: consumerRoot },
+  );
+  const { stdout: freshBlobType } = await execFileAsync(
+    'git',
+    ['cat-file', '-t', freshBlobOid.trim()],
+    { cwd: consumerRoot },
+  );
+  t.is(freshBlobType.trim(), 'blob');
+  const { stdout: freshBlob } = await execFileAsync(
+    'git',
+    ['cat-file', '-p', `${pushedOid}:agent/notes.md`],
+    { cwd: consumerRoot },
+  );
+  t.is(freshBlob, freshContent);
+
+  // The edited existing file round-trips its new contents too.
+  const { stdout: readmeBlob } = await execFileAsync(
+    'git',
+    ['cat-file', '-p', `${pushedOid}:README.md`],
+    { cwd: consumerRoot },
+  );
+  t.is(readmeBlob, editedReadme);
+});

--- a/packages/agent-tools/test/git-remote-fixtures.js
+++ b/packages/agent-tools/test/git-remote-fixtures.js
@@ -1,0 +1,146 @@
+// @ts-check
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { makeNativeGitBackend } from '@endo/git';
+import { makeGit } from '@endo/exo-git';
+import { makeMount, lineageOf } from '@endo/daemon/src/mount.js';
+import { makeFilePowers } from '@endo/daemon/src/daemon-node-powers.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Compose a `mount -> native-git backend -> Git` over an existing on-disk
+ * working tree. This is the shared bootstrap both round-trip tests repeat: the
+ * filesystem mount provides the data plane, the native backend the control
+ * plane, and `makeGit` mints the exo `Git` capability over the pair.
+ *
+ * @param {string} root absolute path to a git working tree
+ * @returns {{ git: ReturnType<typeof makeGit>, mount: ReturnType<typeof makeMount>, root: string }}
+ */
+export const composeGitOverWorktree = async root => {
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: root, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot: root });
+  await backend.assertRepositoryRoot();
+  const git = makeGit({ mount, backend, lineageOf });
+  return { git, mount, root };
+};
+
+/**
+ * Provision an empty git working tree at a tmp path with a single empty initial
+ * commit on `main`, then compose a `mount -> Git` over it. Used by the
+ * push/fetch round-trip that pushes from a freshly initialized local repo.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @returns {Promise<{ git: ReturnType<typeof makeGit>, mount: ReturnType<typeof makeMount>, root: string }>}
+ */
+export const provisionGitContext = async t => {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'git-remote-'));
+  t.teardown(() => fs.promises.rm(root, { recursive: true, force: true }));
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '--allow-empty',
+      '-m',
+      'init',
+    ],
+    { cwd: root },
+  );
+  return composeGitOverWorktree(root);
+};
+
+/**
+ * Clone an existing source working tree into a bare `file://` remote.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} sourceRepo absolute path to a non-bare source repository
+ * @returns {Promise<string>} absolute path to the bare remote
+ */
+export const provisionBareRemote = async (t, sourceRepo) => {
+  const remoteParent = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'git-remote-bare-'),
+  );
+  t.teardown(() =>
+    fs.promises.rm(remoteParent, { recursive: true, force: true }),
+  );
+  const remoteRoot = path.join(remoteParent, 'remote.git');
+  await execFileAsync('git', ['clone', '--bare', sourceRepo, remoteRoot]);
+  return remoteRoot;
+};
+
+/**
+ * Seed a bare `file://` remote with a real commit on `main`, from scratch: init
+ * a fresh source repo with a single real file commit, then clone it bare. Used
+ * by the clone-loop test, which needs material content (not just an empty
+ * commit) on the remote so a host clone has a file to edit.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @returns {Promise<string>} absolute path to the bare remote
+ */
+export const seedBareRemote = async t => {
+  const seedRoot = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'git-clone-loop-seed-'),
+  );
+  t.teardown(() => fs.promises.rm(seedRoot, { recursive: true, force: true }));
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: seedRoot });
+  await fs.promises.writeFile(path.join(seedRoot, 'README.md'), 'seed\n');
+  await execFileAsync('git', ['add', 'README.md'], { cwd: seedRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'seed'],
+    { cwd: seedRoot },
+  );
+
+  const remoteParent = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'git-clone-loop-bare-'),
+  );
+  t.teardown(() =>
+    fs.promises.rm(remoteParent, { recursive: true, force: true }),
+  );
+  const remoteRoot = path.join(remoteParent, 'remote.git');
+  await execFileAsync('git', ['clone', '--bare', seedRoot, remoteRoot]);
+  return remoteRoot;
+};
+
+/**
+ * Advance the bare remote's `main` by one real commit, returning the new head
+ * oid. Clones the remote, commits a new file, pushes, and reports the oid the
+ * remote now points at, so a fetch/pull round-trip can assert against it.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {string} remoteRoot absolute path to a bare remote
+ * @returns {Promise<string>} the new `main` head oid
+ */
+export const advanceRemoteMain = async (t, remoteRoot) => {
+  const cloneRoot = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'git-remote-upstream-'),
+  );
+  t.teardown(() => fs.promises.rm(cloneRoot, { recursive: true, force: true }));
+  await execFileAsync('git', ['clone', remoteRoot, cloneRoot]);
+  await fs.promises.writeFile(
+    path.join(cloneRoot, 'upstream.txt'),
+    'upstream\n',
+  );
+  await execFileAsync('git', ['add', 'upstream.txt'], { cwd: cloneRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'upstream'],
+    { cwd: cloneRoot },
+  );
+  await execFileAsync('git', ['push', 'origin', 'main'], { cwd: cloneRoot });
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'main'], {
+    cwd: cloneRoot,
+  });
+  return stdout.trim();
+};

--- a/packages/agent-tools/test/git-remote-fixtures.js
+++ b/packages/agent-tools/test/git-remote-fixtures.js
@@ -20,7 +20,7 @@ const execFileAsync = promisify(execFile);
  * plane, and `makeGit` mints the exo `Git` capability over the pair.
  *
  * @param {string} root absolute path to a git working tree
- * @returns {{ git: ReturnType<typeof makeGit>, mount: ReturnType<typeof makeMount>, root: string }}
+ * @returns {Promise<{ git: ReturnType<typeof makeGit>, mount: ReturnType<typeof makeMount>, root: string }>}
  */
 export const composeGitOverWorktree = async root => {
   const filePowers = makeFilePowers({ fs, path });

--- a/packages/agent-tools/test/git-remote-roundtrip.test.js
+++ b/packages/agent-tools/test/git-remote-roundtrip.test.js
@@ -1,0 +1,154 @@
+// @ts-check
+
+// Establish a SES perimeter (provides the `harden` global).
+// eslint-disable-next-line import/order
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+import { E } from '@endo/far';
+import { makeGitRemote } from '@endo/exo-git';
+
+import {
+  provisionGitContext,
+  provisionBareRemote,
+  advanceRemoteMain,
+} from './git-remote-fixtures.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * End-to-end proof that the exo `Git` + `GitRemote` capabilities move real git
+ * objects over a `file://` remote through the bounded native data plane. A
+ * freshly initialized local repo fetches, fast-forward pulls, and pushes a new
+ * branch against a real bare remote; the assertions check the structured
+ * fetch/pull/push results, the materialized working-tree contents, the upstream
+ * tracking config the push set, and the controller's audit trail.
+ */
+test('GitRemote fetch / pull / push use the bounded native data plane', async t => {
+  const { git, mount, root } = await provisionGitContext(t);
+  const remoteRoot = await provisionBareRemote(t, root);
+  const remoteUrl = pathToFileURL(remoteRoot).href;
+  const remoteHead = await advanceRemoteMain(t, remoteRoot);
+
+  const { remote, controller } = makeGitRemote({
+    git,
+    name: 'origin',
+    policy: {
+      url: remoteUrl,
+      allowLocalFileTransport: true,
+      allowedDirections: ['fetch', 'push'],
+      fetchRefspecs: ['+refs/heads/main:refs/remotes/origin/main'],
+      pushRefspecs: ['refs/heads/agent/*:refs/heads/agent/*'],
+      allowDelete: true,
+    },
+  });
+
+  const fetchResult = await E(remote).fetch({ prune: true });
+  const fetchUpdates = [...fetchResult.updatedRefs];
+  t.is(fetchUpdates.length, 1);
+  t.deepEqual(fetchUpdates[0], {
+    local: {
+      name: 'refs/remotes/origin/main',
+      kind: 'branch',
+      oid: remoteHead,
+    },
+    remote: 'refs/heads/main',
+    result: 'created',
+  });
+  const fetched = await E(git).revParse('refs/remotes/origin/main');
+  t.is(fetched.oid, remoteHead);
+
+  const pullResult = await E(remote).pull({
+    branch: 'refs/remotes/origin/main',
+    strategy: 'ff-only',
+  });
+  t.is(pullResult.integration, 'fast-forward');
+  t.deepEqual(
+    [...pullResult.fetch.updatedRefs],
+    [
+      {
+        local: {
+          name: 'refs/remotes/origin/main',
+          kind: 'branch',
+          oid: remoteHead,
+        },
+        remote: 'refs/heads/main',
+        result: 'up-to-date',
+      },
+    ],
+  );
+  t.is(await E(mount).readText(['upstream.txt']), 'upstream\n');
+
+  const upToDatePullResult = await E(remote).pull({
+    branch: 'refs/remotes/origin/main',
+    strategy: 'ff-only',
+  });
+  t.is(upToDatePullResult.integration, 'up-to-date');
+
+  await E(git).createBranch('agent/topic', { switchAfterCreate: true });
+  const note = await E(mount).entry(['agent.txt']);
+  await E(mount).writeText(note, 'agent\n');
+  await E(git).add([note]);
+  await E(git).commit('test: agent branch');
+  const pushResult = await E(remote).push({
+    source: 'refs/heads/agent/topic',
+    destination: 'refs/heads/agent/topic',
+    setUpstream: true,
+  });
+  const { stdout: pushedRef } = await execFileAsync(
+    'git',
+    ['show-ref', '--hash', 'refs/heads/agent/topic'],
+    { cwd: remoteRoot },
+  );
+  const pushedOid = pushedRef.trim();
+  t.regex(pushedOid, /^[0-9a-f]{40}$/u);
+  t.deepEqual(
+    [...pushResult.updatedRefs],
+    [
+      {
+        local: {
+          name: 'refs/heads/agent/topic',
+          kind: 'branch',
+          oid: pushedOid,
+        },
+        remote: 'refs/heads/agent/topic',
+        result: 'created',
+      },
+    ],
+  );
+  const { stdout: upstreamRemote } = await execFileAsync(
+    'git',
+    ['config', '--get', 'branch.agent/topic.remote'],
+    { cwd: root },
+  );
+  const { stdout: upstreamMerge } = await execFileAsync(
+    'git',
+    ['config', '--get', 'branch.agent/topic.merge'],
+    { cwd: root },
+  );
+  t.is(upstreamRemote.trim(), remoteUrl);
+  t.is(upstreamMerge.trim(), 'refs/heads/agent/topic');
+
+  const audit = await E(controller).audit();
+  t.deepEqual(
+    audit.map(event => event.type),
+    ['create', 'fetch', 'pull', 'pull', 'push'],
+  );
+  t.like(audit[1], { type: 'fetch', outcome: 'ok' });
+  t.like(audit[2], {
+    type: 'pull',
+    outcome: 'ok',
+    integration: 'fast-forward',
+  });
+  t.like(audit[3], {
+    type: 'pull',
+    outcome: 'ok',
+    integration: 'up-to-date',
+  });
+  t.like(audit[4], { type: 'push', outcome: 'ok' });
+  t.deepEqual([...audit[4].updatedRefs], [...pushResult.updatedRefs]);
+});

--- a/packages/daemon/test/git-remote.test.js
+++ b/packages/daemon/test/git-remote.test.js
@@ -80,33 +80,6 @@ const provisionBareRemote = async (t, sourceRepo) => {
   return remoteRoot;
 };
 
-/**
- * @param {import('ava').ExecutionContext} t
- * @param {string} remoteRoot
- */
-const advanceRemoteMain = async (t, remoteRoot) => {
-  const cloneRoot = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), 'git-remote-upstream-'),
-  );
-  t.teardown(() => fs.promises.rm(cloneRoot, { recursive: true, force: true }));
-  await execFileAsync('git', ['clone', remoteRoot, cloneRoot]);
-  await fs.promises.writeFile(
-    path.join(cloneRoot, 'upstream.txt'),
-    'upstream\n',
-  );
-  await execFileAsync('git', ['add', 'upstream.txt'], { cwd: cloneRoot });
-  await execFileAsync(
-    'git',
-    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'upstream'],
-    { cwd: cloneRoot },
-  );
-  await execFileAsync('git', ['push', 'origin', 'main'], { cwd: cloneRoot });
-  const { stdout } = await execFileAsync('git', ['rev-parse', 'main'], {
-    cwd: cloneRoot,
-  });
-  return stdout.trim();
-};
-
 test('makeGitRemote produces a paired (remote, controller) facet', async t => {
   const { git } = await provisionGitContext(t);
   const { remote, controller } = makeGitRemote({
@@ -621,139 +594,11 @@ test('GitRemoteController.revoke during in-flight pull aborts before local integ
   t.like(audit[2], { type: 'pull', outcome: 'error' });
 });
 
-test('GitRemote fetch / pull / push use the bounded native data plane', async t => {
-  const { git, mount, root } = await provisionGitContext(t);
-  const remoteRoot = await provisionBareRemote(t, root);
-  const remoteUrl = pathToFileURL(remoteRoot).href;
-  const remoteHead = await advanceRemoteMain(t, remoteRoot);
-
-  const { remote, controller } = makeGitRemote({
-    git,
-    name: 'origin',
-    policy: {
-      url: remoteUrl,
-      allowLocalFileTransport: true,
-      allowedDirections: ['fetch', 'push'],
-      fetchRefspecs: ['+refs/heads/main:refs/remotes/origin/main'],
-      pushRefspecs: ['refs/heads/agent/*:refs/heads/agent/*'],
-      allowDelete: true,
-    },
-  });
-
-  const fetchResult = await E(remote).fetch({ prune: true });
-  const fetchUpdates = [...fetchResult.updatedRefs];
-  t.is(fetchUpdates.length, 1);
-  t.deepEqual(fetchUpdates[0], {
-    local: {
-      name: 'refs/remotes/origin/main',
-      kind: 'branch',
-      oid: remoteHead,
-    },
-    remote: 'refs/heads/main',
-    result: 'created',
-  });
-  const fetched = await E(git).revParse('refs/remotes/origin/main');
-  t.is(fetched.oid, remoteHead);
-
-  const pullResult = await E(remote).pull({
-    branch: 'refs/remotes/origin/main',
-    strategy: 'ff-only',
-  });
-  t.is(pullResult.integration, 'fast-forward');
-  t.deepEqual(
-    [...pullResult.fetch.updatedRefs],
-    [
-      {
-        local: {
-          name: 'refs/remotes/origin/main',
-          kind: 'branch',
-          oid: remoteHead,
-        },
-        remote: 'refs/heads/main',
-        result: 'up-to-date',
-      },
-    ],
-  );
-  t.is(await E(mount).readText(['upstream.txt']), 'upstream\n');
-
-  const upToDatePullResult = await E(remote).pull({
-    branch: 'refs/remotes/origin/main',
-    strategy: 'ff-only',
-  });
-  t.is(upToDatePullResult.integration, 'up-to-date');
-
-  await E(git).createBranch('agent/topic', { switchAfterCreate: true });
-  const note = await E(mount).entry(['agent.txt']);
-  await E(mount).writeText(note, 'agent\n');
-  await E(git).add([note]);
-  await E(git).commit('test: agent branch');
-  const pushResult = await E(remote).push({
-    source: 'refs/heads/agent/topic',
-    destination: 'refs/heads/agent/topic',
-    setUpstream: true,
-  });
-  const { stdout: pushedRef } = await execFileAsync(
-    'git',
-    ['show-ref', '--hash', 'refs/heads/agent/topic'],
-    { cwd: remoteRoot },
-  );
-  const pushedOid = pushedRef.trim();
-  t.regex(pushedOid, /^[0-9a-f]{40}$/u);
-  t.deepEqual(
-    [...pushResult.updatedRefs],
-    [
-      {
-        local: {
-          name: 'refs/heads/agent/topic',
-          kind: 'branch',
-          oid: pushedOid,
-        },
-        remote: 'refs/heads/agent/topic',
-        result: 'created',
-      },
-    ],
-  );
-  const { stdout: upstreamRemote } = await execFileAsync(
-    'git',
-    ['config', '--get', 'branch.agent/topic.remote'],
-    { cwd: root },
-  );
-  const { stdout: upstreamMerge } = await execFileAsync(
-    'git',
-    ['config', '--get', 'branch.agent/topic.merge'],
-    { cwd: root },
-  );
-  t.is(upstreamRemote.trim(), remoteUrl);
-  t.is(upstreamMerge.trim(), 'refs/heads/agent/topic');
-
-  const audit = await E(controller).audit();
-  t.deepEqual(
-    audit.map(event => event.type),
-    ['create', 'fetch', 'pull', 'pull', 'push'],
-  );
-  t.like(audit[1], { type: 'fetch', outcome: 'ok' });
-  t.like(audit[2], {
-    type: 'pull',
-    outcome: 'ok',
-    integration: 'fast-forward',
-  });
-  t.like(audit[3], {
-    type: 'pull',
-    outcome: 'ok',
-    integration: 'up-to-date',
-  });
-  t.like(audit[4], { type: 'push', outcome: 'ok' });
-  t.deepEqual([...audit[4].updatedRefs], [...pushResult.updatedRefs]);
-});
-
 test('GitRemote push round-trips to an independent fetcher over file://', async t => {
   t.timeout(2000);
   // Producer worktree pushes a branch to a real file:// bare remote; a second,
   // independent consumer worktree fetches that same branch back and recovers
-  // the full commit object. This closes the loop the sibling fetch/pull/push
-  // test leaves open: that test verifies the push landed on the bare repo via
-  // show-ref, but never re-fetches the pushed branch into a fresh consumer to
-  // prove the objects (commit + tree + blob) actually transfer back out.
+  // the full commit object.
   const producer = await provisionGitContext(t);
   const remoteRoot = await provisionBareRemote(t, producer.root);
   const remoteUrl = pathToFileURL(remoteRoot).href;


### PR DESCRIPTION
## Description

This PR adds `file://` git integration coverage to `@endo/agent-tools` for the exo-git capabilities used by local agent workflows. The new tests exercise a real bare remote through the `mount -> native-git backend -> Git -> GitRemote` composition and share their setup through `packages/agent-tools/test/git-remote-fixtures.js`.

- `test/git-remote-roundtrip.test.js` covers fetch, fast-forward pull, and push against a bare remote, including structured operation results, materialized working-tree contents, upstream tracking config, and controller audit records.
- `test/git-clone-loop.test.js` covers a local SWE loop that starts from a host-side clone, edits an existing file, creates a nested new path, adds, commits, pushes through the exo, and re-fetches into an independent consumer clone. It verifies the resulting commit and blob contents by object id.

The daemon git-remote test keeps its credential, policy, controller, rejection, and independent-fetcher coverage. The bounded data-plane round-trip now lives with the agent-tools git integration tests where the shared fixture is reused by both new scenarios.

The host-side clone is a deliberate stand-in for a host clone capability being added separately. These tests exercise `file://` only, with no HTTPS or credentials.

### Security Considerations

The PR does not add production authority or new runtime paths. The new coverage uses temporary local repositories and `file://` remotes inside tests to exercise existing git capabilities.

### Scaling Considerations

The new tests create small temporary repositories and run local git commands. They add modest package test time for `@endo/agent-tools` but do not affect runtime resource use.

### Documentation Considerations

No user-facing docs are changed. 

### Testing Considerations

- `yarn workspace @endo/agent-tools lint`
- `yarn workspace @endo/agent-tools test`: 50 passing.
- `yarn prettier --check packages/agent-tools/test/git-remote-fixtures.js`
- `yarn docs`: 0 errors, existing documentation warnings only.
- `yarn lint`: 0 errors, existing ESLint warnings only.

### Compatibility Considerations

None, test-only.

### Upgrade Considerations

None
