### PR TITLE
feat(agent-tools): add SWE task tool slice

### DIFF
--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -13,7 +13,9 @@ arguments before dispatching to a capability.
 import {
   makeTool,
   makeGitTool,
+  makeMountListTool,
   makeMountReadTool,
+  makeMountWriteTool,
 } from '@endo/agent-tools';
 ```
 
@@ -26,7 +28,11 @@ Subpath exports are also available:
 ```js
 import { makeTool } from '@endo/agent-tools/tool.js';
 import { makeGitTool } from '@endo/agent-tools/git-tool.js';
-import { makeMountReadTool } from '@endo/agent-tools/mount-fs.js';
+import {
+  makeMountListTool,
+  makeMountReadTool,
+  makeMountWriteTool,
+} from '@endo/agent-tools/mount-fs.js';
 ```
 
 ## Tool Records
@@ -50,7 +56,8 @@ definitions.
 ## Named Arguments
 
 `makeTool` accepts optional positional guards, but callers pass a JSON object.
-The positional arguments are encoded as `arg0`, `arg1`, and so on:
+The schema's `parameters.properties` insertion order defines how those named
+properties map back to positional arguments:
 
 ```js
 const tool = makeTool({
@@ -59,24 +66,19 @@ const tool = makeTool({
   parameters: harden({
     type: 'object',
     properties: {
-      arg0: { type: 'string', description: 'The commit message.' },
+      message: { type: 'string', description: 'The commit message.' },
     },
-    required: ['arg0'],
+    required: ['message'],
     additionalProperties: false,
   }),
   argGuards: harden([M.string()]),
-  execute: async ({ arg0 }) => E(git).commit(arg0),
+  execute: async ({ message }) => E(git).commit(message),
 });
 
-await tool.invoke({ arg0: 'Update docs' });
+await tool.invoke({ message: 'Update docs' });
 ```
 
-This is the current MCP-facing wire shape: MCP tool calls use named JSON
-object properties, so the adapter gives positional APIs stable `argN` names.
-A future adapter can expose separate variants that accept `{ args: [...] }` or
-another positional shape when the caller supports it.
-
-When guards are present, `invoke` rejects unknown `argN` keys, rejects missing
+When guards are present, `invoke` rejects unknown argument keys, rejects missing
 required arguments declared by the schema, copy-hardens incoming parsed JSON
 objects, and validates supplied positional arguments with `mustMatch` before
 calling `execute`.
@@ -94,6 +96,8 @@ The current slice exposes:
 
 - `log`
 - `diff`
+- `status`
+- `add`
 - `show`
 - `commit`
 - `branches`
@@ -101,13 +105,24 @@ The current slice exposes:
 - `switchBranch`
 - `currentBranch`
 
-Methods that require remotable arguments or can return live capabilities, such
-as `status`, `add`, `restore`, and `filesystemAt`, are not included in this
-first slice.
+`status` returns only JSON-safe row fields: `path`, `index`, `worktree`, and
+`renamedFrom` when present. It deliberately omits the capability-bearing
+`entry` and `node` fields from the underlying `Git.status()` result.
 
-## Filesystem Tool
+`add` accepts repo-relative path strings. The tool resolves those paths by
+filtering the same `Git.status()` rows and then calls the underlying
+capability-bearing `Git.add(entries)` method with the matched entries. This
+keeps the staging tool bounded by the granted `Git` capability and avoids
+requiring a separate filesystem grant, at the cost of only staging paths that
+`status()` reports.
 
-`makeMountReadTool(fs)` builds one read-only `mountReadText` tool over an
+Methods that require remotable arguments or can return live capabilities
+directly, such as `restore` and `filesystemAt`, are not included in this slice.
+History-rewriting workflows such as `merge` and `rebase` are also deferred.
+
+## Filesystem Tools
+
+`makeMountReadTool(fs)` builds a read-only `mountReadText` tool over an
 `@endo/platform/fs/extended` `Filesystem` capability:
 
 ```js
@@ -115,14 +130,21 @@ import { readOnly } from '@endo/platform/fs/extended';
 import { makeMountReadTool } from '@endo/agent-tools/mount-fs.js';
 
 const readTool = makeMountReadTool(readOnly(projectFs));
-const content = await readTool.execute({ path: 'README.md' });
+const content = await readTool.invoke({ path: 'README.md' });
 ```
 
 The tool reads UTF-8 text by walking the filesystem tree, opening the final
 file, and reading a bounded byte range. The supplied `Filesystem` capability
 enforces containment, symlink handling, attenuation, subtree scoping, and
-revocation. The tool retains the same 50k character text cap as the existing
-file reader.
+revocation. The tool retains a 50k character text cap by default.
+
+`makeMountWriteTool(fs)` builds a `mountWriteText` tool that writes UTF-8 text
+to a mount-relative file path, creating the file when absent and truncating
+prior contents on overwrite.
+
+`makeMountListTool(fs)` builds a `mountList` tool that lists a mount-relative
+directory path and returns only child `name` and `kind` fields. The result does
+not expose directory cursor or node capabilities.
 
 ## Schema Conformance
 

--- a/packages/agent-tools/mount-fs.d.ts
+++ b/packages/agent-tools/mount-fs.d.ts
@@ -1,1 +1,5 @@
-export { makeMountReadTool } from './src/mount-fs.js';
+export {
+  makeMountListTool,
+  makeMountReadTool,
+  makeMountWriteTool,
+} from './src/mount-fs.js';

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -3,7 +3,7 @@
 
 /** @import { ERef } from '@endo/eventual-send' */
 /** @import { InterfaceGuard, Pattern } from '@endo/patterns' */
-/** @import { GitToolCapability, ToolRecord } from './types.js' */
+/** @import { GitStatusToolEntry, GitToolCapability, ToolRecord } from './types.js' */
 
 /** @typedef {Record<keyof GitToolCapability, (...args: unknown[]) => Promise<unknown>>} GitToolDispatch */
 
@@ -11,6 +11,7 @@ import { E } from '@endo/eventual-send';
 import {
   getInterfaceGuardPayload,
   getMethodGuardPayload,
+  M,
 } from '@endo/patterns';
 import { GitInterface } from '@endo/exo-git';
 
@@ -19,7 +20,9 @@ import { makeTool } from './tool.js';
 /**
  * JSON Schemas for the Git methods exposed as agent tools. Methods that need
  * remotable arguments or return live capabilities are excluded; runtime arg
- * guards come from `GitInterface`.
+ * guards come from `GitInterface` where the tool shape mirrors the Git method
+ * shape. Rebase and merge remain out of scope for this curated slice: those
+ * workflows require additional policy around conflict and history handling.
  */
 
 const NO_ARGS = harden({
@@ -43,11 +46,19 @@ const REF_PROP = harden({
     'structured ref record.',
 });
 
+const PATHS_PROP = harden({
+  type: 'array',
+  items: { type: 'string' },
+  description: 'Repo-relative paths to stage.',
+});
+
 /**
  * This package intentionally exposes only a curated JSON-safe `EndoGit` slice
  * for now. Methods that remotely accept capabilities or can return
- * capabilities, including non-empty `status()` rows, need capref/result
- * serialization and are deferred future work.
+ * capabilities need capref/result serialization and are deferred future work.
+ * `status()` is exposed by projecting only JSON-safe row fields, and `add()`
+ * accepts repo-relative path strings that are resolved against those status
+ * rows before calling the underlying capability-bearing Git method.
  *
  * @type {Record<keyof GitToolCapability, { description: string, parameters: object }>}
  */
@@ -67,6 +78,21 @@ const gitToolSchemas = harden({
       type: 'object',
       properties: { options: OPTIONS_PROP },
       required: [],
+      additionalProperties: false,
+    },
+  },
+  status: {
+    description:
+      'List changed paths with JSON-safe index and worktree state only.',
+    parameters: NO_ARGS,
+  },
+  add: {
+    description:
+      'Stage changed files by repo-relative path, resolving paths through git status.',
+    parameters: {
+      type: 'object',
+      properties: { paths: PATHS_PROP },
+      required: ['paths'],
       additionalProperties: false,
     },
   },
@@ -149,6 +175,102 @@ const positionalArgGuards = method => {
 };
 
 /**
+ * @param {Record<string, unknown>} argsRecord
+ * @param {string} toolName
+ */
+const assertNoArgs = (argsRecord, toolName) => {
+  const keys = Object.keys(argsRecord);
+  if (keys.length > 0) {
+    throw new Error(`unexpected ${toolName} argument key "${keys[0]}"`);
+  }
+};
+
+/**
+ * @param {Record<string, unknown>} argsRecord
+ * @returns {string[]}
+ */
+const getPathArgs = argsRecord => {
+  const { paths } = /** @type {{ paths?: unknown }} */ (argsRecord);
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error('git add requires a non-empty paths array');
+  }
+  for (const path of paths) {
+    if (typeof path !== 'string' || path === '') {
+      throw new Error('git add paths must be non-empty strings');
+    }
+  }
+  return harden([...paths]);
+};
+
+/**
+ * @param {unknown} row
+ * @returns {GitStatusToolEntry}
+ */
+const sanitizeStatusRow = row => {
+  const { path, index, worktree, renamedFrom } =
+    /** @type {{ path: string, index: string, worktree: string, renamedFrom?: string }} */ (
+      row
+    );
+  const indexStatus = /** @type {GitStatusToolEntry['index']} */ (
+    /** @type {unknown} */ (index)
+  );
+  const worktreeStatus = /** @type {GitStatusToolEntry['worktree']} */ (
+    /** @type {unknown} */ (worktree)
+  );
+  return harden({
+    path,
+    index: indexStatus,
+    worktree: worktreeStatus,
+    ...(renamedFrom !== undefined ? { renamedFrom } : {}),
+  });
+};
+
+/**
+ * Resolve repo-relative paths to the entry capabilities already minted by the
+ * granted Git capability's status rows. This lets the tool present a JSON-safe
+ * path API without acquiring any filesystem authority beyond `gitCap`.
+ *
+ * @param {GitToolDispatch} git
+ * @param {string[]} paths
+ * @returns {Promise<object[]>}
+ */
+const statusEntriesForPaths = async (git, paths) => {
+  const rawRows = await git.status();
+  const rows = /** @type {{ path: string, entry: object }[]} */ (rawRows);
+  const byPath = new Map(rows.map(row => [row.path, row]));
+  const entries = [];
+  for (const path of paths) {
+    const row = byPath.get(path);
+    if (row === undefined) {
+      throw new Error(`git add path is not present in status: ${path}`);
+    }
+    entries.push(row.entry);
+  }
+  return harden(entries);
+};
+
+/**
+ * @param {GitToolDispatch} git
+ * @param {Record<string, unknown>} argsRecord
+ */
+const executeStatus = async (git, argsRecord) => {
+  assertNoArgs(argsRecord, 'status');
+  const rawRows = await git.status();
+  const rows = /** @type {unknown[]} */ (rawRows);
+  return harden(rows.map(sanitizeStatusRow));
+};
+
+/**
+ * @param {GitToolDispatch} git
+ * @param {Record<string, unknown>} argsRecord
+ */
+const executeAdd = async (git, argsRecord) => {
+  const paths = getPathArgs(argsRecord);
+  const entries = await statusEntriesForPaths(git, paths);
+  return git.add(entries);
+};
+
+/**
  * Build agent-tool records for a live `Git` capability.
  *
  * @param {ERef<GitToolCapability>} gitCap
@@ -172,8 +294,16 @@ export const makeGitTool = gitCap => {
       name: method,
       description: schema.description,
       parameters: schema.parameters,
-      argGuards,
-      execute: async argsRecord => {
+      argGuards: method === 'add' ? harden([M.arrayOf(M.string())]) : argGuards,
+      execute: argsRecord => {
+        const gitMethod = /** @type {keyof GitToolCapability} */ (method);
+        const git = /** @type {GitToolDispatch} */ (E(gitCap));
+        if (method === 'status') {
+          return executeStatus(git, argsRecord);
+        }
+        if (method === 'add') {
+          return executeAdd(git, argsRecord);
+        }
         // Marshal named args back to positional order by declared name.
         const positional = paramNames.map(paramName => argsRecord[paramName]);
         while (
@@ -182,8 +312,6 @@ export const makeGitTool = gitCap => {
         ) {
           positional.pop();
         }
-        const gitMethod = /** @type {keyof GitToolCapability} */ (method);
-        const git = /** @type {GitToolDispatch} */ (E(gitCap));
         return git[gitMethod](...positional);
       },
     });

--- a/packages/agent-tools/src/index.d.ts
+++ b/packages/agent-tools/src/index.d.ts
@@ -1,3 +1,7 @@
 export { makeTool } from './tool.js';
 export { makeGitTool } from './git-tool.js';
-export { makeMountReadTool } from './mount-fs.js';
+export {
+  makeMountListTool,
+  makeMountReadTool,
+  makeMountWriteTool,
+} from './mount-fs.js';

--- a/packages/agent-tools/src/index.js
+++ b/packages/agent-tools/src/index.js
@@ -2,4 +2,8 @@
 
 export { makeTool } from './tool.js';
 export { makeGitTool } from './git-tool.js';
-export { makeMountReadTool } from './mount-fs.js';
+export {
+  makeMountListTool,
+  makeMountReadTool,
+  makeMountWriteTool,
+} from './mount-fs.js';

--- a/packages/agent-tools/src/mount-fs.d.ts
+++ b/packages/agent-tools/src/mount-fs.d.ts
@@ -6,3 +6,9 @@ export declare const makeMountReadTool: (
   fs: ERef<Filesystem>,
   opts?: MountReadToolOptions,
 ) => ToolRecord;
+
+export declare const makeMountWriteTool: (
+  fs: ERef<Filesystem>,
+) => ToolRecord;
+
+export declare const makeMountListTool: (fs: ERef<Filesystem>) => ToolRecord;

--- a/packages/agent-tools/src/mount-fs.js
+++ b/packages/agent-tools/src/mount-fs.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 /** @import { ERef } from '@endo/eventual-send' */
-/** @import { File, Filesystem } from '@endo/platform/fs/extended' */
+/** @import { Directory, File, Filesystem } from '@endo/platform/fs/extended' */
 /** @import { ToolRecord } from './types.js' */
 
 import { E } from '@endo/eventual-send';
@@ -32,6 +32,85 @@ const mountReadTextParameters = harden({
   required: ['path'],
   additionalProperties: false,
 });
+
+const mountWriteTextParameters = harden({
+  type: 'object',
+  properties: {
+    path: {
+      type: 'string',
+      description: 'Mount-relative path to the file to write.',
+    },
+    content: {
+      type: 'string',
+      description: 'UTF-8 text content to write.',
+    },
+  },
+  required: ['path', 'content'],
+  additionalProperties: false,
+});
+
+const mountListParameters = harden({
+  type: 'object',
+  properties: {
+    path: {
+      type: 'string',
+      description: 'Mount-relative path to the directory to list.',
+    },
+  },
+  required: ['path'],
+  additionalProperties: false,
+});
+
+/**
+ * @param {string} toolName
+ * @param {Record<string, unknown>} args
+ * @param {string[]} allowed
+ */
+const rejectExtraArgs = (toolName, args, allowed) => {
+  const allowedSet = new Set(allowed);
+  for (const key of Object.keys(args)) {
+    if (!allowedSet.has(key)) {
+      throw new Error(`unexpected ${toolName} argument key "${key}"`);
+    }
+  }
+};
+
+/**
+ * @param {string} toolName
+ * @param {Record<string, unknown>} args
+ * @param {string} key
+ * @returns {string}
+ */
+const requireStringArg = (toolName, args, key) => {
+  const value = args[key];
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`${toolName} requires a non-empty string ${key}`);
+  }
+  return value;
+};
+
+/**
+ * `walk` expects one `Directory.lookup` segment at a time. Empty path
+ * components become `.` no-op steps, so `/a`, `a//b`, and `a/` work.
+ *
+ * @param {string} path
+ * @returns {string[]}
+ */
+const pathSegments = path =>
+  path
+    .split('/')
+    .map(segment => segment || '.')
+    .filter(segment => segment !== '.');
+
+/**
+ * @param {ERef<Filesystem>} fs
+ * @param {string[]} segments
+ * @returns {Promise<Directory>}
+ */
+const directoryAt = async (fs, segments) =>
+  /** @type {Promise<Directory>} */ (
+    /** @type {unknown} */ (walk(E(fs).root(), segments))
+  );
 
 /**
  * A read-only filesystem tool bound to an `@endo/platform/fs/extended`
@@ -79,12 +158,7 @@ export const makeMountReadTool = (fs, opts = {}) => {
       if (typeof path !== 'string' || path === '') {
         throw new Error('mountReadText requires a non-empty string path');
       }
-      // `walk` expects one `Directory.lookup` segment at a time. Empty path
-      // components become `.` no-op steps, so `/a`, `a//b`, and `a/` work.
-      const segments = path
-        .split('/')
-        .map(segment => segment || '.')
-        .filter(segment => segment !== '.');
+      const segments = pathSegments(path);
       const file = /** @type {File} */ (
         /** @type {unknown} */ (walk(E(fs).root(), segments))
       );
@@ -102,3 +176,80 @@ export const makeMountReadTool = (fs, opts = {}) => {
   });
 };
 harden(makeMountReadTool);
