### PR TITLE
docs: audit agent command guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,33 +186,44 @@ The project uses `plugin:@endo/internal` which extends `prettier`,
 This enforces harden-exports, restricts plus operands, and requires PascalCase
 for interfaces.
 
-## Testing
+## Commands
 
-- Runtime tests: `yarn test` (uses `ava`)
-- Type tests: `yarn lint:types` (uses `tsd` — test files are `test/types.test-d.ts`)
-- Lint: `yarn lint` (runs both `lint:types` and `lint:eslint`)
-- Yarn 4 via corepack: `npx corepack yarn install`
-- Package tests: `cd packages/<name> && npx ava`
-- Daemon integration tests:
-  `cd packages/daemon && npx ava test/endo.test.js --timeout=120s`
-- Syntax check without SES runtime: `node --check <file.js>`
-- Full module loading requires the Endo daemon because SES lockdown provides
-  `harden` as a global.
+- Install dependencies with `corepack yarn install`.
+  CI enables Corepack shims before running an immutable Yarn install; use the
+  direct Corepack form in locked-down shells that cannot write global shims.
+- Run `yarn format` at the root to apply Prettier to `.github` and `packages`.
+- Run root lint with `yarn lint` when the change is cross-cutting.
+  Root lint runs Prettier, repository ESLint, and shell checks; it does not run
+  typechecking.
+- Run package lint with `yarn workspace <pkg-name> lint` or
+  `yarn --cwd packages/<name> lint`.
+  Package lint usually runs `lint:types` and `lint:eslint`; check the package
+  scripts when the distinction matters.
+- Run typechecking with `yarn lint:types` in the changed package, or
+  `yarn build:types` at the root when exported declarations or cross-package
+  types may have changed.
+- Run `yarn docs` at the root when API docs or exported type surfaces may have
+  changed.
+  This is a CI gate, including for documentation-only PRs, and catches broken
+  `@import` specifiers, missing exported members, and cross-package type drift.
+- Run package tests from the root with
+  `yarn workspace <pkg-name> test <file>`, or equivalently with
+  `yarn --cwd packages/<name> test <file>`.
+  Test timeouts are configured per package; do not add ad-hoc AVA timeout
+  overrides unless you are deliberately changing that package's test behavior.
 
-Always run `yarn lint` in each package you've modified before committing.
+Full module loading may require the Endo daemon because SES lockdown provides
+`harden` as a global.
 
 ### Pre-PR checklist
 
 Reviewers repeatedly flag the same classes of fix-up.
 Running the following before pushing avoids the churn:
 
-- `yarn format` — Prettier drift is the single most common review nit.
-- `yarn lint` in the changed package (and root, if the changes are
-  cross-cutting) — catches ESLint-only rules such as `harden-exports` and
-  `no-underscore-dangle`.
-- `yarn docs` or `tsc --build` — catches missing members on exported
-  interfaces, type-too-narrow/too-wide drift, and broken `@import` specifiers.
-- The package's `npx ava` — at least the tests nearest the change.
+- The relevant commands from the Commands section above.
+  At minimum, format, package lint, typechecking, and the nearest package tests.
+- Root `yarn docs` when public API docs or exported type surfaces may have
+  changed.
 - If the change adds or updates a dependency, commit `yarn.lock` in its own
   commit, separately from the `package.json` change, with the message
   `chore: Update yarn.lock`.
@@ -300,39 +311,6 @@ Run `yarn clean` instead of `yarn build:types:clean` to reset in this case:
 `yarn build:types:clean` only runs TypeScript's project-reference clean, so it
 does not remove stale declaration files that TypeScript has started treating as
 inputs.
-
-## Familiar (Electron shell)
-
-### Testing
-
-- Unit tests:
-  `npx ava packages/daemon/test/gateway.test.js packages/daemon/test/formula-identifier.test.js --timeout=90s`
-- Build: `cd packages/familiar && yarn bundle && yarn package`
-- Lint: `cd packages/familiar && yarn lint`
-- Gateway tests fork a full daemon per test.
-  They must be `test.serial` to avoid resource contention.
-- Tests set `ENDO_ADDR=127.0.0.1:0` so the gateway binds to an OS-assigned port,
-  avoiding conflicts with a running daemon on the default port 8920.
-- Kill leftover daemon processes between test runs:
-  `pkill -f "daemon-node.*packages/daemon/tmp"` and
-  `rm -rf packages/daemon/tmp/`.
-- Worker logs are in
-  `packages/daemon/tmp/<test>/state/worker/<id>/worker.log`.
-  Check these when the APPS formula hangs silently.
-
-### Architecture constraints
-
-- The Electron main process must never import `@endo/init` or `ses`.
-  SES lockdown freezes Electron internals.
-- Unconfined plugins (e.g., `web-server-node.js`) run inside an
-  already-locked-down worker and must not import `ses` or `@endo/init`
-  themselves; doing so causes double-lockdown errors.
-- Electron Forge requires `electron` in `devDependencies` to detect the version.
-  If it is only in `dependencies`, packaging fails with "Could not find any
-  Electron packages in devDependencies".
-- Port 0 (OS-assigned) is falsy in JavaScript.
-  Use `port !== '' ? Number(port) : default` instead of
-  `Number(port) || default`.
 
 ## Markdown style
 

--- a/packages/daemon/AGENTS.md
+++ b/packages/daemon/AGENTS.md
@@ -95,6 +95,20 @@ daemon rather than supplied by the user.
 
 The gateway (`src/daemon.js` line ~851) rejects requests for non-local node IDs with `"Gateway can only provide local values"`. After a daemon restart, the node number changes, so any client holding a stale formula ID from a previous session will hit this error.
 
