### PR TITLE
fix(daemon): settle ws-relay unknown-peer teardown

### DIFF
--- a/packages/daemon/src/networks/ws-relay.js
+++ b/packages/daemon/src/networks/ws-relay.js
@@ -43,6 +43,13 @@ const protocol = 'ws-relay+captp0';
 
 const MAX_RECONNECT_DELAY_MS = 30_000;
 const INITIAL_RECONNECT_DELAY_MS = 1000;
+const DEFAULT_OPEN_TIMEOUT_MS = 30_000;
+
+/** @param {unknown} reason */
+const formatReason = reason =>
+  reason instanceof Error
+    ? `${reason.name}: ${reason.message}`
+    : String(reason);
 
 /**
  * Build a channel-to-stream adapter. Each multiplexed channel becomes
@@ -101,6 +108,15 @@ export const make = async (
     throw new Error('ws-relay network requires WS_RELAY_DOMAIN in env');
   }
 
+  const configuredOpenTimeoutMs = Number(env.WS_RELAY_OPEN_TIMEOUT_MS);
+  const openTimeoutMs =
+    env.WS_RELAY_OPEN_TIMEOUT_MS === undefined ||
+    env.WS_RELAY_OPEN_TIMEOUT_MS === ''
+      ? DEFAULT_OPEN_TIMEOUT_MS
+      : Number.isFinite(configuredOpenTimeoutMs) && configuredOpenTimeoutMs > 0
+        ? configuredOpenTimeoutMs
+        : DEFAULT_OPEN_TIMEOUT_MS;
+
   const localNodeIdBytes = fromHex(localNodeId);
 
   /**
@@ -133,6 +149,39 @@ export const make = async (
   let stopped = false;
 
   const { promise: stoppedPromise, resolve: resolveStopped } = makePromiseKit();
+
+  /**
+   * @param {Promise<void>} closed
+   * @param {string} label
+   * @param {() => void} onClosed
+   */
+  const trackConnectionClosed = (closed, label, onClosed) => {
+    const observedClosed = closed.then(
+      () => undefined,
+      reason => {
+        if (!stopped) {
+          console.warn(
+            `Endo daemon ${label} over ${protocol} closed with error: ${formatReason(reason)}`,
+          );
+        }
+      },
+    );
+    connectionClosedPromises.add(observedClosed);
+    observedClosed
+      .then(
+        () => {
+          connectionClosedPromises.delete(observedClosed);
+          onClosed();
+        },
+        error => {
+          connectionClosedPromises.delete(observedClosed);
+          console.error(
+            `Endo daemon ${label} close observer failed: ${formatReason(error)}`,
+          );
+        },
+      )
+      .catch(() => {});
+  };
 
   /**
    * @param {number} channelId
@@ -201,9 +250,7 @@ export const make = async (
     );
 
     const closedRace = Promise.race([closed, capTpClosed]);
-    connectionClosedPromises.add(closedRace);
-    closedRace.finally(() => {
-      connectionClosedPromises.delete(closedRace);
+    trackConnectionClosed(closedRace, 'inbound relay connection', () => {
       console.log(
         `Endo daemon closed relay connection ${connectionNumber} over ${protocol} at ${new Date().toISOString()}`,
       );
@@ -389,7 +436,7 @@ export const make = async (
       currentWs = null;
     }
     closeAllChannels();
-    await Promise.all(Array.from(connectionClosedPromises));
+    await Promise.allSettled(Array.from(connectionClosedPromises));
     resolveStopped(undefined);
   };
 
@@ -448,11 +495,30 @@ export const make = async (
       resolve: resolveOpen,
       reject: rejectOpen,
     } = makePromiseKit();
+    opened.catch(() => {});
     pendingOpens.set(channelId, { resolve: resolveOpen, reject: rejectOpen });
 
-    currentWs.send(encodeOpen(channelId, targetNodeIdBytes));
+    const openTimer = setTimeout(() => {
+      if (!pendingOpens.has(channelId)) {
+        return;
+      }
+      pendingOpens.delete(channelId);
+      sendClose(channelId);
+      rejectOpen(
+        new Error(`Timed out opening relay channel to ${targetNodeId}`),
+      );
+    }, openTimeoutMs);
 
-    await opened;
+    try {
+      currentWs.send(encodeOpen(channelId, targetNodeIdBytes));
+      await opened;
+    } catch (error) {
+      pendingOpens.delete(channelId);
+      sendClose(channelId);
+      throw error;
+    } finally {
+      clearTimeout(openTimer);
+    }
 
     console.log(
       `Endo daemon connected ${connectionNumber} over ${protocol} at ${new Date().toISOString()}`,
@@ -470,9 +536,7 @@ export const make = async (
     );
 
     const closedRace = Promise.race([closed, capTpClosed]);
-    connectionClosedPromises.add(closedRace);
-    closedRace.finally(() => {
-      connectionClosedPromises.delete(closedRace);
+    trackConnectionClosed(closedRace, 'outbound relay connection', () => {
       cancelConnection();
       console.log(
         `Endo daemon closed outbound relay connection ${connectionNumber} over ${protocol} at ${new Date().toISOString()}`,

--- a/packages/daemon/test/ws-relay.test.js
+++ b/packages/daemon/test/ws-relay.test.js
@@ -1,5 +1,5 @@
 // @ts-nocheck
-/* global process, setTimeout */
+/* global clearTimeout, process, setTimeout */
 
 // Establish a perimeter:
 // eslint-disable-next-line import/order