+
+/**
+ * A writable filesystem tool bound to an `@endo/platform/fs/extended`
+ * `Filesystem` capability. Writes UTF-8 text to a file by root-relative path,
+ * creating the file when absent and truncating prior contents on overwrite.
+ *
+ * The path is split into `Filesystem` segments and resolved by `walk`.
+ * Confinement, symlink containment, and revocation are enforced by the
+ * `Filesystem` capability this tool receives.
+ *
+ * @param {ERef<Filesystem>} fs An `@endo/platform/fs/extended` `Filesystem` ERef.
+ * @returns {ToolRecord}
+ */
+export const makeMountWriteTool = fs =>
+  makeTool({
+    name: 'mountWriteText',
+    description:
+      'Write UTF-8 text to the mounted project directory. ' +
+      'Path is relative to the mount root; "../" escapes are rejected.',
+    parameters: mountWriteTextParameters,
+    execute: async args => {
+      rejectExtraArgs('mountWriteText', args, ['path', 'content']);
+      const path = requireStringArg('mountWriteText', args, 'path');
+      const { content } = /** @type {{ content?: unknown }} */ (args);
+      if (typeof content !== 'string') {
+        throw new Error('mountWriteText requires a string content');
+      }
+      const segments = pathSegments(path);
+      const name = segments.pop();
+      if (name === undefined) {
+        throw new Error('mountWriteText requires a file path');
+      }
+      const dir = await directoryAt(fs, segments);
+      await E(/** @type {object} */ (dir)).write(name, content);
+      return undefined;
+    },
+  });
+harden(makeMountWriteTool);
+
+/**
+ * A directory listing filesystem tool bound to an
+ * `@endo/platform/fs/extended` `Filesystem` capability. Returns only child
+ * names and kinds, keeping cursor and node capabilities out of the result.
+ *
+ * The path is split into `Filesystem` segments and resolved by `walk`.
+ * Confinement, symlink containment, and revocation are enforced by the
+ * `Filesystem` capability this tool receives.
+ *
+ * @param {ERef<Filesystem>} fs An `@endo/platform/fs/extended` `Filesystem` ERef.
+ * @returns {ToolRecord}
+ */
+export const makeMountListTool = fs =>
+  makeTool({
+    name: 'mountList',
+    description:
+      'List child names and kinds in the mounted project directory. ' +
+      'Path is relative to the mount root; "../" escapes are rejected.',
+    parameters: mountListParameters,
+    execute: async args => {
+      rejectExtraArgs('mountList', args, ['path']);
+      const path = requireStringArg('mountList', args, 'path');
+      const dir = await directoryAt(fs, pathSegments(path));
+      const cursor = await E(/** @type {object} */ (dir)).list();
+      const entries = /** @type {{ name: string, kind: string }[]} */ (
+        await E(cursor).toArray()
+      );
+      return harden(
+        entries.map(({ name, kind }) =>
+          harden({
+            name,
+            kind,
+          }),
+        ),
+      );
+    },
+  });
+harden(makeMountListTool);

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -4,23 +4,50 @@ import type { EndoGit } from '@endo/exo-git';
 import type { Pattern } from '@endo/patterns';
 
 /**
- * The read- and branch-navigation slice of `EndoGit` the git tool catalog
- * exposes to an LLM.
+ * JSON-safe projection of an `EndoGit.status()` row. The underlying row carries
+ * entry/node capabilities; the tool result deliberately omits them.
+ */
+export interface GitStatusToolEntry {
+  path: string;
+  index:
+    | 'clean'
+    | 'added'
+    | 'modified'
+    | 'deleted'
+    | 'renamed'
+    | 'copied'
+    | 'conflicted';
+  worktree:
+    | 'clean'
+    | 'modified'
+    | 'deleted'
+    | 'untracked'
+    | 'ignored'
+    | 'conflicted';
+  renamedFrom?: string;
+}
+
+/**
+ * The SWE-task slice of `EndoGit` the git tool catalog exposes to an LLM.
  *
  * Deliberately omits the destructive and history-rewriting methods of `EndoGit`
  * — `merge`, `rebase`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
- * family, and the working-tree/detach mutators (`add`, `switch`, `detach`,
+ * family, and the working-tree/detach mutators (`switch`, `detach`,
  * `worktree`). Those carry authority a tool surface handed to a model should not
  * advertise: they can discard uncommitted work or rewrite shared history.
- * `commit`, `createBranch`, and `switchBranch` are included as the additive,
- * non-destructive write surface. Widening this `Pick` is a deliberate authority
- * decision, not a convenience — add a method only when the tool surface is meant
- * to grant it.
+ * `status` is projected to JSON-safe fields by the tool maker. `add` is exposed
+ * as a path-based staging tool that resolves those paths through `status()` rows
+ * before it calls the underlying capability-bearing method. `commit`,
+ * `createBranch`, and `switchBranch` remain the additive, non-destructive write
+ * surface. Widening this `Pick` is a deliberate authority decision, not a
+ * convenience — add a method only when the tool surface is meant to grant it.
  */
 export type GitToolCapability = Pick<
   EndoGit,
   | 'log'
   | 'diff'