+## Testing
+
+- Run package tests from the root with
+  `yarn workspace @endo/daemon test test/endo.test.js`.
+  The daemon AVA config sets a 5 minute timeout, so do not add shorter
+  one-off timeout flags.
+- Gateway, daemon, and fork-based tests must be `test.serial` because they fork
+  a full daemon per test and share filesystem state.
+- Tests set `ENDO_ADDR=127.0.0.1:0` so the gateway binds to an OS-assigned port,
+  avoiding conflicts with a running daemon on the default port 8920.
+- Worker logs are in
+  `packages/daemon/tmp/<test>/state/worker/<id>/worker.log`.
+  Check these when daemon-backed scenarios hang silently.
+
 ## Merge Policy
 
 Never use `--ours` or `--theirs` strategies when merging. All conflicts must be resolved manually by understanding both sides of the change.

--- a/packages/familiar/AGENTS.md
+++ b/packages/familiar/AGENTS.md
@@ -1,0 +1,15 @@
+# Familiar Development Guide
+
+## Architecture Constraints
+
+- The Electron main process must never import `@endo/init` or `ses`.
+  SES lockdown freezes Electron internals.
+- Unconfined plugins run inside an already-locked-down worker and must not
+  import `ses` or `@endo/init` themselves; doing so causes double-lockdown
+  errors.
+- Electron Forge requires `electron` in `devDependencies` to detect the version.
+  If it is only in `dependencies`, packaging fails with "Could not find any
+  Electron packages in devDependencies".
+- Port 0, meaning OS-assigned, is falsy in JavaScript.
+  Use `port !== '' ? Number(port) : default` instead of
+  `Number(port) || default`.

--- a/packages/familiar/CLAUDE.md
+++ b/packages/familiar/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/genie/AGENTS.md
+++ b/packages/genie/AGENTS.md
@@ -362,10 +362,10 @@ A change in any one of them needs the chain re-validated.
 
 ```sh
 # Genie unit tests (spawners, command tool, memory, etc.)
-cd packages/genie && npx ava
+yarn workspace @endo/genie test
 
 # Sandbox unit tests (factory, drivers, blocked ranges)
-cd packages/sandbox && npx ava
+yarn workspace @endo/sandbox test
 ```
 
 These run on any OS and do not require `bubblewrap`.
@@ -374,18 +374,10 @@ backend-agnostic factory contract, and the egress filter regression.
 
 ### Integration path (Linux + bubblewrap)
 
-```sh
-# Workspace tool scenario — daemon + setup.js + LLM round-trip.
-cd packages/genie && yarn test:integration
-
-# Sandbox slice scenario — verifies bash actually runs in a slice
-# (daemon path).
-cd packages/genie && yarn test:integration:sandbox-slice
-
-# Same probe shape, dev-repl path — verifies bash actually runs in a
-# slice when invoked through `dev-repl.js -c` instead of the daemon.
-cd packages/genie && yarn test:integration:dev-repl-sandbox
-```
+Run the `@endo/genie` integration scripts from the root with
+`yarn workspace @endo/genie <script>`.
+The relevant scripts are `test:integration`, `test:integration:sandbox-slice`,
+and `test:integration:dev-repl-sandbox`.
 
 The `sandbox-slice` scenario boots a real Endo daemon, runs `setup.js`
 with `GENIE_WORKSPACE=$tmpdir`, waits for the agent to announce


### PR DESCRIPTION
## Description

This expands the agent-instruction update from a narrow AVA invocation tweak into an audit of the root and package AGENTS guidance.

Root `AGENTS.md` now has one Commands section for install, format, root-vs-package lint, typechecking, docs, and package tests. The guidance routes package tests through Yarn workspace or `yarn --cwd` forms so the repository uses its pinned dependencies under the Yarn pnpm linker instead of relying on absent `node_modules/.bin` entries or registry-fetched `npx` binaries. It also removes ad-hoc AVA timeout overrides in favor of each package's own AVA configuration.

Package-specific notes moved down: daemon integration-test details now live in `packages/daemon/AGENTS.md`, and Familiar's Electron constraints now live in a new `packages/familiar/AGENTS.md` with the matching `CLAUDE.md` pointer. `packages/genie/AGENTS.md` now uses root-level Yarn workspace commands instead of `cd packages/...` choreography.

### Security Considerations

No security impact; this is documentation-only.

### Scaling Considerations

No scaling impact.

### Documentation Considerations

This makes the agent-facing instructions match the repo's Yarn 4/pnpm-linker workflow, package-level AVA configuration, and CI behavior. It also calls out `yarn docs` as a CI gate because it catches broken API documentation/type surfaces, including broken `@import` specifiers and missing exported members.

### Testing Considerations

Passed: `corepack yarn install`; `yarn format`; `yarn lint`; `yarn build:types`; `yarn lint:prettier`; `yarn --cwd packages/genie lint`; `yarn workspace @endo/genie test`; `yarn --cwd packages/genie test test/tokens.test.js`; `yarn workspace @endo/sandbox test`; `yarn workspace @endo/daemon test test/endo.test.js`; `rg -n 'npx ava|node --check' AGENTS.md packages -g 'AGENTS.md'`.

Known current-base failures observed while verifying the documented gates: `yarn docs` fails with existing Typedoc/TypeScript errors in tests around mount capability typing plus unrelated narrowed constants, and package lint for `@endo/daemon` / `@endo/familiar` fails on existing type/eslint issues outside this docs-only change.

### Compatibility Considerations

No runtime compatibility impact.

### Upgrade Considerations

No upgrade impact.
