### PR TITLE
feat(daemon): map registry snapshots to compartments

### DIFF
--- a/.changeset/snapshot-mapper-extension.md
+++ b/.changeset/snapshot-mapper-extension.md
@@ -1,0 +1,5 @@
+---
+'@endo/compartment-mapper': minor
+---
+
+Expose `mapPackageDescriptors` for callers that provide their own dependency-location resolver instead of a physical `node_modules` tree.

--- a/packages/compartment-mapper/index.js
+++ b/packages/compartment-mapper/index.js
@@ -15,7 +15,10 @@ export {
   importArchive,
 } from './src/import-archive.js';
 export { search } from './src/search.js';
-export { compartmentMapForNodeModules } from './src/node-modules.js';
+export {
+  compartmentMapForNodeModules,
+  mapPackageDescriptors,
+} from './src/node-modules.js';
 export {
   makeScript as makeBundle,
   writeScript as writeBundle,

--- a/packages/compartment-mapper/node-modules.js
+++ b/packages/compartment-mapper/node-modules.js
@@ -1,4 +1,4 @@
 // eslint-disable-next-line import/export -- just types
 export * from './src/types-external.js';
 
-export { mapNodeModules } from './src/node-modules.js';
+export { mapNodeModules, mapPackageDescriptors } from './src/node-modules.js';

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -460,6 +460,7 @@ const graphPackage = async (
   logicalPathGraph,
   {
     commonDependencyDescriptors = {},
+    dependencyLocationHook,
     log = noop,
     packageDependenciesHook,
     policy,
@@ -559,6 +560,7 @@ const graphPackage = async (
         {
           optional,
           commonDependencyDescriptors,
+          dependencyLocationHook,
           log,
           packageDependenciesHook,
           policy,
@@ -695,17 +697,21 @@ const gatherDependency = async (
   {
     optional = false,
     commonDependencyDescriptors = {},
+    dependencyLocationHook,
     log = noop,
     packageDependenciesHook,
     policy,
   } = {},
 ) => {
-  const dependency = await findPackage(
-    readDescriptor,
-    canonical,
-    packageLocation,
-    name,
-  );
+  const dependency =
+    (await dependencyLocationHook?.({
+      packageLocation,
+      dependencyName: name,
+      readDescriptor,
+      canonical,
+      log,
+    })) ??
+    (await findPackage(readDescriptor, canonical, packageLocation, name));
 
   if (dependency === undefined) {
     // allow the dependency to be missing if optional
@@ -732,6 +738,7 @@ const gatherDependency = async (
     logicalPathGraph,
     {
       commonDependencyDescriptors,
+      dependencyLocationHook,
       log,
       packageDependenciesHook,
       policy,
@@ -771,7 +778,7 @@ const graphPackages = async (
   languageOptions,
   strict,
   logicalPathGraph,
-  { log = noop, packageDependenciesHook, policy } = {},
+  { dependencyLocationHook, log = noop, packageDependenciesHook, policy } = {},
 ) => {
   const memo = create(null);
   /**
@@ -840,6 +847,7 @@ const graphPackages = async (
     logicalPathGraph,
     {
       commonDependencyDescriptors,
+      dependencyLocationHook,
       log,
       packageDependenciesHook,
       policy,
@@ -1360,6 +1368,7 @@ export const compartmentMapForNodeModules_ = async (
     unknownCanonicalNameHook,
     packageDataHook,
     packageDependenciesHook,
+    dependencyLocationHook,
     additionalLocations = [],
   } = options;
 
@@ -1399,7 +1408,7 @@ export const compartmentMapForNodeModules_ = async (
     languageOptions,
     strict,
     logicalPathGraph,
-    { log, policy, packageDependenciesHook },
+    { dependencyLocationHook, log, policy, packageDependenciesHook },
   );
 
   // Graph additional package locations that are not reachable from the entry's
@@ -1442,7 +1451,13 @@ export const compartmentMapForNodeModules_ = async (
       languageOptions,
       strict,
       logicalPathGraph,
-      { commonDependencyDescriptors: {}, log, packageDependenciesHook, policy },
+      {
+        commonDependencyDescriptors: {},
+        dependencyLocationHook,
+        log,
+        packageDependenciesHook,
+        policy,
+      },
     );
 
     if (additionalModules && graph[additionalLocation]) {
@@ -1586,3 +1601,9 @@ export const mapNodeModules = async (
  * @deprecated Use {@link mapNodeModules} instead.
  */
 export const compartmentMapForNodeModules = compartmentMapForNodeModules_;
+
+/**
+ * Lower-level package descriptor mapper for callers that provide their own
+ * dependency-location resolver instead of a physical node_modules tree.
+ */
+export const mapPackageDescriptors = compartmentMapForNodeModules_;

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -30,7 +30,8 @@ import type {
 } from './compartment-map-schema.js';
 import type { PackageDescriptor } from './node-modules.js';
 import type { SomePolicy } from './policy-schema.js';
-import type { HashFn, ReadFn, ReadPowers } from './powers.js';
+import type { MaybeReadDescriptorFn } from './internal.js';
+import type { CanonicalFn, HashFn, ReadFn, ReadPowers } from './powers.js';
 import type { LiteralUnion } from './typescript.js';
 
 export type { CanonicalName, PackageDescriptor };
@@ -94,6 +95,24 @@ export type PackageDependenciesHook = (params: {
   dependencies: Readonly<Set<CanonicalName>>;
   log: LogFn;
 }) => Partial<{ dependencies: Set<CanonicalName> }> | void;
+
+export type DependencyLocationHook = (params: {
+  packageLocation: FileUrlString;
+  dependencyName: string;
+  readDescriptor: MaybeReadDescriptorFn;
+  canonical: CanonicalFn;
+  log: LogFn;
+}) =>
+  | Promise<
+      | { packageLocation: FileUrlString; packageDescriptor: PackageDescriptor }
+      | undefined
+    >
+  | { packageLocation: FileUrlString; packageDescriptor: PackageDescriptor }
+  | undefined;
+
+export type DependencyLocationHookOption = {
+  dependencyLocationHook?: DependencyLocationHook | undefined;
+};
 
 /**
  * The `moduleSource` property value for {@link ModuleSourceHook}
@@ -305,7 +324,8 @@ export type MapNodeModulesHookOptions = {
 export type CompartmentMapForNodeModulesOptions = Omit<
   MapNodeModulesOptions,
   'conditions' | 'tags'
->;
+> &
+  DependencyLocationHookOption;
 
 /**
  * Options for `captureFromMap()`

--- a/packages/compartment-mapper/src/types/node-modules.ts
+++ b/packages/compartment-mapper/src/types/node-modules.ts
@@ -9,6 +9,7 @@ import type {
   LanguageForExtension,
 } from './compartment-map-schema.js';
 import type {
+  DependencyLocationHookOption,
   FileUrlString,
   LogOptions,
   PackageDependenciesHook,
@@ -86,6 +87,7 @@ export type PackageDependenciesHookOption = {
 export type GraphPackageOptions = LogOptions &
   PolicyOption &
   PackageDependenciesHookOption &
+  DependencyLocationHookOption &
   CommonDependencyDescriptorsOptions;
 
 /**
@@ -93,7 +95,8 @@ export type GraphPackageOptions = LogOptions &
  */
 export type GraphPackagesOptions = LogOptions &
   PolicyOption &
-  PackageDependenciesHookOption;
+  PackageDependenciesHookOption &
+  DependencyLocationHookOption;
 
 /**
  * Options for `gatherDependency()`
@@ -106,6 +109,7 @@ export type GatherDependencyOptions = {
   optional?: boolean | undefined;
 } & LogOptions &
   PackageDependenciesHookOption &
+  DependencyLocationHookOption &
   PolicyOption &
   CommonDependencyDescriptorsOptions;
 

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -23,6 +23,8 @@ import { makeEndoClient } from './src/client.js';
 
 // Reexports:
 export { makeEndoClient } from './src/client.js';
+export { mapSnapshot } from './src/map-snapshot.js';
+export { makeMountReadPowers } from './src/worker-import.js';
 
 const removePath = async removalPath => {
   return fs.promises

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -31,7 +31,9 @@
     "./pet-name.js": "./src/pet-name.js",
     "./type-guards.js": "./src/type-guards.js",
     "./src/interfaces.js": "./src/interfaces.js",
+    "./src/map-snapshot.js": "./src/map-snapshot.js",
     "./src/mount.js": "./src/mount.js",
+    "./src/worker-import.js": "./src/worker-import.js",
     "./src/daemon-node-powers.js": "./src/daemon-node-powers.js",
     "./package.json": "./package.json"
   },

--- a/packages/daemon/src/map-snapshot.js
+++ b/packages/daemon/src/map-snapshot.js
@@ -1,0 +1,249 @@
+// @ts-check
+/// <reference types="ses" />
+
+import { mapPackageDescriptors } from '@endo/compartment-mapper/node-modules.js';
+import { E } from '@endo/eventual-send';
+import { Fail, q } from '@endo/errors';
+
+import { makeMountReadPowers, packageLocationForKey } from './worker-import.js';
+
+/** @import { RegistryResolution } from './registry.js' */
+
+const textDecoder = new TextDecoder();
+
+export const entryPackageLocation = 'file:///';
+harden(entryPackageLocation);
+
+/**
+ * @param {string} version
+ * @returns {[number, number, number] | undefined}
+ */
+const parseVersion = version => {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (match === null) {
+    return undefined;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+/**
+ * @param {string} a
+ * @param {string} b
+ */
+const compareVersions = (a, b) => {
+  const aParts = parseVersion(a);
+  const bParts = parseVersion(b);
+  if (aParts === undefined || bParts === undefined) {
+    return a.localeCompare(b);
+  }
+  for (const index of [0, 1, 2]) {
+    const difference = aParts[index] - bParts[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return 0;
+};
+
+/**
+ * @param {string} version
+ * @param {string} range
+ */
+const satisfiesRange = (version, range) => {
+  const specifier = range.startsWith('workspace:') ? range.slice(10) : range;
+  if (specifier === '' || specifier === '*' || specifier === 'latest') {
+    return true;
+  }
+  if (specifier === '^' || specifier === '~') {
+    return true;
+  }
+  const versionParts = parseVersion(version);
+  if (versionParts === undefined) {
+    return version === specifier;
+  }
+  const [major, minor, patch] = versionParts;
+  const caretMatch = /^\^(\d+)(?:\.(\d+))?(?:\.(\d+))?$/.exec(specifier);
+  if (caretMatch !== null) {
+    const rangeMajor = Number(caretMatch[1]);
+    const rangeMinor = Number(caretMatch[2] || 0);
+    const rangePatch = Number(caretMatch[3] || 0);
+    return (
+      major === rangeMajor &&
+      (minor > rangeMinor || (minor === rangeMinor && patch >= rangePatch))
+    );
+  }
+  const majorMatch = /^(\d+)(?:\.x)?$/.exec(specifier);
+  if (majorMatch !== null) {
+    return major === Number(majorMatch[1]);
+  }
+  const exactParts = parseVersion(specifier);
+  if (exactParts !== undefined) {
+    return compareVersions(version, specifier) === 0;
+  }
+  return false;
+};
+
+/**
+ * @param {Record<string, string>[]} maps
+ * @param {string} dependencyName
+ */
+const dependencyRange = (maps, dependencyName) => {
+  for (const map of maps) {
+    const range = map[dependencyName];
+    if (range !== undefined) {
+      return range;
+    }
+  }
+  return undefined;
+};
+
+/** @param {string | undefined} entry */
+const normalizeEntry = entry => {
+  const moduleSpecifier = entry || './index.js';
+  if (
+    moduleSpecifier === '.' ||
+    moduleSpecifier.startsWith('./') ||
+    moduleSpecifier.startsWith('../')
+  ) {
+    return moduleSpecifier;
+  }
+  return `./${moduleSpecifier}`;
+};
+
+/**
+ * @param {object} args
+ * @param {unknown} args.registry
+ * @param {unknown} args.mount
+ * @param {string} [args.entry]
+ * @param {RegistryResolution} [args.resolution]
+ * @param {object} [args.resolveOptions]
+ * @param {object} [args.mapOptions]
+ */
+export const mapSnapshot = async ({
+  registry,
+  mount,
+  entry,
+  resolution: resolutionOption,
+  resolveOptions = {},
+  mapOptions = {},
+}) => {
+  const packageJsonBytes = await makeMountReadPowers({
+    entryMount: mount,
+    registry,
+    resolution: harden({
+      packagesByKey: {},
+      keys: [],
+      resolutionHash: 'sha256-empty',
+      diagnostics: harden({
+        unmetOptionals: [],
+        workspaceVersionMismatches: [],
+      }),
+    }),
+  }).read('file:///package.json');
+  const packageDescriptor = JSON.parse(textDecoder.decode(packageJsonBytes));
+  const resolution =
+    resolutionOption ||
+    (await E(/** @type {any} */ (registry)).resolve(
+      packageJsonBytes,
+      resolveOptions,
+    ));
+  const readPowers = makeMountReadPowers({
+    entryMount: mount,
+    registry,
+    resolution,
+  });
+
+  const packageLocationByKey = new Map(
+    Object.keys(resolution.packagesByKey).map(key => [
+      key,
+      packageLocationForKey(key),
+    ]),
+  );
+  const keyByPackageLocation = new Map(
+    [...packageLocationByKey.entries()].map(([key, location]) => [
+      location,
+      key,
+    ]),
+  );
+  const packageRecords = Object.entries(resolution.packagesByKey);
+
+  const dependencyLocationHook = async ({
+    packageLocation,
+    dependencyName,
+    readDescriptor,
+  }) => {
+    const workspaceKey = packageLocationByKey.get(dependencyName);
+    const workspaceRecord = resolution.packagesByKey[dependencyName];
+    if (workspaceKey !== undefined && workspaceRecord?.workspace) {
+      return harden({
+        packageLocation: workspaceKey,
+        packageDescriptor: workspaceRecord.packageJson,
+      });
+    }
+
+    const importerKey = keyByPackageLocation.get(packageLocation);
+    const importerDescriptor =
+      packageLocation === entryPackageLocation
+        ? packageDescriptor
+        : importerKey === undefined
+          ? undefined
+          : resolution.packagesByKey[importerKey]?.packageJson;
+    importerDescriptor !== undefined ||
+      Fail`Cannot find importer descriptor for ${q(packageLocation)}`;
+
+    const range = dependencyRange(
+      [
+        importerDescriptor.dependencies || {},
+        importerDescriptor.peerDependencies || {},
+        importerDescriptor.optionalDependencies || {},
+      ],
+      dependencyName,
+    );
+
+    const candidates = packageRecords
+      .filter(([_key, record]) => !record.workspace)
+      .filter(([_key, record]) => record.name === dependencyName)
+      .filter(([_key, record]) =>
+        range === undefined ? true : satisfiesRange(record.version, range),
+      )
+      .sort(([_aKey, a], [_bKey, b]) => compareVersions(b.version, a.version));
+
+    const [key, record] = candidates[0] || [];
+    if (key === undefined) {
+      return undefined;
+    }
+    const targetLocation = packageLocationByKey.get(key);
+    targetLocation !== undefined ||
+      Fail`Cannot find package location for resolved dependency ${q(key)}`;
+    const descriptor =
+      record.packageJson || (await readDescriptor(targetLocation));
+    descriptor !== undefined ||
+      Fail`Cannot find package descriptor for resolved dependency ${q(key)}`;
+    return harden({
+      packageLocation: targetLocation,
+      packageDescriptor: descriptor,
+    });
+  };
+
+  const compartmentMap = await mapPackageDescriptors(
+    readPowers,
+    entryPackageLocation,
+    new Set(),
+    packageDescriptor,
+    normalizeEntry(entry),
+    harden({
+      ...mapOptions,
+      additionalLocations: [
+        ...[...packageLocationByKey.values()].map(location =>
+          harden({ location }),
+        ),
+        .../** @type {any} */ (mapOptions.additionalLocations || []),
+      ],
+      dependencyLocationHook,
+      strict: true,
+    }),
+  );
+
+  return harden({ compartmentMap, resolution, readPowers });
+};
+harden(mapSnapshot);

--- a/packages/daemon/src/registry.js
+++ b/packages/daemon/src/registry.js
@@ -1,0 +1,610 @@
+// @ts-check
+/// <reference types="ses" />
+/* eslint-disable max-classes-per-file -- Registry errors are local to this resolver. */
+/* eslint-disable no-await-in-loop -- MVS advances a deterministic dependency frontier. */
+/* eslint-disable no-continue -- Frontier edge classifiers are clearest as early exits. */
+/* eslint-disable @jessie.js/safe-await-separator -- The resolver awaits inside the frontier loop. */
+
+/**
+ * @typedef {Record<string, string>} DependencyMap
+ *
+ * @typedef {{
+ *   name: string;
+ *   version: string;
+ *   dependencies?: DependencyMap;
+ *   peerDependencies?: DependencyMap;
+ *   optionalDependencies?: DependencyMap;
+ * }} PackageJson
+ *
+ * @typedef {{
+ *   packageJson: PackageJson;
+ *   integrity?: string;
+ *   treeRef?: unknown;
+ * }} RegistryPackageRecord
+ *
+ * @typedef {{
+ *   name: string;
+ *   version: string;
+ *   packageJson: PackageJson;
+ *   integrity: string;
+ *   treeRef: unknown;
+ * }} RegistryPackageSelection
+ *
+ * @typedef {{
+ *   listVersions: (
+ *     name: string,
+ *     options?: { offline?: boolean },
+ *   ) => Promise<string[]> | string[];
+ *   fetchPackage: (
+ *     name: string,
+ *     version: string,
+ *     options?: { offline?: boolean },
+ *   ) => Promise<RegistryPackageRecord | undefined> | RegistryPackageRecord | undefined;
+ * }} RegistryPackageSource
+ *
+ * @typedef {{
+ *   packageJson: PackageJson;
+ *   treeRef?: unknown;
+ * }} WorkspacePackageRecord
+ *
+ * @typedef {{
+ *   packages: Record<string, WorkspacePackageRecord | PackageJson>;
+ * }} RegistryWorkspaceRoot
+ *
+ * @typedef {{
+ *   offline?: boolean;
+ *   workspaceRoot?: RegistryWorkspaceRoot;
+ * }} RegistryResolveOptions
+ *
+ * @typedef {{
+ *   importer: string;
+ *   name: string;
+ *   range: string;
+ *   reason: string;
+ * }} RegistryDependencyDiagnostic
+ *
+ * @typedef {{
+ *   name: string;
+ *   version: string;
+ *   treeRef: unknown;
+ *   integrity: string;
+ *   workspace?: boolean;
+ * }} RegistryResolutionPackage
+ *
+ * @typedef {{
+ *   packagesByKey: Record<string, RegistryResolutionPackage>;
+ *   keys: string[];
+ *   resolutionHash: string;
+ *   diagnostics: {
+ *     unmetOptionals: RegistryDependencyDiagnostic[];
+ *     workspaceVersionMismatches: RegistryDependencyDiagnostic[];
+ *   };
+ * }} RegistryResolution
+ *
+ * @typedef {{
+ *   resolve: (
+ *     packageJsonBytes: Uint8Array | string | PackageJson,
+ *     options?: RegistryResolveOptions,
+ *   ) => Promise<RegistryResolution>;
+ * }} RegistryResolver
+ *
+ * @typedef {{
+ *   name: string;
+ *   range: string;
+ *   source: 'dependencies' | 'optionalDependencies';
+ *   importer: string;
+ * }} DependencyEdge
+ *
+ * @typedef {{
+ *   importer: string;
+ *   name: string;
+ *   range: string;
+ * }} PeerRequirement
+ */
+
+import { createHash } from 'node:crypto';
+
+import { q } from '@endo/errors';
+
+export class RegistryMissingPackageError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = 'RegistryMissingPackageError';
+  }
+}
+harden(RegistryMissingPackageError);
+
+export class RegistryOfflineError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = 'RegistryOfflineError';
+  }
+}
+harden(RegistryOfflineError);
+
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
+/**
+ * @param {Uint8Array | string | PackageJson} packageJsonBytes
+ * @returns {PackageJson}
+ */
+const parsePackageJson = packageJsonBytes => {
+  if (typeof packageJsonBytes === 'string') {
+    return JSON.parse(packageJsonBytes);
+  }
+  if (packageJsonBytes instanceof Uint8Array) {
+    return JSON.parse(textDecoder.decode(packageJsonBytes));
+  }
+  return packageJsonBytes;
+};
+
+/**
+ * @param {PackageJson} packageJson
+ * @returns {string}
+ */
+const packageName = packageJson => packageJson.name || '<entry>';
+
+/**
+ * @param {DependencyEdge[]} frontier
+ * @param {PackageJson} packageJson
+ */
+const enqueueRuntimeDependencies = (frontier, packageJson) => {
+  const importer = packageName(packageJson);
+  for (const [name, range] of Object.entries(packageJson.dependencies || {})) {
+    frontier.push({ name, range, source: 'dependencies', importer });
+  }
+  for (const [name, range] of Object.entries(
+    packageJson.optionalDependencies || {},
+  )) {
+    frontier.push({ name, range, source: 'optionalDependencies', importer });
+  }
+};
+
+/**
+ * @param {PeerRequirement[]} peerRequirements
+ * @param {PackageJson} packageJson
+ */
+const recordPeerDependencies = (peerRequirements, packageJson) => {
+  const importer = packageName(packageJson);
+  for (const [name, range] of Object.entries(
+    packageJson.peerDependencies || {},
+  )) {
+    peerRequirements.push({ importer, name, range });
+  }
+};
+
+/** @param {string} specifier */
+const isWorkspaceSpecifier = specifier => specifier.startsWith('workspace:');
+
+/**
+ * @param {RegistryWorkspaceRoot | undefined} workspaceRoot
+ * @param {string} name
+ * @returns {WorkspacePackageRecord | undefined}
+ */
+const getWorkspacePackage = (workspaceRoot, name) => {
+  if (workspaceRoot === undefined) {
+    return undefined;
+  }
+  const record = workspaceRoot.packages[name];
+  if (record === undefined) {
+    return undefined;
+  }
+  if ('packageJson' in record) {
+    return record;
+  }
+  return { packageJson: record };
+};
+
+/**
+ * @param {string} version
+ * @returns {[number, number, number] | undefined}
+ */
+const parseVersion = version => {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (match === null) {
+    return undefined;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+/**
+ * @param {string} version
+ * @returns {number | undefined}
+ */
+const versionMajor = version => parseVersion(version)?.[0];
+
+/**
+ * @param {string} a
+ * @param {string} b
+ */
+const compareVersions = (a, b) => {
+  const aParts = parseVersion(a);
+  const bParts = parseVersion(b);
+  if (aParts === undefined || bParts === undefined) {
+    return a.localeCompare(b);
+  }
+  for (const index of [0, 1, 2]) {
+    const difference = aParts[index] - bParts[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return 0;
+};
+
+/**
+ * @param {string} version
+ * @param {string} range
+ * @returns {boolean}
+ */
+const satisfiesRange = (version, range) => {
+  const workspaceSpecifier = isWorkspaceSpecifier(range);
+  const specifier = workspaceSpecifier ? range.slice(10) : range;
+  if (specifier === '' || specifier === '*' || specifier === 'latest') {
+    return true;
+  }
+  if (workspaceSpecifier && (specifier === '^' || specifier === '~')) {
+    return true;
+  }
+  const versionParts = parseVersion(version);
+  if (versionParts === undefined) {
+    return version === specifier;
+  }
+  const [major, minor, patch] = versionParts;
+
+  const caretMatch = /^\^(\d+)(?:\.(\d+))?(?:\.(\d+))?$/.exec(specifier);
+  if (caretMatch !== null) {
+    const rangeMajor = Number(caretMatch[1]);
+    const rangeMinor = Number(caretMatch[2] || 0);
+    const rangePatch = Number(caretMatch[3] || 0);
+    if (major !== rangeMajor) {
+      return false;
+    }
+    if (minor < rangeMinor) {
+      return false;
+    }
+    return minor !== rangeMinor || patch >= rangePatch;
+  }
+
+  const majorMatch = /^(\d+)(?:\.x)?$/.exec(specifier);
+  if (majorMatch !== null) {
+    return major === Number(majorMatch[1]);
+  }
+
+  const exactParts = parseVersion(specifier);
+  if (exactParts !== undefined) {
+    return compareVersions(version, specifier) === 0;
+  }
+
+  return false;
+};
+
+/**
+ * @param {string} range
+ * @param {string[]} versions
+ * @returns {number[]}
+ */
+const majorsForRange = (range, versions) => {
+  const specifier = isWorkspaceSpecifier(range) ? range.slice(10) : range;
+  const caretMatch = /^\^(\d+)(?:\.(\d+))?(?:\.(\d+))?$/.exec(specifier);
+  if (caretMatch !== null) {
+    return [Number(caretMatch[1])];
+  }
+  const majorMatch = /^(\d+)(?:\.x)?$/.exec(specifier);
+  if (majorMatch !== null) {
+    return [Number(majorMatch[1])];
+  }
+  const exactParts = parseVersion(specifier);
+  if (exactParts !== undefined) {
+    return [exactParts[0]];
+  }
+  const majors = new Set();
+  for (const version of versions) {
+    const major = versionMajor(version);
+    if (major !== undefined && satisfiesRange(version, range)) {
+      majors.add(major);
+    }
+  }
+  return [...majors].sort((a, b) => a - b);
+};
+
+/**
+ * @param {string} name
+ * @param {string} version
+ */
+const registryKey = (name, version) => `${name}@${version}`;
+
+/** @param {string} name */
+const workspaceKey = name => name;
+
+/**
+ * @param {Record<string, RegistryResolutionPackage>} packagesByKey
+ */
+const computeResolutionHash = packagesByKey => {
+  const keys = Object.keys(packagesByKey).sort();
+  const hash = createHash('sha256');
+  for (const key of keys) {
+    const entry = packagesByKey[key];
+    hash.update(key);
+    hash.update('\0');
+    hash.update(entry.integrity);
+    hash.update('\0');
+  }
+  return `sha256-${hash.digest('hex')}`;
+};
+
+/**
+ * @param {RegistryPackageSource} packageSource
+ * @param {string} name
+ * @param {number} major
+ * @param {string[]} requirements
+ * @param {{ offline?: boolean }} options
+ * @returns {Promise<RegistryPackageSelection | undefined>}
+ */
+const selectGreatestSatisfying = async (
+  packageSource,
+  name,
+  major,
+  requirements,
+  options,
+) => {
+  const versions = await packageSource.listVersions(name, options);
+  let selectedVersion;
+  for (const version of versions) {
+    if (versionMajor(version) !== major) {
+      continue;
+    }
+    if (!requirements.every(range => satisfiesRange(version, range))) {
+      continue;
+    }
+    if (
+      selectedVersion === undefined ||
+      compareVersions(selectedVersion, version) < 0
+    ) {
+      selectedVersion = version;
+    }
+  }
+  if (selectedVersion === undefined) {
+    return undefined;
+  }
+  const record = await packageSource.fetchPackage(
+    name,
+    selectedVersion,
+    options,
+  );
+  if (record === undefined) {
+    return undefined;
+  }
+  const { packageJson, treeRef = registryKey(name, selectedVersion) } = record;
+  return {
+    name,
+    version: selectedVersion,
+    packageJson,
+    treeRef,
+    integrity:
+      record.integrity || `sha512-${registryKey(name, selectedVersion)}`,
+  };
+};
+
+/**
+ * @param {RegistryPackageSource} packageSource
+ * @returns {RegistryResolver}
+ */
+export const makeRegistryResolver = packageSource => {
+  const resolve = async (packageJsonBytes, options = {}) => {
+    const root = parsePackageJson(packageJsonBytes);
+    /** @type {DependencyEdge[]} */
+    const frontier = [];
+    /** @type {PeerRequirement[]} */
+    const peerRequirements = [];
+    /** @type {RegistryDependencyDiagnostic[]} */
+    const unmetOptionals = [];
+    /** @type {RegistryDependencyDiagnostic[]} */
+    const workspaceVersionMismatches = [];
+    /** @type {Record<string, RegistryResolutionPackage>} */
+    const packagesByKey = {};
+    /** @type {Map<string, Map<number, { requirements: Set<string>, selection?: RegistryPackageSelection }>>} */
+    const registrySelections = new Map();
+    const seenWorkspacePackages = new Set();
+
+    enqueueRuntimeDependencies(frontier, root);
+    recordPeerDependencies(peerRequirements, root);
+
+    while (frontier.length > 0) {
+      const edge = /** @type {DependencyEdge} */ (frontier.shift());
+      const workspaceRecord = getWorkspacePackage(
+        options.workspaceRoot,
+        edge.name,
+      );
+      if (workspaceRecord !== undefined) {
+        const { packageJson } = workspaceRecord;
+        if (!satisfiesRange(packageJson.version, edge.range)) {
+          workspaceVersionMismatches.push({
+            importer: edge.importer,
+            name: edge.name,
+            range: edge.range,
+            reason: `${edge.name}@${packageJson.version} does not satisfy ${edge.range}`,
+          });
+        }
+        const key = workspaceKey(edge.name);
+        packagesByKey[key] = harden({
+          name: edge.name,
+          version: packageJson.version,
+          treeRef: workspaceRecord.treeRef || key,
+          integrity: `workspace:${edge.name}@${packageJson.version}`,
+          workspace: true,
+        });
+        if (!seenWorkspacePackages.has(edge.name)) {
+          seenWorkspacePackages.add(edge.name);
+          enqueueRuntimeDependencies(frontier, packageJson);
+          recordPeerDependencies(peerRequirements, packageJson);
+        }
+        continue;
+      }
+
+      if (isWorkspaceSpecifier(edge.range)) {
+        if (edge.source === 'optionalDependencies') {
+          unmetOptionals.push({
+            importer: edge.importer,
+            name: edge.name,
+            range: edge.range,
+            reason:
+              'workspace dependency declared but no enclosing workspace root',
+          });
+          continue;
+        }
+        throw new RegistryMissingPackageError(
+          `workspace dependency ${q(edge.name)} declared but no enclosing workspace root`,
+        );
+      }
+
+      const versions = await packageSource.listVersions(edge.name, {
+        offline: options.offline,
+      });
+      const majors = majorsForRange(edge.range, versions);
+      if (majors.length === 0) {
+        const reason = `no ${edge.name} versions satisfy ${edge.range}`;
+        if (edge.source === 'optionalDependencies') {
+          unmetOptionals.push({
+            importer: edge.importer,
+            name: edge.name,
+            range: edge.range,
+            reason,
+          });
+          continue;
+        }
+        throw new RegistryMissingPackageError(reason);
+      }
+
+      let nameSelections = registrySelections.get(edge.name);
+      if (nameSelections === undefined) {
+        nameSelections = new Map();
+        registrySelections.set(edge.name, nameSelections);
+      }
+
+      for (const major of majors) {
+        let majorSelection = nameSelections.get(major);
+        if (majorSelection === undefined) {
+          majorSelection = { requirements: new Set() };
+          nameSelections.set(major, majorSelection);
+        }
+        majorSelection.requirements.add(edge.range);
+
+        const selected = await selectGreatestSatisfying(
+          packageSource,
+          edge.name,
+          major,
+          [...majorSelection.requirements],
+          { offline: options.offline },
+        );
+        if (selected === undefined) {
+          const reason = `no ${edge.name} ${major}.x version satisfies ${[
+            ...majorSelection.requirements,
+          ].join(', ')}`;
+          if (edge.source === 'optionalDependencies') {
+            unmetOptionals.push({
+              importer: edge.importer,
+              name: edge.name,
+              range: edge.range,
+              reason,
+            });
+            continue;
+          }
+          throw new RegistryMissingPackageError(reason);
+        }
+
+        const previousVersion = majorSelection.selection?.version;
+        majorSelection.selection = selected;
+        if (
+          previousVersion !== undefined &&
+          previousVersion !== selected.version
+        ) {
+          delete packagesByKey[registryKey(edge.name, previousVersion)];
+        }
+        packagesByKey[registryKey(edge.name, selected.version)] = harden({
+          name: edge.name,
+          version: selected.version,
+          treeRef: selected.treeRef,
+          integrity: selected.integrity,
+        });
+        if (previousVersion !== selected.version) {
+          enqueueRuntimeDependencies(frontier, selected.packageJson);
+          recordPeerDependencies(peerRequirements, selected.packageJson);
+        }
+      }
+    }
+
+    for (const peer of peerRequirements) {
+      const matchingKeys = Object.keys(packagesByKey).filter(key => {
+        const entry = packagesByKey[key];
+        return (
+          entry.name === peer.name && satisfiesRange(entry.version, peer.range)
+        );
+      });
+      if (matchingKeys.length === 0) {
+        throw new RegistryMissingPackageError(
+          `package ${q(peer.importer)} declares unmet peer dependency ${q(
+            peer.name,
+          )} ${q(peer.range)}`,
+        );
+      }
+    }
+
+    const keys = Object.keys(packagesByKey).sort();
+    const resolutionHash = computeResolutionHash(packagesByKey);
+    return harden({
+      packagesByKey,
+      keys,
+      resolutionHash,
+      diagnostics: harden({
+        unmetOptionals,
+        workspaceVersionMismatches,
+      }),
+    });
+  };
+
+  return harden({ resolve });
+};
+harden(makeRegistryResolver);
+
+/**
+ * @param {Record<string, Record<string, RegistryPackageRecord | PackageJson>>} packages
+ * @param {{ offlineNames?: string[] }} [options]
+ * @returns {RegistryPackageSource}
+ */
+export const makeMemoryRegistryPackageSource = (packages, options = {}) => {
+  const offlineNames = new Set(options.offlineNames || []);
+  return harden({
+    listVersions: (name, listOptions = {}) => {
+      if (listOptions.offline && offlineNames.has(name)) {
+        throw new RegistryOfflineError(
+          `offline registry cache has no metadata for ${q(name)}`,
+        );
+      }
+      return Object.keys(packages[name] || {}).sort(compareVersions);
+    },
+    fetchPackage: (name, version, fetchOptions = {}) => {
+      if (fetchOptions.offline && offlineNames.has(name)) {
+        throw new RegistryOfflineError(
+          `offline registry cache has no package ${q(registryKey(name, version))}`,
+        );
+      }
+      const record = packages[name]?.[version];
+      if (record === undefined) {
+        return undefined;
+      }
+      if ('packageJson' in record) {
+        return record;
+      }
+      return { packageJson: record };
+    },
+  });
+};
+harden(makeMemoryRegistryPackageSource);
+
+export const encodePackageJson = packageJson =>
+  textEncoder.encode(JSON.stringify(packageJson));
+harden(encodePackageJson);

--- a/packages/daemon/src/registry.js
+++ b/packages/daemon/src/registry.js
@@ -66,6 +66,7 @@
  * @typedef {{
  *   name: string;
  *   version: string;
+ *   packageJson: PackageJson;
  *   treeRef: unknown;
  *   integrity: string;
  *   workspace?: boolean;
@@ -433,6 +434,7 @@ export const makeRegistryResolver = packageSource => {
         packagesByKey[key] = harden({
           name: edge.name,
           version: packageJson.version,
+          packageJson,
           treeRef: workspaceRecord.treeRef || key,
           integrity: `workspace:${edge.name}@${packageJson.version}`,
           workspace: true,
@@ -527,6 +529,7 @@ export const makeRegistryResolver = packageSource => {
         packagesByKey[registryKey(edge.name, selected.version)] = harden({
           name: edge.name,
           version: selected.version,
+          packageJson: selected.packageJson,
           treeRef: selected.treeRef,
           integrity: selected.integrity,
         });

--- a/packages/daemon/src/worker-import.js
+++ b/packages/daemon/src/worker-import.js
@@ -1,0 +1,188 @@
+// @ts-check
+/// <reference types="ses" />
+
+import { E } from '@endo/eventual-send';
+import { Fail, q } from '@endo/errors';
+
+/** @import { RegistryResolution } from './registry.js' */
+
+const textEncoder = new TextEncoder();
+
+/**
+ * @param {AsyncIterable<Uint8Array> | AsyncIterator<Uint8Array>} reader
+ * @returns {Promise<Uint8Array>}
+ */
+const bytesFromReader = async reader => {
+  /** @type {Uint8Array[]} */
+  const chunks = [];
+  let length = 0;
+  const iterable =
+    Symbol.asyncIterator in Object(reader)
+      ? /** @type {AsyncIterable<Uint8Array>} */ (reader)
+      : harden({
+          [Symbol.asyncIterator]: () =>
+            /** @type {AsyncIterator<Uint8Array>} */ (reader),
+        });
+  for await (const chunk of iterable) {
+    chunks.push(chunk);
+    length += chunk.byteLength;
+  }
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+};
+
+/**
+ * @param {unknown} blob
+ * @returns {Promise<Uint8Array | undefined>}
+ */
+const maybeReadBlobBytes = async blob => {
+  if (blob === undefined) {
+    return undefined;
+  }
+  if (typeof blob === 'object' && blob !== null && 'bytes' in blob) {
+    const bytes = await E(/** @type {any} */ (blob)).bytes();
+    if (bytes instanceof Uint8Array) {
+      return bytes;
+    }
+  }
+  if (typeof blob === 'object' && blob !== null && 'text' in blob) {
+    const text = await E(/** @type {any} */ (blob)).text();
+    return textEncoder.encode(text);
+  }
+  if (
+    typeof blob === 'object' &&
+    blob !== null &&
+    'getInfo' in blob &&
+    'fetch' in blob
+  ) {
+    const info = await E(/** @type {any} */ (blob)).getInfo();
+    const size = BigInt(info.size ?? info.length ?? 0);
+    const reader = await E(/** @type {any} */ (blob)).fetch(0n, size);
+    return bytesFromReader(/** @type {any} */ (reader));
+  }
+  return undefined;
+};
+
+/**
+ * @param {unknown} tree
+ * @param {string[]} path
+ * @returns {Promise<Uint8Array | undefined>}
+ */
+const maybeReadTreeBytes = async (tree, path) => {
+  const pathName = path.join('/');
+  if (typeof tree === 'object' && tree !== null && 'readBytes' in tree) {
+    return E(/** @type {any} */ (tree)).readBytes(pathName);
+  }
+  if (typeof tree === 'object' && tree !== null && 'maybeReadBytes' in tree) {
+    return E(/** @type {any} */ (tree)).maybeReadBytes(pathName);
+  }
+  if (typeof tree === 'object' && tree !== null && 'maybeReadText' in tree) {
+    const text = await E(/** @type {any} */ (tree)).maybeReadText(path);
+    if (text !== undefined) {
+      return textEncoder.encode(text);
+    }
+  }
+  if (typeof tree === 'object' && tree !== null && 'readText' in tree) {
+    try {
+      const text = await E(/** @type {any} */ (tree)).readText(path);
+      return textEncoder.encode(text);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof tree === 'object' && tree !== null && 'lookup' in tree) {
+    try {
+      const node = await E(/** @type {any} */ (tree)).lookup(path);
+      return maybeReadBlobBytes(node);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+/** @param {string} key */
+export const packageLocationForKey = key =>
+  new URL(`${key}/`, 'file:///').toString();
+harden(packageLocationForKey);
+
+/**
+ * @param {string} location
+ * @param {Set<string>} packageKeys
+ */
+const parseSnapshotLocation = (location, packageKeys) => {
+  const url = new URL(location);
+  url.protocol === 'file:' ||
+    Fail`Snapshot location must be a file URL: ${q(location)}`;
+  const segments = url.pathname
+    .split('/')
+    .filter(Boolean)
+    .map(decodeURIComponent);
+  if (segments.length >= 2 && segments[0].startsWith('@')) {
+    const key = `${segments[0]}/${segments[1]}`;
+    if (packageKeys.has(key)) {
+      return harden({ key, path: segments.slice(2) });
+    }
+  }
+  if (segments.length >= 1 && packageKeys.has(segments[0])) {
+    return harden({ key: segments[0], path: segments.slice(1) });
+  }
+  return harden({ key: undefined, path: segments });
+};
+
+/**
+ * @param {object} args
+ * @param {unknown} args.entryMount
+ * @param {unknown} [args.registry]
+ * @param {RegistryResolution} args.resolution
+ */
+export const makeMountReadPowers = ({ entryMount, registry, resolution }) => {
+  const packagesByKey = new Map(Object.entries(resolution.packagesByKey));
+  const packageKeys = new Set(packagesByKey.keys());
+
+  /** @param {string} location */
+  const maybeRead = async location => {
+    const { key, path } = parseSnapshotLocation(location, packageKeys);
+    if (key === undefined) {
+      return maybeReadTreeBytes(entryMount, path);
+    }
+    const record = packagesByKey.get(key);
+    if (record === undefined) {
+      return undefined;
+    }
+    if (path.length === 1 && path[0] === 'package.json') {
+      return textEncoder.encode(JSON.stringify(record.packageJson));
+    }
+    let { treeRef } = record;
+    if (treeRef === undefined && registry !== undefined && !record.workspace) {
+      const split = key.lastIndexOf('@');
+      split > 0 || Fail`Cannot infer package name and version from ${q(key)}`;
+      const name = key.slice(0, split);
+      const version = key.slice(split + 1);
+      treeRef = await E(/** @type {any} */ (registry)).fetch(name, version);
+      packagesByKey.set(key, harden({ ...record, treeRef }));
+    }
+    return maybeReadTreeBytes(treeRef, path);
+  };
+
+  /** @param {string} location */
+  const read = async location => {
+    const bytes = await maybeRead(location);
+    if (bytes === undefined) {
+      throw Error(`Cannot read snapshot location ${q(location)}`);
+    }
+    return bytes;
+  };
+
+  return harden({
+    read,
+    maybeRead,
+    canonical: async location => location,
+  });
+};
+harden(makeMountReadPowers);

--- a/packages/daemon/test/map-snapshot.test.js
+++ b/packages/daemon/test/map-snapshot.test.js
@@ -1,0 +1,185 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { mapSnapshot } from '../src/map-snapshot.js';
+
+const textEncoder = new TextEncoder();
+
+const packageJson = (name, version, fields = {}) =>
+  harden({ name, version, main: './index.js', ...fields });
+
+const makeTree = files =>
+  harden({
+    async maybeReadText(pathArg) {
+      const path = Array.isArray(pathArg) ? pathArg.join('/') : pathArg;
+      return files[path];
+    },
+    async readText(pathArg) {
+      const path = Array.isArray(pathArg) ? pathArg.join('/') : pathArg;
+      const text = files[path];
+      if (text === undefined) {
+        throw new Error(`ENOENT ${path}`);
+      }
+      return text;
+    },
+  });
+
+const makeRegistry = resolution =>
+  harden({
+    async resolve(packageJsonBytes) {
+      tLikePackageJsonBytes(packageJsonBytes);
+      return resolution;
+    },
+    async fetch(name, version) {
+      return resolution.packagesByKey[`${name}@${version}`].treeRef;
+    },
+  });
+
+const tLikePackageJsonBytes = packageJsonBytes => {
+  if (!(packageJsonBytes instanceof Uint8Array)) {
+    throw new Error('expected package.json bytes');
+  }
+};
+
+test('mapSnapshot maps incompatible majors to distinct package compartments', async t => {
+  const entryPackage = packageJson('entry', '1.0.0', {
+    dependencies: { pkg: '^1.0.0', transitive: '^1.0.0' },
+  });
+  const pkg1 = packageJson('pkg', '1.0.0');
+  const pkg2 = packageJson('pkg', '2.0.0');
+  const transitive = packageJson('transitive', '1.0.0', {
+    dependencies: { pkg: '^2.0.0' },
+  });
+  const resolution = harden({
+    packagesByKey: {
+      'pkg@1.0.0': {
+        name: 'pkg',
+        version: '1.0.0',
+        packageJson: pkg1,
+        treeRef: makeTree({
+          'package.json': JSON.stringify(pkg1),
+          'index.js': 'export const version = "one";',
+        }),
+        integrity: 'sha512-pkg-1',
+      },
+      'pkg@2.0.0': {
+        name: 'pkg',
+        version: '2.0.0',
+        packageJson: pkg2,
+        treeRef: makeTree({
+          'package.json': JSON.stringify(pkg2),
+          'index.js': 'export const version = "two";',
+        }),
+        integrity: 'sha512-pkg-2',
+      },
+      'transitive@1.0.0': {
+        name: 'transitive',
+        version: '1.0.0',
+        packageJson: transitive,
+        treeRef: makeTree({
+          'package.json': JSON.stringify(transitive),
+          'index.js': 'import "pkg";',
+        }),
+        integrity: 'sha512-transitive',
+      },
+    },
+    keys: ['pkg@1.0.0', 'pkg@2.0.0', 'transitive@1.0.0'],
+    resolutionHash: 'sha256-multi-major',
+    diagnostics: harden({ unmetOptionals: [], workspaceVersionMismatches: [] }),
+  });
+
+  const { compartmentMap, readPowers } = await mapSnapshot({
+    registry: makeRegistry(resolution),
+    mount: makeTree({
+      'package.json': JSON.stringify(entryPackage),
+      'index.js': 'import "pkg"; import "transitive";',
+    }),
+    resolution,
+  });
+
+  t.is(
+    compartmentMap.compartments['file:///'].scopes.pkg.compartment,
+    'file:///pkg@1.0.0/',
+  );
+  t.is(
+    compartmentMap.compartments['file:///transitive@1.0.0/'].scopes.pkg
+      .compartment,
+    'file:///pkg@2.0.0/',
+  );
+  t.deepEqual(
+    await readPowers.read('file:///pkg@2.0.0/index.js'),
+    textEncoder.encode('export const version = "two";'),
+  );
+});
+
+test('mapSnapshot uses versionless workspace locations and keeps registry peers', async t => {
+  const entryPackage = packageJson('entry', '1.0.0', {
+    dependencies: { '@endo/patterns': 'workspace:^', consumer: '^1.0.0' },
+  });
+  const workspacePatterns = packageJson('@endo/patterns', '9.0.0');
+  const registryPatterns = packageJson('@endo/patterns', '1.0.0');
+  const consumer = packageJson('consumer', '1.0.0', {
+    dependencies: { '@endo/patterns': '^1.0.0' },
+  });
+  const resolution = harden({
+    packagesByKey: {
+      '@endo/patterns': {
+        name: '@endo/patterns',
+        version: '9.0.0',
+        packageJson: workspacePatterns,
+        treeRef: makeTree({
+          'package.json': JSON.stringify(workspacePatterns),
+          'index.js': 'export const source = "workspace";',
+        }),
+        integrity: 'workspace:@endo/patterns@9.0.0',
+        workspace: true,
+      },
+      '@endo/patterns@1.0.0': {
+        name: '@endo/patterns',
+        version: '1.0.0',
+        packageJson: registryPatterns,
+        treeRef: makeTree({
+          'package.json': JSON.stringify(registryPatterns),
+          'index.js': 'export const source = "registry";',
+        }),
+        integrity: 'sha512-patterns-1',
+      },
+      'consumer@1.0.0': {
+        name: 'consumer',
+        version: '1.0.0',
+        packageJson: consumer,
+        treeRef: makeTree({
+          'package.json': JSON.stringify(consumer),
+          'index.js': 'import "@endo/patterns";',
+        }),
+        integrity: 'sha512-consumer',
+      },
+    },
+    keys: ['@endo/patterns', '@endo/patterns@1.0.0', 'consumer@1.0.0'],
+    resolutionHash: 'sha256-workspace',
+    diagnostics: harden({ unmetOptionals: [], workspaceVersionMismatches: [] }),
+  });
+
+  const { compartmentMap, readPowers } = await mapSnapshot({
+    registry: makeRegistry(resolution),
+    mount: makeTree({
+      'package.json': JSON.stringify(entryPackage),
+      'index.js': 'import "@endo/patterns"; import "consumer";',
+    }),
+    resolution,
+  });
+
+  t.truthy(compartmentMap.compartments['file:///@endo/patterns/']);
+  t.truthy(compartmentMap.compartments['file:///@endo/patterns@1.0.0/']);
+  t.is(
+    compartmentMap.compartments['file:///consumer@1.0.0/'].scopes[
+      '@endo/patterns'
+    ].compartment,
+    'file:///@endo/patterns/',
+  );
+  t.deepEqual(
+    await readPowers.read('file:///@endo/patterns/index.js'),
+    textEncoder.encode('export const source = "workspace";'),
+  );
+});

--- a/packages/daemon/test/registry-mvs.test.js
+++ b/packages/daemon/test/registry-mvs.test.js
@@ -1,0 +1,213 @@
+// @ts-nocheck
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import {
+  RegistryMissingPackageError,
+  RegistryOfflineError,
+  encodePackageJson,
+  makeMemoryRegistryPackageSource,
+  makeRegistryResolver,
+} from '../src/registry.js';
+
+const packageJson = (name, version, fields = {}) =>
+  harden({ name, version, ...fields });
+
+const makeResolver = packages =>
+  makeRegistryResolver(makeMemoryRegistryPackageSource(packages));
+
+test('MVS widens a package to the greatest mentioned minor in a major', async t => {
+  const resolver = makeResolver({
+    a: {
+      '1.0.0': packageJson('a', '1.0.0'),
+      '1.2.0': packageJson('a', '1.2.0'),
+      '1.3.0': packageJson('a', '1.3.0'),
+    },
+    b: {
+      '1.0.0': packageJson('b', '1.0.0', {
+        dependencies: { a: '^1.2.0' },
+      }),
+    },
+  });
+
+  const resolution = await resolver.resolve(
+    encodePackageJson(
+      packageJson('entry', '1.0.0', {
+        dependencies: { a: '^1.0.0', b: '^1.0.0' },
+      }),
+    ),
+  );
+
+  t.deepEqual(resolution.keys, ['a@1.3.0', 'b@1.0.0']);
+  t.is(resolution.packagesByKey['a@1.3.0'].version, '1.3.0');
+  t.regex(resolution.resolutionHash, /^sha256-[0-9a-f]{64}$/);
+});
+
+test('MVS keeps incompatible majors under distinct RegistryResolution keys', async t => {
+  const resolver = makeResolver({
+    a: {
+      '1.0.0': packageJson('a', '1.0.0'),
+      '1.5.0': packageJson('a', '1.5.0'),
+      '2.0.0': packageJson('a', '2.0.0'),
+      '2.3.0': packageJson('a', '2.3.0'),
+    },
+    b: {
+      '1.0.0': packageJson('b', '1.0.0', {
+        dependencies: { a: '^2.0.0' },
+      }),
+    },
+  });
+
+  const resolution = await resolver.resolve(
+    packageJson('entry', '1.0.0', {
+      dependencies: { a: '^1.0.0', b: '^1.0.0' },
+    }),
+  );
+
+  t.deepEqual(resolution.keys, ['a@1.5.0', 'a@2.3.0', 'b@1.0.0']);
+});
+
+test('offline mode resolves from the cached package table', async t => {
+  const resolver = makeResolver({
+    a: {
+      '1.0.0': packageJson('a', '1.0.0'),
+    },
+  });
+
+  const resolution = await resolver.resolve(
+    packageJson('entry', '1.0.0', { dependencies: { a: '^1.0.0' } }),
+    { offline: true },
+  );
+
+  t.deepEqual(resolution.keys, ['a@1.0.0']);
+});
+
+test('offline mode reports RegistryOfflineError on a cache miss', async t => {
+  const source = makeMemoryRegistryPackageSource(
+    {
+      a: {
+        '1.0.0': packageJson('a', '1.0.0'),
+      },
+    },
+    { offlineNames: ['a'] },
+  );
+  const resolver = makeRegistryResolver(source);
+
+  await t.throwsAsync(
+    () =>
+      resolver.resolve(
+        packageJson('entry', '1.0.0', { dependencies: { a: '^1.0.0' } }),
+        { offline: true },
+      ),
+    { instanceOf: RegistryOfflineError },
+  );
+});
+
+test('workspace dependencies resolve to versionless workspace keys', async t => {
+  const resolver = makeResolver({});
+
+  const resolution = await resolver.resolve(
+    packageJson('lib-a', '1.0.0', {
+      dependencies: { 'lib-b': 'workspace:^' },
+    }),
+    {
+      workspaceRoot: {
+        packages: {
+          'lib-b': packageJson('lib-b', '1.5.0'),
+        },
+      },
+    },
+  );
+
+  t.deepEqual(resolution.keys, ['lib-b']);
+  t.true(resolution.packagesByKey['lib-b'].workspace);
+  t.is(resolution.packagesByKey['lib-b'].version, '1.5.0');
+  t.deepEqual(resolution.diagnostics.workspaceVersionMismatches, []);
+});
+
+test('workspace version mismatch is diagnostic, not fatal', async t => {
+  const resolver = makeResolver({});
+
+  const resolution = await resolver.resolve(
+    packageJson('lib-a', '1.0.0', {
+      dependencies: { 'lib-b': '^2.0.0' },
+    }),
+    {
+      workspaceRoot: {
+        packages: {
+          'lib-b': packageJson('lib-b', '1.0.0'),
+        },
+      },
+    },
+  );
+
+  t.deepEqual(resolution.keys, ['lib-b']);
+  t.like(resolution.diagnostics.workspaceVersionMismatches[0], {
+    importer: 'lib-a',
+    name: 'lib-b',
+    range: '^2.0.0',
+  });
+});
+
+test('satisfied peerDependencies pass the post-walk check', async t => {
+  const resolver = makeResolver({
+    'pkg-a': {
+      '1.0.0': packageJson('pkg-a', '1.0.0', {
+        peerDependencies: { react: '^18.0.0' },
+      }),
+    },
+    react: {
+      '18.2.0': packageJson('react', '18.2.0'),
+    },
+  });
+
+  const resolution = await resolver.resolve(
+    packageJson('entry', '1.0.0', {
+      dependencies: { 'pkg-a': '^1.0.0', react: '^18.0.0' },
+    }),
+  );
+
+  t.deepEqual(resolution.keys, ['pkg-a@1.0.0', 'react@18.2.0']);
+});
+
+test('unmet peerDependencies reject with RegistryMissingPackageError', async t => {
+  const resolver = makeResolver({
+    'pkg-a': {
+      '1.0.0': packageJson('pkg-a', '1.0.0', {
+        peerDependencies: { react: '^18.0.0' },
+      }),
+    },
+    react: {
+      '18.2.0': packageJson('react', '18.2.0'),
+    },
+  });
+
+  await t.throwsAsync(
+    () =>
+      resolver.resolve(
+        packageJson('entry', '1.0.0', {
+          dependencies: { 'pkg-a': '^1.0.0' },
+        }),
+      ),
+    {
+      instanceOf: RegistryMissingPackageError,
+      message: /pkg-a.*react/,
+    },
+  );
+});
+
+test('missing optionalDependencies are carried as diagnostics', async t => {
+  const resolver = makeResolver({});
+
+  const resolution = await resolver.resolve(
+    packageJson('entry', '1.0.0', {
+      optionalDependencies: { fsevents: '^2.0.0' },
+    }),
+  );
+
+  t.deepEqual(resolution.keys, []);
+  t.like(resolution.diagnostics.unmetOptionals[0], {
+    importer: 'entry',
+    name: 'fsevents',
+    range: '^2.0.0',
+  });
+});


### PR DESCRIPTION
## Summary
- add compartment-mapper dependency-location hook and exported mapPackageDescriptors helper
- add daemon mapSnapshot and makeMountReadPowers for archive-shaped snapshot layouts
- include package descriptors in RegistryResolution records for mapper graph walking
- cover multi-major and workspace-vs-registry layout behavior

Stacked on #564 (MVS resolver).

## Tests
- HOME=/work/yarn-home COREPACK_HOME=/work/corepack-home yarn ava packages/daemon/test/map-snapshot.test.js
- HOME=/work/yarn-home COREPACK_HOME=/work/corepack-home yarn ava packages/daemon/test/registry-mvs.test.js
- HOME=/work/yarn-home COREPACK_HOME=/work/corepack-home yarn workspace @endo/daemon lint
- HOME=/work/yarn-home COREPACK_HOME=/work/corepack-home yarn workspace @endo/compartment-mapper lint
- HOME=/work/yarn-home COREPACK_HOME=/work/corepack-home yarn workspace @endo/compartment-mapper test