@@ -189,8 +189,14 @@ const prepareHost = async t => {
  * @param {import('ava').ExecutionContext<any>} t
  * @param {string} relayUrl
  * @param {string} relayDomain
+ * @param {Record<string, string>} [extraEnv]
  */
-const prepareHostWithWsRelay = async (t, relayUrl, relayDomain) => {
+const prepareHostWithWsRelay = async (
+  t,
+  relayUrl,
+  relayDomain,
+  extraEnv = {},
+) => {
   const { host } = await prepareHost(t);
 
   const servicePath = path.join(dirname, 'src', 'networks', 'ws-relay.js');
@@ -202,6 +208,7 @@ const prepareHostWithWsRelay = async (t, relayUrl, relayDomain) => {
     env: {
       WS_RELAY_URL: relayUrl,
       WS_RELAY_DOMAIN: relayDomain,
+      ...extraEnv,
     },
   });
   await E(host).move(['ws-relay-network'], ['@nets', 'ws-relay']);
@@ -359,6 +366,7 @@ test.serial(
         t,
         relay.relayUrl,
         relay.relayDomain,
+        { WS_RELAY_OPEN_TIMEOUT_MS: '1000' },
       );
 
       // Fabricate a peer info with a bogus node ID that is not connected
@@ -389,17 +397,22 @@ test.serial(
 
       // The lookup should reject, not hang indefinitely.
       // We race against a timeout to catch infinite hangs.
+      let timeoutId;
       const timeout = new Promise((_resolve, reject) => {
-        setTimeout(
+        timeoutId = setTimeout(
           () => reject(new Error('Timed out waiting for failure')),
-          30_000,
+          10_000,
         );
       });
 
-      await t.throwsAsync(
-        () => Promise.race([E(hostA).lookup(['bogus']), timeout]),
-        { message: /.*/ },
-      );
+      try {
+        await t.throwsAsync(
+          () => Promise.race([E(hostA).lookup(['bogus']), timeout]),
+          { message: /Timed out opening relay channel/u },
+        );
+      } finally {
+        clearTimeout(timeoutId);
+      }
     } finally {
       await relay.teardown();
     }

--- a/packages/relay-server/src/relay.js
+++ b/packages/relay-server/src/relay.js
@@ -82,6 +82,29 @@ export const makeRelay = domain => {
   };
 
   /**
+   * Cancel an open request that has not yet been paired with a target peer.
+   *
+   * @param {import('ws').WebSocket} ws
+   * @param {number} ch
+   */
+  const removePendingOpen = (ws, ch) => {
+    for (const [target, pending] of pendingOpens.entries()) {
+      const filtered = pending.filter(
+        // eslint-disable-next-line @endo/restrict-comparison-operands
+        p => !(p.ws === ws && p.chId === ch),
+      );
+      if (filtered.length !== pending.length) {
+        if (filtered.length === 0) {
+          pendingOpens.delete(target);
+        } else {
+          pendingOpens.set(target, filtered);
+        }
+        return;
+      }
+    }
+  };
+
+  /**
    * @param {import('ws').WebSocket} ws
    * @param {Uint8Array} data
    */
@@ -302,6 +325,9 @@ export const makeRelay = domain => {
             otherConn.channels.delete(other.chId);
           }
           bridges.delete(bk);
+          conn.channels.delete(channelId);
+        } else {
+          removePendingOpen(ws, channelId);
           conn.channels.delete(channelId);
         }
         break;


### PR DESCRIPTION
## Summary

Connecting to a relay peer that the relay does not know about used to
stall until an ambient teardown fired, and the eventual close raced with
CapTP so the failure surfaced as a late "Connection lost" diagnostic and a
derivative unhandled rejection.

This change settles that teardown:

- add an explicit ws-relay channel-open timeout so a connection to an
  unknown relay peer rejects promptly instead of waiting on teardown;
- observe ws-relay connection-close races so a closing channel no longer
  produces a derivative unhandled rejection; and
- let the relay server cancel a pending open when its source closes an
  as-yet-unopened channel.

## Testing

- `yarn --cwd packages/daemon ava --serial test/ws-relay.test.js`
- `yarn --cwd packages/daemon ava --serial test/ws-relay.test.js --match="connect fails gracefully when peer is unknown to relay"` — run 10× as a stress loop; passes consistently.
- `yarn --cwd packages/daemon lint`
- `yarn --cwd packages/relay-server lint`
- `yarn --cwd packages/relay-server test`

Regression evidence: temporarily raising the ws-relay channel-open timeout
above the test guard reproduced the old behaviour — the unknown-peer test
failed with "Timed out waiting for failure" and the late "Connection lost"
CapTP diagnostic reappeared. Restoring the 1000 ms timeout makes the focused
test pass again.