+  | 'status'
+  | 'add'
   | 'show'
   | 'commit'
   | 'branches'
@@ -85,3 +112,7 @@ export declare function makeMountReadTool(
   fs: ERef<Filesystem>,
   opts?: MountReadToolOptions,
 ): ToolRecord;
+
+export declare function makeMountWriteTool(fs: ERef<Filesystem>): ToolRecord;
+
+export declare function makeMountListTool(fs: ERef<Filesystem>): ToolRecord;

--- a/packages/agent-tools/test/git-flow.test.js
+++ b/packages/agent-tools/test/git-flow.test.js
@@ -28,13 +28,11 @@ import { makeGitTool } from '../src/git-tool.js';
  * a real on-disk repository: the records `invoke` correctly, the named→positional
  * marshal reaches the capability, and the capability's results flow back.
  *
- * The capability-heavy methods are deliberately NOT part of the tool slice and
- * are driven through the raw `Git` cap instead: `add` (its
- * `M.arrayOf(M.remotable())` arg awaits the handle-table / capref registry),
- * `status` (its non-empty rows mint remotable nodes), and `filesystemAt` (it
- * returns a live `Filesystem` remotable) all await the capref/result
- * serialization of a later PR. The in-slice, JSON-safe methods (`commit`, `log`,
- * the branch operations) go through the tool records.
+ * The capability-heavy methods that still return live remotables are
+ * deliberately NOT part of the tool slice and are driven through the raw `Git`
+ * cap instead: `filesystemAt` returns a live `Filesystem` remotable and awaits
+ * result serialization of a later PR. The in-slice, JSON-safe methods (`add`,
+ * `status`, `commit`, `log`, the branch operations) go through the tool records.
  */
 
 const execFileAsync = promisify(execFile);
