### PR TITLE
feat(git): add commit amend and reword

### DIFF
--- a/.changeset/git-history-tools.md
+++ b/.changeset/git-history-tools.md
@@ -1,0 +1,12 @@
+---
+'@endo/git': minor
+'@endo/exo-git': major
+'@endo/agent-tools': minor
+'@endo/agentry': minor
+'@endo/daemon': minor
+---
+
+Add commit amendment and commit-message rewording to the Git APIs.
+`@endo/agent-tools` provides these history-rewrite operations through the new explicitly elevated `makeGitHistoryTool` maker; the default `makeGitTool` inventory continues to expose only new-commit creation.
+`makeGit` now takes powers separately from `{ readOnly, allowHistoryRewrite }` options; callers must migrate from the former single-object signature in this major `@endo/exo-git` change.
+`@endo/daemon` adds the public `provideGit` history-rewrite option and `GitFormula` support.

--- a/designs/agentry-git-verb-gaps.md
+++ b/designs/agentry-git-verb-gaps.md
@@ -27,9 +27,9 @@ acceptance contract for these verbs.
 
 | Workflow need | EndoGit shape | Code-mode shape | JSON tool slice |
 |---|---|---|---|
-| Commit amend | extend `commit(message, options?)` with `{ amend?: true }` | generated from the `EndoGit` type | include as the existing `commit` tool's optional `options.amend` |
+| Commit amend | extend `commit(message, options?)` with `{ amend?: true }` | generated from the `EndoGit` type | expose through explicit `makeGitHistoryTool` |
 | Cherry-pick | `cherryPick(ref, options?)` | generated from the `EndoGit` type | include with string or structured ref plus JSON options |
-| Reword commit | `reword(ref, message)` | generated from the `EndoGit` type | include with string or structured ref plus message |
+| Reword commit | `reword(ref, message)` | generated from the `EndoGit` type | expose through explicit `makeGitHistoryTool` using a JSON-safe ref |
 | Rebase autosquash | extend `rebase(input)` with `{ autosquash?: boolean }` for `mode: 'start'` | generated from the `EndoGit` type | include the `mode: 'start'` autosquash case |
 | Conflict-side selection | `checkoutConflict(entries, side)` with `side: 'ours' \| 'theirs'` | generated from the `EndoGit` type | include as `paths: string[]`, resolved to entries by the tool |
 
@@ -142,11 +142,11 @@ Code mode receives all five additions automatically by regenerating
 This is the first consumer because stack-surgery eval scenarios can hold
 `EndoMountEntry` values from `status()` and can sequence `rebase` control calls.
 
-The JSON tool slice should also include the first-cut mutators whose wire
-arguments are plain JSON:
+The explicit elevated JSON history-tool slice includes the first-cut mutators
+whose wire arguments are plain JSON:
 
-- `commit(message, options?)` grows the optional `options.amend` flag on the
-  existing `commit` tool.
+- `commit(message, options?)` exposes the optional `options.amend` flag through
+  `makeGitHistoryTool`, not the default `makeGitTool` inventory.
 - `cherryPick(ref, options?)` and `reword(ref, message)` use the same
   JSON-safe ref convention as `show`, `merge`, `createBranch({ startPoint })`,
   and other ref-bearing git tools.

--- a/designs/daemon-agent-tools.md
+++ b/designs/daemon-agent-tools.md
@@ -499,17 +499,19 @@ stack-surgery eval lane, per
 the `stack-surgery` scenario in `designs/agentry-git-eval-scenarios.md` (draft
 PR #636, branch `design/agentry-git-eval-scenarios`).
 
-- [ ] `commit({ amend })` and `reword(ref, message)` across all surfaces
-  at once: exo + `GitInterface` guard + `GitBackend` + native impl +
-  code-mode regen (`packages/agentry/src/execute/git-types.js`) + JSON
-  tools (the `commit` tool's optional `options.amend`; `reword` on the
-  JSON-safe ref convention).
+- [x] `commit({ amend })` and `reword(ref, message)` across the local Git and
+  code-mode surfaces: exo + `GitInterface` guard + `GitBackend` + native impl +
+  code-mode regen (`packages/agentry/src/execute/git-types.js`).
+  The default
+  JSON tool inventory retains only new-commit creation; an explicit
+  `makeGitHistoryTool` maker exposes amend and reword when a host deliberately
+  grants history-rewrite authority.
 - [ ] Extend the `473b718b3` contract test (branch
   `docs/agentry-git-rebase-evals`) so the exo type, `GitInterface`,
   `packages/exo-git/src/types.js`, `types.d.ts`, and the generated
   code-mode declarations cannot drift.
-- [ ] Tests: read-only rejection for each mutator; non-interactive
-  editor behavior for reword.
+- [x] Tests: read-only rejection for each mutator; non-interactive editor
+  behavior, branch attachment, and merge-topology preservation for reword.
 
 ### Phase 6: Stack-replay and conflict resolution (agentry eval lane)
 

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -12,6 +12,7 @@ arguments before dispatching to a capability.
 ```js
 import {
   makeTool,
+  makeGitHistoryTool,
   makeGitTool,
   makeGitMountTools,
   makeMountReadTool,
@@ -30,7 +31,7 @@ Subpath exports are also available:
 
 ```js
 import { makeTool } from '@endo/agent-tools/tool.js';
-import { makeGitTool } from '@endo/agent-tools/git-tool.js';
+import { makeGitHistoryTool, makeGitTool } from '@endo/agent-tools/git-tool.js';
 import { makeGitMountTools } from '@endo/agent-tools/git-mount-tool.js';
 import { makeMountReadTool } from '@endo/agent-tools/mount-fs.js';
 ```
@@ -107,6 +108,22 @@ The current slice exposes:
 - `switchBranch`
 - `currentBranch`
 
+The default `commit` tool creates a new commit and does not accept
+`options.amend`.
+History rewriting is intentionally excluded from this default inventory.
+Hosts that deliberately grant that authority can construct the separate
+elevated tool set:
+
+```js
+const historyTools = makeGitHistoryTool(git);
+```
+
+It exposes `commit` with `options.amend` and `reword`.
+Do not combine this set with `makeGitTool` without resolving the duplicate
+`commit` tool name in the host's catalog.
+The host controls whether a model sees the normal commit-only or elevated
+history-rewrite variant.
+
 This slice holds only the JSON-transparent methods whose hand-authored tool
 schema maps one-to-one onto their `GitInterface` guard. Methods whose native
 signatures traffic in live capabilities — `status` (its rows carry mount-entry
@@ -130,7 +147,7 @@ const mountTools = makeGitMountTools(git);
   the worktree root rather than escaping it; a path that addresses only the
   root (`.`, `/`) is rejected.
 
-The two makers compose into the full status/diff/log/add/commit surface:
+The normal makers compose into the full status/diff/log/add/commit surface:
 
 ```js
 const gitTools = [...makeGitTool(git), ...makeGitMountTools(git)];

--- a/packages/agent-tools/git-tool.d.ts
+++ b/packages/agent-tools/git-tool.d.ts
@@ -1,1 +1,1 @@
-export { makeGitTool } from './src/git-tool.js';
+export { makeGitHistoryTool, makeGitTool } from './src/git-tool.js';

--- a/packages/agent-tools/src/git-tool.d.ts
+++ b/packages/agent-tools/src/git-tool.d.ts
@@ -1,6 +1,14 @@
 import type { ERef } from '@endo/eventual-send';
-import type { GitToolCapability, ToolRecord } from './types.js';
+import type {
+  GitHistoryToolCapability,
+  GitToolCapability,
+  ToolRecord,
+} from './types.js';
 
 export declare const makeGitTool: (
   gitCap: ERef<GitToolCapability>,
+) => ToolRecord[];
+
+export declare const makeGitHistoryTool: (
+  gitCap: ERef<GitHistoryToolCapability>,
 ) => ToolRecord[];

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -3,9 +3,9 @@
 
 /** @import { ERef } from '@endo/eventual-send' */
 /** @import { InterfaceGuard, Pattern } from '@endo/patterns' */
-/** @import { GitToolCapability, ToolRecord } from './types.js' */
+/** @import { GitHistoryToolCapability, GitToolCapability, ToolRecord } from './types.js' */
 
-/** @typedef {Record<keyof GitToolCapability, (...args: unknown[]) => Promise<unknown>>} GitToolDispatch */
+/** @typedef {Record<keyof GitToolCapability | keyof GitHistoryToolCapability, (...args: unknown[]) => Promise<unknown>>} GitToolDispatch */
 
 import { E } from '@endo/eventual-send';
 import {
@@ -55,6 +55,23 @@ const REF_PROP = harden({
     'structured ref record.',
 });
 
+const COMMIT_OPTIONS_PROP = harden({
+  type: 'object',
+  properties: {
+    amend: {
+      type: 'boolean',
+      description: 'Amend HEAD instead of creating a new commit.',
+    },
+  },
+  required: [],
+  additionalProperties: false,
+});
+
+const COMMIT_PROP = harden({
+  type: 'string',
+  description: 'The commit message.',
+});
+
 /**
  * This package intentionally exposes only a curated JSON-safe `EndoGit` slice
  * for now. Methods that remotely accept capabilities or can return
@@ -96,7 +113,7 @@ const gitToolSchemas = harden({
     parameters: {
       type: 'object',
       properties: {
-        message: { type: 'string', description: 'The commit message.' },
+        message: COMMIT_PROP,
       },
       required: ['message'],
       additionalProperties: false,
@@ -136,11 +153,46 @@ const gitToolSchemas = harden({
   },
 });
 
+/** @type {Record<keyof GitHistoryToolCapability, { description: string, parameters: object }>} */
+const gitHistoryToolSchemas = harden({
+  commit: {
+    description: 'Record staged changes, or amend HEAD when requested.',
+    parameters: {
+      type: 'object',
+      properties: {
+        message: COMMIT_PROP,
+        options: COMMIT_OPTIONS_PROP,
+      },
+      required: ['message'],
+      additionalProperties: false,
+    },
+  },
+  reword: {
+    description: 'Replace a commit message while keeping its patch unchanged.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ref: REF_PROP,
+        message: { type: 'string', description: 'The replacement message.' },
+      },
+      required: ['ref', 'message'],
+      additionalProperties: false,
+    },
+  },
+});
+
 /**
  * @type {(keyof GitToolCapability)[]}
  */
 const gitToolMethods = harden(
   /** @type {(keyof GitToolCapability)[]} */ (Object.keys(gitToolSchemas)),
+);
+
+/** @type {(keyof GitHistoryToolCapability)[]} */
+const gitHistoryToolMethods = harden(
+  /** @type {(keyof GitHistoryToolCapability)[]} */ (
+    Object.keys(gitHistoryToolSchemas)
+  ),
 );
 
 /**
@@ -163,15 +215,19 @@ const positionalArgGuards = method => {
 /**
  * Build agent-tool records for a live `Git` capability.
  *
- * @param {ERef<GitToolCapability>} gitCap
+ * @param {ERef<GitToolCapability | GitHistoryToolCapability>} gitCap
  *   A live `Git` capability. The exo `Git` cap is reached by dynamic method
  *   name through `E`, so this records only the invocation shape this maker
  *   needs.
+ * @param {(keyof GitToolDispatch)[]} methods
+ * @param {Partial<Record<keyof GitToolDispatch, { description: string, parameters: object }>>} schemas
  * @returns {ToolRecord[]}
  */
