### PR TITLE
feat(git): add conflict side checkout

### DIFF
--- a/packages/agent-tools/src/git-mount-tool.js
+++ b/packages/agent-tools/src/git-mount-tool.js
@@ -26,9 +26,11 @@ import { makeTool } from './tool.js';
  * The git tools in this module bridge the `EndoGit` methods whose native
  * signatures traffic in live capabilities — `status()` returns rows bearing
  * `EndoMountEntry` / node remotables, while `add()` and `checkoutConflict()`
- * take arrays of `EndoMountEntry` remotables. They cannot sit in the
- * JSON-transparent, one-to-one guard-mapped slice `makeGitTool` exposes. Each tool here holds the
- * mount/git capability pair (the mount reached through `Git.worktree()`) and
+ * take arrays of `EndoMountEntry` remotables.
+ * They cannot sit in the JSON-transparent, one-to-one guard-mapped slice
+ * `makeGitTool` exposes.
+ * Each tool here holds the mount/git capability pair (the mount reached
+ * through `Git.worktree()`) and
  * converts at the boundary: path strings in, JSON-safe records out. The
  * capability, never a path string, remains the confinement boundary — a `../`
  * segment is contained by the mount (clamped at the worktree root), not by a
@@ -131,7 +133,8 @@ const entriesForSegments = async (gitCap, segmentsByPath) => {
 
 /**
  * Build the mount-bridged git tool records — `status`, `add`, and
- * `checkoutConflict` — for a live `Git` capability. These complement
+ * `checkoutConflict` — for a live `Git` capability.
+ * These complement
  * `makeGitTool`'s JSON-transparent slice.
  *
  * @param {ERef<GitMountToolCapability>} gitCap A live `Git` capability. The

--- a/packages/agent-tools/src/git-mount-tool.js
+++ b/packages/agent-tools/src/git-mount-tool.js
@@ -7,7 +7,7 @@
 
 /**
  * The one worktree-mount method this bridge needs: `entry(segments)` mints the
- * `EndoMountEntry` remotable `Git.add` consumes. `@endo/exo-git` aliases
+ * `EndoMountEntry` remotable Git mutation methods consume. `@endo/exo-git` aliases
  * `EndoMount` to `unknown` to stay free of a circular `@endo/daemon` type
  * dependency (the full-fidelity `EndoMount` interface lives in `@endo/daemon`),
  * so we name the single method we reach through the mount locally rather than
@@ -23,11 +23,11 @@ import { M } from '@endo/patterns';
 import { makeTool } from './tool.js';
 
 /**
- * The git tools in this module bridge the two `EndoGit` methods whose native
+ * The git tools in this module bridge the `EndoGit` methods whose native
  * signatures traffic in live capabilities — `status()` returns rows bearing
- * `EndoMountEntry` / node remotables, and `add()` takes an array of
- * `EndoMountEntry` remotables — so they cannot sit in the JSON-transparent,
- * one-to-one guard-mapped slice `makeGitTool` exposes. Each tool here holds the
+ * `EndoMountEntry` / node remotables, while `add()` and `checkoutConflict()`
+ * take arrays of `EndoMountEntry` remotables. They cannot sit in the
+ * JSON-transparent, one-to-one guard-mapped slice `makeGitTool` exposes. Each tool here holds the
  * mount/git capability pair (the mount reached through `Git.worktree()`) and
  * converts at the boundary: path strings in, JSON-safe records out. The
  * capability, never a path string, remains the confinement boundary — a `../`
@@ -67,6 +67,21 @@ const addParameters = harden({
   additionalProperties: false,
 });
 
+const checkoutConflictParameters = harden({
+  type: 'object',
+  properties: {
+    paths: addParameters.properties.paths,
+    side: {
+      enum: ['ours', 'theirs'],
+      description:
+        'The unmerged index side to select for every path. "ours" selects ' +
+        'the current branch side; "theirs" selects the incoming side.',
+    },
+  },
+  required: ['paths', 'side'],
+  additionalProperties: false,
+});
+
 /**
  * Split a mount-relative path string into entry segments, dropping empty and
  * `.` components so `a/b`, `a//b`, and `a/b/` resolve identically. A `..`
@@ -82,10 +97,42 @@ const pathToSegments = path =>
   path.split('/').filter(segment => segment !== '' && segment !== '.');
 
 /**
- * Build the mount-bridged git tool records — `status` and `add` — for a live
- * `Git` capability. These complement `makeGitTool`'s JSON-transparent slice to
- * complete the daemon-agent-tools Phase 3 surface (status/diff/log/add/commit);
- * `diff`, `log`, and `commit` come from `makeGitTool`.
+ * @param {string} verb
+ * @param {string[]} paths
+ * @returns {string[][]}
+ */
+const pathsToSegments = (verb, paths) => {
+  if (paths.length === 0) {
+    throw new Error(`${verb} requires a non-empty array of paths`);
+  }
+  return paths.map(path => {
+    if (path === '') {
+      throw new Error(`${verb} paths must be non-empty strings`);
+    }
+    const segments = pathToSegments(path);
+    if (segments.length === 0) {
+      throw new Error(
+        `${verb} paths must address a file, not the worktree root`,
+      );
+    }
+    return segments;
+  });
+};
+
+/**
+ * @param {ERef<GitMountToolCapability>} gitCap
+ * @param {string[][]} segmentsByPath
+ * @returns {Promise<EndoMountEntry[]>}
+ */
+const entriesForSegments = async (gitCap, segmentsByPath) => {
+  const mount = /** @type {WorktreeMount} */ (await E(gitCap).worktree());
+  return Promise.all(segmentsByPath.map(segments => E(mount).entry(segments)));
+};
+
+/**
+ * Build the mount-bridged git tool records — `status`, `add`, and
+ * `checkoutConflict` — for a live `Git` capability. These complement
+ * `makeGitTool`'s JSON-transparent slice.
  *
  * @param {ERef<GitMountToolCapability>} gitCap A live `Git` capability. The
  *   worktree mount is reached through `E(gitCap).worktree()`; a writable Git
@@ -131,9 +178,6 @@ export const makeGitMountTools = gitCap => {
     argGuards: harden([M.arrayOf(M.string())]),
     execute: async args => {
       const { paths } = /** @type {{ paths: string[] }} */ (args);
-      if (paths.length === 0) {
-        throw new Error('add requires a non-empty array of paths');
-      }
       // Normalize every path up front and reject any that addresses no file.
       // Beyond the empty string, a path built only from dropped components
       // (`.`, `/`, `//`, `./`) collapses to zero segments, which would resolve
@@ -141,31 +185,37 @@ export const makeGitMountTools = gitCap => {
       // rejected by the backend only with an opaque low-level error. Reject it
       // here, at the tool, with a clear message. A leading `..` is deliberately
       // NOT rejected here: the mount contains it (clamped at the root).
-      const segmentsByPath = paths.map(path => {
-        if (path === '') {
-          throw new Error('add paths must be non-empty strings');
-        }
-        const segments = pathToSegments(path);
-        if (segments.length === 0) {
-          throw new Error(
-            'add paths must address a file, not the worktree root',
-          );
-        }
-        return segments;
-      });
+      const segmentsByPath = pathsToSegments('add', paths);
       // Resolve each path to an `EndoMountEntry` minted by this Git's own
       // worktree mount, so `Git.add`'s lineage check accepts it. `callWhen`
       // does not deeply await array elements, so the entries must be settled
       // remotables — not promises — before the call.
-      const mount = /** @type {WorktreeMount} */ (await E(gitCap).worktree());
-      const entries = await Promise.all(
-        segmentsByPath.map(segments => E(mount).entry(segments)),
-      );
+      const entries = await entriesForSegments(gitCap, segmentsByPath);
       await E(gitCap).add(harden(entries));
       return `Staged ${paths.length} path${paths.length === 1 ? '' : 's'}.`;
     },
   });
 
-  return harden([statusTool, addTool]);
+  const checkoutConflictTool = makeTool({
+    name: 'checkoutConflict',
+    description:
+      'Resolve conflicted paths by selecting the current branch side ' +
+      '("ours") or incoming side ("theirs"), then stage the resolution.',
+    parameters: checkoutConflictParameters,
+    argGuards: harden([M.arrayOf(M.string()), M.or('ours', 'theirs')]),
+    execute: async args => {
+      const { paths, side } =
+        /** @type {{ paths: string[], side: 'ours' | 'theirs' }} */ (args);
+      const segmentsByPath = pathsToSegments('checkoutConflict', paths);
+      const entries = await entriesForSegments(gitCap, segmentsByPath);
+      await E(gitCap).checkoutConflict(harden(entries), side);
+      return (
+        `Selected ${side} for ${paths.length} conflicted ` +
+        `path${paths.length === 1 ? '' : 's'}.`
+      );
+    },
+  });
+
+  return harden([statusTool, addTool, checkoutConflictTool]);
 };
 harden(makeGitMountTools);

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -11,6 +11,7 @@ import { E } from '@endo/eventual-send';
 import {
   getInterfaceGuardPayload,
   getMethodGuardPayload,
+  M,
 } from '@endo/patterns';
 import { GitInterface } from '@endo/exo-git';
 
@@ -66,6 +67,47 @@ const COMMIT_OPTIONS_PROP = harden({
   required: [],
   additionalProperties: false,
 });
