### PR TITLE
feat(git): add stack replay verbs

### DIFF
--- a/.changeset/git-history-tools.md
+++ b/.changeset/git-history-tools.md
@@ -6,7 +6,7 @@
 '@endo/daemon': minor
 ---
 
-Add commit amendment and commit-message rewording to the Git APIs.
+Add cherry-pick and autosquash rebase alongside commit amendment and commit-message rewording in the Git APIs.
 `@endo/agent-tools` provides these history-rewrite operations through the new explicitly elevated `makeGitHistoryTool` maker; the default `makeGitTool` inventory continues to expose only new-commit creation.
 `makeGit` now takes powers separately from `{ readOnly, allowHistoryRewrite }` options; callers must migrate from the former single-object signature in this major `@endo/exo-git` change.
 `@endo/daemon` adds the public `provideGit` history-rewrite option and `GitFormula` support.

--- a/.changeset/git-history-tools.md
+++ b/.changeset/git-history-tools.md
@@ -6,7 +6,7 @@
 '@endo/daemon': minor
 ---
 
-Add cherry-pick and autosquash rebase alongside commit amendment and commit-message rewording in the Git APIs.
+Add commit amendment and commit-message rewording to the Git APIs.
 `@endo/agent-tools` provides these history-rewrite operations through the new explicitly elevated `makeGitHistoryTool` maker; the default `makeGitTool` inventory continues to expose only new-commit creation.
 `makeGit` now takes powers separately from `{ readOnly, allowHistoryRewrite }` options; callers must migrate from the former single-object signature in this major `@endo/exo-git` change.
 `@endo/daemon` adds the public `provideGit` history-rewrite option and `GitFormula` support.

--- a/.changeset/git-stack-replay.md
+++ b/.changeset/git-stack-replay.md
@@ -2,7 +2,7 @@
 '@endo/git': minor
 '@endo/exo-git': major
 '@endo/agent-tools': minor
-'@endo/agentry': minor
+'@endo/agentry': major
 ---
 
 Add cherry-pick and structured autosquash rebase operations to the Git APIs.