@@ -106,22 +104,20 @@ const byNameOf = tools => name => {
 };
 
 test('makeGitTool drives a real Git cap: stage → status → commit → log → filesystemAt', async t => {
-  const { repoRoot, mount, git } = await provisionGit(t);
+  const { repoRoot, git } = await provisionGit(t);
   const byName = byNameOf(makeGitTool(git));
 
-  // Write and stage a file. `add` is not in the tool slice, so stage through
-  // the raw cap; the rest of the flow is driven through the tool records.
+  // Write and stage a file through the path-based `add` tool.
   await fs.promises.writeFile(
     path.join(repoRoot, 'greeting.txt'),
     'hello tools',
   );
-  const entry = await E(mount).entry(['greeting.txt']);
-  await E(git).add([entry]);
+  await byName('add').invoke({ paths: ['greeting.txt'] });
 
-  // `status` is not part of the tool slice (its non-empty rows mint
-  // remotable nodes that await the capref/result serialization of a later
-  // PR), so read status through the raw cap; it reports the staged file.
-  const staged = await E(git).status();
+  // `status` (tool) reports only JSON-safe row fields for the staged file.
+  const staged = /** @type {Array<{ path: string }>} */ (
+    await byName('status').invoke({})
+  );
   t.true(
     staged.some(row => row.path === 'greeting.txt'),
     'status should report the staged file',
@@ -134,8 +130,10 @@ test('makeGitTool drives a real Git cap: stage → status → commit → log →
   t.regex(commit.oid, /^[0-9a-f]{7,64}$/);
   t.is(commit.summary, 'add greeting');
 
-  // Status (raw cap) is clean once the file is committed.
-  const afterStatus = await E(git).status();
+  // Status (tool) is clean once the file is committed.
+  const afterStatus = /** @type {Array<{ path: string }>} */ (
+    await byName('status').invoke({})
+  );
   t.false(
     afterStatus.some(row => row.path === 'greeting.txt'),
     'the committed file should no longer be dirty',
@@ -153,10 +151,15 @@ test('makeGitTool drives a real Git cap: stage → status → commit → log →
   // through the raw cap; walk the read-only `@endo/platform/fs/extended` Filesystem over the
   // committed tree to read the committed file content back.
   const fsView = await E(git).filesystemAt('HEAD');
-  const root = await E(/** @type {any} */ (fsView)).root();
-  const file = /** @type {any} */ (await walk(root, ['greeting.txt']));
-  const opened = await E(file).open({ read: true });
-  const bytes = await collectBytes(await E(opened).read(0n));
+  const root = await E(/** @type {{ root: () => unknown }} */ (fsView)).root();
+  const file = /** @type {{ open: (opts: object) => unknown }} */ (
+    await walk(/** @type {object} */ (root), ['greeting.txt'])
+  );
+  const opened = /** @type {{ read: (offset: bigint) => unknown }} */ (
+    await E(file).open({ read: true })
+  );
+  const reader = /** @type {object} */ (await E(opened).read(0n));
+  const bytes = await collectBytes(reader);
   t.is(new TextDecoder().decode(bytes), 'hello tools');
 });
 
@@ -201,16 +204,16 @@ test('the runtime guard rejects a bad arg before reaching the live cap', async t
   await t.throwsAsync(() => byName('commit').invoke({ bogus: 'x' }));
 });
 
-test('the deferred add/restore methods are absent from the slice', t => {
+test('the path-based add tool is present and restore remains deferred', t => {
   // The cap is only touched at invoke time, so an empty object suffices to
   // inspect the record names.
   const tools = makeGitTool(
     /** @type {import('../src/types.js').GitToolCapability} */ (harden({})),
   );
   const names = new Set(tools.map(tool => tool.name));
-  // `add`/`restore` take `M.arrayOf(M.remotable())` and stay out of the slice
-  // until the capref registry lands; this pins the contract that justifies the
-  // raw-cap staging above.
-  t.false(names.has('add'));
+  // `add` is exposed as a path-based staging tool. `restore` still takes
+  // capability-bearing entries and can discard work, so it stays out of this
+  // curated slice.
+  t.true(names.has('add'));
   t.false(names.has('restore'));
 });

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -10,11 +10,14 @@ import { Far } from '@endo/pass-style';
 import { makeGitTool } from '../src/git-tool.js';
 
 /** @import { ERef } from '@endo/eventual-send' */
+/** @import { GitStatusEntry } from '@endo/exo-git' */
 /** @import { GitToolCapability } from '../src/types.js' */
 
 const SLICE = [
   'log',
   'diff',
+  'status',
+  'add',
   'show',
   'commit',
   'branches',
@@ -27,9 +30,10 @@ const SLICE = [
  * Stub Git capability that records the method name and positional args.
  *
  * @param {unknown[][]} calls An array each call appends its `[name, ...args]` to.
+ * @param {GitStatusEntry[]} [statusRows]
  * @returns {ERef<GitToolCapability>}
  */
-const makeStubGit = calls => {
+const makeStubGit = (calls, statusRows = []) => {
   /** @type {GitToolCapability} */
   const stubGit = {
     log: async (...a) => {
@@ -39,6 +43,13 @@ const makeStubGit = calls => {
     diff: async (...a) => {
       calls.push(['diff', ...a]);
       return '';
+    },
+    status: async (...a) => {
+      calls.push(['status', ...a]);
+      return harden(statusRows);
+    },
+    add: async (...a) => {
+      calls.push(['add', ...a]);
     },
     show: async (...a) => {
       calls.push(['show', ...a]);
@@ -83,10 +94,10 @@ test('makeGitTool builds one record per non-remotable-slice method', t => {
 test('makeGitTool omits cap-heavy methods', t => {
   const tools = makeGitTool(makeStubGit([]));
   const names = new Set(tools.map(tool => tool.name));
-  t.false(names.has('status'));
-  t.false(names.has('add'));
   t.false(names.has('restore'));
   t.false(names.has('filesystemAt'));
+  t.false(names.has('merge'));
+  t.false(names.has('rebase'));
 });
 
 test('invoke marshals named args to positional and calls the capability', async t => {
@@ -151,6 +162,8 @@ test('the schemas advertise real, declarative property names', t => {
   t.deepEqual(propsOf('show'), ['ref']);
   t.deepEqual(propsOf('createBranch'), ['name', 'options']);
   t.deepEqual(propsOf('switchBranch'), ['branch']);
+  t.deepEqual(propsOf('status'), []);
+  t.deepEqual(propsOf('add'), ['paths']);
   t.deepEqual(propsOf('log'), ['options']);
   t.deepEqual(propsOf('diff'), ['options']);
 });
@@ -175,6 +188,103 @@ test('invoke resolves named args by their real property names', async t => {
     ['switchBranch', 'feature'],
     ['log', { maxCount: 3 }],
   ]);
+});
+
+test('status returns only JSON-safe row fields', async t => {
+  const entry = Far('Entry', {});
+  const node = Far('Node', {});
+  const tools = makeGitTool(
+    makeStubGit(
+      [],
+      [
+        harden({
+          entry,
+          node,
+          path: 'src/a.js',
+          index: 'modified',
+          worktree: 'clean',
+        }),
+        harden({
+          entry,
+          path: 'src/b.js',
+          index: 'renamed',
+          worktree: 'modified',
+          renamedFrom: 'src/old-b.js',
+        }),
+      ],
+    ),
+  );
+  const status = tools.find(tool => tool.name === 'status');
+  if (!status) throw new Error('no status tool');
+
+  const rows = /** @type {Array<Record<string, unknown>>} */ (
+    await status.invoke({})
+  );
+  t.deepEqual(rows, [
+    { path: 'src/a.js', index: 'modified', worktree: 'clean' },
+    {
+      path: 'src/b.js',
+      index: 'renamed',
+      worktree: 'modified',
+      renamedFrom: 'src/old-b.js',
+    },
+  ]);
+  t.false(Object.hasOwn(/** @type {object} */ (rows[0]), 'entry'));
+  t.false(Object.hasOwn(/** @type {object} */ (rows[0]), 'node'));
+});
+
+test('add resolves repo-relative paths through status rows before staging', async t => {
+  const calls = [];
+  const entryA = Far('EntryA', {});
+  const entryB = Far('EntryB', {});
+  const tools = makeGitTool(
+    makeStubGit(calls, [
+      harden({
+        entry: entryA,
+        path: 'a.txt',
+        index: 'modified',
+        worktree: 'modified',
+      }),
+      harden({
+        entry: entryB,
+        path: 'sub/b.txt',
+        index: 'clean',
+        worktree: 'untracked',
+      }),
+    ]),
+  );
+  const add = tools.find(tool => tool.name === 'add');
+  if (!add) throw new Error('no add tool');
+
+  await add.invoke({ paths: ['sub/b.txt', 'a.txt'] });
+
+  t.is(calls.length, 2);
+  t.deepEqual(calls[0], ['status']);
+  t.is(calls[1][0], 'add');
+  t.deepEqual(calls[1][1], [entryB, entryA]);
+});
+
+test('add rejects paths not present in status before staging', async t => {
+  const calls = [];
+  const tools = makeGitTool(
+    makeStubGit(calls, [
+      harden({
+        entry: Far('Entry', {}),
+        path: 'a.txt',
+        index: 'modified',
+        worktree: 'modified',
+      }),
+    ]),
+  );
+  const add = tools.find(tool => tool.name === 'add');
+  if (!add) throw new Error('no add tool');
+
+  const err = await t.throwsAsync(() => add.invoke({ paths: ['missing.txt'] }));
+  t.true(
+    err !== undefined && err.message.includes('missing.txt'),
+    `error should name the unresolved path; got: ${err?.message}`,
+  );
+  t.deepEqual(calls, [['status']]);
 });
 
 test('invoke rejects a wrong property name and a missing required one', async t => {

--- a/packages/agent-tools/test/mount-fs.test.js
+++ b/packages/agent-tools/test/mount-fs.test.js
@@ -22,7 +22,11 @@ import {
   chroot,
 } from '@endo/platform/fs/extended';
 
-import { makeMountReadTool } from '../src/mount-fs.js';
+import {
+  makeMountListTool,
+  makeMountReadTool,
+  makeMountWriteTool,
+} from '../src/mount-fs.js';
 import { toPiAgentTool } from '../src/pi.js';
 
 /**
@@ -304,6 +308,159 @@ test('bridges through toPiAgentTool and reads a file end to end', async t => {
   const result = await agentTool.execute('call-1', { path: 'a.txt' });
   t.deepEqual(result.content, [{ type: 'text', text: 'bridged content' }]);
   t.is(result.details, 'bridged content');
+});
+
+test('writes a text file inside the filesystem', async t => {
+  const rootPath = makeTempRoot(t);
+  const filesystem = makeNodeFilesystem({ rootPath });
+
+  const tool = makeMountWriteTool(filesystem);
+  await null;
+  t.is(
+    await tool.invoke({ path: 'new.txt', content: 'hello write' }),
+    undefined,
+  );
+  t.is(fs.readFileSync(path.join(rootPath, 'new.txt'), 'utf-8'), 'hello write');
+});
+
+test('writes an empty file and overwrites shorter content with truncation', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'note.txt'), 'original content');
+  const filesystem = makeNodeFilesystem({ rootPath });
+
+  const tool = makeMountWriteTool(filesystem);
+  await tool.invoke({ path: 'note.txt', content: 'new' });
+  t.is(fs.readFileSync(path.join(rootPath, 'note.txt'), 'utf-8'), 'new');
+
+  await tool.invoke({ path: 'empty.txt', content: '' });
+  t.is(fs.readFileSync(path.join(rootPath, 'empty.txt'), 'utf-8'), '');
+});
+
+test('writes through a chroot subtree view as the new root', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.mkdirSync(path.join(rootPath, 'sub'));
+  const filesystem = chroot(makeNodeFilesystem({ rootPath }), ['sub']);
+
+  const tool = makeMountWriteTool(filesystem);
+  await null;
+  await tool.invoke({ path: 'inside.txt', content: 'subtree' });
+  t.is(
+    fs.readFileSync(path.join(rootPath, 'sub', 'inside.txt'), 'utf-8'),
+    'subtree',
+  );
+  t.false(fs.existsSync(path.join(rootPath, 'inside.txt')));
+});
+
+test('write rejects extra arguments before any filesystem send', async t => {
+  let touched = false;
+  const filesystem = Far('UntouchedWriteFilesystem', {
+    root() {
+      touched = true;
+      throw new Error('filesystem should not be touched');
+    },
+  });
+  const tool = makeMountWriteTool(
+    /** @type {ERef<Filesystem>} */ (/** @type {unknown} */ (filesystem)),
+  );
+
+  const err = await t.throwsAsync(() =>
+    tool.invoke({ path: 'a.txt', content: 'x', extra: true }),
+  );
+  t.true(
+    err !== undefined && err.message.includes('extra'),
+    `error message should name the offending key; got: ${err?.message}`,
+  );
+  t.false(touched);
+});
+
+test('write rejects a missing path or non-string content before any send', async t => {
+  let touched = false;
+  const filesystem = Far('UntouchedInvalidWriteFilesystem', {
+    root() {
+      touched = true;
+      throw new Error('filesystem should not be touched');
+    },
+  });
+  const tool = makeMountWriteTool(
+    /** @type {ERef<Filesystem>} */ (/** @type {unknown} */ (filesystem)),
+  );
+
+  await t.throwsAsync(() => tool.invoke({ content: 'x' }), {
+    message: /non-empty string path/,
+  });
+  await t.throwsAsync(() => tool.invoke({ path: 'a.txt', content: 1 }), {
+    message: /string content/,
+  });
+  t.false(touched);
+});
+
+test('write remains bounded by read-only filesystem authority', async t => {
+  const rootPath = makeTempRoot(t);
+  const filesystem = readOnly(makeNodeFilesystem({ rootPath }));
+  const tool = makeMountWriteTool(filesystem);
+
+  await null;
+  await t.throwsAsync(
+    () => tool.invoke({ path: 'a.txt', content: 'blocked' }),
+    {
+      message: /EACCES/,
+    },
+  );
+  t.false(fs.existsSync(path.join(rootPath, 'a.txt')));
+});
+
+test('lists child names and kinds without exposing node capabilities', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.writeFileSync(path.join(rootPath, 'a.txt'), 'a');
+  fs.mkdirSync(path.join(rootPath, 'sub'));
+  fs.writeFileSync(path.join(rootPath, 'sub', 'b.txt'), 'b');
+  const filesystem = makeNodeFilesystem({ rootPath });
+
+  const tool = makeMountListTool(filesystem);
+  const rows = /** @type {{ name: string, kind: string }[]} */ (
+    await tool.invoke({ path: '.' })
+  );
+  const sorted = [...rows].sort((a, b) => a.name.localeCompare(b.name));
+  t.deepEqual(sorted, [
+    { name: 'a.txt', kind: 'file' },
+    { name: 'sub', kind: 'directory' },
+  ]);
+  t.false(Object.hasOwn(/** @type {object} */ (sorted[0]), 'qid'));
+});
+
+test('lists through a chroot subtree view as the new root', async t => {
+  const rootPath = makeTempRoot(t);
+  fs.mkdirSync(path.join(rootPath, 'sub'));
+  fs.writeFileSync(path.join(rootPath, 'sub', 'c.txt'), 'c');
+  fs.writeFileSync(path.join(rootPath, 'top.txt'), 'top');
+  const filesystem = chroot(makeNodeFilesystem({ rootPath }), ['sub']);
+
+  const tool = makeMountListTool(filesystem);
+  await null;
+  t.deepEqual(await tool.invoke({ path: '.' }), [
+    { name: 'c.txt', kind: 'file' },
+  ]);
+});
+
+test('list rejects extra or missing path arguments before any filesystem send', async t => {
+  let touched = false;
+  const filesystem = Far('UntouchedListFilesystem', {
+    root() {
+      touched = true;
+      throw new Error('filesystem should not be touched');
+    },
+  });
+  const tool = makeMountListTool(
+    /** @type {ERef<Filesystem>} */ (/** @type {unknown} */ (filesystem)),
+  );
+
+  await t.throwsAsync(() => tool.invoke({ path: '.', extra: true }), {
+    message: /extra/,
+  });
+  await t.throwsAsync(() => tool.invoke({}), {
+    message: /non-empty string path/,
+  });
+  t.false(touched);
 });
 
 test('fails closed after the Filesystem is revoked, with no ambient fallback', async t => {

--- a/packages/agent-tools/types-index.d.ts
+++ b/packages/agent-tools/types-index.d.ts
@@ -1,4 +1,8 @@
 export type * from './src/types.js';
 export { makeTool } from './src/tool.js';
 export { makeGitTool } from './src/git-tool.js';
-export { makeMountReadTool } from './src/mount-fs.js';
+export {
+  makeMountListTool,
+  makeMountReadTool,
+  makeMountWriteTool,
+} from './src/mount-fs.js';

--- a/packages/agent-tools/types-index.js
+++ b/packages/agent-tools/types-index.js
@@ -1,3 +1,7 @@
 export { makeTool } from './src/tool.js';
 export { makeGitTool } from './src/git-tool.js';
-export { makeMountReadTool } from './src/mount-fs.js';
+export {
+  makeMountListTool,
+  makeMountReadTool,
+  makeMountWriteTool,
+} from './src/mount-fs.js';


### PR DESCRIPTION
## Description

`@endo/agent-tools` now exposes enough of the granted Git and filesystem capabilities for a classic tool-calling agent to complete a minimal stage-and-commit task. The Git slice gains JSON-safe status rows and a path-based staging tool, while the filesystem slice gains UTF-8 write and directory list tools.

The staging tool resolves repo-relative paths by filtering `Git.status()` rows and then stages the matched entry capabilities through the granted `Git` cap. This keeps staging bounded by the Git authority already granted to the tool catalog and avoids requiring a separate filesystem grant, with the tradeoff that it can only stage paths reported by status. Restore, merge, and rebase remain intentionally out of scope.

### Security Considerations

This change adds write authority only when the caller grants a writable `Filesystem` or writable `Git` capability. Git status results omit the capability-bearing `entry` and `node` fields, directory listings return only child names and kinds, and filesystem path confinement, symlink containment, attenuation, and revocation remain enforced by the supplied `Filesystem` capability.

### Scaling Considerations

`add` reads current status rows to resolve requested paths, and `mountList` drains the directory cursor for the requested directory. The existing text read cap remains unchanged.

### Documentation Considerations

The package README documents the new Git and filesystem tools, including the status-filtering staging tradeoff and the deferred restore/rebase/merge scope. No migration steps are required.

### Testing Considerations

Unit and integration tests cover the new tool records, JSON-safe status/list projections, path-based staging over a live Git cap, write/list filesystem behavior, chroot/read-only/revocation behavior, and schema/guard agreement. Regression-test note: temporarily adding `entry` back to status rows made `status returns only JSON-safe row fields` fail with leaked `entry` fields; temporarily returning full directory cursor entries made the list projection tests fail with leaked `qid` metadata. Both temporary breaks were reverted and the targeted tests pass.

### Compatibility Considerations

The change is additive to the existing tool catalog. Existing tool names, schemas, and subpath exports continue to work.

### Upgrade Considerations

No live production upgrade action is required.