+
+const CHERRY_PICK_OPTIONS_PROP = harden({
+  type: 'object',
+  properties: {
+    noCommit: {
+      type: 'boolean',
+      description:
+        'Apply the patch to the index and worktree without committing.',
+    },
+  },
+  required: [],
+  additionalProperties: false,
+});
+
+const REBASE_START_INPUT_PROP = harden({
+  type: 'object',
+  properties: {
+    mode: { const: 'start' },
+    upstream: {
+      type: 'string',
+      description: 'The upstream ref to replay the current branch onto.',
+    },
+    autosquash: {
+      type: 'boolean',
+      description: 'Fold fixup!/squash! commits during the replay.',
+    },
+  },
+  required: ['mode', 'upstream'],
+  additionalProperties: false,
+});
+
+const REBASE_START_INPUT_SHAPE = M.splitRecord(
+  {
+    mode: 'start',
+    upstream: M.string(),
+  },
+  {
+    autosquash: M.boolean(),
+  },
+  {},
+);
 
 /**
  * This package intentionally exposes only a curated JSON-safe `EndoGit` slice
@@ -127,6 +169,29 @@ const gitToolSchemas = harden({
       additionalProperties: false,
     },
   },
+  cherryPick: {
+    description: 'Replay an existing commit onto the current branch.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ref: REF_PROP,
+        options: CHERRY_PICK_OPTIONS_PROP,
+      },
+      required: ['ref'],
+      additionalProperties: false,
+    },
+  },
+  rebase: {
+    description: 'Replay the current branch onto an upstream ref.',
+    parameters: {
+      type: 'object',
+      properties: {
+        input: REBASE_START_INPUT_PROP,
+      },
+      required: ['input'],
+      additionalProperties: false,
+    },
+  },
   branches: {
     description: 'List the repository branches.',
     parameters: NO_ARGS,
@@ -169,6 +234,13 @@ const gitToolMethods = harden(
 );
 
 /**
+ * @type {Partial<Record<keyof GitToolCapability, Pattern[]>>}
+ */
+const gitToolArgGuards = harden({
+  rebase: harden([REBASE_START_INPUT_SHAPE]),
+});
+
+/**
  * Positional arg guards for a method, required first and then optional.
  * `getMethodGuardPayload` unwraps the `M.callWhen` await-arg wrappers.
  *
@@ -197,7 +269,7 @@ const positionalArgGuards = method => {
 export const makeGitTool = gitCap => {
   const records = gitToolMethods.map(method => {
     const schema = gitToolSchemas[method];
-    const argGuards = positionalArgGuards(method);
+    const argGuards = gitToolArgGuards[method] || positionalArgGuards(method);
     // The schema's declared property order is the positional argument order,
     // matching the convention `makeTool` applies to the named-args record.
     const paramNames = Object.keys(

--- a/packages/agent-tools/src/git-tool.js
+++ b/packages/agent-tools/src/git-tool.js
@@ -55,6 +55,18 @@ const REF_PROP = harden({
     'structured ref record.',
 });
 
+const COMMIT_OPTIONS_PROP = harden({
+  type: 'object',
+  properties: {
+    amend: {
+      type: 'boolean',
+      description: 'Amend HEAD instead of creating a new commit.',
+    },
+  },
+  required: [],
+  additionalProperties: false,
+});
+
 /**
  * This package intentionally exposes only a curated JSON-safe `EndoGit` slice
  * for now. Methods that remotely accept capabilities or can return
@@ -97,8 +109,21 @@ const gitToolSchemas = harden({
       type: 'object',
       properties: {
         message: { type: 'string', description: 'The commit message.' },
+        options: COMMIT_OPTIONS_PROP,
       },
       required: ['message'],
+      additionalProperties: false,
+    },
+  },
+  reword: {
+    description: 'Replace a commit message while keeping its patch unchanged.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ref: REF_PROP,
+        message: { type: 'string', description: 'The replacement message.' },
+      },
+      required: ['ref', 'message'],
       additionalProperties: false,
     },
   },

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -12,10 +12,11 @@ import type { Pattern } from '@endo/patterns';
  * — `merge`, `rebase`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
  * family, and the working-tree/detach mutators (`switch`, `detach`). Those carry
  * authority a tool surface handed to a model should not advertise: they can
- * discard uncommitted work or rewrite shared history. `commit`, `createBranch`,
- * and `switchBranch` are included as the additive, non-destructive write
- * surface. Widening this `Pick` is a deliberate authority decision, not a
- * convenience — add a method only when the tool surface is meant to grant it.
+ * discard uncommitted work or rewrite shared history. `commit`, `reword`,
+ * `createBranch`, and `switchBranch` are included as the narrow write surface
+ * the local git tool intentionally grants. Widening this `Pick` is a deliberate
+ * authority decision, not a convenience — add a method only when the tool
+ * surface is meant to grant it.
  *
  * This slice holds only the JSON-transparent methods whose hand-authored tool
  * schemas map one-to-one onto their `GitInterface` guards (the divergence gate
@@ -31,6 +32,7 @@ export type GitToolCapability = Pick<
   | 'diff'
   | 'show'
   | 'commit'
+  | 'reword'
   | 'branches'
   | 'createBranch'
   | 'switchBranch'

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -50,11 +50,12 @@ export type GitToolCapability = Pick<
  * with `EndoMountEntry` / node remotables and `add()` takes an array of
  * `EndoMountEntry` remotables — so their tool wire (JSON-safe rows out, path
  * strings in) diverges from the raw `GitInterface` guard by design. `add` is the
- * additive staging half of the commit loop; it stages but never discards.
+ * additive staging half of the commit loop; `checkoutConflict` selects and
+ * stages one side of existing unmerged entries.
  */
 export type GitMountToolCapability = Pick<
   EndoGit,