--- a/.changeset/git-stack-replay.md
+++ b/.changeset/git-stack-replay.md
@@ -1,0 +1,13 @@
+---
+'@endo/git': minor
+'@endo/exo-git': major
+'@endo/agent-tools': minor
+'@endo/agentry': minor
+---
+
+Add cherry-pick and structured autosquash rebase operations to the Git APIs.
+`@endo/agent-tools` exposes these history-rewrite operations through the
+explicitly elevated `makeGitHistoryTool` maker.
+Code-mode agents that need the history-rewrite surface must select
+`gitMode: 'historyRewrite'` with a Git capability that has history-rewrite
+authority.

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -118,7 +118,10 @@ elevated tool set:
 const historyTools = makeGitHistoryTool(git);
 ```
 
-It exposes `commit` with `options.amend` and `reword`.
+It exposes `commit` with `options.amend`, `reword`, `cherryPick`, and an
+autosquash-capable `rebase` start operation.
+Rebase control modes remain available through the elevated code-mode Git
+capability, but are not exposed as JSON tools.
 Do not combine this set with `makeGitTool` without resolving the duplicate
 `commit` tool name in the host's catalog.
 The host controls whether a model sees the normal commit-only or elevated

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -106,7 +106,7 @@ const REBASE_START_INPUT_PROP = harden({
 const REBASE_START_INPUT_SHAPE = M.splitRecord(
   { mode: 'start', upstream: M.string() },
   { autosquash: M.boolean() },
-  {},
+  harden({}),
 );
 
 /**
@@ -250,11 +250,6 @@ const gitHistoryToolMethods = harden(
   ),
 );
 
-/** @type {Partial<Record<keyof GitHistoryToolCapability, Pattern[]>>} */
-const gitHistoryToolArgGuards = harden({
-  rebase: harden([REBASE_START_INPUT_SHAPE]),
-});
-
 /**
  * Positional arg guards for a method, required first and then optional.
  * `getMethodGuardPayload` unwraps the `M.callWhen` await-arg wrappers.
@@ -271,6 +266,13 @@ const positionalArgGuards = method => {
   );
   return harden([...argGuards, ...(optionalArgGuards || [])]);
 };
+
+/** @type {Partial<Record<keyof GitHistoryToolCapability, Pattern[]>>} */
+const gitHistoryToolArgGuards = harden({
+  rebase: harden([
+    M.and(positionalArgGuards('rebase')[0], REBASE_START_INPUT_SHAPE),
+  ]),
+});
 
 /**
  * Build agent-tool records for a live `Git` capability.

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -14,6 +14,7 @@ import {
   M,
 } from '@endo/patterns';
 import { GitInterface } from '@endo/exo-git';
+import { GitRebaseStartInputShape } from '@endo/exo-git/src/interfaces.js';
 
 import { makeTool } from './tool.js';
 
@@ -102,12 +103,6 @@ const REBASE_START_INPUT_PROP = harden({
   required: ['mode', 'upstream'],
   additionalProperties: false,
 });
-
-const REBASE_START_INPUT_SHAPE = M.splitRecord(
-  { mode: 'start', upstream: M.string() },
-  { autosquash: M.boolean() },
-  harden({}),
-);
 
 /**
  * This package intentionally exposes only a curated JSON-safe `EndoGit` slice
@@ -270,7 +265,7 @@ const positionalArgGuards = method => {
 /** @type {Partial<Record<keyof GitHistoryToolCapability, Pattern[]>>} */
 const gitHistoryToolArgGuards = harden({
   rebase: harden([
-    M.and(positionalArgGuards('rebase')[0], REBASE_START_INPUT_SHAPE),
+    M.and(positionalArgGuards('rebase')[0], GitRebaseStartInputShape),
   ]),
 });
 

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -72,6 +72,41 @@ const COMMIT_PROP = harden({
   description: 'The commit message.',
 });
 
+const CHERRY_PICK_OPTIONS_PROP = harden({
+  type: 'object',
+  properties: {
+    noCommit: {
+      type: 'boolean',
+      description: 'Apply the patch to the index and worktree without committing.',
+    },
+  },
+  required: [],
+  additionalProperties: false,
+});
+
+const REBASE_START_INPUT_PROP = harden({
+  type: 'object',
+  properties: {
+    mode: { const: 'start' },
+    upstream: {
+      type: 'string',
+      description: 'The upstream ref to replay the current branch onto.',
+    },
+    autosquash: {
+      type: 'boolean',
+      description: 'Fold fixup!/squash! commits during the replay.',
+    },
+  },
+  required: ['mode', 'upstream'],
+  additionalProperties: false,
+});
+
+const REBASE_START_INPUT_SHAPE = M.splitRecord(
+  { mode: 'start', upstream: M.string() },
+  { autosquash: M.boolean() },
+  {},
+);
+
 /**
  * This package intentionally exposes only a curated JSON-safe `EndoGit` slice
  * for now. Methods that remotely accept capabilities or can return
@@ -179,6 +214,24 @@ const gitHistoryToolSchemas = harden({
       additionalProperties: false,
     },
   },
+  cherryPick: {
+    description: 'Replay an existing commit onto the current branch.',
+    parameters: {
+      type: 'object',
+      properties: { ref: REF_PROP, options: CHERRY_PICK_OPTIONS_PROP },
+      required: ['ref'],
+      additionalProperties: false,
+    },
+  },
+  rebase: {
+    description: 'Replay the current branch onto an upstream ref.',
+    parameters: {
+      type: 'object',
+      properties: { input: REBASE_START_INPUT_PROP },
+      required: ['input'],
+      additionalProperties: false,
+    },
+  },
 });
 
 /**
@@ -194,6 +247,11 @@ const gitHistoryToolMethods = harden(
     Object.keys(gitHistoryToolSchemas)
   ),
 );
+
+/** @type {Partial<Record<keyof GitHistoryToolCapability, Pattern[]>>} */
+const gitHistoryToolArgGuards = harden({
+  rebase: harden([REBASE_START_INPUT_SHAPE]),
+});
 
 /**
  * Positional arg guards for a method, required first and then optional.
@@ -221,14 +279,15 @@ const positionalArgGuards = method => {
  *   needs.
  * @param {(keyof GitToolDispatch)[]} methods
  * @param {Partial<Record<keyof GitToolDispatch, { description: string, parameters: object }>>} schemas
+ * @param {Partial<Record<keyof GitToolDispatch, Pattern[]>>} argGuardsByMethod
  * @returns {ToolRecord[]}
  */
-const makeGitTools = (gitCap, methods, schemas) => {
+const makeGitTools = (gitCap, methods, schemas, argGuardsByMethod = {}) => {
   const records = methods.map(method => {
     const schema = /** @type {{ description: string, parameters: object }} */ (
       schemas[method]
     );
-    const argGuards = positionalArgGuards(method);
+    const argGuards = argGuardsByMethod[method] || positionalArgGuards(method);
     // The schema's declared property order is the positional argument order,
     // matching the convention `makeTool` applies to the named-args record.
     const paramNames = Object.keys(
@@ -278,5 +337,10 @@ harden(makeGitTool);
  * @returns {ToolRecord[]}
  */
 export const makeGitHistoryTool = gitCap =>
-  makeGitTools(gitCap, gitHistoryToolMethods, gitHistoryToolSchemas);
+  makeGitTools(
+    gitCap,
+    gitHistoryToolMethods,
+    gitHistoryToolSchemas,
+    gitHistoryToolArgGuards,
+  );
 harden(makeGitHistoryTool);

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -11,6 +11,7 @@ import { E } from '@endo/eventual-send';
 import {
   getInterfaceGuardPayload,
   getMethodGuardPayload,
+  M,
 } from '@endo/patterns';
 import { GitInterface } from '@endo/exo-git';
 
@@ -77,7 +78,8 @@ const CHERRY_PICK_OPTIONS_PROP = harden({
   properties: {
     noCommit: {
       type: 'boolean',
-      description: 'Apply the patch to the index and worktree without committing.',
+      description:
+        'Apply the patch to the index and worktree without committing.',
     },
   },
   required: [],

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -9,7 +9,7 @@ import type { Pattern } from '@endo/patterns';
  * the default git tool catalog exposes to an LLM.
  *
  * Deliberately omits the destructive and history-rewriting methods of `EndoGit`
- * — `merge`, `rebase`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
+ * — `merge`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
  * family, the working-tree/detach mutators (`switch`, `detach`), and history
  * rewrites (`commit` with `amend`, `reword`, `cherryPick`, `rebase`).
  * Those carry authority a tool

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -11,7 +11,7 @@ import type { Pattern } from '@endo/patterns';
  * Deliberately omits the destructive and history-rewriting methods of `EndoGit`
  * — `merge`, `rebase`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
  * family, the working-tree/detach mutators (`switch`, `detach`), and history
- * rewrites (`commit` with `amend`, `reword`).
+ * rewrites (`commit` with `amend`, `reword`, `cherryPick`, `rebase`).
  * Those carry authority a tool
  * surface handed to a model should not advertise: they can discard uncommitted
  * work or rewrite shared history. `commit` is included only through the default
@@ -43,9 +43,12 @@ export type GitToolCapability = Pick<
 /**
  * Explicitly elevated history-rewrite slice for `makeGitHistoryTool`.
  * Hosts must opt into constructing these tools; the default `makeGitTool`
- * inventory does not advertise either operation.
+ * inventory does not advertise these operations.
  */
-export type GitHistoryToolCapability = Pick<EndoGit, 'commit' | 'reword'>;
+export type GitHistoryToolCapability = Pick<
+  EndoGit,
+  'commit' | 'reword' | 'cherryPick' | 'rebase'
+>;
 
 /**
  * The mount-bridged slice of `EndoGit` behind `makeGitMountTools`: `status` and

--- a/packages/agent-tools/test/divergence.test.js
+++ b/packages/agent-tools/test/divergence.test.js
@@ -6,7 +6,7 @@ import '@endo/init/debug.js';
 
 /** @import { ERef } from '@endo/eventual-send' */
 /** @import { InterfaceGuard, Pattern } from '@endo/patterns' */
-/** @import { GitToolCapability, ToolRecord } from '../src/types.js' */
+/** @import { GitHistoryToolCapability, GitToolCapability, ToolRecord } from '../src/types.js' */
 
 import test from 'ava';
 import { Ajv } from 'ajv';
@@ -19,7 +19,7 @@ import {
 import { Far } from '@endo/pass-style';
 import { GitInterface } from '@endo/exo-git';
 
-import { makeGitTool } from '../src/git-tool.js';
+import { makeGitHistoryTool, makeGitTool } from '../src/git-tool.js';
 
 /**
  * Conformance checks for hand-authored JSON Schemas and runtime guards.
@@ -33,10 +33,25 @@ const ajv = new Ajv({ strict: false });
  * @param {string} method
  */
 const guardShapeFor = method => {
-  if (method === 'rebase') {
-    return {
-      requiredCount: 1,
-      guards: harden([
+  const { methodGuards } = getInterfaceGuardPayload(
+    /** @type {InterfaceGuard} */ (GitInterface),
+  );
+  const { argGuards, optionalArgGuards } = getMethodGuardPayload(
+    methodGuards[method],
+  );
+  const optional = optionalArgGuards || [];
+  const shape = {
+    requiredCount: argGuards.length,
+    guards: harden([...argGuards, ...optional]),
+  };
+  if (method !== 'rebase') {
+    return shape;
+  }
+  return {
+    ...shape,
+    guards: harden([
+      M.and(
+        shape.guards[0],
         M.splitRecord(
           {
             mode: 'start',
@@ -45,21 +60,10 @@ const guardShapeFor = method => {
           {
             autosquash: M.boolean(),
           },
-          {},
+          harden({}),
         ),
-      ]),
-    };
-  }
-  const { methodGuards } = getInterfaceGuardPayload(
-    /** @type {InterfaceGuard} */ (GitInterface),
-  );
-  const { argGuards, optionalArgGuards } = getMethodGuardPayload(
-    methodGuards[method],
-  );
-  const optional = optionalArgGuards || [];
-  return {
-    requiredCount: argGuards.length,
-    guards: harden([...argGuards, ...optional]),
+      ),
+    ]),
   };
 };
 
@@ -125,10 +129,13 @@ const slotRecords = harden([
   { slot0: { nested: { x: 1 } } },
   { slot0: { mode: 'start', upstream: 'main' } },
   { slot0: { mode: 'start', upstream: 'main', autosquash: true } },
+  { slot0: { mode: 'continue' } },
   { slot0: { mode: 'continue', autosquash: true } },
   { slot0: harden({ author: 'alice', oneline: true, maxCount: 10 }) },
   { slot0: 'a', slot1: { a: 1, b: 2 } },
   { slot0: 'a', slot1: { nested: { x: 1 } } },
+  { slot0: 'a', slot1: { amend: true } },
+  { slot0: 'a', slot1: { noCommit: true } },
   { slot0: 'a', slot1: harden({ track: true, startPoint: 'main' }) },
 ]);
 
@@ -174,6 +181,13 @@ const gitTools = makeGitTool(
   ),
 );
 
+const gitHistoryTools = makeGitHistoryTool(
+  // This test inspects schemas and guards; it never invokes the capability.
+  /** @type {ERef<GitHistoryToolCapability>} */ (
+    /** @type {unknown} */ (Far('InertGitHistory', {}))
+  ),
+);
+
 /**
  * For one git tool, assert its hand-authored JSON Schema and its runtime guard
  * agree on every candidate args record.
@@ -200,13 +214,21 @@ const schemaGuardAgree = test.macro({
     }
     t.true(checked > 0);
   },
-  title(_providedTitle, /** @type {ToolRecord} */ tool) {
-    return `schema ⟷ guard agree for git.${tool.name}`;
+  title(providedTitle, /** @type {ToolRecord} */ tool) {
+    return providedTitle || `schema ⟷ guard agree for git.${tool.name}`;
   },
 });
 
 for (const tool of gitTools) {
   test(schemaGuardAgree, tool);
+}
+
+for (const tool of gitHistoryTools) {
+  test(
+    `schema ⟷ guard agree for gitHistory.${tool.name}`,
+    schemaGuardAgree,
+    tool,
+  );
 }
 
 // --- bigint synthetic case ----------------------------------------------

--- a/packages/agent-tools/test/divergence.test.js
+++ b/packages/agent-tools/test/divergence.test.js
@@ -33,6 +33,23 @@ const ajv = new Ajv({ strict: false });
  * @param {string} method
  */
 const guardShapeFor = method => {
+  if (method === 'rebase') {
+    return {
+      requiredCount: 1,
+      guards: harden([
+        M.splitRecord(
+          {
+            mode: 'start',
+            upstream: M.string(),
+          },
+          {
+            autosquash: M.boolean(),
+          },
+          {},
+        ),
+      ]),
+    };
+  }
   const { methodGuards } = getInterfaceGuardPayload(
     /** @type {InterfaceGuard} */ (GitInterface),
   );
@@ -106,6 +123,9 @@ const slotRecords = harden([
   // Open-object option records.
   { slot0: { a: 1, b: 2 } },
   { slot0: { nested: { x: 1 } } },
+  { slot0: { mode: 'start', upstream: 'main' } },
+  { slot0: { mode: 'start', upstream: 'main', autosquash: true } },
+  { slot0: { mode: 'continue', autosquash: true } },
   { slot0: harden({ author: 'alice', oneline: true, maxCount: 10 }) },
   { slot0: 'a', slot1: { a: 1, b: 2 } },
   { slot0: 'a', slot1: { nested: { x: 1 } } },

--- a/packages/agent-tools/test/divergence.test.js
+++ b/packages/agent-tools/test/divergence.test.js
@@ -18,6 +18,7 @@ import {
 } from '@endo/patterns';
 import { Far } from '@endo/pass-style';
 import { GitInterface } from '@endo/exo-git';
+import { GitRebaseStartInputShape } from '@endo/exo-git/src/interfaces.js';
 
 import { makeGitHistoryTool, makeGitTool } from '../src/git-tool.js';
 
@@ -49,21 +50,7 @@ const guardShapeFor = method => {
   }
   return {
     ...shape,
-    guards: harden([
-      M.and(
-        shape.guards[0],
-        M.splitRecord(
-          {
-            mode: 'start',
-            upstream: M.string(),
-          },
-          {
-            autosquash: M.boolean(),
-          },
-          harden({}),
-        ),
-      ),
-    ]),
+    guards: harden([M.and(shape.guards[0], GitRebaseStartInputShape)]),
   };
 };
 

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -81,6 +81,14 @@ const makeHistoryStubGit = calls =>
       calls.push(['reword', ...a]);
       return { oid: 'x', summary: a[1] };
     },
+    cherryPick: async (...a) => {
+      calls.push(['cherryPick', ...a]);
+      return '';
+    },
+    rebase: async (...a) => {
+      calls.push(['rebase', ...a]);
+      return '';
+    },
   });
 
 test('makeGitTool builds one record per non-remotable-slice method', t => {
@@ -174,7 +182,12 @@ test('the schemas advertise real, declarative property names', t => {
 test('makeGitHistoryTool requires an explicit elevated capability', async t => {
   const calls = [];
   const tools = makeGitHistoryTool(makeHistoryStubGit(calls));
-  t.deepEqual(tools.map(tool => tool.name).sort(), ['commit', 'reword']);
+  t.deepEqual(tools.map(tool => tool.name).sort(), [
+    'cherryPick',
+    'commit',
+    'rebase',
+    'reword',
+  ]);
   const byName = name => {
     const found = tools.find(tool => tool.name === name);
     if (!found) throw new Error(`no history tool named ${name}`);
@@ -186,9 +199,18 @@ test('makeGitHistoryTool requires an explicit elevated capability', async t => {
     options: harden({ amend: true }),
   });
   await byName('reword').invoke({ ref: 'HEAD~1', message: 'new subject' });
+  await byName('cherryPick').invoke({
+    ref: 'side',
+    options: harden({ noCommit: true }),
+  });
+  await byName('rebase').invoke({
+    input: harden({ mode: 'start', upstream: 'main', autosquash: true }),
+  });
   t.deepEqual(calls, [
     ['commit', 'amended message', { amend: true }],
     ['reword', 'HEAD~1', 'new subject'],
+    ['cherryPick', 'side', { noCommit: true }],
+    ['rebase', { mode: 'start', upstream: 'main', autosquash: true }],
   ]);
 });
 

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -208,6 +208,7 @@ test('makeGitHistoryTool requires an explicit elevated capability', async t => {
   });
   await t.throwsAsync(
     byName('rebase').invoke({ input: harden({ mode: 'abort' }) }),
+    { message: /rebase input.*missing properties.*upstream/ },
   );
   t.deepEqual(calls, [
     ['commit', 'amended message', { amend: true }],

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -206,6 +206,9 @@ test('makeGitHistoryTool requires an explicit elevated capability', async t => {
   await byName('rebase').invoke({
     input: harden({ mode: 'start', upstream: 'main', autosquash: true }),
   });
+  await t.throwsAsync(
+    byName('rebase').invoke({ input: harden({ mode: 'abort' }) }),
+  );
   t.deepEqual(calls, [
     ['commit', 'amended message', { amend: true }],
     ['reword', 'HEAD~1', 'new subject'],

--- a/packages/agentry/scripts/code-mode-git-extract.js
+++ b/packages/agentry/scripts/code-mode-git-extract.js
@@ -33,7 +33,12 @@ import {
 const GIT_TYPES_TS_URL = new URL('../../exo-git/src/types.ts', import.meta.url);
 const GIT_ROOT_TYPE = 'EndoGit';
 
-export const GIT_HISTORY_MEMBERS = harden(['commit', 'reword']);
+export const GIT_HISTORY_MEMBERS = harden([
+  'commit',
+  'reword',
+  'cherryPick',
+  'rebase',
+]);
 harden(GIT_HISTORY_MEMBERS);
 
 /**

--- a/packages/agentry/scripts/code-mode-git-extract.js
+++ b/packages/agentry/scripts/code-mode-git-extract.js
@@ -94,10 +94,22 @@ export const buildGitIRs = () =>
     (() => {
       const fileName = fileURLToPath(GIT_TYPES_TS_URL);
       const text = readFileSync(fileName, 'utf8');
+      const fullGit = extractTsFileTextIR({
+        fileName,
+        text,
+        rootType: GIT_ROOT_TYPE,
+      });
       const git = extractTsFileTextIR({
         fileName,
         text,
         rootType: GIT_ROOT_TYPE,
+        memberFilter: fullGit.members
+          .filter(
+            member =>
+              !GIT_HISTORY_MEMBERS.includes(member.name) ||
+              member.name === 'commit',
+          )
+          .map(member => member.name),
       });
       const gitHistory = extractTsFileTextIR({
         fileName,
@@ -112,20 +124,14 @@ export const buildGitIRs = () =>
       return {
         git: harden({
           rootName: 'EndoGit',
-          members: git.members
-            .filter(
-              member =>
-                !GIT_HISTORY_MEMBERS.includes(member.name) ||
-                member.name === 'commit',
-            )
-            .map(member =>
-              member.name === 'commit'
-                ? harden({
-                    ...commit,
-                    signature: withoutOptionalFinalArgument(commit.signature),
-                  })
-                : member,
-            ),
+          members: git.members.map(member =>
+            member.name === 'commit'
+              ? harden({
+                  ...commit,
+                  signature: withoutOptionalFinalArgument(commit.signature),
+                })
+              : member,
+          ),
           auxTypes: git.auxTypes.filter(
             type => type.name !== 'GitCommitOptions',
           ),

--- a/packages/agentry/src/execute/git-types.js
+++ b/packages/agentry/src/execute/git-types.js
@@ -55,9 +55,6 @@ export const gitCodeModeTypeDeclarations = harden({
 };
 type EndoMount = unknown;
 type EndoMountEntry = unknown;
-type GitCherryPickOptions = {
-    noCommit?: boolean;
-};
 type GitCommit = {
     oid: string;
     summary: string;
@@ -88,15 +85,6 @@ type GitLogOptions = {
 type GitMergeOptions = {
     fastForwardOnly?: boolean;
     noFastForward?: boolean;
-};
-type GitRebaseInput = {
-    mode: 'start';
-    upstream: string;
-    autosquash?: boolean;
-} | {
-    mode: 'continue' | 'abort' | 'skip';
-    upstream?: never;
-    autosquash?: never;
 };
 type GitRef = {
     name: string;

--- a/packages/agentry/src/execute/git-types.js
+++ b/packages/agentry/src/execute/git-types.js
@@ -43,7 +43,6 @@ export const gitCodeModeTypeDeclarations = harden({
   detach: (ref: GitRef | string) => Promise<void>;
   switch: (ref: GitRef | string) => Promise<void>;
   merge: (ref: GitRef | string, options?: GitMergeOptions) => Promise<string>;
-  rebase: (input: GitRebaseInput) => Promise<string>;
   stashPush: (options?: GitStashPushOptions) => Promise<string>;
   stashList: () => Promise<string[]>;
   stashShow: (index?: number) => Promise<string>;
@@ -56,6 +55,9 @@ export const gitCodeModeTypeDeclarations = harden({
 };
 type EndoMount = unknown;
 type EndoMountEntry = unknown;
+type GitCherryPickOptions = {
+    noCommit?: boolean;
+};
 type GitCommit = {
     oid: string;
     summary: string;
@@ -88,8 +90,13 @@ type GitMergeOptions = {
     noFastForward?: boolean;
 };
 type GitRebaseInput = {
-    mode?: 'start' | 'continue' | 'abort' | 'skip';
-    upstream?: string;
+    mode: 'start';
+    upstream: string;
+    autosquash?: boolean;
+} | {
+    mode: 'continue' | 'abort' | 'skip';
+    upstream?: never;
+    autosquash?: never;
 };
 type GitRef = {
     name: string;
@@ -121,6 +128,11 @@ type ReadableTreeView = unknown;`,
     aux: `type EndoGitHistory = {
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+  cherryPick: (ref: GitRef | string, options?: GitCherryPickOptions) => Promise<string>;
+  rebase: (input: GitRebaseInput) => Promise<string>;
+};
+type GitCherryPickOptions = {
+    noCommit?: boolean;
 };
 type GitCommit = {
     oid: string;
@@ -130,6 +142,15 @@ type GitCommit = {
 };
 type GitCommitOptions = {
     amend?: boolean;
+};
+type GitRebaseInput = {
+    mode: 'start';
+    upstream: string;
+    autosquash?: boolean;
+} | {
+    mode: 'continue' | 'abort' | 'skip';
+    upstream?: never;
+    autosquash?: never;
 };
 type GitRef = {
     name: string;

--- a/packages/agentry/src/execute/git.js
+++ b/packages/agentry/src/execute/git.js
@@ -41,7 +41,7 @@ export const makeGitGlobal = ({
     description: readOnly
       ? 'Read-only @endo/exo-git Git capability for repository inspection.'
       : historyRewrite
-        ? 'History-rewrite @endo/exo-git Git capability for amend and reword.'
+        ? 'History-rewrite @endo/exo-git Git capability for amend, reword, cherry-pick, and rebase.'
         : 'Read/write @endo/exo-git Git capability for repository changes.',
     declaration: readOnly
       ? gitCodeModeTypeDeclarations.gitReadOnly

--- a/packages/agentry/test/code-mode-types.test.js
+++ b/packages/agentry/test/code-mode-types.test.js
@@ -111,6 +111,16 @@ test('base and history git declarations split history rewrite authority', t => {
       member.signature.includes('GitCommitOptions'),
     ),
   );
+  for (const historyOnlyType of [
+    'GitCommitOptions',
+    'GitCherryPickOptions',
+    'GitRebaseInput',
+  ]) {
+    t.false(
+      git.auxTypes.some(type => type.name === historyOnlyType),
+      `base git declaration should omit ${historyOnlyType}`,
+    );
+  }
 });
 
 // The FS `.d.ts` is a stub, so `workspace` is derived from the interface

--- a/packages/agentry/test/code-mode.test.js
+++ b/packages/agentry/test/code-mode.test.js
@@ -257,6 +257,8 @@ test('makeCodeModeAgent configures one history-rewrite git capability', async t 
     ),
   );
   t.true(systemPrompt.includes('reword:'));
+  t.true(systemPrompt.includes('cherryPick:'));
+  t.true(systemPrompt.includes('rebase:'));
 });
 
 test('makeCodeModeAgent rejects ordinary Git for history-rewrite mode', async t => {

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -21,6 +21,8 @@ import { iterateBytesReader } from '@endo/exo-stream/iterate-bytes-reader.js';
 import { makeFilePowers } from '../src/daemon-node-powers.js';
 import { lineageOf, makeMount } from '../src/mount.js';
 
+/** @import { GitRebaseInput } from '@endo/exo-git' */
+
 const execFileAsync = nodePromisify(execFile);
 
 /**
@@ -2222,7 +2224,12 @@ test('NativeGitBackend.rebase rejects autosquash outside start mode', async t =>
   await Promise.all(
     ['continue', 'abort', 'skip'].map(mode =>
       t.throwsAsync(
-        () => backend.rebase(/** @type {any} */ ({ mode, autosquash: true })),
+        () =>
+          backend.rebase(
+            /** @type {GitRebaseInput} */ (
+              /** @type {unknown} */ ({ mode, autosquash: true })
+            ),
+          ),
         {
           message: /autosquash is only valid for mode start/,
         },

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -602,6 +602,12 @@ test('Git history rewrite authority defaults off and can be elevated', async t =
   await t.throwsAsync(E(git).reword(first.oid, 'blocked reword'), {
     message: /without history-rewrite authority/,
   });
+  await t.throwsAsync(E(git).cherryPick(first.oid), {
+    message: /without history-rewrite authority/,
+  });
+  await t.throwsAsync(E(git).rebase({ mode: 'start', upstream: 'main' }), {
+    message: /without history-rewrite authority/,
+  });
 
   await fs.promises.writeFile(path.join(repoRoot, 'history.txt'), 'two\n');
   await E(git).add([entry]);
@@ -908,7 +914,10 @@ test('Git.cherryPick replays a commit through the native backend', async t => {
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
   const backend = makeNativeGitBackend({ repoRoot });
-  const git = makeGit({ mount, backend, lineageOf });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
 
   await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
   await fs.promises.writeFile(path.join(repoRoot, 'side.txt'), 'side\n');
@@ -947,7 +956,10 @@ test('Git.cherryPick noCommit applies without creating a commit', async t => {
   const filePowers = makeFilePowers({ fs, path });
   const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
   const backend = makeNativeGitBackend({ repoRoot });
-  const git = makeGit({ mount, backend, lineageOf });
+  const git = makeGit(
+    { mount, backend, lineageOf },
+    { allowHistoryRewrite: true },
+  );
 
   const initialHead = (await E(git).revParse('HEAD')).oid;
   await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -114,7 +114,7 @@ test('Git exo advertises the full GitInterface', async t => {
   }
 
   // Mutation
-  for (const name of ['add', 'restore', 'commit', 'reword']) {
+  for (const name of ['add', 'restore', 'commit', 'reword', 'cherryPick']) {
     t.true(methods.includes(name), `Git should advertise ${name}`);
   }
 
@@ -199,6 +199,17 @@ test('Git.readOnly() attenuates mutating operations but preserves reads', async 
   await t.throwsAsync(E(readOnlyGit).reword('HEAD', 'should fail'), {
     message: /read-only Git capability/,
   });
+  await t.throwsAsync(E(readOnlyGit).cherryPick('HEAD'), {
+    message: /read-only Git capability/,
+  });
+  await t.throwsAsync(
+    E(readOnlyGit).rebase({
+      mode: 'start',
+      upstream: 'main',
+      autosquash: true,
+    }),
+    { message: /read-only Git capability/ },
+  );
   await t.throwsAsync(E(readOnlyGit).switchBranch('main'), {
     message: /read-only Git capability/,
   });
@@ -892,6 +903,123 @@ test('Git.reword accepts HEAD while detached but rejects an ancestor', async t =
   });
 });
 
+test('Git.cherryPick replays a commit through the native backend', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'side.txt'), 'side\n');
+  await execFileAsync('git', ['add', 'side.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'side commit',
+    ],
+    { cwd: repoRoot },
+  );
+  const sideOid = (await E(git).revParse('HEAD')).oid || '';
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+
+  await E(git).cherryPick(sideOid);
+
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'side.txt'), 'utf8'),
+    'side\n',
+  );
+  const log = await E(git).log({ maxCount: 2 });
+  t.deepEqual(
+    log.map(commit => commit.summary),
+    ['side commit', 'init commit'],
+  );
+});
+
+test('Git.cherryPick noCommit applies without creating a commit', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  const initialHead = (await E(git).revParse('HEAD')).oid;
+  await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'pending.txt'), 'pending\n');
+  await execFileAsync('git', ['add', 'pending.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'pending commit',
+    ],
+    { cwd: repoRoot },
+  );
+  const sideOid = (await E(git).revParse('HEAD')).oid || '';
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+
+  await E(git).cherryPick(sideOid, { noCommit: true });
+
+  t.is((await E(git).revParse('HEAD')).oid, initialHead);
+  const status = await E(git).status();
+  const pending = status.find(row => row.path === 'pending.txt');
+  t.truthy(pending);
+  t.is(pending && pending.index, 'added');
+});
+
+test('NativeGitBackend.cherryPick stops cleanly on conflict', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'base\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'base file'],
+    { cwd: repoRoot },
+  );
+
+  await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'side\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'side edit'],
+    { cwd: repoRoot },
+  );
+  const sideOid = (
+    await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot })
+  ).stdout.trim();
+
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'main\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'main edit'],
+    { cwd: repoRoot },
+  );
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await t.throwsAsync(() => backend.cherryPick(sideOid), {
+    message: /cherry-pick failed|CONFLICT/,
+  });
+  const status = await backend.status();
+  const conflicted = status.find(row => row.path === 'conflict.txt');
+  t.truthy(conflicted);
+  t.is(conflicted && conflicted.index, 'conflicted');
+  t.is(conflicted && conflicted.worktree, 'conflicted');
+});
+
 test('Git scaffold methods all surface a clear "not yet implemented"', async t => {
   const mount = await provisionMount(t);
   const backend = makeNotYetImplementedBackend();
@@ -909,6 +1037,9 @@ test('Git scaffold methods all surface a clear "not yet implemented"', async t =
     message: /not yet implemented/,
   });
   await t.throwsAsync(E(git).reword('HEAD', 'msg'), {
+    message: /not yet implemented/,
+  });
+  await t.throwsAsync(E(git).cherryPick('HEAD'), {
     message: /not yet implemented/,
   });
   await t.throwsAsync(E(git).branches(), { message: /not yet implemented/ });
@@ -2020,6 +2151,71 @@ test('NativeGitBackend.rebase rebases a local branch onto upstream', async t => 
   t.deepEqual(
     commits.map(commit => commit.summary),
     ['feature commit', 'main commit'],
+  );
+});
+
+test('NativeGitBackend.rebase supports autosquash on start', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync('git', ['switch', '-c', 'feature'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'topic.txt'), 'one\n');
+  await execFileAsync('git', ['add', 'topic.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'topic'],
+    { cwd: repoRoot },
+  );
+  await fs.promises.writeFile(path.join(repoRoot, 'topic.txt'), 'two\n');
+  await execFileAsync('git', ['add', 'topic.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'fixup! topic',
+    ],
+    { cwd: repoRoot },
+  );
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'main.txt'), 'main\n');
+  await execFileAsync('git', ['add', 'main.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'main'],
+    { cwd: repoRoot },
+  );
+  await execFileAsync('git', ['switch', 'feature'], { cwd: repoRoot });
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await backend.rebase({ mode: 'start', upstream: 'main', autosquash: true });
+
+  const commits = await backend.log({ maxCount: 3 });
+  t.deepEqual(
+    commits.map(commit => commit.summary),
+    ['topic', 'main', 'init commit'],
+  );
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'topic.txt'), 'utf8'),
+    'two\n',
+  );
+});
+
+test('NativeGitBackend.rebase rejects autosquash outside start mode', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const backend = makeNativeGitBackend({ repoRoot });
+
+  await Promise.all(
+    ['continue', 'abort', 'skip'].map(mode =>
+      t.throwsAsync(
+        () => backend.rebase(/** @type {any} */ ({ mode, autosquash: true })),
+        {
+          message: /autosquash is only valid for mode start/,
+        },
+      ),
+    ),
   );
 });
 

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -15,6 +15,7 @@ import { GitInterface } from './interfaces.js';
 /**
  * @import {
  *   EndoGit,
+ *   GitCherryPickOptions,
  *   GitCommit,
  *   GitCommitOptions,
  *   GitCreateBranchOptions,
@@ -149,6 +150,7 @@ harden(getGitBackend);
  * @property {(paths: string[], opts?: GitRestoreOptions) => Promise<void>} restore
  * @property {(message: string, opts?: GitCommitOptions) => Promise<GitCommit>} commit
  * @property {(ref: string, message: string) => Promise<GitCommit>} reword
+ * @property {(ref: string, opts?: GitCherryPickOptions) => Promise<string>} cherryPick
  * @property {() => Promise<GitRef | undefined>} currentBranch
  * @property {() => Promise<GitRef[]>} branches
  * @property {(name: string, opts?: GitCreateBranchOptions) => Promise<GitRef>} createBranch
@@ -476,6 +478,11 @@ export const makeGit = (
       return backend.reword(refName(ref), message);
     },
 
+    async cherryPick(ref, options = {}) {
+      assertWritable('cherryPick');
+      return backend.cherryPick(refName(ref), options);
+    },
+
     async currentBranch() {
       return backend.currentBranch();
     },
@@ -602,7 +609,8 @@ export const makeGit = (
     },
   };
 
-  const exo = makeExo('Git', GitInterface, gitMethods);
+  // eslint-disable-next-line jsdoc/reject-any-type -- GitInterface's guard-derived type is wider than the public rebase union.
+  const exo = makeExo('Git', /** @type {any} */ (GitInterface), gitMethods);
 
   const typed = /** @type {EndoGit} */ (/** @type {unknown} */ (exo));
   gitReadOnly.set(typed, readOnly);
@@ -638,6 +646,7 @@ export const makeNotYetImplementedBackend = () => {
     restore: async () => fail('restore'),
     commit: async () => fail('commit'),
     reword: async () => fail('reword'),
+    cherryPick: async () => fail('cherryPick'),
     currentBranch: async () => fail('currentBranch'),
     branches: async () => fail('branches'),
     createBranch: async () => fail('createBranch'),

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -611,7 +611,11 @@ export const makeGit = (
     },
   };
 
-  // eslint-disable-next-line jsdoc/reject-any-type -- GitInterface's guard-derived type is wider than the public rebase union.
+  // Cast: literal patterns infer broad `Key` types, while `GitRebaseInput`
+  // preserves the discriminated union for callers.
+  // The runtime guard remains in place and rejects invalid mode-specific
+  // fields.
+  // eslint-disable-next-line jsdoc/reject-any-type
   const exo = makeExo('Git', /** @type {any} */ (GitInterface), gitMethods);
 
   const typed = /** @type {EndoGit} */ (/** @type {unknown} */ (exo));

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -480,6 +480,7 @@ export const makeGit = (
 
     async cherryPick(ref, options = {}) {
       assertWritable('cherryPick');
+      assertHistoryRewrite('cherryPick');
       return backend.cherryPick(refName(ref), options);
     },
 
@@ -528,6 +529,7 @@ export const makeGit = (
 
     async rebase(input) {
       assertWritable('rebase');
+      assertHistoryRewrite('rebase');
       return backend.rebase(input);
     },
 

--- a/packages/exo-git/src/interfaces.js
+++ b/packages/exo-git/src/interfaces.js
@@ -70,6 +70,29 @@ const GitCommitOptionsShape = M.splitRecord(
   harden({}),
 );
 
+const GitCherryPickOptionsShape = M.splitRecord(
+  {},
+  { noCommit: M.boolean() },
+  harden({}),
+);
+
+const GitRebaseStartInputShape = M.splitRecord(
+  { mode: 'start', upstream: M.string() },
+  { autosquash: M.boolean() },
+  harden({}),
+);
+
+const GitRebaseControlInputShape = M.splitRecord(
+  { mode: M.or('continue', 'abort', 'skip') },
+  {},
+  harden({}),
+);
+
+const GitRebaseInputShape = M.or(
+  GitRebaseStartInputShape,
+  GitRebaseControlInputShape,
+);
+
 // #endregion
 
 export const GitInterface = M.interface('Git', {
@@ -95,6 +118,9 @@ export const GitInterface = M.interface('Git', {
     .optional(GitCommitOptionsShape)
     .returns(GitCommitShape),
   reword: M.callWhen(RefArgShape, M.string()).returns(GitCommitShape),
+  cherryPick: M.callWhen(RefArgShape)
+    .optional(GitCherryPickOptionsShape)
+    .returns(M.string()),
   currentBranch: M.callWhen().returns(M.or(GitRefShape, M.undefined())),
   branches: M.callWhen().returns(M.arrayOf(GitRefShape)),
   createBranch: M.callWhen(M.string())
@@ -110,7 +136,7 @@ export const GitInterface = M.interface('Git', {
   merge: M.callWhen(RefArgShape)
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.string()),
-  rebase: M.callWhen(M.recordOf(M.string(), M.any())).returns(M.string()),
+  rebase: M.callWhen(GitRebaseInputShape).returns(M.string()),
   stashPush: M.callWhen()
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.string()),

--- a/packages/exo-git/src/interfaces.js
+++ b/packages/exo-git/src/interfaces.js
@@ -76,11 +76,12 @@ const GitCherryPickOptionsShape = M.splitRecord(
   harden({}),
 );
 
-const GitRebaseStartInputShape = M.splitRecord(
+export const GitRebaseStartInputShape = M.splitRecord(
   { mode: 'start', upstream: M.string() },
   { autosquash: M.boolean() },
   harden({}),
 );
+harden(GitRebaseStartInputShape);
 
 const GitRebaseControlInputShape = M.splitRecord(
   { mode: M.or('continue', 'abort', 'skip') },

--- a/packages/exo-git/src/types.ts
+++ b/packages/exo-git/src/types.ts
@@ -65,6 +65,10 @@ export type GitCommitOptions = {
   amend?: boolean;
 };
 
+export type GitCherryPickOptions = {
+  noCommit?: boolean;
+};
+
 export type GitCreateBranchOptions = {
   startPoint?: string;
   switchAfterCreate?: boolean;
@@ -79,10 +83,17 @@ export type GitMergeOptions = {
   noFastForward?: boolean;
 };
 
-export type GitRebaseInput = {
-  mode?: 'start' | 'continue' | 'abort' | 'skip';
-  upstream?: string;
-};
+export type GitRebaseInput =
+  | {
+      mode: 'start';
+      upstream: string;
+      autosquash?: boolean;
+    }
+  | {
+      mode: 'continue' | 'abort' | 'skip';
+      upstream?: never;
+      autosquash?: never;
+    };
 
 export type GitStashPushOptions = {
   message?: string;
@@ -239,6 +250,10 @@ export type EndoGit = {
   ) => Promise<void>;
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+  cherryPick: (
+    ref: GitRef | string,
+    options?: GitCherryPickOptions,
+  ) => Promise<string>;
   currentBranch: () => Promise<GitRef | undefined>;
   branches: () => Promise<GitRef[]>;
   createBranch: (

--- a/packages/exo-git/test/types.test.ts
+++ b/packages/exo-git/test/types.test.ts
@@ -3,6 +3,7 @@ import type {
   EndoGit,
   EndoMount,
   EndoMountEntry,
+  GitCherryPickOptions,
   GitCommit,
   GitCommitOptions,
   GitCreateBranchOptions,
@@ -43,6 +44,10 @@ type ExpectedEndoGit = {
   ) => Promise<void>;
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+  cherryPick: (
+    ref: GitRef | string,
+    options?: GitCherryPickOptions,
+  ) => Promise<string>;
   currentBranch: () => Promise<GitRef | undefined>;
   branches: () => Promise<GitRef[]>;
   createBranch: (

--- a/packages/git/src/native-git-backend.js
+++ b/packages/git/src/native-git-backend.js
@@ -38,6 +38,7 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: false });
  *   GitBackendStashPushOptions,
  * } from '@endo/exo-git/src/git.js'
  * @import {
+ *   GitCherryPickOptions,
  *   GitCommit,
  *   GitCommitOptions,
  *   GitCreateBranchOptions,
@@ -2357,6 +2358,25 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
     },
 
     /**
+     * @param {string} ref
+     * @param {GitCherryPickOptions} [opts]
+     * @returns {Promise<string>}
+     */
+    cherryPick: async (ref, opts = {}) => {
+      const target = requireRevision(ref, 'cherryPick.ref');
+      await assertNoExecutableRepoConfig();
+      const args = ['cherry-pick'];
+      if (opts.noCommit !== undefined && typeof opts.noCommit !== 'boolean') {
+        throw new Error('cherryPick.noCommit must be a boolean');
+      }
+      if (opts.noCommit) {
+        args.push('--no-commit');
+      }
+      args.push('--end-of-options', target);
+      return runGit(args);
+    },
+
+    /**
      * @returns {Promise<GitRef | undefined>}
      */
     currentBranch: async () => {
@@ -2506,11 +2526,32 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
     rebase: async input => {
       await assertNoExecutableRepoConfig();
       if (input.mode === 'start') {
-        return runGit([
-          'rebase',
+        const args = ['rebase'];
+        if (input.autosquash !== undefined) {
+          if (typeof input.autosquash !== 'boolean') {
+            throw new Error('rebase.autosquash must be a boolean');
+          }
+          if (input.autosquash) {
+            args.push('--autosquash', '--interactive');
+          }
+        }
+        args.push(
           '--end-of-options',
           requireRevision(input.upstream, 'rebase.upstream'),
-        ]);
+        );
+        return runGit(args);
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(input, 'autosquash') &&
+        input.autosquash !== undefined
+      ) {
+        throw new Error('rebase.autosquash is only valid for mode start');
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(input, 'upstream') &&
+        input.upstream !== undefined
+      ) {
+        throw new Error('rebase.upstream is only valid for mode start');
       }
       if (input.mode === 'continue') {
         return runGit(['rebase', '--continue']);

--- a/packages/git/src/native-git-backend.js
+++ b/packages/git/src/native-git-backend.js
@@ -192,9 +192,8 @@ const makeGitEnv = repoRoot => ({
   // command completes non-interactively.  Takes precedence over any
   // repository-local `core.editor`.
   GIT_EDITOR: 'true',
-  // The same no-op for the rebase todo-list editor, should an
-  // interactive rebase ever be wired in.  Takes precedence over any
-  // repository-local `sequence.editor`.
+  // The same no-op for the interactive rebase used by the autosquash path.
+  // Takes precedence over any repository-local `sequence.editor`.
   GIT_SEQUENCE_EDITOR: ':',
   // Suppress the opportunistic index refresh that read commands
   // (status, diff) otherwise perform.  Without this, a "read-only"
@@ -2533,6 +2532,8 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
           }
           if (input.autosquash) {
             args.push('--autosquash', '--interactive');
+          } else {
+            args.push('--no-autosquash');
           }
         }
         args.push(


### PR DESCRIPTION
Refs: #644

## Description

Adds the next stack-replay Git operations following #644: elevated local Git capabilities can cherry-pick a ref, optionally without committing, and can start a rebase with autosquash for fixup and squash cleanup flows. Code mode exposes cherry-pick and the complete rebase control union, while the JSON tool catalog exposes cherry-pick and only the single-step rebase start operation.

The ordinary Git tool and code-mode surfaces continue to omit these operations. Rebase continue, abort, and skip remain outside the JSON tool catalog so that this change does not expand that catalog into a conflict-resolution loop.

### Security Considerations

Cherry-pick and rebase require an explicitly elevated history-rewrite Git capability. Read-only and ordinary read/write capabilities reject them before reaching the backend, refs still pass through the existing revision safety checks, and native execution retains the sanitized Git environment plus repository identity and executable-config checks.

### Scaling Considerations

The operations run bounded native Git commands through the existing backend path. Autosquash uses interactive rebase with the existing noninteractive sequence-editor override, so it does not introduce an interactive or long-running UI loop.

### Documentation Considerations

The agent-tool documentation and generated code-mode declarations distinguish the elevated cherry-pick and rebase operations from the ordinary Git surface. No saved-data migration is required.

### Testing Considerations

Coverage includes type, interface-guard, generated-declaration, and JSON-schema drift checks; authority and read-only rejection; native cherry-pick, no-commit, and conflict-stop behavior; and native autosquash replay and mode validation. Removing the start-only JSON-tool guard made the rebase attenuation assertion fail, changing the cherry-pick option schema made the schema/guard parity test fail, and restoring each implementation restored the passing suite.

Verified with the affected package lint and test suites, the composite type build, repository lint and formatting, API documentation generation, and the repository's changed-path gates.

### Compatibility Considerations

Cherry-pick and autosquash are additive API capabilities. Rebase now requires the same explicit history-rewrite authority as the other stack-replay operations, so hosts that previously exposed rebase through an ordinary Git capability must opt into the elevated capability.

### Upgrade Considerations

Deploy the updated Git, exo-git, agent-tools, and agentry packages together so the backend, runtime guards, generated declarations, and tool schemas stay aligned. Hosts that expose rebase must request history-rewrite authority and select the elevated tool or code-mode surface.
