### PR TITLE
refactor(daemon): align locator hint terminology

### DIFF
--- a/packages/chat/test/component/channel-header.test.js
+++ b/packages/chat/test/component/channel-header.test.js
@@ -123,8 +123,8 @@ const makeMocks = ({ members = [], heatConfig = null } = {}) => {
   });
 
   const powers = Far('Powers', {
-    locateForSharing(petName) {
-      calls.push({ method: 'locateForSharing', args: [petName] });
+    locateWithHints(petName) {
+      calls.push({ method: 'locateWithHints', args: [petName] });
       return Promise.resolve(`endo://localhost/?id=${petName}`);
     },
     locate(petName) {
@@ -313,9 +313,9 @@ test.serial(
 
     click($container.querySelector('[data-action="link"]'));
 
-    await waitFor(() => calls.some(c => c.method === 'locateForSharing'));
+    await waitFor(() => calls.some(c => c.method === 'locateWithHints'));
     t.true(
-      calls.some(c => c.method === 'locateForSharing'),
+      calls.some(c => c.method === 'locateWithHints'),
       'should resolve a shareable locator',
     );
     await waitFor(() => !$container.querySelector('.invite-delivery-modal'));

--- a/packages/daemon/locator.js
+++ b/packages/daemon/locator.js
@@ -4,12 +4,14 @@
 // Scope: locator-side functions only (parse, validate, format, inspect the
 // `endo://` URL form). Identifier-side functions (`idFromLocator`,
 // `externalizeId`, `internalizeLocator`) and test-only helpers (`LOCAL_NODE`
-// sentinel, `formatLocatorForSharing`) are masked; they remain importable
-// from `./src/locator.js` for in-package callers.
+// sentinel) are masked; they remain importable from `./src/locator.js` for
+// in-package callers.
 
 export {
   addressesFromLocator,
   assertValidLocator,
   formatLocator,
+  formatLocatorWithHints,
+  hintsFromLocator,
   parseLocator,
 } from './src/locator.js';

--- a/packages/daemon/src/help-text-data.js
+++ b/packages/daemon/src/help-text-data.js
@@ -134,8 +134,8 @@ export const helpTextEntries = harden([
         "getPeerInfo() -> Promise<{node: string, addresses: string[]}>\nGet this node's peer information for sharing with others.",
       addPeerInfo:
         'addPeerInfo(peerInfo) -> Promise<void>\nAdd information about a remote peer.\npeerInfo: { node: string, addresses: string[] }',
-      locateForSharing:
-        'locateForSharing(...petNamePath) -> Promise<string | undefined>\nLocate a formula and return a locator URL with connection hints.\nThe returned locator includes network addresses from all registered netlayers,\nallowing remote peers to connect and access the value.\nExample: locateForSharing("my-channel") returns a shareable locator URL.',
+      locateWithHints:
+        'locateWithHints(...petNamePath) -> Promise<string | undefined>\nLocate a formula and return a locator URL with connection hints.\nThe returned locator includes network addresses from all registered netlayers,\nallowing remote peers to connect and access the value.\nExample: locateWithHints("my-channel") returns a shareable locator URL.',
       adoptFromLocator:
         'adoptFromLocator(locator, petNameOrPath) -> Promise<void>\nAdopt a value from a locator that includes connection hints.\nParses the locator to extract peer info, establishes a connection if needed,\nand writes the formula ID into the local pet store.\nExample: adoptFromLocator("endo://node.../formula@hint?type=channel", "remote-channel")',
       invite:

--- a/packages/daemon/src/help.md
+++ b/packages/daemon/src/help.md
@@ -435,12 +435,12 @@ Get this node's peer information for sharing with others.
 Add information about a remote peer.
 peerInfo: { node: string, addresses: string[] }
 
-## locateForSharing(...petNamePath) -> Promise<string | undefined>
+## locateWithHints(...petNamePath) -> Promise<string | undefined>
 
 Locate a formula and return a locator URL with connection hints.
 The returned locator includes network addresses from all registered netlayers,
 allowing remote peers to connect and access the value.
-Example: locateForSharing("my-channel") returns a shareable locator URL.
+Example: locateWithHints("my-channel") returns a shareable locator URL.
 
 ## adoptFromLocator(locator, petNameOrPath) -> Promise<void>
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -23,11 +23,16 @@ import {
 } from './pet-name.js';
 import {
   assertFormulaNumber,
-  assertNodeNumber,
   parseId,
   formatId,
 } from './formula-identifier.js';
-import { formatLocator, idFromLocator, internalizeLocator } from './locator.js';
+import {
+  formatLocator,
+  formatLocatorWithHints,
+  idFromLocator,
+  internalizeLocator,
+  parseLocator,
+} from './locator.js';
 import { toHex, fromHex } from './hex.js';
 import { makePetSitter } from './pet-sitter.js';
 
@@ -1371,60 +1376,49 @@ export const makeHostMaker = ({
       // directory must already exist.
       const { namePath: guestNamePath, petName: guestLeaf } =
         petNamePathFrom(guestName);
+      const {
+        number: invitationNumber,
+        node: peerKey,
+        hints,
+      } = parseLocator(invitationLocator);
       const url = new URL(invitationLocator);
-      const daemonNode = url.hostname;
-      // Path components are `@`-delimited and URL-encoded.  The first
-      // component is the invitation's formula address; the rest are
-      // connection hints.
-      const [invitationNumber, ...addresses] = url.pathname
-        .replace(/^\//, '')
-        .split('@')
-        .map(decodeURIComponent);
       const remoteHandleNumber = url.searchParams.get('from');
-      // The remote handle's node may differ from the daemon node when
+      // The remote handle's node may differ from the peer key when
       // agent keys are used as formula nodes.
       const remoteHandleNodeParam = url.searchParams.get('fromNode');
 
-      daemonNode || assert.Fail`Invitation must have a hostname`;
       if (!remoteHandleNumber) {
         throw makeError(`Invitation must have a "from" parameter`);
       }
-      if (!invitationNumber) {
-        throw makeError(`Invitation must include a formula number`);
-      }
-      assertNodeNumber(daemonNode);
       assertFormulaNumber(remoteHandleNumber);
-      assertFormulaNumber(invitationNumber);
 
       /** @type {PeerInfo} */
       const peerInfo = {
-        node: daemonNode,
-        addresses,
+        node: peerKey,
+        addresses: hints,
       };
       // eslint-disable-next-line no-use-before-define
       await addPeerInfo(peerInfo);
 
       // Register the remote agent key so we can route to its daemon.
-      if (remoteHandleNodeParam && remoteHandleNodeParam !== daemonNode) {
-        writeRemoteAgentKey(remoteHandleNodeParam, daemonNode);
+      if (remoteHandleNodeParam && remoteHandleNodeParam !== peerKey) {
+        writeRemoteAgentKey(remoteHandleNodeParam, peerKey);
       }
 
       const invitationId = formatId({
         number: invitationNumber,
-        node: daemonNode,
+        node: peerKey,
       });
 
       const { number: handleNumber, node: handleNode } = parseId(handleId);
       // eslint-disable-next-line no-use-before-define
       const { addresses: hostAddresses } = await getPeerInfo();
-      // Build the handle locator with `@`-delimited URL-encoded path
-      // components: the first component is the handle's formula number,
-      // and subsequent components are connection hints.
-      const handlePath = [handleNumber, ...hostAddresses]
-        .map(encodeURIComponent)
-        .join('@');
-      const handleUrl = new URL(`endo://${localNodeNumber}/${handlePath}`);
-      handleUrl.searchParams.set('type', 'handle');
+      const handleLocatorWithoutHandleNode = formatLocatorWithHints(
+        formatId({ number: handleNumber, node: localNodeNumber }),
+        'handle',
+        hostAddresses,
+      );
+      const handleUrl = new URL(handleLocatorWithoutHandleNode);
       // Include the handle's node if it differs from the daemon node
       // (i.e. it uses an agent key).
       if (handleNode !== localNodeNumber) {
@@ -1468,7 +1462,7 @@ export const makeHostMaker = ({
       // Store the remote handle under guestName for mail delivery.
       // Use the handle's actual node (which may be an agent key) if
       // provided, falling back to the daemon node.
-      const remoteHandleNode = remoteHandleNodeParam || daemonNode;
+      const remoteHandleNode = remoteHandleNodeParam || peerKey;
       const remoteHandleId = formatId({
         number: /** @type {import('./types.js').FormulaNumber} */ (
           remoteHandleNumber
@@ -1534,21 +1528,21 @@ export const makeHostMaker = ({
       return peerInfo;
     };
 
-    /** @type {EndoHost['locateForSharing']} */
-    const locateForSharing = async (...petNamePath) => {
+    /** @type {EndoHost['locateWithHints']} */
+    const locateWithHints = async (...petNamePath) => {
       return E(directory).locate(...petNamePath);
     };
 
     /** @type {EndoHost['adoptFromLocator']} */
     const adoptFromLocator = async (locator, petNameOrPath) => {
       const { namePath } = petNamePathFrom(petNameOrPath);
-      const { id, addresses } = internalizeLocator(locator);
-      if (addresses.length > 0) {
+      const { id, hints } = internalizeLocator(locator);
+      if (hints.length > 0) {
         const { node: nodeNumber } = parseId(id);
         /** @type {PeerInfo} */
         const peerInfo = {
           node: nodeNumber,
-          addresses,
+          addresses: hints,
         };
         await addPeerInfo(peerInfo);
       }
@@ -1926,7 +1920,7 @@ export const makeHostMaker = ({
       addPeerInfo,
       listKnownPeers,
       followPeerChanges,
-      locateForSharing,
+      locateWithHints,
       adoptFromLocator,
       deliver,
       makeChannel: makeChannelCmd,

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -385,8 +385,8 @@ export const HostInterface = M.interface('EndoHost', {
   listKnownPeers: M.call().returns(M.promise()),
   // Follow changes to the known peers store
   followPeerChanges: M.call().returns(M.promise()),
-  // Locate a formula with connection hints for sharing with remote peers
-  locateForSharing: M.call().rest(NamePathShape).returns(M.promise()),
+  // Locate a formula with connection hints.
+  locateWithHints: M.call().rest(NamePathShape).returns(M.promise()),
   // Adopt a value from a locator with connection hints
   adoptFromLocator: M.call(LocatorShape, NameOrPathShape).returns(M.promise()),
   // Create an invitation

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @import { FormulaNumber, NodeNumber, FormulaIdentifier } from './types.js' */
+/** @import { ConnectionHint, FormulaNumber, NodeNumber, FormulaIdentifier } from './types.js' */
 
 import { makeError, q } from '@endo/errors';
 import { formatId, isValidNumber, parseId } from './formula-identifier.js';
@@ -92,7 +92,7 @@ const encodePathComponents = components =>
 
 /**
  * @param {string} allegedLocator
- * @returns {{ formulaType: string, node: NodeNumber, number: FormulaNumber, hints: string[] }}
+ * @returns {{ formulaType: string, node: NodeNumber, number: FormulaNumber, hints: ConnectionHint[] }}
  */
 export const parseLocator = allegedLocator => {
   const errorPrefix = `Invalid locator ${q(allegedLocator)}:`;
@@ -178,29 +178,43 @@ export const idFromLocator = locator => {
  *
  * @param {string} id - The full formula identifier.
  * @param {string} formulaType - The type of the formula with the given id.
- * @param {string[]} addresses - Network addresses (connection hints).
+ * @param {ConnectionHint[]} hints - Connection hints.
  */
-export const formatLocatorForSharing = (id, formulaType, addresses) => {
+export const formatLocatorWithHints = (id, formulaType, hints) => {
   const { number, node } = parseId(id);
   assertValidLocatorType(formulaType);
   const url = new URL(
-    `endo://${node}${encodePathComponents([number, ...addresses])}`,
+    `endo://${node}${encodePathComponents([number, ...hints])}`,
   );
   url.searchParams.set('type', formulaType);
   return url.toString();
 };
 
 /**
- * Extract connection hint addresses from a locator, if any.
+ * Compatibility alias for the previous connection-hint formatter name.
+ *
+ * @deprecated Use formatLocatorWithHints.
+ */
+export const formatLocatorForSharing = formatLocatorWithHints;
+
+/**
+ * Extract connection hints from a locator, if any.
  *
  * @param {string} locator
- * @returns {string[]}
+ * @returns {ConnectionHint[]}
  */
-export const addressesFromLocator = locator => {
+export const hintsFromLocator = locator => {
   const url = new URL(locator);
   const [, ...hints] = decodePathComponents(url.pathname);
   return hints;
 };
+
+/**
+ * Compatibility alias for the previous connection-hint extractor name.
+ *
+ * @deprecated Use hintsFromLocator.
+ */
+export const addressesFromLocator = hintsFromLocator;
 
 /**
  * Convert an internal formula identifier to a locator for agent
@@ -209,17 +223,12 @@ export const addressesFromLocator = locator => {
  * @param {FormulaIdentifier} id - Internal formula identifier.
  * @param {string} formulaType - The type of the formula.
  * @param {NodeNumber} agentNodeNumber - The agent's public key.
- * @param {string[]} [addresses] - Optional network addresses.
+ * @param {ConnectionHint[]} [hints] - Optional connection hints.
  * @returns {string} A locator string.
  */
-export const externalizeId = (
-  id,
-  formulaType,
-  agentNodeNumber,
-  addresses = [],
-) => {
-  if (addresses.length > 0) {
-    return formatLocatorForSharing(id, formulaType, addresses);
+export const externalizeId = (id, formulaType, agentNodeNumber, hints = []) => {
+  if (hints.length > 0) {
+    return formatLocatorWithHints(id, formulaType, hints);
   }
   return formatLocator(id, formulaType);
 };
@@ -230,10 +239,10 @@ export const externalizeId = (
  * actual node numbers (no sentinel normalization needed).
  *
  * @param {string} locator - A locator string.
- * @returns {{ id: FormulaIdentifier, formulaType: string, addresses: string[] }}
+ * @returns {{ id: FormulaIdentifier, formulaType: string, hints: ConnectionHint[], addresses: ConnectionHint[] }}
  */
 export const internalizeLocator = locator => {
   const { number, node, formulaType, hints } = parseLocator(locator);
   const id = formatId({ number, node });
-  return { id, formulaType, addresses: hints };
+  return { id, formulaType, hints, addresses: hints };
 };

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1600,8 +1600,8 @@ export interface EndoHost extends EndoAgent {
     intervalMs: number,
     label?: string,
   ): Promise<unknown>;
-  /** Locate a formula with connection hints for sharing with remote peers. */
-  locateForSharing(...petNamePath: string[]): Promise<string | undefined>;
+  /** Locate a formula with connection hints. */
+  locateWithHints(...petNamePath: string[]): Promise<string | undefined>;
   /** Adopt a value from a locator that includes connection hints. */
   adoptFromLocator(
     locator: string,

--- a/packages/daemon/test/channel-relay.test.js
+++ b/packages/daemon/test/channel-relay.test.js
@@ -235,7 +235,7 @@ test.serial(
       await E(channel).createInvitation('Bob');
 
       // --- Host A: generate a sharing locator ---
-      const locator = await E(hostA).locateForSharing('test-channel');
+      const locator = await E(hostA).locateWithHints('test-channel');
       t.truthy(locator, 'locator should be generated');
       t.assert(
         /** @type {string} */ (locator).startsWith('endo://'),
@@ -304,7 +304,7 @@ test.serial(
         .then(ch => E(ch).createInvitation('Carol'));
 
       // Generate locator
-      const locator = await E(hostA).locateForSharing('test-channel');
+      const locator = await E(hostA).locateWithHints('test-channel');
 
       // Simulate the broken chat UI flow: extract formula ID but
       // discard connection hints (use write instead of adoptFromLocator).
@@ -370,7 +370,7 @@ test.serial(
       await E(channel).createInvitation('Bob');
 
       // Host B adopts and joins
-      const locator = await E(hostA).locateForSharing('chat-room');
+      const locator = await E(hostA).locateWithHints('chat-room');
       await E(hostB).adoptFromLocator(
         /** @type {string} */ (locator),
         'remote-chat',
@@ -431,7 +431,7 @@ test.serial(
       await E(hostA).evaluate('@main', '"shared value"', [], [], ['my-val']);
 
       // Host A generates locator (includes connection hints)
-      const locator = await E(hostA).locateForSharing('my-val');
+      const locator = await E(hostA).locateWithHints('my-val');
       t.truthy(locator, 'locator should exist');
 
       // Verify locator has connection hints (subsequent `@`-delimited

--- a/packages/daemon/test/locator.test.js
+++ b/packages/daemon/test/locator.test.js
@@ -6,6 +6,8 @@ import {
   assertValidLocator,
   formatLocator,
   formatLocatorForSharing,
+  formatLocatorWithHints,
+  hintsFromLocator,
   idFromLocator,
   parseLocator,
   externalizeId,
@@ -130,38 +132,46 @@ test('parseLocator - hint containing `/` and `?` round-trips', t => {
   t.deepEqual(parsed.hints, [hint]);
 });
 
-test('formatLocatorForSharing', t => {
+test('formatLocatorWithHints', t => {
   const id = formatId({ number: validId, node: validNode });
-  const addresses = ['iroh+captp0:///peer1', 'tcp+captp0://127.0.0.1:8940'];
-  const locator = formatLocatorForSharing(id, validType, addresses);
+  const hints = ['iroh+captp0:///peer1', 'tcp+captp0://127.0.0.1:8940'];
+  const locator = formatLocatorWithHints(id, validType, hints);
   t.true(locator.startsWith('endo://'));
   const parsed = parseLocator(locator);
   t.is(parsed.number, validId);
   t.is(parsed.node, validNode);
   t.is(parsed.formulaType, validType);
-  t.deepEqual(parsed.hints, addresses);
-  const extractedAddresses = addressesFromLocator(locator);
-  t.deepEqual(extractedAddresses, addresses);
+  t.deepEqual(parsed.hints, hints);
+  const extractedHints = hintsFromLocator(locator);
+  t.deepEqual(extractedHints, hints);
 });
 
-test('formatLocatorForSharing - no addresses', t => {
+test('formatLocatorWithHints - no hints', t => {
   const id = formatId({ number: validId, node: validNode });
-  const locator = formatLocatorForSharing(id, validType, []);
+  const locator = formatLocatorWithHints(id, validType, []);
   t.is(locator, formatLocator(id, validType));
-  t.deepEqual(addressesFromLocator(locator), []);
+  t.deepEqual(hintsFromLocator(locator), []);
 });
 
-test('formatLocatorForSharing - hint with `@` round-trips', t => {
+test('formatLocatorWithHints - hint with `@` round-trips', t => {
   const id = formatId({ number: validId, node: validNode });
-  const addresses = ['tcp:user@example.com:8920'];
-  const locator = formatLocatorForSharing(id, validType, addresses);
+  const hints = ['tcp:user@example.com:8920'];
+  const locator = formatLocatorWithHints(id, validType, hints);
   // The `@` inside the hint is URL-encoded so it does not split the path.
   t.true(locator.includes('user%40example.com'));
-  t.deepEqual(addressesFromLocator(locator), addresses);
+  t.deepEqual(hintsFromLocator(locator), hints);
 });
 
-test('addressesFromLocator - plain locator returns empty', t => {
-  t.deepEqual(addressesFromLocator(makeLocator()), []);
+test('hintsFromLocator - plain locator returns empty', t => {
+  t.deepEqual(hintsFromLocator(makeLocator()), []);
+});
+
+test('previous connection-hint helper names remain aliases', t => {
+  const id = formatId({ number: validId, node: validNode });
+  const hints = ['tcp:user@example.com:8920'];
+  const locator = formatLocatorForSharing(id, validType, hints);
+  t.is(locator, formatLocatorWithHints(id, validType, hints));
+  t.deepEqual(addressesFromLocator(locator), hintsFromLocator(locator));
 });
 
 // --- externalizeId, internalizeLocator ---
@@ -233,10 +243,11 @@ test('externalizeId / internalizeLocator round-trip preserves remote node', t =>
 
 test('internalizeLocator extracts connection hints', t => {
   const id = formatId({ number: validId, node: validNode });
-  const addresses = ['tcp://127.0.0.1:8940', 'ws://example.com'];
-  const locator = formatLocatorForSharing(id, validType, addresses);
+  const hints = ['tcp://127.0.0.1:8940', 'ws://example.com'];
+  const locator = formatLocatorWithHints(id, validType, hints);
   const result = internalizeLocator(locator);
-  t.deepEqual(result.addresses, addresses);
+  t.deepEqual(result.hints, hints);
+  t.deepEqual(result.addresses, hints);
 });
 
 // --- Format verification ---

--- a/packages/space-channel/src/channel-header.js
+++ b/packages/space-channel/src/channel-header.js
@@ -111,7 +111,7 @@ harden(lockoutMsToSlider);
 
 /**
  * Resolve a shareable `endo://` locator for a channel pet name, preferring the
- * host's `locateForSharing` and falling back to `locate` (guest / directory).
+ * host's `locateWithHints` and falling back to `locate` (guest / directory).
  * Returns null if no usable locator can be produced.
  *
  * @param {unknown} powers
@@ -123,10 +123,10 @@ const resolveLocator = async (powers, channelPetName, viewMode) => {
   let rawLocator;
   try {
     rawLocator = await E(
-      /** @type {{ locateForSharing: (...args: string[]) => Promise<string> }} */ (
+      /** @type {{ locateWithHints: (...args: string[]) => Promise<string> }} */ (
         powers
       ),
-    ).locateForSharing(channelPetName);
+    ).locateWithHints(channelPetName);
   } catch {
     rawLocator = await E(
       /** @type {{ locate: (...args: string[]) => Promise<string> }} */ (

--- a/packages/spaces-util/src/command-executor.js
+++ b/packages/spaces-util/src/command-executor.js
@@ -678,7 +678,7 @@ export const createCommandExecutor = ({
           console.log(
             `[Chat] Generating shareable locator for "${petNameStr}"...`,
           );
-          const locator = await E(powers).locateForSharing(...pathParts);
+          const locator = await E(powers).locateWithHints(...pathParts);
           if (!locator) {
             throw new Error(`No value found for "${petNameStr}"`);
           }


### PR DESCRIPTION
## Summary

- rename hint-aware locator helpers to `formatLocatorWithHints` and `hintsFromLocator` while retaining low-level compatibility aliases
- expose the host sharing API as `locateWithHints` and update the host accept/adopt paths to use hint terminology
- refresh daemon help, types, and tests for the new locator wording

## Testing

- `node --check packages/daemon/src/locator.js && node --check packages/daemon/src/host.js && node --check packages/daemon/src/interfaces.js`
- `yarn ava packages/daemon/test/locator.test.js --timeout=90s`
- `yarn prettier --check packages/daemon/src/locator.js packages/daemon/locator.js packages/daemon/src/host.js packages/daemon/src/interfaces.js packages/daemon/src/types.d.ts packages/daemon/src/help.md packages/daemon/src/help-text-data.js packages/daemon/test/locator.test.js packages/daemon/test/channel-relay.test.js`
- `yarn workspace @endo/daemon lint` (passes with existing warnings)
- `yarn ava packages/daemon/test/channel-relay.test.js --timeout=120s` from a short-path verification checkout, because the primary worktree path exceeds the daemon UNIX socket path limit