-  'status' | 'add' | 'worktree'
+  'status' | 'add' | 'checkoutConflict' | 'worktree'
 >;
 
 export interface ToolSpec {

--- a/packages/agent-tools/src/types.ts
+++ b/packages/agent-tools/src/types.ts
@@ -9,14 +9,15 @@ import type { Pattern } from '@endo/patterns';
  * exposes to an LLM.
  *
  * Deliberately omits the destructive and history-rewriting methods of `EndoGit`
- * — `merge`, `rebase`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
+ * — `merge`, `restore`, `deleteBranch`, `renameBranch`, the `stash*`
  * family, and the working-tree/detach mutators (`switch`, `detach`). Those carry
  * authority a tool surface handed to a model should not advertise: they can
  * discard uncommitted work or rewrite shared history. `commit`, `reword`,
- * `createBranch`, and `switchBranch` are included as the narrow write surface
- * the local git tool intentionally grants. Widening this `Pick` is a deliberate
- * authority decision, not a convenience — add a method only when the tool
- * surface is meant to grant it.
+ * `cherryPick`, the `mode: "start"` case of `rebase`, `createBranch`, and
+ * `switchBranch` are included as the narrow write surface the local git tool
+ * intentionally grants. Widening this `Pick` is a deliberate authority
+ * decision, not a convenience — add a method only when the tool surface is
+ * meant to grant it.
  *
  * This slice holds only the JSON-transparent methods whose hand-authored tool
  * schemas map one-to-one onto their `GitInterface` guards (the divergence gate
@@ -33,6 +34,8 @@ export type GitToolCapability = Pick<
   | 'show'
   | 'commit'
   | 'reword'
+  | 'cherryPick'
+  | 'rebase'
   | 'branches'
   | 'createBranch'
   | 'switchBranch'

--- a/packages/agent-tools/test/divergence.test.js
+++ b/packages/agent-tools/test/divergence.test.js
@@ -33,6 +33,23 @@ const ajv = new Ajv({ strict: false });
  * @param {string} method
  */
 const guardShapeFor = method => {
+  if (method === 'rebase') {
+    return {
+      requiredCount: 1,
+      guards: harden([
+        M.splitRecord(
+          {
+            mode: 'start',
+            upstream: M.string(),
+          },
+          {
+            autosquash: M.boolean(),
+          },
+          {},
+        ),
+      ]),
+    };
+  }
   const { methodGuards } = getInterfaceGuardPayload(
     /** @type {InterfaceGuard} */ (GitInterface),
   );
@@ -106,6 +123,9 @@ const slotRecords = harden([
   // Open-object option records.
   { slot0: { a: 1, b: 2 } },
   { slot0: { nested: { x: 1 } } },
+  { slot0: { mode: 'start', upstream: 'main' } },
+  { slot0: { mode: 'start', upstream: 'main', autosquash: true } },
+  { slot0: { mode: 'continue', autosquash: true } },
   { slot0: harden({ author: 'alice', oneline: true, maxCount: 10 }) },
   { slot0: 'a', slot1: { a: 1, b: 2 } },
   { slot0: 'a', slot1: { nested: { x: 1 } } },

--- a/packages/agent-tools/test/git-flow.test.js
+++ b/packages/agent-tools/test/git-flow.test.js
@@ -217,17 +217,18 @@ test('the runtime guard rejects a bad arg before reaching the live cap', async t
   await t.throwsAsync(() => byName('commit').invoke({ bogus: 'x' }));
 });
 
-test('add/restore stay out of the JSON-transparent makeGitTool slice', t => {
+test('add/restore/checkoutConflict stay out of makeGitTool', t => {
   // The cap is only touched at invoke time, so an empty object suffices to
   // inspect the record names.
   const tools = makeGitTool(
     /** @type {import('../src/types.js').GitToolCapability} */ (harden({})),
   );
   const names = new Set(tools.map(tool => tool.name));
-  // `add`/`restore` take `M.arrayOf(M.remotable())`, so they cannot sit in the
-  // one-to-one guard-mapped slice. `add` is now served by the mount-bridged
-  // `makeGitMountTools` (proved above); `restore` remains deferred entirely.
+  // These methods take `M.arrayOf(M.remotable())`, so they cannot sit in the
+  // one-to-one guard-mapped slice. `add` and `checkoutConflict` are served by
+  // the mount-bridged `makeGitMountTools`; `restore` remains deferred entirely.
   t.false(names.has('add'));
+  t.false(names.has('checkoutConflict'));
   t.false(names.has('restore'));
   t.false(names.has('status'));
 
@@ -239,6 +240,7 @@ test('add/restore stay out of the JSON-transparent makeGitTool slice', t => {
     ).map(tool => tool.name),
   );
   t.true(mountToolNames.has('add'));
+  t.true(mountToolNames.has('checkoutConflict'));
   t.true(mountToolNames.has('status'));
   t.false(mountToolNames.has('restore'));
 });

--- a/packages/agent-tools/test/git-mount-tool.test.js
+++ b/packages/agent-tools/test/git-mount-tool.test.js
@@ -31,9 +31,10 @@ const makeStubMount = () =>
   });
 
 /**
- * Stub Git capability that bridges through a stub mount. The mutating methods
- * record the repo-relative path each supplied entry resolves to, so a test can
- * assert the path→entry marshalling reached the cap intact.
+ * Stub Git capability that bridges through a stub mount.
+ * The mutating methods record the repo-relative path each supplied entry
+ * resolves to, so a test can assert the path→entry marshalling reached the cap
+ * intact.
  *
  * @param {{ statusRows?: unknown[], addCalls?: unknown[][], checkoutConflictCalls?: unknown[][] }} [opts]
  * @returns {ERef<GitMountToolCapability>}

--- a/packages/agent-tools/test/git-mount-tool.test.js
+++ b/packages/agent-tools/test/git-mount-tool.test.js
@@ -31,14 +31,18 @@ const makeStubMount = () =>
   });
 
 /**
- * Stub Git capability that bridges through a stub mount. `add` records the
- * repo-relative path each supplied entry resolves to (via `segments()`), so a
- * test can assert the path→entry marshalling reached the cap intact.
+ * Stub Git capability that bridges through a stub mount. The mutating methods
+ * record the repo-relative path each supplied entry resolves to, so a test can
+ * assert the path→entry marshalling reached the cap intact.
  *
- * @param {{ statusRows?: unknown[], addCalls?: unknown[][] }} [opts]
+ * @param {{ statusRows?: unknown[], addCalls?: unknown[][], checkoutConflictCalls?: unknown[][] }} [opts]
  * @returns {ERef<GitMountToolCapability>}
  */
-const makeStubGit = ({ statusRows = [], addCalls = [] } = {}) => {
+const makeStubGit = ({
+  statusRows = [],
+  addCalls = [],
+  checkoutConflictCalls = [],
+} = {}) => {
   const mount = makeStubMount();
   return /** @type {ERef<GitMountToolCapability>} */ (
     /** @type {unknown} */ (
@@ -56,15 +60,26 @@ const makeStubGit = ({ statusRows = [], addCalls = [] } = {}) => {
           );
           addCalls.push(paths);
         },
+        checkoutConflict: async (entries, side) => {
+          await null;
+          const paths = await Promise.all(
+            entries.map(async entry => {
+              await null;
+              const segments = await E(entry).segments();
+              return segments.join('/');
+            }),
+          );
+          checkoutConflictCalls.push([paths, side]);
+        },
       })
     )
   );
 };
 
-test('makeGitMountTools builds a status and an add record', t => {
+test('makeGitMountTools builds status, add, and checkoutConflict records', t => {
   const tools = makeGitMountTools(makeStubGit());
   const names = tools.map(tool => tool.name).sort();
-  t.deepEqual(names, ['add', 'status']);
+  t.deepEqual(names, ['add', 'checkoutConflict', 'status']);
   for (const tool of tools) {
     t.is(typeof tool.description, 'string');
     t.truthy(tool.parameters);
@@ -137,6 +152,50 @@ test('add resolves path strings to mount entries and calls the cap', async t => 
   });
   t.deepEqual(addCalls, [['src/a.js', 'src/dir/b.js']]);
   t.is(result, 'Staged 2 paths.');
+});
+
+test('checkoutConflict resolves path strings and side to the cap', async t => {
+  const checkoutConflictCalls = [];
+  const tools = makeGitMountTools(makeStubGit({ checkoutConflictCalls }));
+  const result = await byNameOf(tools)('checkoutConflict').invoke({
+    paths: ['src/a.js', 'src/dir/b.js'],
+    side: 'theirs',
+  });
+  t.deepEqual(checkoutConflictCalls, [
+    [['src/a.js', 'src/dir/b.js'], 'theirs'],
+  ]);
+  t.is(result, 'Selected theirs for 2 conflicted paths.');
+});
+
+test('checkoutConflict rejects bad side/path shapes', async t => {
+  const checkoutConflictCalls = [];
+  const tools = makeGitMountTools(makeStubGit({ checkoutConflictCalls }));
+  const byName = byNameOf(tools);
+  await t.throwsAsync(
+    () =>
+      byName('checkoutConflict').invoke({
+        paths: ['a.js'],
+        side: 'base',
+      }),
+    { message: /side/ },
+  );
+  await t.throwsAsync(
+    () =>
+      byName('checkoutConflict').invoke({
+        paths: [],
+        side: 'ours',
+      }),
+    { message: /non-empty/ },
+  );
+  await t.throwsAsync(
+    () =>
+      byName('checkoutConflict').invoke({
+        paths: ['.'],
+        side: 'ours',
+      }),
+    { message: /worktree root/ },
+  );
+  t.deepEqual(checkoutConflictCalls, []);
 });
 
 test('add normalizes redundant path separators before resolving', async t => {

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -17,6 +17,7 @@ const SLICE = [
   'diff',
   'show',
   'commit',
+  'reword',
   'branches',
   'createBranch',
   'switchBranch',
@@ -47,6 +48,10 @@ const makeStubGit = calls => {
     commit: async (...a) => {
       calls.push(['commit', ...a]);
       return { oid: 'x', summary: a[0] };
+    },
+    reword: async (...a) => {
+      calls.push(['reword', ...a]);
+      return { oid: 'x', summary: a[1] };
     },
     branches: async (...a) => {
       calls.push(['branches', ...a]);
@@ -101,12 +106,19 @@ test('invoke marshals named args to positional and calls the capability', async 
   await null;
 
   await byName('commit').invoke({ message: 'a message' });
+  await byName('commit').invoke({
+    message: 'amended message',
+    options: harden({ amend: true }),
+  });
+  await byName('reword').invoke({ ref: 'HEAD~1', message: 'new subject' });
   await byName('createBranch').invoke({ name: 'feature' });
   await byName('createBranch').invoke({ name: 'feature', options: harden({}) });
   await byName('log').invoke({});
 
   t.deepEqual(calls, [
     ['commit', 'a message'],
+    ['commit', 'amended message', { amend: true }],
+    ['reword', 'HEAD~1', 'new subject'],
     ['createBranch', 'feature'],
     ['createBranch', 'feature', {}],
     ['log'],
@@ -147,7 +159,8 @@ test('the schemas advertise real, declarative property names', t => {
     }
   }
 
-  t.deepEqual(propsOf('commit'), ['message']);
+  t.deepEqual(propsOf('commit'), ['message', 'options']);
+  t.deepEqual(propsOf('reword'), ['ref', 'message']);
   t.deepEqual(propsOf('show'), ['ref']);
   t.deepEqual(propsOf('createBranch'), ['name', 'options']);
   t.deepEqual(propsOf('switchBranch'), ['branch']);

--- a/packages/agent-tools/test/git-tool.test.js
+++ b/packages/agent-tools/test/git-tool.test.js
@@ -18,6 +18,8 @@ const SLICE = [
   'show',
   'commit',
   'reword',
+  'cherryPick',
+  'rebase',
   'branches',
   'createBranch',
   'switchBranch',
@@ -52,6 +54,14 @@ const makeStubGit = calls => {
     reword: async (...a) => {
       calls.push(['reword', ...a]);
       return { oid: 'x', summary: a[1] };
+    },
+    cherryPick: async (...a) => {
+      calls.push(['cherryPick', ...a]);
+      return '';
+    },
+    rebase: async (...a) => {
+      calls.push(['rebase', ...a]);
+      return '';
     },
     branches: async (...a) => {
       calls.push(['branches', ...a]);
@@ -111,6 +121,14 @@ test('invoke marshals named args to positional and calls the capability', async 
     options: harden({ amend: true }),
   });
   await byName('reword').invoke({ ref: 'HEAD~1', message: 'new subject' });
+  await byName('cherryPick').invoke({ ref: 'side' });
+  await byName('cherryPick').invoke({
+    ref: 'side',
+    options: harden({ noCommit: true }),
+  });
+  await byName('rebase').invoke({
+    input: harden({ mode: 'start', upstream: 'main', autosquash: true }),
+  });
   await byName('createBranch').invoke({ name: 'feature' });
   await byName('createBranch').invoke({ name: 'feature', options: harden({}) });
   await byName('log').invoke({});
@@ -119,6 +137,9 @@ test('invoke marshals named args to positional and calls the capability', async 
     ['commit', 'a message'],
     ['commit', 'amended message', { amend: true }],
     ['reword', 'HEAD~1', 'new subject'],
+    ['cherryPick', 'side'],
+    ['cherryPick', 'side', { noCommit: true }],
+    ['rebase', { mode: 'start', upstream: 'main', autosquash: true }],
     ['createBranch', 'feature'],
     ['createBranch', 'feature', {}],
     ['log'],
@@ -161,6 +182,8 @@ test('the schemas advertise real, declarative property names', t => {
 
   t.deepEqual(propsOf('commit'), ['message', 'options']);
   t.deepEqual(propsOf('reword'), ['ref', 'message']);
+  t.deepEqual(propsOf('cherryPick'), ['ref', 'options']);
+  t.deepEqual(propsOf('rebase'), ['input']);
   t.deepEqual(propsOf('show'), ['ref']);
   t.deepEqual(propsOf('createBranch'), ['name', 'options']);
   t.deepEqual(propsOf('switchBranch'), ['branch']);
@@ -180,14 +203,44 @@ test('invoke resolves named args by their real property names', async t => {
   await null;
 
   await byName('show').invoke({ ref: 'HEAD' });
+  await byName('cherryPick').invoke({ ref: { name: 'HEAD', kind: 'commit' } });
   await byName('switchBranch').invoke({ branch: 'feature' });
   await byName('log').invoke({ options: harden({ maxCount: 3 }) });
 
   t.deepEqual(calls, [
     ['show', 'HEAD'],
+    ['cherryPick', { name: 'HEAD', kind: 'commit' }],
     ['switchBranch', 'feature'],
     ['log', { maxCount: 3 }],
   ]);
+});
+
+test('rebase JSON tool only exposes start mode with autosquash', async t => {
+  const tools = makeGitTool(makeStubGit([]));
+  const rebase = tools.find(tool => tool.name === 'rebase');
+  if (!rebase) throw new Error('no rebase tool');
+
+  await null;
+
+  await t.notThrowsAsync(() =>
+    rebase.invoke({ input: { mode: 'start', upstream: 'main' } }),
+  );
+  await t.notThrowsAsync(() =>
+    rebase.invoke({
+      input: { mode: 'start', upstream: 'main', autosquash: true },
+    }),
+  );
+  await Promise.all(
+    ['continue', 'abort', 'skip'].map(async mode => {
+      const err = await t.throwsAsync(() =>
+        rebase.invoke({ input: { mode, autosquash: true } }),
+      );
+      t.true(
+        err !== undefined && err.message.includes('rebase input'),
+        `error should name rebase input for ${mode}; got: ${err?.message}`,
+      );
+    }),
+  );
 });
 
 test('invoke rejects a wrong property name and a missing required one', async t => {

--- a/packages/agentry/src/execute/git-types.js
+++ b/packages/agentry/src/execute/git-types.js
@@ -33,6 +33,7 @@ export const gitCodeModeTypeDeclarations = harden({
   revParse: (ref: GitRef | string) => Promise<GitRef>;
   add: (entries: EndoMountEntry[]) => Promise<void>;
   restore: (entries: EndoMountEntry[], options?: GitRestoreOptions) => Promise<void>;
+  checkoutConflict: (entries: EndoMountEntry[], side: GitConflictSide) => Promise<void>;
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
   cherryPick: (ref: GitRef | string, options?: GitCherryPickOptions) => Promise<string>;
@@ -70,6 +71,7 @@ type GitCommit = {
 type GitCommitOptions = {
     amend?: boolean;
 };
+type GitConflictSide = 'ours' | 'theirs';
 type GitCreateBranchOptions = {
     startPoint?: string;
     switchAfterCreate?: boolean;

--- a/packages/agentry/src/execute/git-types.js
+++ b/packages/agentry/src/execute/git-types.js
@@ -33,7 +33,8 @@ export const gitCodeModeTypeDeclarations = harden({
   revParse: (ref: GitRef | string) => Promise<GitRef>;
   add: (entries: EndoMountEntry[]) => Promise<void>;
   restore: (entries: EndoMountEntry[], options?: GitRestoreOptions) => Promise<void>;
-  commit: (message: string) => Promise<GitCommit>;
+  commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
+  reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
   currentBranch: () => Promise<GitRef | undefined>;
   branches: () => Promise<GitRef[]>;
   createBranch: (name: string, options?: GitCreateBranchOptions) => Promise<GitRef>;
@@ -61,6 +62,9 @@ type GitCommit = {
     summary: string;
     author?: string;
     committedAt?: number;
+};
+type GitCommitOptions = {
+    amend?: boolean;
 };
 type GitCreateBranchOptions = {
     startPoint?: string;

--- a/packages/agentry/src/execute/git-types.js
+++ b/packages/agentry/src/execute/git-types.js
@@ -35,6 +35,7 @@ export const gitCodeModeTypeDeclarations = harden({
   restore: (entries: EndoMountEntry[], options?: GitRestoreOptions) => Promise<void>;
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+  cherryPick: (ref: GitRef | string, options?: GitCherryPickOptions) => Promise<string>;
   currentBranch: () => Promise<GitRef | undefined>;
   branches: () => Promise<GitRef[]>;
   createBranch: (name: string, options?: GitCreateBranchOptions) => Promise<GitRef>;
@@ -57,6 +58,9 @@ export const gitCodeModeTypeDeclarations = harden({
 };
 type EndoMount = unknown;
 type EndoMountEntry = unknown;
+type GitCherryPickOptions = {
+    noCommit?: boolean;
+};
 type GitCommit = {
     oid: string;
     summary: string;
@@ -92,8 +96,13 @@ type GitMergeOptions = {
     noFastForward?: boolean;
 };
 type GitRebaseInput = {
-    mode?: 'start' | 'continue' | 'abort' | 'skip';
-    upstream?: string;
+    mode: 'start';
+    upstream: string;
+    autosquash?: boolean;
+} | {
+    mode: 'continue' | 'abort' | 'skip';
+    upstream?: never;
+    autosquash?: never;
 };
 type GitRef = {
     name: string;

--- a/packages/agentry/test/code-mode.test.js
+++ b/packages/agentry/test/code-mode.test.js
@@ -230,7 +230,9 @@ test('a typed global injects its generated declaration into the prompt', t => {
   t.true(systemPrompt.includes('declare const git: EndoGit;'));
   t.true(systemPrompt.includes('type EndoGit = {'));
   t.true(
-    systemPrompt.includes('commit: (message: string) => Promise<GitCommit>;'),
+    systemPrompt.includes(
+      'commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;',
+    ),
   );
   // workspace: guard-derived, reaching the Directory surface transitively.
   t.true(systemPrompt.includes('declare const workspace: Filesystem;'));

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -108,7 +108,7 @@ test('Git exo advertises the full GitInterface', async t => {
   }
 
   // Mutation
-  for (const name of ['add', 'restore', 'commit', 'reword']) {
+  for (const name of ['add', 'restore', 'commit', 'reword', 'cherryPick']) {
     t.true(methods.includes(name), `Git should advertise ${name}`);
   }
 
@@ -193,6 +193,17 @@ test('Git.readOnly() attenuates mutating operations but preserves reads', async 
   await t.throwsAsync(E(readOnlyGit).reword('HEAD', 'should fail'), {
     message: /read-only Git capability/,
   });
+  await t.throwsAsync(E(readOnlyGit).cherryPick('HEAD'), {
+    message: /read-only Git capability/,
+  });
+  await t.throwsAsync(
+    E(readOnlyGit).rebase({
+      mode: 'start',
+      upstream: 'main',
+      autosquash: true,
+    }),
+    { message: /read-only Git capability/ },
+  );
   await t.throwsAsync(E(readOnlyGit).switchBranch('main'), {
     message: /read-only Git capability/,
   });
@@ -588,6 +599,123 @@ test('Git.reword replaces one ancestor message without an editor', async t => {
   t.is(stdout, 'first\n');
 });
 
+test('Git.cherryPick replays a commit through the native backend', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'side.txt'), 'side\n');
+  await execFileAsync('git', ['add', 'side.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'side commit',
+    ],
+    { cwd: repoRoot },
+  );
+  const sideOid = (await E(git).revParse('HEAD')).oid || '';
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+
+  await E(git).cherryPick(sideOid);
+
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'side.txt'), 'utf8'),
+    'side\n',
+  );
+  const log = await E(git).log({ maxCount: 2 });
+  t.deepEqual(
+    log.map(commit => commit.summary),
+    ['side commit', 'init commit'],
+  );
+});
+
+test('Git.cherryPick noCommit applies without creating a commit', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  const initialHead = (await E(git).revParse('HEAD')).oid;
+  await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'pending.txt'), 'pending\n');
+  await execFileAsync('git', ['add', 'pending.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'pending commit',
+    ],
+    { cwd: repoRoot },
+  );
+  const sideOid = (await E(git).revParse('HEAD')).oid || '';
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+
+  await E(git).cherryPick(sideOid, { noCommit: true });
+
+  t.is((await E(git).revParse('HEAD')).oid, initialHead);
+  const status = await E(git).status();
+  const pending = status.find(row => row.path === 'pending.txt');
+  t.truthy(pending);
+  t.is(pending && pending.index, 'added');
+});
+
+test('NativeGitBackend.cherryPick stops cleanly on conflict', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'base\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'base file'],
+    { cwd: repoRoot },
+  );
+
+  await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'side\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'side edit'],
+    { cwd: repoRoot },
+  );
+  const sideOid = (
+    await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot })
+  ).stdout.trim();
+
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'main\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'main edit'],
+    { cwd: repoRoot },
+  );
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await t.throwsAsync(() => backend.cherryPick(sideOid), {
+    message: /cherry-pick failed|CONFLICT/,
+  });
+  const status = await backend.status();
+  const conflicted = status.find(row => row.path === 'conflict.txt');
+  t.truthy(conflicted);
+  t.is(conflicted && conflicted.index, 'conflicted');
+  t.is(conflicted && conflicted.worktree, 'conflicted');
+});
+
 test('Git scaffold methods all surface a clear "not yet implemented"', async t => {
   const mount = await provisionMount(t);
   const backend = makeNotYetImplementedBackend();
@@ -602,6 +730,9 @@ test('Git scaffold methods all surface a clear "not yet implemented"', async t =
     message: /not yet implemented/,
   });
   await t.throwsAsync(E(git).reword('HEAD', 'msg'), {
+    message: /not yet implemented/,
+  });
+  await t.throwsAsync(E(git).cherryPick('HEAD'), {
     message: /not yet implemented/,
   });
   await t.throwsAsync(E(git).branches(), { message: /not yet implemented/ });
@@ -1699,6 +1830,69 @@ test('NativeGitBackend.rebase rebases a local branch onto upstream', async t => 
     commits.map(commit => commit.summary),
     ['feature commit', 'main commit'],
   );
+});
+
+test('NativeGitBackend.rebase supports autosquash on start', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync('git', ['switch', '-c', 'feature'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'topic.txt'), 'one\n');
+  await execFileAsync('git', ['add', 'topic.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'topic'],
+    { cwd: repoRoot },
+  );
+  await fs.promises.writeFile(path.join(repoRoot, 'topic.txt'), 'two\n');
+  await execFileAsync('git', ['add', 'topic.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.email=t@t',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-m',
+      'fixup! topic',
+    ],
+    { cwd: repoRoot },
+  );
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'main.txt'), 'main\n');
+  await execFileAsync('git', ['add', 'main.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'main'],
+    { cwd: repoRoot },
+  );
+  await execFileAsync('git', ['switch', 'feature'], { cwd: repoRoot });
+
+  const backend = makeNativeGitBackend({ repoRoot });
+  await backend.rebase({ mode: 'start', upstream: 'main', autosquash: true });
+
+  const commits = await backend.log({ maxCount: 3 });
+  t.deepEqual(
+    commits.map(commit => commit.summary),
+    ['topic', 'main', 'init commit'],
+  );
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'topic.txt'), 'utf8'),
+    'two\n',
+  );
+});
+
+test('NativeGitBackend.rebase rejects autosquash outside start mode', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const backend = makeNativeGitBackend({ repoRoot });
+
+  for (const mode of ['continue', 'abort', 'skip']) {
+    await t.throwsAsync(
+      () => backend.rebase(/** @type {any} */ ({ mode, autosquash: true })),
+      {
+        message: /autosquash is only valid for mode start/,
+      },
+    );
+  }
 });
 
 test('NativeGitBackend.rebase continues a conflicted rebase without an interactive editor', async t => {

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -108,7 +108,7 @@ test('Git exo advertises the full GitInterface', async t => {
   }
 
   // Mutation
-  for (const name of ['add', 'restore', 'commit']) {
+  for (const name of ['add', 'restore', 'commit', 'reword']) {
     t.true(methods.includes(name), `Git should advertise ${name}`);
   }
 
@@ -182,6 +182,15 @@ test('Git.readOnly() attenuates mutating operations but preserves reads', async 
     message: /read-only Git capability/,
   });
   await t.throwsAsync(E(readOnlyGit).commit('should fail'), {
+    message: /read-only Git capability/,
+  });
+  await t.throwsAsync(
+    E(readOnlyGit).commit('should also fail', { amend: true }),
+    {
+      message: /read-only Git capability/,
+    },
+  );
+  await t.throwsAsync(E(readOnlyGit).reword('HEAD', 'should fail'), {
     message: /read-only Git capability/,
   });
   await t.throwsAsync(E(readOnlyGit).switchBranch('main'), {
@@ -509,6 +518,76 @@ test('Git.readOnly allows immutable tree reads', async t => {
   t.is(await E(blob).text(), 'audit\n');
 });
 
+test('Git.commit can amend HEAD through the native backend', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await fs.promises.writeFile(path.join(repoRoot, 'amend.txt'), 'one\n');
+  const entry = await E(mount).entry(['amend.txt']);
+  await E(git).add([entry]);
+  const first = await E(git).commit('first subject');
+
+  await fs.promises.writeFile(path.join(repoRoot, 'amend.txt'), 'two\n');
+  await E(git).add([entry]);
+  const amended = await E(git).commit('amended subject', { amend: true });
+
+  t.not(amended.oid, first.oid);
+  t.is(amended.summary, 'amended subject');
+  const log = await E(git).log({ maxCount: 3 });
+  t.deepEqual(
+    log.map(commit => commit.summary),
+    ['amended subject', 'init commit'],
+  );
+});
+
+test('Git.reword replaces one ancestor message without an editor', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await execFileAsync('git', ['config', '--local', 'core.editor', 'false'], {
+    cwd: repoRoot,
+  });
+  await execFileAsync(
+    'git',
+    ['config', '--local', 'sequence.editor', 'false'],
+    {
+      cwd: repoRoot,
+    },
+  );
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await fs.promises.writeFile(path.join(repoRoot, 'first.txt'), 'first\n');
+  const firstEntry = await E(mount).entry(['first.txt']);
+  await E(git).add([firstEntry]);
+  const first = await E(git).commit('first subject');
+
+  await fs.promises.writeFile(path.join(repoRoot, 'second.txt'), 'second\n');
+  const secondEntry = await E(mount).entry(['second.txt']);
+  await E(git).add([secondEntry]);
+  await E(git).commit('second subject');
+
+  const reworded = await E(git).reword(first.oid, 'replacement subject');
+  t.not(reworded.oid, first.oid);
+  t.is(reworded.summary, 'replacement subject');
+
+  const log = await E(git).log({ maxCount: 3 });
+  t.deepEqual(
+    log.map(commit => commit.summary),
+    ['second subject', 'replacement subject', 'init commit'],
+  );
+  const { stdout } = await execFileAsync(
+    'git',
+    ['show', `${reworded.oid}:first.txt`],
+    { cwd: repoRoot },
+  );
+  t.is(stdout, 'first\n');
+});
+
 test('Git scaffold methods all surface a clear "not yet implemented"', async t => {
   const mount = await provisionMount(t);
   const backend = makeNotYetImplementedBackend();
@@ -520,6 +599,9 @@ test('Git scaffold methods all surface a clear "not yet implemented"', async t =
   await t.throwsAsync(E(git).status(), { message: /not yet implemented/ });
   await t.throwsAsync(E(git).log({}), { message: /not yet implemented/ });
   await t.throwsAsync(E(git).commit('msg'), {
+    message: /not yet implemented/,
+  });
+  await t.throwsAsync(E(git).reword('HEAD', 'msg'), {
     message: /not yet implemented/,
   });
   await t.throwsAsync(E(git).branches(), { message: /not yet implemented/ });

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -108,7 +108,14 @@ test('Git exo advertises the full GitInterface', async t => {
   }
 
   // Mutation
-  for (const name of ['add', 'restore', 'commit', 'reword', 'cherryPick']) {
+  for (const name of [
+    'add',
+    'restore',
+    'checkoutConflict',
+    'commit',
+    'reword',
+    'cherryPick',
+  ]) {
     t.true(methods.includes(name), `Git should advertise ${name}`);
   }
 
@@ -179,6 +186,9 @@ test('Git.readOnly() attenuates mutating operations but preserves reads', async 
 
   const entry = await E(mount).entry(['new.txt']);
   await t.throwsAsync(E(readOnlyGit).add([entry]), {
+    message: /read-only Git capability/,
+  });
+  await t.throwsAsync(E(readOnlyGit).checkoutConflict([entry], 'ours'), {
     message: /read-only Git capability/,
   });
   await t.throwsAsync(E(readOnlyGit).commit('should fail'), {
@@ -716,6 +726,123 @@ test('NativeGitBackend.cherryPick stops cleanly on conflict', async t => {
   t.is(conflicted && conflicted.worktree, 'conflicted');
 });
 
+test('Git.checkoutConflict selects and stages ours in a merge conflict', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'base\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'base file'],
+    { cwd: repoRoot },
+  );
+
+  await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'side\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'side edit'],
+    { cwd: repoRoot },
+  );
+
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'main\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'main edit'],
+    { cwd: repoRoot },
+  );
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await t.throwsAsync(E(git).merge('side'), {
+    message: /CONFLICT|Automatic merge failed/,
+  });
+  const entry = await E(mount).entry(['conflict.txt']);
+  await E(git).checkoutConflict([entry], 'ours');
+
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'conflict.txt'), 'utf8'),
+    'main\n',
+  );
+  const { stdout: staged } = await execFileAsync(
+    'git',
+    ['show', ':conflict.txt'],
+    { cwd: repoRoot },
+  );
+  t.is(staged, 'main\n');
+  const { stdout: unmerged } = await execFileAsync(
+    'git',
+    ['ls-files', '-u', '--', 'conflict.txt'],
+    { cwd: repoRoot },
+  );
+  t.is(unmerged, '');
+});
+
+test('Git.checkoutConflict selects and stages theirs in a cherry-pick conflict', async t => {
+  const repoRoot = await provisionGitWorktree(t);
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'base\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'base file'],
+    { cwd: repoRoot },
+  );
+
+  await execFileAsync('git', ['switch', '-c', 'side'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'side\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'side edit'],
+    { cwd: repoRoot },
+  );
+  const sideOid = (
+    await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot })
+  ).stdout.trim();
+
+  await execFileAsync('git', ['switch', 'main'], { cwd: repoRoot });
+  await fs.promises.writeFile(path.join(repoRoot, 'conflict.txt'), 'main\n');
+  await execFileAsync('git', ['add', 'conflict.txt'], { cwd: repoRoot });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=T', 'commit', '-m', 'main edit'],
+    { cwd: repoRoot },
+  );
+
+  const filePowers = makeFilePowers({ fs, path });
+  const mount = makeMount({ rootPath: repoRoot, readOnly: false, filePowers });
+  const backend = makeNativeGitBackend({ repoRoot });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  await t.throwsAsync(E(git).cherryPick(sideOid), {
+    message: /cherry-pick failed|CONFLICT/,
+  });
+  const entry = await E(mount).entry(['conflict.txt']);
+  await E(git).checkoutConflict([entry], 'theirs');
+
+  t.is(
+    await fs.promises.readFile(path.join(repoRoot, 'conflict.txt'), 'utf8'),
+    'side\n',
+  );
+  const { stdout: staged } = await execFileAsync(
+    'git',
+    ['show', ':conflict.txt'],
+    { cwd: repoRoot },
+  );
+  t.is(staged, 'side\n');
+  const { stdout: unmerged } = await execFileAsync(
+    'git',
+    ['ls-files', '-u', '--', 'conflict.txt'],
+    { cwd: repoRoot },
+  );
+  t.is(unmerged, '');
+});
+
 test('Git scaffold methods all surface a clear "not yet implemented"', async t => {
   const mount = await provisionMount(t);
   const backend = makeNotYetImplementedBackend();
@@ -733,6 +860,10 @@ test('Git scaffold methods all surface a clear "not yet implemented"', async t =
     message: /not yet implemented/,
   });
   await t.throwsAsync(E(git).cherryPick('HEAD'), {
+    message: /not yet implemented/,
+  });
+  const entry = await E(mount).entry(['conflict.txt']);
+  await t.throwsAsync(E(git).checkoutConflict([entry], 'ours'), {
     message: /not yet implemented/,
   });
   await t.throwsAsync(E(git).branches(), { message: /not yet implemented/ });
@@ -2146,6 +2277,46 @@ test('Git.add wraps EndoMountEntry inputs and refuses cross-mount entries', asyn
   await t.throwsAsync(E(git).add([otherEntry]), {
     message: /different mount lineage/,
   });
+});
+
+test('Git.checkoutConflict refuses unauthenticated and cross-mount entries before backend mutation', async t => {
+  const mount = await provisionMount(t);
+  let mutationCalls = 0;
+  const backend = harden({
+    ...makeNotYetImplementedBackend(),
+    checkoutConflict: async () => {
+      mutationCalls += 1;
+    },
+  });
+  const git = makeGit({ mount, backend, lineageOf });
+
+  const ownEntry = await E(mount).entry(['conflict.txt']);
+  await E(git).checkoutConflict([ownEntry], 'ours');
+  t.is(mutationCalls, 1);
+
+  const fakeEntry = Far('FakeEntry', {
+    segments: () => harden(['conflict.txt']),
+  });
+  await t.throwsAsync(E(git).checkoutConflict([fakeEntry], 'ours'), {
+    message: /not an EndoMountEntry/,
+  });
+  t.is(mutationCalls, 1);
+
+  const otherRoot = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'cross-git-'),
+  );
+  t.teardown(() => fs.promises.rm(otherRoot, { recursive: true, force: true }));
+  const filePowers = makeFilePowers({ fs, path });
+  const otherMount = makeMount({
+    rootPath: otherRoot,
+    readOnly: false,
+    filePowers,
+  });
+  const otherEntry = await E(otherMount).entry(['conflict.txt']);
+  await t.throwsAsync(E(git).checkoutConflict([otherEntry], 'theirs'), {
+    message: /different mount lineage/,
+  });
+  t.is(mutationCalls, 1);
 });
 
 test('Git.commit through the public exo returns a structured commit record', async t => {

--- a/packages/daemon/test/git.test.js
+++ b/packages/daemon/test/git.test.js
@@ -2016,14 +2016,16 @@ test('NativeGitBackend.rebase rejects autosquash outside start mode', async t =>
   const repoRoot = await provisionGitWorktree(t);
   const backend = makeNativeGitBackend({ repoRoot });
 
-  for (const mode of ['continue', 'abort', 'skip']) {
-    await t.throwsAsync(
-      () => backend.rebase(/** @type {any} */ ({ mode, autosquash: true })),
-      {
-        message: /autosquash is only valid for mode start/,
-      },
-    );
-  }
+  await Promise.all(
+    ['continue', 'abort', 'skip'].map(mode =>
+      t.throwsAsync(
+        () => backend.rebase(/** @type {any} */ ({ mode, autosquash: true })),
+        {
+          message: /autosquash is only valid for mode start/,
+        },
+      ),
+    ),
+  );
 });
 
 test('NativeGitBackend.rebase continues a conflicted rebase without an interactive editor', async t => {

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -15,6 +15,7 @@ import { GitInterface } from './interfaces.js';
 /**
  * @import {
  *   EndoGit,
+ *   GitCherryPickOptions,
  *   GitCommit,
  *   GitCommitOptions,
  *   GitCreateBranchOptions,
@@ -136,6 +137,7 @@ harden(getGitBackend);
  * @property {(paths: string[], opts?: GitRestoreOptions) => Promise<void>} restore
  * @property {(message: string, opts?: GitCommitOptions) => Promise<GitCommit>} commit
  * @property {(ref: string, message: string) => Promise<GitCommit>} reword
+ * @property {(ref: string, opts?: GitCherryPickOptions) => Promise<string>} cherryPick
  * @property {() => Promise<GitRef | undefined>} currentBranch
  * @property {() => Promise<GitRef[]>} branches
  * @property {(name: string, opts?: GitCreateBranchOptions) => Promise<GitRef>} createBranch
@@ -443,6 +445,11 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
       return backend.reword(refName(ref), message);
     },
 
+    async cherryPick(ref, options = {}) {
+      assertWritable('cherryPick');
+      return backend.cherryPick(refName(ref), options);
+    },
+
     async currentBranch() {
       return backend.currentBranch();
     },
@@ -566,7 +573,8 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
     },
   };
 
-  const exo = makeExo('Git', GitInterface, gitMethods);
+  // eslint-disable-next-line jsdoc/reject-any-type -- GitInterface's guard-derived type is wider than the public rebase union.
+  const exo = makeExo('Git', /** @type {any} */ (GitInterface), gitMethods);
 
   const typed = /** @type {EndoGit} */ (/** @type {unknown} */ (exo));
   gitReadOnly.set(typed, readOnly);
@@ -601,6 +609,7 @@ export const makeNotYetImplementedBackend = () => {
     restore: async () => fail('restore'),
     commit: async () => fail('commit'),
     reword: async () => fail('reword'),
+    cherryPick: async () => fail('cherryPick'),
     currentBranch: async () => fail('currentBranch'),
     branches: async () => fail('branches'),
     createBranch: async () => fail('createBranch'),

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -16,6 +16,7 @@ import { GitInterface } from './interfaces.js';
  * @import {
  *   EndoGit,
  *   GitCommit,
+ *   GitCommitOptions,
  *   GitCreateBranchOptions,
  *   GitDeleteBranchOptions,
  *   GitDiffOptions,
@@ -133,7 +134,8 @@ harden(getGitBackend);
  * @property {(ref: string) => Promise<GitRef>} revParse
  * @property {(paths: string[]) => Promise<void>} add
  * @property {(paths: string[], opts?: GitRestoreOptions) => Promise<void>} restore
- * @property {(message: string) => Promise<GitCommit>} commit
+ * @property {(message: string, opts?: GitCommitOptions) => Promise<GitCommit>} commit
+ * @property {(ref: string, message: string) => Promise<GitCommit>} reword
  * @property {() => Promise<GitRef | undefined>} currentBranch
  * @property {() => Promise<GitRef[]>} branches
  * @property {(name: string, opts?: GitCreateBranchOptions) => Promise<GitRef>} createBranch
@@ -431,9 +433,14 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
       return backend.restore(paths, options);
     },
 
-    async commit(message) {
+    async commit(message, options = {}) {
       assertWritable('commit');
-      return backend.commit(message);
+      return backend.commit(message, options);
+    },
+
+    async reword(ref, message) {
+      assertWritable('reword');
+      return backend.reword(refName(ref), message);
     },
 
     async currentBranch() {
@@ -593,6 +600,7 @@ export const makeNotYetImplementedBackend = () => {
     add: async () => fail('add'),
     restore: async () => fail('restore'),
     commit: async () => fail('commit'),
+    reword: async () => fail('reword'),
     currentBranch: async () => fail('currentBranch'),
     branches: async () => fail('branches'),
     createBranch: async () => fail('createBranch'),

--- a/packages/exo-git/src/git.js
+++ b/packages/exo-git/src/git.js
@@ -18,6 +18,7 @@ import { GitInterface } from './interfaces.js';
  *   GitCherryPickOptions,
  *   GitCommit,
  *   GitCommitOptions,
+ *   GitConflictSide,
  *   GitCreateBranchOptions,
  *   GitDeleteBranchOptions,
  *   GitDiffOptions,
@@ -135,6 +136,7 @@ harden(getGitBackend);
  * @property {(ref: string) => Promise<GitRef>} revParse
  * @property {(paths: string[]) => Promise<void>} add
  * @property {(paths: string[], opts?: GitRestoreOptions) => Promise<void>} restore
+ * @property {(paths: string[], side: GitConflictSide) => Promise<void>} checkoutConflict
  * @property {(message: string, opts?: GitCommitOptions) => Promise<GitCommit>} commit
  * @property {(ref: string, message: string) => Promise<GitCommit>} reword
  * @property {(ref: string, opts?: GitCherryPickOptions) => Promise<string>} cherryPick
@@ -435,6 +437,12 @@ export const makeGit = ({ mount, backend, readOnly = false, lineageOf }) => {
       return backend.restore(paths, options);
     },
 
+    async checkoutConflict(entries, side) {
+      assertWritable('checkoutConflict');
+      const paths = await entriesToRepoPaths(entries);
+      return backend.checkoutConflict(paths, side);
+    },
+
     async commit(message, options = {}) {
       assertWritable('commit');
       return backend.commit(message, options);
@@ -607,6 +615,7 @@ export const makeNotYetImplementedBackend = () => {
     revParse: async () => fail('revParse'),
     add: async () => fail('add'),
     restore: async () => fail('restore'),
+    checkoutConflict: async () => fail('checkoutConflict'),
     commit: async () => fail('commit'),
     reword: async () => fail('reword'),
     cherryPick: async () => fail('cherryPick'),

--- a/packages/exo-git/src/interfaces.js
+++ b/packages/exo-git/src/interfaces.js
@@ -62,6 +62,46 @@ const GitCommitShape = M.splitRecord(
   },
 );
 
+const GitCommitOptionsShape = M.splitRecord(
+  {},
+  {
+    amend: M.boolean(),
+  },
+  {},
+);
+
+const GitCherryPickOptionsShape = M.splitRecord(
+  {},
+  {
+    noCommit: M.boolean(),
+  },
+  {},
+);
+
+const GitRebaseStartInputShape = M.splitRecord(
+  {
+    mode: 'start',
+    upstream: M.string(),
+  },
+  {
+    autosquash: M.boolean(),
+  },
+  {},
+);
+
+const GitRebaseControlInputShape = M.splitRecord(
+  {
+    mode: M.or('continue', 'abort', 'skip'),
+  },
+  {},
+  {},
+);
+
+const GitRebaseInputShape = M.or(
+  GitRebaseStartInputShape,
+  GitRebaseControlInputShape,
+);
+
 // #endregion
 
 export const GitInterface = M.interface('Git', {
@@ -84,9 +124,12 @@ export const GitInterface = M.interface('Git', {
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.undefined()),
   commit: M.callWhen(M.string())
-    .optional(M.recordOf(M.string(), M.any()))
+    .optional(GitCommitOptionsShape)
     .returns(GitCommitShape),
   reword: M.callWhen(RefArgShape, M.string()).returns(GitCommitShape),
+  cherryPick: M.callWhen(RefArgShape)
+    .optional(GitCherryPickOptionsShape)
+    .returns(M.string()),
   currentBranch: M.callWhen().returns(M.or(GitRefShape, M.undefined())),
   branches: M.callWhen().returns(M.arrayOf(GitRefShape)),
   createBranch: M.callWhen(M.string())
@@ -102,7 +145,7 @@ export const GitInterface = M.interface('Git', {
   merge: M.callWhen(RefArgShape)
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.string()),
-  rebase: M.callWhen(M.recordOf(M.string(), M.any())).returns(M.string()),
+  rebase: M.callWhen(GitRebaseInputShape).returns(M.string()),
   stashPush: M.callWhen()
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.string()),

--- a/packages/exo-git/src/interfaces.js
+++ b/packages/exo-git/src/interfaces.js
@@ -83,7 +83,10 @@ export const GitInterface = M.interface('Git', {
   restore: M.callWhen(M.arrayOf(M.remotable()))
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.undefined()),
-  commit: M.callWhen(M.string()).returns(GitCommitShape),
+  commit: M.callWhen(M.string())
+    .optional(M.recordOf(M.string(), M.any()))
+    .returns(GitCommitShape),
+  reword: M.callWhen(RefArgShape, M.string()).returns(GitCommitShape),
   currentBranch: M.callWhen().returns(M.or(GitRefShape, M.undefined())),
   branches: M.callWhen().returns(M.arrayOf(GitRefShape)),
   createBranch: M.callWhen(M.string())

--- a/packages/exo-git/src/interfaces.js
+++ b/packages/exo-git/src/interfaces.js
@@ -70,6 +70,8 @@ const GitCommitOptionsShape = M.splitRecord(
   {},
 );
 
+const GitConflictSideShape = M.or(M.eq('ours'), M.eq('theirs'));
+
 const GitCherryPickOptionsShape = M.splitRecord(
   {},
   {
@@ -123,6 +125,10 @@ export const GitInterface = M.interface('Git', {
   restore: M.callWhen(M.arrayOf(M.remotable()))
     .optional(M.recordOf(M.string(), M.any()))
     .returns(M.undefined()),
+  checkoutConflict: M.callWhen(
+    M.arrayOf(M.remotable()),
+    GitConflictSideShape,
+  ).returns(M.undefined()),
   commit: M.callWhen(M.string())
     .optional(GitCommitOptionsShape)
     .returns(GitCommitShape),

--- a/packages/exo-git/src/types.ts
+++ b/packages/exo-git/src/types.ts
@@ -61,6 +61,8 @@ export type GitRestoreOptions = {
   staged?: boolean;
 };
 
+export type GitConflictSide = 'ours' | 'theirs';
+
 export type GitCommitOptions = {
   amend?: boolean;
 };
@@ -247,6 +249,10 @@ export type EndoGit = {
   restore: (
     entries: EndoMountEntry[],
     options?: GitRestoreOptions,
+  ) => Promise<void>;
+  checkoutConflict: (
+    entries: EndoMountEntry[],
+    side: GitConflictSide,
   ) => Promise<void>;
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;

--- a/packages/exo-git/src/types.ts
+++ b/packages/exo-git/src/types.ts
@@ -65,6 +65,10 @@ export type GitCommitOptions = {
   amend?: boolean;
 };
 
+export type GitCherryPickOptions = {
+  noCommit?: boolean;
+};
+
 export type GitCreateBranchOptions = {
   startPoint?: string;
   switchAfterCreate?: boolean;
@@ -79,10 +83,17 @@ export type GitMergeOptions = {
   noFastForward?: boolean;
 };
 
-export type GitRebaseInput = {
-  mode?: 'start' | 'continue' | 'abort' | 'skip';
-  upstream?: string;
-};
+export type GitRebaseInput =
+  | {
+      mode: 'start';
+      upstream: string;
+      autosquash?: boolean;
+    }
+  | {
+      mode: 'continue' | 'abort' | 'skip';
+      upstream?: never;
+      autosquash?: never;
+    };
 
 export type GitStashPushOptions = {
   message?: string;
@@ -239,6 +250,10 @@ export type EndoGit = {
   ) => Promise<void>;
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+  cherryPick: (
+    ref: GitRef | string,
+    options?: GitCherryPickOptions,
+  ) => Promise<string>;
   currentBranch: () => Promise<GitRef | undefined>;
   branches: () => Promise<GitRef[]>;
   createBranch: (

--- a/packages/exo-git/src/types.ts
+++ b/packages/exo-git/src/types.ts
@@ -61,6 +61,10 @@ export type GitRestoreOptions = {
   staged?: boolean;
 };
 
+export type GitCommitOptions = {
+  amend?: boolean;
+};
+
 export type GitCreateBranchOptions = {
   startPoint?: string;
   switchAfterCreate?: boolean;
@@ -233,7 +237,8 @@ export type EndoGit = {
     entries: EndoMountEntry[],
     options?: GitRestoreOptions,
   ) => Promise<void>;
-  commit: (message: string) => Promise<GitCommit>;
+  commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
+  reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
   currentBranch: () => Promise<GitRef | undefined>;
   branches: () => Promise<GitRef[]>;
   createBranch: (

--- a/packages/exo-git/test/types.test.ts
+++ b/packages/exo-git/test/types.test.ts
@@ -3,6 +3,7 @@ import type {
   EndoGit,
   EndoMount,
   EndoMountEntry,
+  GitCherryPickOptions,
   GitCommit,
   GitCommitOptions,
   GitCreateBranchOptions,
@@ -43,6 +44,10 @@ type ExpectedEndoGit = {
   ) => Promise<void>;
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+  cherryPick: (
+    ref: GitRef | string,
+    options?: GitCherryPickOptions,
+  ) => Promise<string>;
   currentBranch: () => Promise<GitRef | undefined>;
   branches: () => Promise<GitRef[]>;
   createBranch: (

--- a/packages/exo-git/test/types.test.ts
+++ b/packages/exo-git/test/types.test.ts
@@ -6,6 +6,7 @@ import type {
   GitCherryPickOptions,
   GitCommit,
   GitCommitOptions,
+  GitConflictSide,
   GitCreateBranchOptions,
   GitDeleteBranchOptions,
   GitDiffOptions,
@@ -41,6 +42,10 @@ type ExpectedEndoGit = {
   restore: (
     entries: EndoMountEntry[],
     options?: GitRestoreOptions,
+  ) => Promise<void>;
+  checkoutConflict: (
+    entries: EndoMountEntry[],
+    side: GitConflictSide,
   ) => Promise<void>;
   commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
   reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;

--- a/packages/exo-git/test/types.test.ts
+++ b/packages/exo-git/test/types.test.ts
@@ -1,5 +1,22 @@
 import { makeGit } from '../src/git.js';
-import type { EndoGit } from '../src/types.js';
+import type {
+  EndoGit,
+  EndoMount,
+  EndoMountEntry,
+  GitCommit,
+  GitCommitOptions,
+  GitCreateBranchOptions,
+  GitDeleteBranchOptions,
+  GitDiffOptions,
+  GitLogOptions,
+  GitMergeOptions,
+  GitRebaseInput,
+  GitRef,
+  GitRestoreOptions,
+  GitStashPushOptions,
+  GitStatusEntry,
+  ReadableTreeView,
+} from '../src/types.js';
 
 type Equal<Left, Right> =
   (<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2
@@ -11,3 +28,46 @@ type Assert<T extends true> = T;
 type MakeGitReturn = ReturnType<typeof makeGit>;
 
 type _MakeGitReturnsEndoGit = Assert<Equal<MakeGitReturn, EndoGit>>;
+
+type ExpectedEndoGit = {
+  worktree: () => Promise<EndoMount | ReadableTreeView>;
+  status: () => Promise<GitStatusEntry[]>;
+  diff: (options?: GitDiffOptions) => Promise<string>;
+  log: (options?: GitLogOptions) => Promise<GitCommit[]>;
+  show: (ref: GitRef | string) => Promise<string>;
+  revParse: (ref: GitRef | string) => Promise<GitRef>;
+  add: (entries: EndoMountEntry[]) => Promise<void>;
+  restore: (
+    entries: EndoMountEntry[],
+    options?: GitRestoreOptions,
+  ) => Promise<void>;
+  commit: (message: string, options?: GitCommitOptions) => Promise<GitCommit>;
+  reword: (ref: GitRef | string, message: string) => Promise<GitCommit>;
+  currentBranch: () => Promise<GitRef | undefined>;
+  branches: () => Promise<GitRef[]>;
+  createBranch: (
+    name: string,
+    options?: GitCreateBranchOptions,
+  ) => Promise<GitRef>;
+  deleteBranch: (
+    name: string,
+    options?: GitDeleteBranchOptions,
+  ) => Promise<void>;
+  renameBranch: (from: string, to: string) => Promise<void>;
+  switchBranch: (name: string) => Promise<void>;
+  detach: (ref: GitRef | string) => Promise<void>;
+  switch: (ref: GitRef | string) => Promise<void>;
+  merge: (ref: GitRef | string, options?: GitMergeOptions) => Promise<string>;
+  rebase: (input: GitRebaseInput) => Promise<string>;
+  stashPush: (options?: GitStashPushOptions) => Promise<string>;
+  stashList: () => Promise<string[]>;
+  stashShow: (index?: number) => Promise<string>;
+  stashApply: (index?: number) => Promise<void>;
+  stashPop: (index?: number) => Promise<void>;
+  stashDrop: (index?: number) => Promise<void>;
+  tree: (ref: GitRef | string) => Promise<ReadableTreeView>;
+  filesystemAt: (ref: GitRef | string) => Promise<unknown>;
+  readOnly: () => EndoGit;
+};
+
+type _EndoGitMatchesExpectedSurface = Assert<Equal<EndoGit, ExpectedEndoGit>>;

--- a/packages/git/src/native-git-backend.js
+++ b/packages/git/src/native-git-backend.js
@@ -38,6 +38,7 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: false });
  *   GitBackendStashPushOptions,
  * } from '@endo/exo-git/src/git.js'
  * @import {
+ *   GitCherryPickOptions,
  *   GitCommit,
  *   GitCommitOptions,
  *   GitCreateBranchOptions,
@@ -2302,6 +2303,25 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
     },
 
     /**
+     * @param {string} ref
+     * @param {GitCherryPickOptions} [opts]
+     * @returns {Promise<string>}
+     */
+    cherryPick: async (ref, opts = {}) => {
+      const target = requireRevision(ref, 'cherryPick.ref');
+      await assertNoExecutableRepoConfig();
+      const args = ['cherry-pick'];
+      if (opts.noCommit !== undefined && typeof opts.noCommit !== 'boolean') {
+        throw new Error('cherryPick.noCommit must be a boolean');
+      }
+      if (opts.noCommit) {
+        args.push('--no-commit');
+      }
+      args.push('--end-of-options', target);
+      return runGit(args);
+    },
+
+    /**
      * @returns {Promise<GitRef | undefined>}
      */
     currentBranch: async () => {
@@ -2451,11 +2471,32 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
     rebase: async input => {
       await assertNoExecutableRepoConfig();
       if (input.mode === 'start') {
-        return runGit([
-          'rebase',
+        const args = ['rebase'];
+        if (input.autosquash !== undefined) {
+          if (typeof input.autosquash !== 'boolean') {
+            throw new Error('rebase.autosquash must be a boolean');
+          }
+          if (input.autosquash) {
+            args.push('--autosquash', '--interactive');
+          }
+        }
+        args.push(
           '--end-of-options',
           requireRevision(input.upstream, 'rebase.upstream'),
-        ]);
+        );
+        return runGit(args);
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(input, 'autosquash') &&
+        input.autosquash !== undefined
+      ) {
+        throw new Error('rebase.autosquash is only valid for mode start');
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(input, 'upstream') &&
+        input.upstream !== undefined
+      ) {
+        throw new Error('rebase.upstream is only valid for mode start');
       }
       if (input.mode === 'continue') {
         return runGit(['rebase', '--continue']);

--- a/packages/git/src/native-git-backend.js
+++ b/packages/git/src/native-git-backend.js
@@ -41,6 +41,7 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: false });
  *   GitCherryPickOptions,
  *   GitCommit,
  *   GitCommitOptions,
+ *   GitConflictSide,
  *   GitCreateBranchOptions,
  *   GitDeleteBranchOptions,
  *   GitMergeOptions,
@@ -2196,6 +2197,30 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
       if (opts.staged) args.push('--staged');
       args.push('--', ...paths);
       await runGit(args);
+    },
+
+    /**
+     * Select one side of an unmerged index entry, write it to the worktree,
+     * and stage the path so the conflict is resolved through Git's index
+     * stages rather than by synthesizing file bytes.
+     *
+     * @param {string[]} paths
+     * @param {GitConflictSide} side
+     * @returns {Promise<void>}
+     */
+    checkoutConflict: async (paths, side) => {
+      if (!Array.isArray(paths) || paths.length === 0) {
+        throw new Error('checkoutConflict: paths must be a non-empty array');
+      }
+      for (const p of paths) {
+        requireNonEmptyString(p, 'checkoutConflict path');
+      }
+      if (side !== 'ours' && side !== 'theirs') {
+        throw new Error('checkoutConflict.side must be ours or theirs');
+      }
+      await assertNoExecutableRepoConfig();
+      await runGit(['checkout', `--${side}`, '--', ...paths]);
+      await runGit(['add', '--', ...paths]);
     },
 
     /**

--- a/packages/git/src/native-git-backend.js
+++ b/packages/git/src/native-git-backend.js
@@ -39,6 +39,7 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: false });
  * } from '@endo/exo-git/src/git.js'
  * @import {
  *   GitCommit,
+ *   GitCommitOptions,
  *   GitCreateBranchOptions,
  *   GitDeleteBranchOptions,
  *   GitMergeOptions,
@@ -1733,6 +1734,30 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
   };
 
   /**
+   * @param {string} ref
+   * @returns {Promise<GitCommit>}
+   */
+  const readCommitRecord = async ref => {
+    const raw = await runGitRaw([
+      'log',
+      '-1',
+      '--pretty=format:%H%x09%s%x09%an%x09%ct',
+      '--end-of-options',
+      ref,
+    ]);
+    const out = raw.trim();
+    const [oid, summary, author, committedAtStr] = out.split('\t');
+    return harden({
+      oid,
+      summary,
+      author,
+      committedAt: committedAtStr
+        ? Number.parseInt(committedAtStr, 10)
+        : undefined,
+    });
+  };
+
+  /**
    * @param {string} blobOid
    * @returns {unknown}
    */
@@ -2177,30 +2202,103 @@ export const makeNativeGitBackend = ({ repoRoot }) => {
      * Returns a `GitCommit` record reflecting the new HEAD.
      *
      * @param {string} message
+     * @param {GitCommitOptions} [opts]
      * @returns {Promise<GitCommit>}
      */
-    commit: async message => {
+    commit: async (message, opts = {}) => {
       requireNonEmptyString(message, 'commit message');
       await assertNoExecutableRepoConfig();
       // -m embeds the message inline; --allow-empty-message is left off
       // so the daemon does not silently accept blank messages.
-      await runGit(['commit', '-m', message]);
+      const args = ['commit'];
+      if (opts.amend !== undefined && typeof opts.amend !== 'boolean') {
+        throw new Error('commit.amend must be a boolean');
+      }
+      if (opts.amend) {
+        args.push('--amend');
+      }
+      args.push('-m', message);
+      await runGit(args);
       // Read back the new HEAD's record so the caller learns the oid.
-      const rawHead = await runGitRaw([
-        'log',
-        '-1',
-        '--pretty=format:%H%x09%s%x09%an%x09%ct',
+      return readCommitRecord('HEAD');
+    },
+
+    /**
+     * Replace one commit's message without invoking an editor.  The target
+     * commit is recreated with the same tree and parents, then any descendants
+     * on the current HEAD are replayed onto the replacement commit.
+     *
+     * @param {string} ref
+     * @param {string} message
+     * @returns {Promise<GitCommit>}
+     */
+    reword: async (ref, message) => {
+      const target = requireRevision(ref, 'reword.ref');
+      requireNonEmptyString(message, 'reword message');
+      await assertNoExecutableRepoConfig();
+
+      const targetOid = (
+        await runGitRaw([
+          'rev-parse',
+          '--verify',
+          '--end-of-options',
+          `${target}^{commit}`,
+        ])
+      ).trim();
+      const headOid = (
+        await runGitRaw([
+          'rev-parse',
+          '--verify',
+          '--end-of-options',
+          'HEAD^{commit}',
+        ])
+      ).trim();
+
+      if (targetOid === headOid) {
+        await runGit(['commit', '--amend', '-m', message]);
+        return readCommitRecord('HEAD');
+      }
+
+      try {
+        await runGitRaw(['merge-base', '--is-ancestor', targetOid, headOid]);
+      } catch {
+        throw new Error('reword.ref must name HEAD or an ancestor of HEAD');
+      }
+
+      const treeOid = (
+        await runGitRaw([
+          'rev-parse',
+          '--verify',
+          '--end-of-options',
+          `${targetOid}^{tree}`,
+        ])
+      ).trim();
+      const parentsText = (
+        await runGitRaw(['show', '-s', '--format=%P', targetOid])
+      ).trim();
+      const authorText = await runGitRaw([
+        'show',
+        '-s',
+        '--format=%an%x00%ae%x00%aI',
+        targetOid,
       ]);
-      const out = rawHead.trim();
-      const [oid, summary, author, committedAtStr] = out.split('\t');
-      return harden({
-        oid,
-        summary,
-        author,
-        committedAt: committedAtStr
-          ? Number.parseInt(committedAtStr, 10)
-          : undefined,
-      });
+      const [authorName, authorEmail, authorDate] = authorText
+        .replace(/\n$/u, '')
+        .split('\0');
+      const args = ['commit-tree', treeOid];
+      for (const parent of parentsText === '' ? [] : parentsText.split(' ')) {
+        args.push('-p', parent);
+      }
+      args.push('-m', message);
+      const replacementOid = (
+        await runGitRaw(args, {
+          GIT_AUTHOR_NAME: authorName,
+          GIT_AUTHOR_EMAIL: authorEmail,
+          GIT_AUTHOR_DATE: authorDate,
+        })
+      ).trim();
+      await runGit(['rebase', '--onto', replacementOid, targetOid, 'HEAD']);
+      return readCommitRecord(replacementOid);
     },
 
     /**


### PR DESCRIPTION
## Summary

- Add `checkoutConflict(entries, side)` to the Git capability, interface guard, backend contract, native backend, and generated type/code-mode surfaces.
- Add the `checkoutConflict({ paths, side })` JSON mount tool, resolving granted worktree paths before invoking the capability.
- Cover read-only rejection, entry lineage rejection, JSON dispatch/schema behavior, and native ours/theirs conflict resolution that stages the selected index side.

Depends on #645.

## Testing

- `npx corepack yarn workspace @endo/agent-tools test test/git-mount-tool.test.js test/git-flow.test.js test/divergence.test.js`
- `npx corepack yarn workspace @endo/exo-git exec tsc --noEmit`
- `npx corepack yarn workspace @endo/daemon test test/git.test.js`
- `npx corepack yarn workspace @endo/agent-tools test test/git-mount-tool.test.js --match='*checkoutConflict*'`
- `npx corepack yarn workspace @endo/daemon test test/git.test.js --match='*checkoutConflict*'`
- `npx corepack yarn workspace @endo/exo-git lint`
- `npx corepack yarn workspace @endo/git lint`
- `npx corepack yarn workspace @endo/agent-tools lint`
- `npx corepack yarn workspace @endo/exo-git test`
- `npx corepack yarn workspace @endo/git test`
- `/home/agent/scripts/checks/run-all.sh --dry-run --base origin/pr/645 --repo .`

Root `yarn docs` and a later root `yarn build:types` run still fail on existing monorepo type/declaration-output issues outside this diff.