-export const makeGitTool = gitCap => {
-  const records = gitToolMethods.map(method => {
-    const schema = gitToolSchemas[method];
+const makeGitTools = (gitCap, methods, schemas) => {
+  const records = methods.map(method => {
+    const schema = /** @type {{ description: string, parameters: object }} */ (
+      schemas[method]
+    );
     const argGuards = positionalArgGuards(method);
     // The schema's declared property order is the positional argument order,
     // matching the convention `makeTool` applies to the named-args record.
@@ -194,7 +250,7 @@ export const makeGitTool = gitCap => {
         ) {
           positional.pop();
         }
-        const gitMethod = /** @type {keyof GitToolCapability} */ (method);
+        const gitMethod = /** @type {keyof GitToolDispatch} */ (method);
         const git = /** @type {GitToolDispatch} */ (E(gitCap));
         return git[gitMethod](...positional);
       },
@@ -202,4 +258,25 @@ export const makeGitTool = gitCap => {
   });
   return harden(records);
 };
+
+/**
+ * Build the default attenuated agent-tool records for a live `Git` capability.
+ *
+ * @param {ERef<GitToolCapability>} gitCap
+ * @returns {ToolRecord[]}
+ */
+export const makeGitTool = gitCap =>
+  makeGitTools(gitCap, gitToolMethods, gitToolSchemas);
 harden(makeGitTool);
+
+/**
+ * Build explicitly elevated history-rewrite tool records for a live `Git`
+ * capability.
+ * Hosts must opt in to exposing these operations to a model.
+ *
+ * @param {ERef<GitHistoryToolCapability>} gitCap
+ * @returns {ToolRecord[]}
+ */
+export const makeGitHistoryTool = gitCap =>
+  makeGitTools(gitCap, gitHistoryToolMethods, gitHistoryToolSchemas);
+harden(makeGitHistoryTool);

--- a/packages/agent-tools/src/index.d.ts
+++ b/packages/agent-tools/src/index.d.ts
@@ -1,5 +1,5 @@
 export { makeTool } from './tool.js';
-export { makeGitTool } from './git-tool.js';
+export { makeGitHistoryTool, makeGitTool } from './git-tool.js';
 export { makeGitMountTools } from './git-mount-tool.js';
 export {
   makeMountReadTool,

--- a/packages/agent-tools/src/index.js
+++ b/packages/agent-tools/src/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 export { makeTool } from './tool.js';
-export { makeGitTool } from './git-tool.js';
+export { makeGitHistoryTool, makeGitTool } from './git-tool.js';
 export { makeGitMountTools } from './git-mount-tool.js';
 export {
   makeMountReadTool,

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -5,17 +5,20 @@ import type { EndoShell } from '@endo/exo-shell';
 import type { Pattern } from '@endo/patterns';
 
 /**
- * The read- and branch-navigation slice of `EndoGit` the git tool catalog
- * exposes to an LLM.
+ * The read, branch-navigation, and additive-commit slice of `EndoGit` that
+ * the default git tool catalog exposes to an LLM.
  *
  * Deliberately omits the destructive and history-rewriting methods of `EndoGit`
  * — `merge`, `rebase`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
- * family, and the working-tree/detach mutators (`switch`, `detach`). Those carry
- * authority a tool surface handed to a model should not advertise: they can
- * discard uncommitted work or rewrite shared history. `commit`, `createBranch`,
- * and `switchBranch` are included as the additive, non-destructive write
- * surface. Widening this `Pick` is a deliberate authority decision, not a
- * convenience — add a method only when the tool surface is meant to grant it.
+ * family, the working-tree/detach mutators (`switch`, `detach`), and history
+ * rewrites (`commit` with `amend`, `reword`).
+ * Those carry authority a tool
+ * surface handed to a model should not advertise: they can discard uncommitted
+ * work or rewrite shared history. `commit` is included only through the default
+ * maker's message-only schema, so it creates a new commit.
+ * Widening this `Pick`
+ * is a deliberate authority decision, not a convenience — add a method only
+ * when the tool surface is meant to grant it.
  *
  * This slice holds only the JSON-transparent methods whose hand-authored tool
  * schemas map one-to-one onto their `GitInterface` guards (the divergence gate
@@ -36,6 +39,13 @@ export type GitToolCapability = Pick<
   | 'switchBranch'
   | 'currentBranch'
 >;
+
+/**
+ * Explicitly elevated history-rewrite slice for `makeGitHistoryTool`.
+ * Hosts must opt into constructing these tools; the default `makeGitTool`
+ * inventory does not advertise either operation.
+ */
+export type GitHistoryToolCapability = Pick<EndoGit, 'commit' | 'reword'>;
 
 /**
  * The mount-bridged slice of `EndoGit` behind `makeGitMountTools`: `status` and
@@ -94,6 +104,10 @@ export declare function makeTool(spec: ToolSpec): ToolRecord;
 
 export declare function makeGitTool(
   gitCap: ERef<GitToolCapability>,
+): ToolRecord[];
+
+export declare function makeGitHistoryTool(
+  gitCap: ERef<GitHistoryToolCapability>,
 ): ToolRecord[];
 
 export declare function makeGitMountTools(

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -7,10 +7,10 @@ import '@endo/init/debug.js';
 import test from 'ava';
 import { Far } from '@endo/pass-style';
 
-import { makeGitTool } from '../src/git-tool.js';
+import { makeGitHistoryTool, makeGitTool } from '../src/git-tool.js';
 
 /** @import { ERef } from '@endo/eventual-send' */
-/** @import { GitToolCapability } from '../src/types.js' */
+/** @import { GitHistoryToolCapability, GitToolCapability } from '../src/types.js' */
 
 const SLICE = [
   'log',
@@ -66,6 +66,22 @@ const makeStubGit = calls => {
   };
   return Far('StubGit', stubGit);
 };
+
+/**
+ * @param {unknown[][]} calls
+ * @returns {ERef<GitHistoryToolCapability>}
+ */
+const makeHistoryStubGit = calls =>
+  Far('HistoryStubGit', {
+    commit: async (...a) => {
+      calls.push(['commit', ...a]);
+      return { oid: 'x', summary: a[0] };
+    },
+    reword: async (...a) => {
+      calls.push(['reword', ...a]);
+      return { oid: 'x', summary: a[1] };
+    },
+  });
 
 test('makeGitTool builds one record per non-remotable-slice method', t => {
   const tools = makeGitTool(makeStubGit([]));
@@ -153,6 +169,37 @@ test('the schemas advertise real, declarative property names', t => {
   t.deepEqual(propsOf('switchBranch'), ['branch']);
   t.deepEqual(propsOf('log'), ['options']);
   t.deepEqual(propsOf('diff'), ['options']);
+});
+
+test('makeGitHistoryTool requires an explicit elevated capability', async t => {
+  const calls = [];
+  const tools = makeGitHistoryTool(makeHistoryStubGit(calls));
+  t.deepEqual(tools.map(tool => tool.name).sort(), ['commit', 'reword']);
+  const byName = name => {
+    const found = tools.find(tool => tool.name === name);
+    if (!found) throw new Error(`no history tool named ${name}`);
+    return found;
+  };
+
+  await byName('commit').invoke({
+    message: 'amended message',
+    options: harden({ amend: true }),
+  });
+  await byName('reword').invoke({ ref: 'HEAD~1', message: 'new subject' });
+  t.deepEqual(calls, [
+    ['commit', 'amended message', { amend: true }],
+    ['reword', 'HEAD~1', 'new subject'],
+  ]);
+});
+
+test('makeGitTool rejects history-rewrite options', async t => {
+  const tools = makeGitTool(makeStubGit([]));
+  const commit = tools.find(tool => tool.name === 'commit');
+  if (!commit) throw new Error('no commit tool');
+  await t.throwsAsync(
+    commit.invoke({ message: 'not an amendment', options: { amend: true } }),
+    { message: /options/ },
+  );
 });
 
 test('invoke resolves named args by their real property names', async t => {

--- a/packages/agent-tools/types-index.d.ts
+++ b/packages/agent-tools/types-index.d.ts
@@ -1,6 +1,6 @@
 export type * from './src/types.js';
 export { makeTool } from './src/tool.js';
-export { makeGitTool } from './src/git-tool.js';
+export { makeGitHistoryTool, makeGitTool } from './src/git-tool.js';
 export { makeGitMountTools } from './src/git-mount-tool.js';
 export {
   makeMountReadTool,

--- a/packages/agent-tools/types-index.js
+++ b/packages/agent-tools/types-index.js
@@ -1,5 +1,5 @@
 export { makeTool } from './src/tool.js';
-export { makeGitTool } from './src/git-tool.js';
+export { makeGitHistoryTool, makeGitTool } from './src/git-tool.js';
 export { makeGitMountTools } from './src/git-mount-tool.js';
 export {
   makeMountReadTool,

--- a/packages/agentry/README.md
+++ b/packages/agentry/README.md
@@ -78,11 +78,17 @@ import { makeCodeModeAgent } from '@endo/agentry/execute';
 
 const { agent } = makeCodeModeAgent({
   model,
-  powers: { workspace, git, gitMode: 'readOnly' }, // or 'readWrite'
+  powers: { workspace, git, gitMode: 'historyRewrite' },
 });
 await agent.prompt('Inspect the current branch.');
 await agent.waitForIdle();
 ```
+
+`gitMode` is `'readOnly'`, `'readWrite'` (the default), or
+`'historyRewrite'`.
+The history-rewrite mode requires a Git capability minted with explicit
+history-rewrite authority and advertises the elevated `gitHistory` surface,
+including amend and reword operations.
 
 The model-facing tool surface is intentionally one tool:
 `execute({ source, resultName? })`. Workspace and Git operations happen inside

--- a/packages/agentry/scripts/code-mode-git-extract.js
+++ b/packages/agentry/scripts/code-mode-git-extract.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 /**
- * Git-specific code-mode type extraction: the `git` and `gitReadOnly`
+ * Git-specific code-mode type extraction: the `git`, `gitHistory`, and `gitReadOnly`
  * declarations, built with the generic TypeScript renderer from
  * `@endo/exo-git`'s checked TypeScript typedef source.
  *
@@ -33,6 +33,25 @@ import {
 const GIT_TYPES_TS_URL = new URL('../../exo-git/src/types.ts', import.meta.url);
 const GIT_ROOT_TYPE = 'EndoGit';
 
+export const GIT_HISTORY_MEMBERS = harden(['commit', 'reword']);
+harden(GIT_HISTORY_MEMBERS);
+
+/**
+ * Attenuate a canonical method signature by dropping its optional final
+ * options argument while retaining the extracted parameter and return types.
+ *
+ * @param {string} signature
+ * @returns {string}
+ */
+const withoutOptionalFinalArgument = signature => {
+  const attenuated = signature.replace(/, [^,]+\?: [^)]+(?=\) =>)/u, '');
+  if (attenuated === signature) {
+    throw new Error(`expected an optional final argument in ${signature}`);
+  }
+  return attenuated;
+};
+harden(withoutOptionalFinalArgument);
+
 /**
  * The read-only code-mode git prompt surface: the inspection verbs. Mutating
  * verbs (`add`, `restore`, `commit`, branch/stash mutations, `merge`, `rebase`,
@@ -59,23 +78,54 @@ export const GIT_READONLY_MEMBERS = harden([
 harden(GIT_READONLY_MEMBERS);
 
 /**
- * Build the `git` and `gitReadOnly` IRs from the checked `EndoGit` JSDoc
+ * Build the `git`, `gitHistory`, and `gitReadOnly` IRs from the checked `EndoGit` JSDoc
  * typedef; the read-only IR is the same source narrowed to
  * {@link GIT_READONLY_MEMBERS}.
  *
- * @returns {{ git: import('./code-mode-type-extract.js').GlobalTypeIR, gitReadOnly: import('./code-mode-type-extract.js').GlobalTypeIR }}
+ * @returns {{ git: import('./code-mode-type-extract.js').GlobalTypeIR, gitHistory: import('./code-mode-type-extract.js').GlobalTypeIR, gitReadOnly: import('./code-mode-type-extract.js').GlobalTypeIR }}
  */
 export const buildGitIRs = () =>
   harden(
     (() => {
       const fileName = fileURLToPath(GIT_TYPES_TS_URL);
       const text = readFileSync(fileName, 'utf8');
+      const git = extractTsFileTextIR({
+        fileName,
+        text,
+        rootType: GIT_ROOT_TYPE,
+      });
+      const gitHistory = extractTsFileTextIR({
+        fileName,
+        text,
+        rootType: GIT_ROOT_TYPE,
+        memberFilter: GIT_HISTORY_MEMBERS,
+      });
+      const commit = git.members.find(member => member.name === 'commit');
+      if (commit === undefined) {
+        throw new Error('EndoGit must define commit');
+      }
       return {
-        git: extractTsFileTextIR({
-          fileName,
-          text,
-          rootType: GIT_ROOT_TYPE,
+        git: harden({
+          rootName: 'EndoGit',
+          members: git.members
+            .filter(
+              member =>
+                !GIT_HISTORY_MEMBERS.includes(member.name) ||
+                member.name === 'commit',
+            )
+            .map(member =>
+              member.name === 'commit'
+                ? harden({
+                    ...commit,
+                    signature: withoutOptionalFinalArgument(commit.signature),
+                  })
+                : member,
+            ),
+          auxTypes: git.auxTypes.filter(
+            type => type.name !== 'GitCommitOptions',
+          ),
         }),
+        gitHistory: harden({ ...gitHistory, rootName: 'EndoGitHistory' }),
         gitReadOnly: extractTsFileTextIR({
           fileName,
           text,
@@ -88,14 +138,15 @@ export const buildGitIRs = () =>
 harden(buildGitIRs);
 
 /**
- * Render the `git` and `gitReadOnly` `{ aux, body }` declaration strings.
+ * Render the `git`, `gitHistory`, and `gitReadOnly` `{ aux, body }` declaration strings.
  *
- * @returns {Record<'git' | 'gitReadOnly', { aux: string, body: string }>}
+ * @returns {Record<'git' | 'gitHistory' | 'gitReadOnly', { aux: string, body: string }>}
  */
 export const buildGitTypeDeclarations = () => {
   const irs = buildGitIRs();
   return harden({
     git: renderDeclaration(irs.git),
+    gitHistory: renderDeclaration(irs.gitHistory),
     gitReadOnly: renderDeclaration(irs.gitReadOnly),
   });
 };

--- a/packages/agentry/src/execute/git-types.js
+++ b/packages/agentry/src/execute/git-types.js
@@ -117,6 +117,27 @@ type GitWorktreeStatus = 'clean' | 'modified' | 'deleted' | 'untracked' | 'ignor
 type ReadableTreeView = unknown;`,
     body: `EndoGit`,
   },
+  gitHistory: {
+    aux: `type EndoGitHistory = {
+  commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
+  reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+};
+type GitCommit = {
+    oid: string;
+    summary: string;
+    author?: string;
+    committedAt?: number;
+};
+type GitCommitOptions = {
+    amend?: boolean;
+};
+type GitRef = {
+    name: string;
+    kind: 'branch' | 'tag' | 'commit' | 'detached';
+    oid?: string;
+};`,
+    body: `EndoGitHistory`,
+  },
   gitReadOnly: {
     aux: `type EndoGit = {
   worktree: () => Promise<EndoMount | ReadableTreeView>;

--- a/packages/agentry/src/execute/git.js
+++ b/packages/agentry/src/execute/git.js
@@ -7,8 +7,8 @@ import { gitCodeModeTypeDeclarations } from './git-types.js';
 
 /**
  * The git exo's per-mode generated TypeScript declarations, keyed by code-mode
- * surface: `git` (read/write) and `gitReadOnly` (inspection verbs only). A
- * consumer composing its own code-mode agent can read these directly to inject
+ * surface: ordinary read/write, history rewrite, and read-only inspection.
+ * A consumer composing its own code-mode agent can read these directly to inject
  * git types into a hand-built global.
  */
 export { gitCodeModeTypeDeclarations };
@@ -25,17 +25,28 @@ export { gitCodeModeTypeDeclarations };
  * @param {string | string[]} [options.petName] Pet name to look the capability
  *   up by; defaults to `name`.
  * @param {boolean} [options.readOnly] Select the read-only prompt surface.
+ * @param {boolean} [options.historyRewrite] Select the history-rewrite prompt
+ *   surface.
  * @returns {CodeModeGlobal}
  */
-export const makeGitGlobal = ({ name, petName = name, readOnly = false }) =>
+export const makeGitGlobal = ({
+  name,
+  petName = name,
+  readOnly = false,
+  historyRewrite = false,
+}) =>
   harden({
     name,
     petName,
     description: readOnly
       ? 'Read-only @endo/exo-git Git capability for repository inspection.'
-      : 'Read/write @endo/exo-git Git capability for repository changes.',
+      : historyRewrite
+        ? 'History-rewrite @endo/exo-git Git capability for amend and reword.'
+        : 'Read/write @endo/exo-git Git capability for repository changes.',
     declaration: readOnly
       ? gitCodeModeTypeDeclarations.gitReadOnly
-      : gitCodeModeTypeDeclarations.git,
+      : historyRewrite
+        ? gitCodeModeTypeDeclarations.gitHistory
+        : gitCodeModeTypeDeclarations.git,
   });
 harden(makeGitGlobal);

--- a/packages/agentry/src/execute/preset.js
+++ b/packages/agentry/src/execute/preset.js
@@ -8,7 +8,7 @@
 /** @import { CodeModeExecute, CodeModeGlobal, CodeModePower, PowerHandle, LookupPowers } from './tool.js' */
 
 import { E } from '@endo/eventual-send';
-import { isGitReadOnly } from '@endo/exo-git';
+import { isGitHistoryRewrite, isGitReadOnly } from '@endo/exo-git';
 
 import { defineAgent } from '../define-agent.js';
 import { getAmbientEnv, makeEnvCredentials } from '../harness/credentials.js';
@@ -53,7 +53,7 @@ const lookupRequiredPower = (powers, petName, label) => {
  * @property {string} [workspacePetName]
  * @property {CodeModePower} [git]
  * @property {string} [gitPetName]
- * @property {'readOnly' | 'readWrite'} [gitMode]
+ * @property {'readOnly' | 'readWrite' | 'historyRewrite'} [gitMode]
  * @property {CodeModeGlobal[]} [namedPowers]
  *
  * @typedef {object} MakeCodeModeAgentOptions
@@ -79,10 +79,9 @@ const lookupRequiredPower = (powers, petName, label) => {
  * This builder only chooses WHICH globals to inject from the configured powers;
  * the per-exo specifics (descriptions, generated declarations, the read-only
  * member policy) live in `git.js` and `fs.js`, which this delegates to. The
- * read-only vs read-write split is a prompt-surface policy: `gitMode:
- * 'readOnly'` selects the `gitReadOnly` declaration (inspection verbs only),
- * while the runtime read-only enforcement stays the exo guard. `namedPowers`
- * stay name-only unless the caller attached its own `declaration`.
+ * `gitMode` selects the one configured Git capability's prompt surface.
+ * Runtime authority remains with that capability; `namedPowers` stay name-only
+ * unless the caller attached its own `declaration`.
  *
  * @param {CodeModePowers} powers
  * @returns {CodeModeGlobal[]}
@@ -106,6 +105,7 @@ const makeCodeModeGlobals = (powers = {}) => {
         name: petNameToBindingName(gitPetName, 'git'),
         petName: gitPetName,
         readOnly: powers.gitMode === 'readOnly',
+        historyRewrite: powers.gitMode === 'historyRewrite',
       }),
     );
   }
@@ -139,6 +139,14 @@ const resolveConfiguredPowers = (powers, lookupPowers) => {
       if (gitReadOnly === false) {
         throw new Error(
           'code-mode gitMode readOnly requires an already read-only Git capability',
+        );
+      }
+    }
+    if (powers.gitMode === 'historyRewrite') {
+      const gitHistoryRewrite = isGitHistoryRewrite(resolved[gitName]);
+      if (gitHistoryRewrite === false) {
+        throw new Error(
+          'code-mode gitMode historyRewrite requires a Git capability with history-rewrite authority',
         );
       }
     }

--- a/packages/agentry/test/code-mode-types.test.js
+++ b/packages/agentry/test/code-mode-types.test.js
@@ -12,6 +12,7 @@ import { fsCodeModeTypeDeclarations } from '../src/execute/fs-types.js';
 import {
   buildGitTypeDeclarations,
   buildGitIRs,
+  GIT_HISTORY_MEMBERS,
   GIT_READONLY_MEMBERS,
 } from '../scripts/code-mode-git-extract.js';
 import {
@@ -54,16 +55,17 @@ test('generated fs-types.js is up to date with its source', t => {
   }
 });
 
-// Guard divergence gate: the TypeScript-canonical git declaration must
-// enumerate exactly the methods the runtime `GitInterface` guard enforces, so
-// the printed types cannot silently drift from the enforcement layer.
-test('git declarations cover exactly the GitInterface guard methods', t => {
+// The base declaration stays guard-canonical except for the deliberately
+// attenuated history-rewrite methods. `gitHistory` carries those separately.
+test('git declarations split the GitInterface history-rewrite method', t => {
   const { git } = buildGitIRs();
   const tsMembers = git.members.map(member => member.name).sort();
   const guardMethods = Object.keys(
     getInterfaceGuardPayload(/** @type {InterfaceGuard} */ (GitInterface))
       .methodGuards,
-  ).sort();
+  )
+    .filter(name => !GIT_HISTORY_MEMBERS.includes(name) || name === 'commit')
+    .sort();
   t.deepEqual(tsMembers, guardMethods);
 });
 
@@ -85,6 +87,30 @@ test('read-only git is a subset of read-write git and omits mutators', t => {
   t.false(gitCodeModeTypeDeclarations.gitReadOnly.aux.includes('commit:'));
   t.true(readOnly.includes('log'));
   t.true(readOnly.includes('diff'));
+});
+
+test('base and history git declarations split history rewrite authority', t => {
+  const { git, gitHistory } = buildGitIRs();
+  const baseCommit = git.members.find(member => member.name === 'commit');
+  if (baseCommit === undefined) {
+    t.fail('base git declaration must include commit');
+    return;
+  }
+  t.is(baseCommit.signature, '(message: string) => Promise<GitCommit>');
+  for (const name of GIT_HISTORY_MEMBERS) {
+    if (name !== 'commit') {
+      t.false(git.members.some(member => member.name === name));
+    }
+  }
+  t.deepEqual(
+    gitHistory.members.map(member => member.name).sort(),
+    [...GIT_HISTORY_MEMBERS].sort(),
+  );
+  t.true(
+    gitHistory.members.some(member =>
+      member.signature.includes('GitCommitOptions'),
+    ),
+  );
 });
 
 // The FS `.d.ts` is a stub, so `workspace` is derived from the interface

--- a/packages/agentry/test/code-mode.test.js
+++ b/packages/agentry/test/code-mode.test.js
@@ -114,14 +114,15 @@ const provisionGitWorktree = async t => {
  * `mountEntryRecords` WeakMap.
  *
  * @param {import('ava').ExecutionContext} t
+ * @param {boolean} [allowHistoryRewrite]
  */
-const makeRealGit = async t => {
+const makeRealGit = async (t, allowHistoryRewrite = false) => {
   const repoRoot = await provisionGitWorktree(t);
   const workspace = makeNodeFilesystem({ rootPath: repoRoot });
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
   const backend = makeNativeGitBackend({ repoRoot });
-  const git = makeGit({ mount, backend, lineageOf });
+  const git = makeGit({ mount, backend, lineageOf }, { allowHistoryRewrite });
   return harden({ repoRoot, workspace, git });
 };
 
@@ -237,6 +238,37 @@ test('a typed global injects its generated declaration into the prompt', t => {
   t.true(systemPrompt.includes('type Directory = {'));
   // The runtime introspection fallback is still advertised.
   t.true(systemPrompt.includes('__getMethodNames__'));
+});
+
+test('makeCodeModeAgent configures one history-rewrite git capability', async t => {
+  const { workspace, git } = await makeRealGit(t, true);
+  const { globals, systemPrompt } = makeCodeModeAgent({
+    model: fauxModel(t, []),
+    powers: { workspace, git, gitMode: 'historyRewrite' },
+  });
+  t.deepEqual(
+    globals.map(global => global.name),
+    ['workspace', 'git'],
+  );
+  t.true(systemPrompt.includes('declare const git: EndoGitHistory;'));
+  t.true(
+    systemPrompt.includes(
+      'commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;',
+    ),
+  );
+  t.true(systemPrompt.includes('reword:'));
+});
+
+test('makeCodeModeAgent rejects ordinary Git for history-rewrite mode', async t => {
+  const { workspace, git } = await makeRealGit(t);
+  t.throws(
+    () =>
+      makeCodeModeAgent({
+        model: fauxModel(t, []),
+        powers: { workspace, git, gitMode: 'historyRewrite' },
+      }),
+    { message: /requires a Git capability with history-rewrite authority/ },
+  );
 });
 
 test('makeCodeModeAgent injects typed git + workspace declarations from powers', async t => {

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -3017,7 +3017,7 @@ const makeDaemonCore = async (
       });
       return mount;
     },
-    git: async ({ mountId }, context) => {
+    git: async ({ mountId, allowHistoryRewrite = false }, context) => {
       context.thisDiesIfThatDies(mountId);
       const mount = await provide(mountId);
       const backing = getMountBacking(mount);
@@ -3046,16 +3046,18 @@ const makeDaemonCore = async (
         repoRoot: backing.physicalRoot,
       });
       await backend.assertRepositoryRoot();
-      return makeGit({
-        // `provide(mountId)` returns a union of cap types; the
-        // `getMountBacking` check above guarantees an `EndoMount`,
-        // but TS can't narrow through it.
-        // eslint-disable-next-line object-shorthand
-        mount: /** @type {object} */ (mount),
-        backend,
-        readOnly: backing.readOnly,
-        lineageOf,
-      });
+      return makeGit(
+        {
+          // `provide(mountId)` returns a union of cap types; the
+          // `getMountBacking` check above guarantees an `EndoMount`,
+          // but TS can't narrow through it.
+          // eslint-disable-next-line object-shorthand
+          mount: /** @type {object} */ (mount),
+          backend,
+          lineageOf,
+        },
+        { readOnly: backing.readOnly, allowHistoryRewrite },
+      );
     },
     shell: async ({ mountId, policy }, context) => {
       context.thisDiesIfThatDies(mountId);
@@ -4310,7 +4312,7 @@ const makeDaemonCore = async (
   };
 
   /** @type {DaemonCore['formulateGit']} */
-  const formulateGit = async (mountId, deferredTasks) => {
+  const formulateGit = async (mountId, allowHistoryRewrite, deferredTasks) => {
     return /** @type {FormulateResult<EndoGit>} */ (
       withFormulaGraphLock(async () => {
         await null;
@@ -4329,6 +4331,7 @@ const makeDaemonCore = async (
         const formula = harden({
           type: 'git',
           mountId,
+          ...(allowHistoryRewrite && { allowHistoryRewrite: true }),
         });
 
         return formulate(formulaNumber, formula);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -519,7 +519,7 @@ export const makeHostMaker = ({
     };
 
     /** @type {EndoHost['provideGit']} */
-    const provideGit = async (mountCap, petName) => {
+    const provideGit = async (mountCap, petName, options = {}) => {
       const { namePath } = petNamePathFrom(petName);
       const mountId = getIdForRef(mountCap);
       if (mountId === undefined) {
@@ -534,7 +534,8 @@ export const makeHostMaker = ({
         E(directory).storeIdentifier(namePath, identifiers.gitId),
       );
 
-      const { value } = await formulateGit(mountId, tasks);
+      const { allowHistoryRewrite = false } = options;
+      const { value } = await formulateGit(mountId, allowHistoryRewrite, tasks);
       return /** @type {EndoGit} */ (value);
     };
 
@@ -804,7 +805,7 @@ export const makeHostMaker = ({
         makeGit: async () => {
           /** @type {DeferredTasks<GitDeferredTaskParams>} */
           const tasks = makeDeferredTasks();
-          const { value, id } = await formulateGit(destMountId, tasks);
+          const { value, id } = await formulateGit(destMountId, false, tasks);
           clonedGitId = id;
           return value;
         },

--- a/packages/daemon/src/interfaces.js
+++ b/packages/daemon/src/interfaces.js
@@ -307,9 +307,9 @@ export const HostInterface = M.interface('EndoHost', {
     )
     .returns(M.promise()),
   // Derive a local Git capability from an authorized mount.
-  provideGit: M.callWhen(M.remotable(), NameOrPathShape).returns(
-    M.remotable('Git'),
-  ),
+  provideGit: M.callWhen(M.remotable(), NameOrPathShape)
+    .optional(M.splitRecord({}, { allowHistoryRewrite: M.boolean() }))
+    .returns(M.remotable('Git')),
   // Derive an allowlisted command-execution Shell from a writable mount.
   provideShell: M.callWhen(
     M.remotable(),

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -269,6 +269,11 @@ export type ScratchMountFormula = {
 export type GitFormula = {
   type: 'git';
   mountId: FormulaIdentifier;
+  /**
+   * Formula-owned history-rewrite authority survives deincarnation and restart.
+   * Absence retains the backward-compatible default denial.
+   */
+  allowHistoryRewrite?: boolean;
 };
 
 /**
@@ -1317,7 +1322,11 @@ export interface EndoHost extends EndoAgent {
     petName: string | string[],
     opts?: { readOnly?: boolean; deniedSegments?: string[] },
   ): Promise<EndoMount>;
-  provideGit(mountCap: EndoMount, petName: string | string[]): Promise<EndoGit>;
+  provideGit(
+    mountCap: EndoMount,
+    petName: string | string[],
+    options?: { allowHistoryRewrite?: boolean },
+  ): Promise<EndoGit>;
   /**
    * Derive an allowlisted, argv-only command-execution `Shell` from a
    * **writable** mount.  The child working directory is resolved host-side
@@ -2344,6 +2353,7 @@ export interface DaemonCore {
 
   formulateGit: (
     mountId: FormulaIdentifier,
+    allowHistoryRewrite: boolean,
     deferredTasks: DeferredTasks<GitDeferredTaskParams>,
   ) => FormulateResult<EndoGit>;
 

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -4555,6 +4555,58 @@ const makeArchiveTree = archiveBytes =>
     },
   });
 
+testNeedsNodeWorker(
+  'provideGit persists history-rewrite authority in its formula',
+  async t => {
+    const { host, config } = await prepareHost(t);
+    const repoPath = path.join(
+      config.statePath,
+      '..',
+      'git-history-policy-repo',
+    );
+    await createGitFixture(repoPath);
+    await fs.promises.writeFile(
+      path.join(repoPath, 'history.txt'),
+      'history rewrite target\n',
+    );
+    await git(repoPath, ['add', 'history.txt']);
+    await git(repoPath, [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'history rewrite target',
+    ]);
+
+    const mount = await E(host).provideMount(repoPath, 'git-history-worktree');
+    const ordinaryGit = await E(host).provideGit(mount, 'git-ordinary');
+    const gitHistory = await E(host).provideGit(mount, 'git-history', {
+      allowHistoryRewrite: true,
+    });
+
+    await t.throwsAsync(
+      E(ordinaryGit).reword('HEAD', 'blocked ordinary rewrite'),
+      {
+        message: /without history-rewrite authority/,
+      },
+    );
+    const amended = await E(gitHistory).commit('amended before cancel', {
+      amend: true,
+    });
+    t.is(amended.summary, 'amended before cancel');
+
+    await E(host).cancel('git-history');
+    const reincarnated = await E(host).lookup('git-history');
+    const reworded = await E(reincarnated).reword(
+      'HEAD',
+      'reworded after reification',
+    );
+    t.is(reworded.summary, 'reworded after reification');
+  },
+);
+
 test('provideGit tree exposes immutable commit contents', async t => {
   const { host, config } = await prepareHost(t);
 

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -45,6 +45,12 @@ const provisionGitWorktree = async t => {
   await execFileAsync('git', ['config', '--local', 'tag.gpgsign', 'false'], {
     cwd: root,
   });
+  await execFileAsync('git', ['config', '--local', 'user.email', 't@t'], {
+    cwd: root,
+  });
+  await execFileAsync('git', ['config', '--local', 'user.name', 'T'], {
+    cwd: root,
+  });
   await execFileAsync(
     'git',
     [
@@ -108,7 +114,7 @@ test('Git exo advertises the full GitInterface', async t => {
   }
 
   // Mutation
-  for (const name of ['add', 'restore', 'commit']) {
+  for (const name of ['add', 'restore', 'commit', 'reword']) {
     t.true(methods.includes(name), `Git should advertise ${name}`);
   }
 
@@ -184,6 +190,15 @@ test('Git.readOnly() attenuates mutating operations but preserves reads', async 
   await t.throwsAsync(E(readOnlyGit).commit('should fail'), {
     message: /read-only Git capability/,
   });
+  await t.throwsAsync(
+    E(readOnlyGit).commit('should also fail', { amend: true }),
+    {
+      message: /read-only Git capability/,
+    },
+  );
+  await t.throwsAsync(E(readOnlyGit).reword('HEAD', 'should fail'), {
+    message: /read-only Git capability/,
+  });
   await t.throwsAsync(E(readOnlyGit).switchBranch('main'), {
     message: /read-only Git capability/,
   });
@@ -250,7 +265,7 @@ test('makeGit can be constructed directly as read-only', async t => {
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: true, filePowers });
   const backend = makeNativeGitBackend({ repoRoot });
-  const git = makeGit({ mount, backend, readOnly: true, lineageOf });
+  const git = makeGit({ mount, backend, lineageOf }, { readOnly: true });
 
   t.is((await E(git).status()).length, 1);
   const entry = await E(mount).entry(['blocked.txt']);
@@ -509,10 +524,381 @@ test('Git.readOnly allows immutable tree reads', async t => {
   t.is(await E(blob).text(), 'audit\n');
 });
 
+test('Git.commit can amend HEAD through the native backend', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  await fs.promises.writeFile(path.join(repoRoot, 'amend.txt'), 'one\n');
+  const entry = await E(mount).entry(['amend.txt']);
+  await E(git).add([entry]);
+  const first = await E(git).commit('first subject');
+
+  await fs.promises.writeFile(path.join(repoRoot, 'amend.txt'), 'two\n');
+  await E(git).add([entry]);
+  const amended = await E(git).commit('amended subject', { amend: true });
+
+  t.not(amended.oid, first.oid);
+  t.is(amended.summary, 'amended subject');
+  const log = await E(git).log({ maxCount: 3 });
+  t.deepEqual(
+    log.map(commit => commit.summary),
+    ['amended subject', 'init commit'],
+  );
+});
+
+test('Git.commit amend refreshes identity after rewriting the root commit', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  await fs.promises.writeFile(path.join(repoRoot, 'root.txt'), 'one\n');
+  const entry = await E(mount).entry(['root.txt']);
+  await E(git).add([entry]);
+  await E(git).commit('amended root subject', { amend: true });
+  const current = await E(git).currentBranch();
+  t.is(current?.name, 'main', 'the next backend call remains authorized');
+});
+
+test('Git history rewrite authority defaults off and can be elevated', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+  const gitHistory = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  await fs.promises.writeFile(path.join(repoRoot, 'history.txt'), 'one\n');
+  const entry = await E(mount).entry(['history.txt']);
+  await E(git).add([entry]);
+  const first = await E(git).commit('first subject');
+  await t.throwsAsync(E(git).commit('blocked amend', { amend: true }), {
+    message: /without history-rewrite authority/,
+  });
+  await t.throwsAsync(E(git).reword(first.oid, 'blocked reword'), {
+    message: /without history-rewrite authority/,
+  });
+
+  await fs.promises.writeFile(path.join(repoRoot, 'history.txt'), 'two\n');
+  await E(git).add([entry]);
+  const amended = await E(gitHistory).commit('amended subject', {
+    amend: true,
+  });
+  const reworded = await E(gitHistory).reword(
+    amended.oid,
+    'replacement subject',
+  );
+  t.is(reworded.summary, 'replacement subject');
+});
+
+test('Git.reword replaces one ancestor message without an editor', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync('git', ['config', '--local', 'core.editor', 'false'], {
+    cwd: repoRoot,
+  });
+  await execFileAsync(
+    'git',
+    ['config', '--local', 'sequence.editor', 'false'],
+    {
+      cwd: repoRoot,
+    },
+  );
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  await fs.promises.writeFile(path.join(repoRoot, 'first.txt'), 'first\n');
+  const firstEntry = await E(mount).entry(['first.txt']);
+  await E(git).add([firstEntry]);
+  const first = await E(git).commit('first subject');
+
+  await fs.promises.writeFile(path.join(repoRoot, 'second.txt'), 'second\n');
+  const secondEntry = await E(mount).entry(['second.txt']);
+  await E(git).add([secondEntry]);
+  await E(git).commit('second subject');
+
+  const { stdout: originalAuthor } = await execFileAsync(
+    'git',
+    ['show', '-s', '--format=%an%x00%ae%x00%aI', first.oid],
+    { cwd: repoRoot },
+  );
+  const reworded = await E(git).reword(first.oid, 'replacement subject');
+  t.not(reworded.oid, first.oid);
+  t.is(reworded.summary, 'replacement subject');
+
+  const log = await E(git).log({ maxCount: 3 });
+  t.deepEqual(
+    log.map(commit => commit.summary),
+    ['second subject', 'replacement subject', 'init commit'],
+  );
+  const { stdout } = await execFileAsync(
+    'git',
+    ['show', `${reworded.oid}:first.txt`],
+    { cwd: repoRoot },
+  );
+  t.is(stdout, 'first\n');
+  const { stdout: replacementAuthor } = await execFileAsync(
+    'git',
+    ['show', '-s', '--format=%an%x00%ae%x00%aI', reworded.oid],
+    { cwd: repoRoot },
+  );
+  t.is(replacementAuthor, originalAuthor, 'reword preserves the author');
+});
+
+test('Git.reword preserves raw author identity despite mailmap entries', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+  await execFileAsync(
+    'git',
+    ['commit', '--allow-empty', '-m', 'raw author subject'],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'Raw Author',
+        GIT_AUTHOR_EMAIL: 'raw@example.test',
+        GIT_COMMITTER_NAME: 'Raw Author',
+        GIT_COMMITTER_EMAIL: 'raw@example.test',
+      },
+    },
+  );
+  const { stdout: original } = await execFileAsync(
+    'git',
+    ['rev-parse', 'HEAD'],
+    {
+      cwd: repoRoot,
+    },
+  );
+  await fs.promises.writeFile(
+    path.join(repoRoot, '.mailmap'),
+    'Canonical Author <canonical@example.test> Raw Author <raw@example.test>\n',
+  );
+  await execFileAsync('git', ['add', '.mailmap'], { cwd: repoRoot });
+  await execFileAsync('git', ['commit', '-m', 'mailmap subject'], {
+    cwd: repoRoot,
+  });
+
+  const reworded = await E(git).reword(original.trim(), 'replacement subject');
+  const { stdout: rawAuthor } = await execFileAsync(
+    'git',
+    ['show', '-s', '--format=%an <%ae>', reworded.oid],
+    { cwd: repoRoot },
+  );
+  t.is(rawAuthor, 'Raw Author <raw@example.test>\n');
+});
+
+test('Git.reword HEAD preserves its committed tree with staged changes', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  await fs.promises.writeFile(path.join(repoRoot, 'committed.txt'), 'one\n');
+  const committedEntry = await E(mount).entry(['committed.txt']);
+  await E(git).add([committedEntry]);
+  await E(git).commit('original subject');
+  const { stdout: originalTree } = await execFileAsync(
+    'git',
+    ['rev-parse', 'HEAD^{tree}'],
+    { cwd: repoRoot },
+  );
+
+  await fs.promises.writeFile(path.join(repoRoot, 'staged.txt'), 'staged\n');
+  const stagedEntry = await E(mount).entry(['staged.txt']);
+  await E(git).add([stagedEntry]);
+  await E(git).reword('HEAD', 'replacement subject');
+
+  const { stdout: replacementTree } = await execFileAsync(
+    'git',
+    ['rev-parse', 'HEAD^{tree}'],
+    { cwd: repoRoot },
+  );
+  t.is(replacementTree, originalTree, 'staged content is not committed');
+  const { stdout: stagedPaths } = await execFileAsync(
+    'git',
+    ['diff', '--cached', '--name-only'],
+    { cwd: repoRoot },
+  );
+  t.is(stagedPaths, 'staged.txt\n', 'staged content remains in the index');
+});
+
+test('Git.reword rejects a commit outside HEAD history', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  await execFileAsync('git', ['switch', '-c', 'other'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'other.txt'), 'other\n');
+  const otherEntry = await E(mount).entry(['other.txt']);
+  await E(git).add([otherEntry]);
+  const other = await E(git).commit('other subject');
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+
+  await t.throwsAsync(E(git).reword(other.oid, 'must reject'), {
+    message: /must name HEAD or an ancestor of HEAD/,
+  });
+});
+
+test('Git.reword rewrites the root commit', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  const reworded = await E(git).reword('HEAD', 'replacement root subject');
+  t.is(reworded.summary, 'replacement root subject');
+  const { stdout: parents } = await execFileAsync(
+    'git',
+    ['show', '-s', '--format=%P', 'HEAD'],
+    { cwd: repoRoot },
+  );
+  t.is(parents, '\n', 'the replacement root has no parents');
+});
+
+test('Git.reword refreshes identity after rewriting an ancestor root commit', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+  const root = await E(git).revParse('HEAD');
+  await fs.promises.writeFile(path.join(repoRoot, 'descendant.txt'), 'one\n');
+  const entry = await E(mount).entry(['descendant.txt']);
+  await E(git).add([entry]);
+  await E(git).commit('descendant subject');
+
+  await E(git).reword(root, 'replacement root subject');
+  const current = await E(git).currentBranch();
+  t.is(current?.name, 'main', 'the next backend call remains authorized');
+});
+
+test('Git.reword keeps its branch attached and preserves merge descendants', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  await fs.promises.writeFile(path.join(repoRoot, 'base.txt'), 'base\n');
+  const baseEntry = await E(mount).entry(['base.txt']);
+  await E(git).add([baseEntry]);
+  const base = await E(git).commit('base subject');
+
+  await execFileAsync('git', ['switch', '-c', 'feature'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'feature.txt'), 'feature\n');
+  const featureEntry = await E(mount).entry(['feature.txt']);
+  await E(git).add([featureEntry]);
+  await E(git).commit('feature subject');
+
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'main.txt'), 'main\n');
+  const mainEntry = await E(mount).entry(['main.txt']);
+  await E(git).add([mainEntry]);
+  await E(git).commit('main subject');
+  await execFileAsync(
+    'git',
+    ['merge', '--no-ff', 'feature', '-m', 'merge feature'],
+    {
+      cwd: repoRoot,
+    },
+  );
+
+  const reworded = await E(git).reword(base.oid, 'replacement subject');
+  t.is(reworded.summary, 'replacement subject');
+
+  const { stdout: branch } = await execFileAsync(
+    'git',
+    ['symbolic-ref', '--short', 'HEAD'],
+    { cwd: repoRoot },
+  );
+  t.is(branch.trim(), 'main');
+  const { stdout: parents } = await execFileAsync(
+    'git',
+    ['show', '-s', '--format=%P', 'HEAD'],
+    { cwd: repoRoot },
+  );
+  t.is(parents.trim().split(' ').length, 2, 'HEAD remains a merge commit');
+  const log = await E(git).log({ maxCount: 10 });
+  t.true(log.some(commit => commit.summary === 'replacement subject'));
+});
+
+test('Git.reword accepts HEAD while detached but rejects an ancestor', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
+
+  await fs.promises.writeFile(path.join(repoRoot, 'first.txt'), 'first\n');
+  const entry = await E(mount).entry(['first.txt']);
+  await E(git).add([entry]);
+  const first = await E(git).commit('first subject');
+  await fs.promises.writeFile(path.join(repoRoot, 'second.txt'), 'second\n');
+  const secondEntry = await E(mount).entry(['second.txt']);
+  await E(git).add([secondEntry]);
+  await E(git).commit('second subject');
+  await execFileAsync('git', ['switch', '--detach'], { cwd: repoRoot });
+
+  const amended = await E(git).reword('HEAD', 'detached replacement');
+  t.is(amended.summary, 'detached replacement');
+  await t.throwsAsync(E(git).reword(first.oid, 'must not detach branch'), {
+    message: /requires a checked-out branch/,
+  });
+});
+
 test('Git scaffold methods all surface a clear "not yet implemented"', async t => {
   const mount = await provisionMount(t);
   const backend = makeNotYetImplementedBackend();
-  const git = makeGit({ mount, backend, lineageOf });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
 
   // A representative sample across category boundaries; the stub backend
   // throws for every op except the formula-instantiation-time
@@ -520,6 +906,9 @@ test('Git scaffold methods all surface a clear "not yet implemented"', async t =
   await t.throwsAsync(E(git).status(), { message: /not yet implemented/ });
   await t.throwsAsync(E(git).log({}), { message: /not yet implemented/ });
   await t.throwsAsync(E(git).commit('msg'), {
+    message: /not yet implemented/,
+  });
+  await t.throwsAsync(E(git).reword('HEAD', 'msg'), {
     message: /not yet implemented/,
   });
   await t.throwsAsync(E(git).branches(), { message: /not yet implemented/ });
@@ -670,6 +1059,21 @@ test('NativeGitBackend.log returns structured commit records', async t => {
     t.is(commit.author, 'T');
     t.is(typeof commit.committedAt, 'number');
   }
+});
+
+test('NativeGitBackend.log preserves a tab in a commit subject', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync(
+    'git',
+    ['commit', '--allow-empty', '-m', 'subject\twith tab'],
+    { cwd: repoRoot },
+  );
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  const [commit] = await backend.log({ maxCount: 1 });
+  t.is(commit.summary, 'subject\twith tab');
+  t.regex(commit.oid, /^[0-9a-f]{40,64}$/);
+  t.is(commit.author, 'T');
 });
 
 test('NativeGitBackend.log honors since / until time-window options', async t => {

--- a/packages/exo-git/README.md
+++ b/packages/exo-git/README.md
@@ -3,7 +3,7 @@
 Remotable exo glue and interface guards for an `EndoGit` capability.
 The package is intentionally Node-free and portable across SES realms — it knows nothing about subprocesses, the file system, or the host's `git` binary.
 
-- `makeGit({ mount, backend, lineageOf, readOnly })` — the `EndoGit` exo factory.  `backend` is any object satisfying the `GitBackend` protocol (`@endo/git` provides the Node-side implementation).
+- `makeGit({ mount, backend, lineageOf }, { readOnly, allowHistoryRewrite })` — the `EndoGit` exo factory.  `backend` is any object satisfying the `GitBackend` protocol (`@endo/git` provides the Node-side implementation).
 - `makeGitRemote({ git, credential, name, policy })` — remote-git companion (fetch / pull / push) bound to a credential cap.
 - `makeBasicCredential`, `makeBearerCredential`, `makeUnavailableGitCredential` — credential capabilities.  Each carries a host-private `GitCredentialController` accessible via `getGitCredentialController(cred)`.
 - `makeGitFsBackend({ backend, treeOid })` — `FsBackend` adapter for an immutable git tree.  Composes with `@endo/endo-fs` `wrapBackend(...)`.

--- a/packages/exo-git/src/git-cloner.js
+++ b/packages/exo-git/src/git-cloner.js
@@ -29,7 +29,7 @@
  * @param {GitRemoteEndpoint} args.endpoint  The reusable remote authority.
  * @param {(input: { url: string, destPath: string, allowLocalFileTransport: boolean, credential?: { kind: string, material: unknown }, signal?: AbortSignal }) => Promise<unknown>} args.clone
  *   Native constructive clone into `destPath` from the endpoint URL.
- * @param {(input: { destMount: object, destPath: string }) => Promise<object>} args.makeGit
+ * @param {(powers: { destMount: object, destPath: string }, opts?: object) => Promise<object>} args.makeGit
  *   Build a writable `Git` over the freshly-cloned destination.
  * @param {(input: { git: object, endpoint: GitRemoteEndpoint }) => Promise<GitRemote>} args.makeRemote
  *   Bind `origin` as a `GitRemote` over endpoint x the new `Git`.
@@ -96,7 +96,7 @@ export const makeGitCloner = ({ endpoint, clone, makeGit, makeRemote }) => {
       }
       endpoint.assertCredentialUnchanged('clone', credentialVersion);
       // The destination is now a worktree; derive its `Git`.
-      const git = await makeGit({ destMount, destPath });
+      const git = await makeGit({ destMount, destPath }, {});
       endpoint.assertCredentialUnchanged('clone', credentialVersion);
       // Compose: endpoint x Git -> origin-pre-bound `GitRemote`.
       const remote = await makeRemote({ git, endpoint });

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -16,6 +16,7 @@ import { GitInterface } from './interfaces.js';
  * @import {
  *   EndoGit,
  *   GitCommit,
+ *   GitCommitOptions,
  *   GitCreateBranchOptions,
  *   GitDeleteBranchOptions,
  *   GitDiffOptions,
@@ -39,6 +40,8 @@ import { GitInterface } from './interfaces.js';
  * @type {WeakMap<object, boolean>}
  */
 const gitReadOnly = new WeakMap();
+/** @type {WeakMap<object, boolean>} */
+const gitHistoryRewrite = new WeakMap();
 /** @type {WeakMap<object, GitBackend>} */
 const gitBackends = new WeakMap();
 
@@ -52,6 +55,17 @@ const gitBackends = new WeakMap();
 export const isGitReadOnly = git =>
   gitReadOnly.get(/** @type {object} */ (git));
 harden(isGitReadOnly);
+
+/**
+ * Host-private accessor: returns whether a daemon-minted Git exo has
+ * history-rewrite authority, or undefined for fakes / remotes not minted here.
+ *
+ * @param {unknown} git
+ * @returns {boolean | undefined}
+ */
+export const isGitHistoryRewrite = git =>
+  gitHistoryRewrite.get(/** @type {object} */ (git));
+harden(isGitHistoryRewrite);
 
 /**
  * Host-private accessor for adjacent daemon providers such as GitRemote.
@@ -133,7 +147,8 @@ harden(getGitBackend);
  * @property {(ref: string) => Promise<GitRef>} revParse
  * @property {(paths: string[]) => Promise<void>} add
  * @property {(paths: string[], opts?: GitRestoreOptions) => Promise<void>} restore
- * @property {(message: string) => Promise<GitCommit>} commit
+ * @property {(message: string, opts?: GitCommitOptions) => Promise<GitCommit>} commit
+ * @property {(ref: string, message: string) => Promise<GitCommit>} reword
  * @property {() => Promise<GitRef | undefined>} currentBranch
  * @property {() => Promise<GitRef[]>} branches
  * @property {(name: string, opts?: GitCreateBranchOptions) => Promise<GitRef>} createBranch
@@ -201,22 +216,30 @@ harden(getGitBackend);
  * authority; the host-private backing grant the formula instantiator
  * used to derive this capability is not part of the public surface).
  *
- * @param {object} args
- * @param {object} args.mount  The `EndoMount` that carries the public
+ * @param {object} powers
+ * @param {object} powers.mount  The `EndoMount` that carries the public
  *   worktree authority.  Returned by `worktree()`.
- * @param {GitBackend} args.backend
- * @param {boolean} [args.readOnly]  True when this Git cap is attenuated
- *   or was derived from a read-only mount.  Mutation methods throw before
- *   the backend can touch the worktree.
- * @param {(value: unknown) => object | undefined} args.lineageOf
+ * @param {GitBackend} powers.backend
+ * @param {(value: unknown) => object | undefined} powers.lineageOf
  *   Returns the mount-lineage sentinel for daemon-minted `EndoMount` /
  *   `EndoMountEntry` values; `undefined` for foreign caps.  The daemon
  *   binds its `mount.js#lineageOf`; in-process unit tests can pass a
  *   stub.  Two entries with the same returned sentinel are guaranteed
  *   to belong to the same mount root.
+ * @param {object} [opts]
+ * @param {boolean} [opts.readOnly]  True when this Git cap is attenuated
+ *   or was derived from a read-only mount.
+ *   Mutation methods throw before
+ *   the backend can touch the worktree.
+ * @param {boolean} [opts.allowHistoryRewrite]  True when this Git cap may
+ *   amend or reword existing commits.
+ *   Defaults to false.
  * @returns {EndoGit}
  */
-export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
+export const makeGit = (
+  { mount, backend, lineageOf },
+  { readOnly = false, allowHistoryRewrite = false } = {},
+) => {
   // The mount's lineage sentinel — used to verify that every entry
   // passed to a path-bearing Git method was minted by this Git's bound
   // mount, not by some other mount this guest may also hold.
@@ -290,6 +313,14 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
     if (readOnly) {
       throw new Error(
         `Git.${methodName} is not permitted on a read-only Git capability`,
+      );
+    }
+  };
+
+  const assertHistoryRewrite = methodName => {
+    if (!allowHistoryRewrite) {
+      throw new Error(
+        `Git.${methodName} is not permitted on a Git capability without history-rewrite authority`,
       );
     }
   };
@@ -431,9 +462,18 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
       return backend.restore(paths, options);
     },
 
-    async commit(message) {
+    async commit(message, options = {}) {
       assertWritable('commit');
-      return backend.commit(message);
+      if (options.amend) {
+        assertHistoryRewrite('commit');
+      }
+      return backend.commit(message, options);
+    },
+
+    async reword(ref, message) {
+      assertWritable('reword');
+      assertHistoryRewrite('reword');
+      return backend.reword(refName(ref), message);
     },
 
     async currentBranch() {
@@ -555,7 +595,10 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
       if (readOnly) {
         return selfExo;
       }
-      return makeGit({ mount, backend, readOnly: true, lineageOf });
+      return makeGit(
+        { mount, backend, lineageOf },
+        { readOnly: true, allowHistoryRewrite: false },
+      );
     },
   };
 
@@ -563,6 +606,7 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
 
   const typed = /** @type {EndoGit} */ (/** @type {unknown} */ (exo));
   gitReadOnly.set(typed, readOnly);
+  gitHistoryRewrite.set(typed, allowHistoryRewrite);
   gitBackends.set(typed, backend);
   selfExo = typed;
   return typed;
@@ -593,6 +637,7 @@ export const makeNotYetImplementedBackend = () => {
     add: async () => fail('add'),
     restore: async () => fail('restore'),
     commit: async () => fail('commit'),
+    reword: async () => fail('reword'),
     currentBranch: async () => fail('currentBranch'),
     branches: async () => fail('branches'),
     createBranch: async () => fail('createBranch'),

--- a/packages/exo-git/src/index.js
+++ b/packages/exo-git/src/index.js
@@ -2,6 +2,7 @@
 
 export {
   makeGit,
+  isGitHistoryRewrite,
   isGitReadOnly,
   getGitBackend,
   makeNotYetImplementedBackend,

--- a/packages/exo-git/src/interfaces.js
+++ b/packages/exo-git/src/interfaces.js
@@ -62,6 +62,14 @@ const GitCommitShape = M.splitRecord(
   },
 );
 
+const GitCommitOptionsShape = M.splitRecord(
+  {},
+  {
+    amend: M.boolean(),
+  },
+  harden({}),
+);
+
 // #endregion
 
 export const GitInterface = M.interface('Git', {
@@ -83,7 +91,10 @@ export const GitInterface = M.interface('Git', {
   restore: M.callWhen(M.arrayOf(M.remotable()))
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.undefined()),
-  commit: M.callWhen(M.string()).returns(GitCommitShape),
+  commit: M.callWhen(M.string())
+    .optional(GitCommitOptionsShape)
+    .returns(GitCommitShape),
+  reword: M.callWhen(RefArgShape, M.string()).returns(GitCommitShape),
   currentBranch: M.callWhen().returns(M.or(GitRefShape, M.undefined())),
   branches: M.callWhen().returns(M.arrayOf(GitRefShape)),
   createBranch: M.callWhen(M.string())

--- a/packages/exo-git/src/types.ts
+++ b/packages/exo-git/src/types.ts
@@ -61,6 +61,10 @@ export type GitRestoreOptions = {
   staged?: boolean;
 };
 
+export type GitCommitOptions = {
+  amend?: boolean;
+};
+
 export type GitCreateBranchOptions = {
   startPoint?: string;
   switchAfterCreate?: boolean;
@@ -233,7 +237,8 @@ export type EndoGit = {
     entries: EndoMountEntry[],
     options?: GitRestoreOptions,
   ) => Promise<void>;
-  commit: (message: string) => Promise<GitCommit>;
+  commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
+  reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
   currentBranch: () => Promise<GitRef | undefined>;
   branches: () => Promise<GitRef[]>;
   createBranch: (

--- a/packages/exo-git/test/git-cloner.test.js
+++ b/packages/exo-git/test/git-cloner.test.js
@@ -101,8 +101,8 @@ test('makeGitCloner composes endpoint and destination into Git plus origin remot
     clone: async input => {
       calls.push(harden({ clone: input }));
     },
-    makeGit: async input => {
-      calls.push(harden({ makeGit: input }));
+    makeGit: async (powers, opts) => {
+      calls.push(harden({ makeGit: harden({ powers, opts }) }));
       return gitCap;
     },
     makeRemote: async input => {
@@ -121,6 +121,10 @@ test('makeGitCloner composes endpoint and destination into Git plus origin remot
     url: 'file:///tmp/repo.git',
     destPath: '/tmp/clone',
     allowLocalFileTransport: true,
+  });
+  t.deepEqual(calls[1].makeGit, {
+    powers: { destMount, destPath: '/tmp/clone' },
+    opts: {},
   });
   t.like(calls[2].makeRemote, {
     git: gitCap,

--- a/packages/exo-git/test/types.test.ts
+++ b/packages/exo-git/test/types.test.ts
@@ -1,5 +1,22 @@
 import { makeGit } from '../src/git.js';
-import type { EndoGit } from '../src/types.js';
+import type {
+  EndoGit,
+  EndoMount,
+  EndoMountEntry,
+  GitCommit,
+  GitCommitOptions,
+  GitCreateBranchOptions,
+  GitDeleteBranchOptions,
+  GitDiffOptions,
+  GitLogOptions,
+  GitMergeOptions,
+  GitRebaseInput,
+  GitRef,
+  GitRestoreOptions,
+  GitStashPushOptions,
+  GitStatusEntry,
+  ReadableTreeView,
+} from '../src/types.js';
 
 type Equal<Left, Right> =
   (<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2
@@ -11,3 +28,46 @@ type Assert<T extends true> = T;
 type MakeGitReturn = ReturnType<typeof makeGit>;
 
 type _MakeGitReturnsEndoGit = Assert<Equal<MakeGitReturn, EndoGit>>;
+
+type ExpectedEndoGit = {
+  worktree: () => Promise<EndoMount | ReadableTreeView>;
+  status: () => Promise<GitStatusEntry[]>;
+  diff: (options?: GitDiffOptions) => Promise<string>;
+  log: (options?: GitLogOptions) => Promise<GitCommit[]>;
+  show: (ref: GitRef | string) => Promise<string>;
+  revParse: (ref: GitRef | string) => Promise<GitRef>;
+  add: (entries: EndoMountEntry[]) => Promise<void>;
+  restore: (
+    entries: EndoMountEntry[],
+    options?: GitRestoreOptions,
+  ) => Promise<void>;
+  commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
+  reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+  currentBranch: () => Promise<GitRef | undefined>;
+  branches: () => Promise<GitRef[]>;
+  createBranch: (
+    name: string,
+    options?: GitCreateBranchOptions,
+  ) => Promise<GitRef>;
+  deleteBranch: (
+    name: string,
+    options?: GitDeleteBranchOptions,
+  ) => Promise<void>;
+  renameBranch: (from: string, to: string) => Promise<void>;
+  switchBranch: (name: string) => Promise<void>;
+  detach: (ref: GitRef | string) => Promise<void>;
+  switch: (ref: GitRef | string) => Promise<void>;
+  merge: (ref: GitRef | string, options?: GitMergeOptions) => Promise<string>;
+  rebase: (input: GitRebaseInput) => Promise<string>;
+  stashPush: (options?: GitStashPushOptions) => Promise<string>;
+  stashList: () => Promise<string[]>;
+  stashShow: (index?: number) => Promise<string>;
+  stashApply: (index?: number) => Promise<void>;
+  stashPop: (index?: number) => Promise<void>;
+  stashDrop: (index?: number) => Promise<void>;
+  tree: (ref: GitRef | string) => Promise<ReadableTreeView>;
+  filesystemAt: (ref: GitRef | string) => Promise<unknown>;
+  readOnly: () => EndoGit;
+};
+
+type _EndoGitMatchesExpectedSurface = Assert<Equal<EndoGit, ExpectedEndoGit>>;

--- a/packages/exo-git/types-index.d.ts
+++ b/packages/exo-git/types-index.d.ts
@@ -1,6 +1,7 @@
 export type * from './src/types.js';
 export {
   makeGit,
+  isGitHistoryRewrite,
   isGitReadOnly,
   getGitBackend,
   makeNotYetImplementedBackend,

--- a/packages/git/src/native-git-backend.js
+++ b/packages/git/src/native-git-backend.js
@@ -39,6 +39,7 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: false });
  * } from '@endo/exo-git/src/git.js'
  * @import {
  *   GitCommit,
+ *   GitCommitOptions,
  *   GitCreateBranchOptions,
  *   GitDeleteBranchOptions,
  *   GitMergeOptions,
@@ -97,6 +98,10 @@ const GIT_MAX_BUFFER = 1024 * 1024;
 const TOOL_OUTPUT_LIMIT = 50_000;
 const MIN_GIT_VERSION = harden([2, 30, 0]);
 const GIT_ASKPASS_FD = 3;
+// Stable, NUL-delimited fields parsed into the public GitCommit record:
+// full OID, subject, author name, and committer time in Unix seconds.
+// Git subjects cannot contain NUL, unlike tabs and newlines.
+const GIT_COMMIT_LOG_FORMAT = '--pretty=tformat:%H%x00%s%x00%an%x00%ct%x00';
 const gitAskpassHelperPath = fileURLToPath(
   new URL('git-askpass-helper.cjs', import.meta.url),
 );
@@ -1733,6 +1738,29 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
   };
 
   /**
+   * @param {string} ref
+   * @returns {Promise<GitCommit>}
+   */
+  const readCommitRecord = async ref => {
+    const raw = await runGitRaw([
+      'log',
+      '-1',
+      GIT_COMMIT_LOG_FORMAT,
+      '--end-of-options',
+      ref,
+    ]);
+    const [oid, summary, author, committedAtStr] = raw.split('\0');
+    return harden({
+      oid,
+      summary,
+      author,
+      committedAt: committedAtStr
+        ? Number.parseInt(committedAtStr, 10)
+        : undefined,
+    });
+  };
+
+  /**
    * @param {string} blobOid
    * @returns {unknown}
    */
@@ -2040,7 +2068,7 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
      * @returns {Promise<GitCommit[]>}
      */
     log: async (options = {}) => {
-      const args = ['log', '--pretty=format:%H%x09%s%x09%an%x09%ct'];
+      const args = ['log', GIT_COMMIT_LOG_FORMAT];
       if (typeof options.maxCount === 'number') {
         if (!Number.isInteger(options.maxCount) || options.maxCount <= 0) {
           throw new Error('log.maxCount must be a positive integer');
@@ -2063,26 +2091,27 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
         args.push('--end-of-options', requireRevision(options.ref, 'log.ref'));
       }
       const rawLog = await runGitRaw(args);
-      const stdout = rawLog.trim();
-      if (stdout === '') {
+      if (rawLog === '') {
         return harden([]);
       }
       /** @type {GitCommit[]} */
       const commits = [];
-      for (const line of stdout.split('\n')) {
-        if (line !== '') {
-          const [oid, summary, author, committedAtStr] = line.split('\t');
-          commits.push(
-            harden({
-              oid,
-              summary,
-              author,
-              committedAt: committedAtStr
-                ? Number.parseInt(committedAtStr, 10)
-                : undefined,
-            }),
-          );
-        }
+      const fields = rawLog.split('\0');
+      for (let index = 0; index + 3 < fields.length; index += 4) {
+        const [oid, summary, author, committedAtStr] = fields.slice(
+          index,
+          index + 4,
+        );
+        commits.push(
+          harden({
+            oid: oid.trim(),
+            summary,
+            author,
+            committedAt: committedAtStr
+              ? Number.parseInt(committedAtStr, 10)
+              : undefined,
+          }),
+        );
       }
       return harden(commits);
     },
@@ -2177,30 +2206,154 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
      * Returns a `GitCommit` record reflecting the new HEAD.
      *
      * @param {string} message
+     * @param {GitCommitOptions} [opts]
      * @returns {Promise<GitCommit>}
      */
-    commit: async message => {
+    commit: async (message, opts = {}) => {
       requireNonEmptyString(message, 'commit message');
       await assertNoExecutableRepoConfig();
       // -m embeds the message inline; --allow-empty-message is left off
       // so the daemon does not silently accept blank messages.
-      await runGit(['commit', '-m', message]);
+      const args = ['commit'];
+      if (opts.amend !== undefined && typeof opts.amend !== 'boolean') {
+        throw new Error('commit.amend must be a boolean');
+      }
+      if (opts.amend) {
+        args.push('--amend');
+      }
+      args.push('-m', message);
+      await runGit(args);
+      if (opts.amend) {
+        // Amending the root commit changes the identity anchor.
+        // The rewrite
+        // above is ours, so adopt its new identity before the readback.
+        const resolvedRepoRoot = await fs.promises.realpath(repoRoot);
+        repositoryIdentity = await captureRepositoryIdentity(resolvedRepoRoot);
+      }
       // Read back the new HEAD's record so the caller learns the oid.
-      const rawHead = await runGitRaw([
-        'log',
-        '-1',
-        '--pretty=format:%H%x09%s%x09%an%x09%ct',
+      return readCommitRecord('HEAD');
+    },
+
+    /**
+     * Replace one commit's message without invoking an editor.
+     * The target commit is recreated with the same tree and parents, then any descendants
+     * on the current HEAD are replayed onto the replacement commit.
+     *
+     * @param {string} ref
+     * @param {string} message
+     * @returns {Promise<GitCommit>}
+     */
+    reword: async (ref, message) => {
+      const target = requireRevision(ref, 'reword.ref');
+      requireNonEmptyString(message, 'reword message');
+      await assertNoExecutableRepoConfig();
+
+      const targetOid = (
+        await runGitRaw([
+          'rev-parse',
+          '--verify',
+          '--end-of-options',
+          `${target}^{commit}`,
+        ])
+      ).trim();
+      const headOid = (
+        await runGitRaw([
+          'rev-parse',
+          '--verify',
+          '--end-of-options',
+          'HEAD^{commit}',
+        ])
+      ).trim();
+
+      let branch;
+      if (targetOid !== headOid) {
+        try {
+          branch = (
+            await runGitRaw(['symbolic-ref', '--quiet', '--short', 'HEAD'])
+          ).trim();
+        } catch {
+          throw new Error(
+            'reword of an ancestor requires a checked-out branch',
+          );
+        }
+        if (branch === '') {
+          throw new Error(
+            'reword of an ancestor requires a checked-out branch',
+          );
+        }
+
+        try {
+          await runGitRaw(['merge-base', '--is-ancestor', targetOid, headOid]);
+        } catch {
+          throw new Error('reword.ref must name HEAD or an ancestor of HEAD');
+        }
+      }
+
+      const treeOid = (
+        await runGitRaw([
+          'rev-parse',
+          '--verify',
+          '--end-of-options',
+          `${targetOid}^{tree}`,
+        ])
+      ).trim();
+      const parentsText = (
+        await runGitRaw(['show', '-s', '--format=%P', targetOid])
+      ).trim();
+      const authorText = await runGitRaw([
+        'show',
+        '-s',
+        '--format=%an%x00%ae%x00%aI',
+        targetOid,
       ]);
-      const out = rawHead.trim();
-      const [oid, summary, author, committedAtStr] = out.split('\t');
-      return harden({
-        oid,
-        summary,
-        author,
-        committedAt: committedAtStr
-          ? Number.parseInt(committedAtStr, 10)
-          : undefined,
-      });
+      const [authorName, authorEmail, authorDate] = authorText
+        .replace(/\n$/u, '')
+        .split('\0');
+      const args = ['commit-tree', treeOid];
+      for (const parent of parentsText === '' ? [] : parentsText.split(' ')) {
+        args.push('-p', parent);
+      }
+      args.push('-m', message);
+      const replacementOid = (
+        await runGitRaw(args, {
+          GIT_AUTHOR_NAME: authorName,
+          GIT_AUTHOR_EMAIL: authorEmail,
+          GIT_AUTHOR_DATE: authorDate,
+        })
+      ).trim();
+      if (targetOid === headOid) {
+        // update-ref changes either the attached branch or detached HEAD without
+        // consulting the index, so staged content cannot enter this rewrite.
+        await runGit(['update-ref', 'HEAD', replacementOid, targetOid]);
+        // Rewording the root commit intentionally changes the identity anchor
+        // that protects against a repository being swapped beneath this cap.
+        // Refresh it only after this backend performed the rewrite itself.
+        const resolvedRepoRoot = await fs.promises.realpath(repoRoot);
+        repositoryIdentity = await captureRepositoryIdentity(resolvedRepoRoot);
+        return readCommitRecord('HEAD');
+      }
+      if (branch === undefined) {
+        throw new Error('reword of an ancestor requires a checked-out branch');
+      }
+      try {
+        await runGit([
+          'rebase',
+          '--rebase-merges',
+          '--onto',
+          replacementOid,
+          targetOid,
+          branch,
+        ]);
+      } catch (error) {
+        // Keep a failed rewrite from leaving the caller's repository mid-rebase.
+        await runGit(['rebase', '--abort']).catch(() => undefined);
+        throw error;
+      }
+      // Rewording a root commit through rebase changes the identity anchor.
+      // Refresh it after the successful rewrite before performing the readback.
+      const resolvedRepoRoot = await fs.promises.realpath(repoRoot);
+      repositoryIdentity = await captureRepositoryIdentity(resolvedRepoRoot);
+      return readCommitRecord(replacementOid);
     },
 
     /**


### PR DESCRIPTION
Refs: #636

## Description

Adds local Git commit amendment and commit-message rewriting across the Endo Git capability surfaces.

- Adds `commit(message, { amend })` and `reword(ref, message)` to the Git exo, runtime guard, backend contract, and native backend.
- Gates history-rewrite operations behind an explicit elevated Git capability; ordinary Git capabilities cannot amend or reword history.
- Separates the elevated JSON and code-mode surfaces into `makeGitHistoryTool` and `gitHistory`, while the default Git tool surface omits history rewriting.
- Refactors `makeGit` into separate authority powers and configuration options.

### Security Considerations

History rewriting is opt-in at capability construction.
The ordinary Git capability and its default agent-tool and code-mode surfaces do not grant amendment or reword authority.
The native backend continues to use sanitized Git invocation, rejects executable repository configuration before mutation, and performs rewording without an editor.

### Scaling Considerations

`commit --amend` uses Git porcelain.
Rewording recreates the target commit and replays its descendants when necessary, so its cost scales with the descendants Git must replay.

### Documentation Considerations

The code-mode declarations distinguish ordinary, read-only, and history-rewrite Git capabilities.
No stored-data migration is required.

### Testing Considerations

Verified:

- `yarn workspace @endo/exo-git lint:types`
- `yarn workspace @endo/exo-git lint`
- `yarn workspace @endo/exo-git test`
- `yarn workspace @endo/agent-tools test test/git-tool.test.js`
- `yarn workspace @endo/agent-tools lint`
- `yarn workspace @endo/agentry gen:code-mode-types`
- `yarn workspace @endo/agentry test test/code-mode-types.test.js test/code-mode.test.js`
- `yarn workspace @endo/daemon test test/git.test.js`
- `git diff --check`

### Compatibility Considerations

Existing `commit(message)` calls continue to work.
The optional commit options object is additive, while amendment and rewording require explicitly elevated construction.

### Upgrade Considerations

Deploy the updated packages together so capability guards, generated declarations, JSON tools, and backend methods remain aligned.
